### PR TITLE
Fix RBAC permissions for stork-account on ConfigMaps

### DIFF
--- a/specs/stork-deployment.yaml
+++ b/specs/stork-deployment.yaml
@@ -80,7 +80,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "update"]
+    verbs: ["get", "create", "update"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get"]


### PR DESCRIPTION
Fixes #19 
Verified on v1.8.0 kubernetes cluster. 
