### PR TITLE
Portworx driver: Check for source not being nil during inspect

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -97,7 +97,9 @@ func (p *portworx) InspectVolume(volumeID string) (*storkvolume.Info, error) {
 			info.DataNodes = append(info.DataNodes, node)
 		}
 	}
-	info.ParentID = vols[0].Source.Parent
+	if vols[0].Source != nil {
+		info.ParentID = vols[0].Source.Parent
+	}
 	return info, nil
 }
 


### PR DESCRIPTION
Issue #45