### PR TITLE
Update sched-ops vendor so that snapshot validation will continue even if the first validate fails

### DIFF
--- a/vendor/github.com/portworx/sched-ops/k8s/k8s.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/k8s.go
@@ -2339,7 +2339,7 @@ func (k *k8sOps) ValidateSnapshot(name string, namespace string, retry bool) err
 			if condition.Type == snap_v1.VolumeSnapshotConditionReady && condition.Status == v1.ConditionTrue {
 				return "", false, nil
 			} else if condition.Type == snap_v1.VolumeSnapshotConditionError && condition.Status == v1.ConditionTrue {
-				return "", false, &ErrSnapshotFailed{
+				return "", true, &ErrSnapshotFailed{
 					ID:    name,
 					Cause: fmt.Sprintf("Snapshot Status %v", status),
 				}
@@ -2381,7 +2381,7 @@ func (k *k8sOps) ValidateSnapshotData(name string, retry bool) error {
 				if condition.Type == snap_v1.VolumeSnapshotDataConditionReady {
 					return "", false, nil
 				} else if condition.Type == snap_v1.VolumeSnapshotDataConditionError {
-					return "", false, &ErrSnapshotDataFailed{
+					return "", true, &ErrSnapshotDataFailed{
 						ID:    name,
 						Cause: fmt.Sprintf("SnapshotData Status %v", snapData.Status),
 					}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -548,10 +548,10 @@
 			"revisionTime": "2018-04-24T20:30:52Z"
 		},
 		{
-			"checksumSHA1": "/1Fk6cklZmiDezqn/YcyXkdGn1c=",
+			"checksumSHA1": "kAUri6c7Sc7FgfbDSs0WlMK3E0M=",
 			"path": "github.com/portworx/sched-ops/k8s",
-			"revision": "c95f794663987163824274badd7e0b3d09498d2c",
-			"revisionTime": "2018-07-18T00:54:50Z"
+			"revision": "6d293bf6918c621e1fbd51e608343bf6c5a9c017",
+			"revisionTime": "2018-07-20T21:32:34Z"
 		},
 		{
 			"checksumSHA1": "5Nh7ppJlsyP/6c2zK5joEHz3I30=",


### PR DESCRIPTION

Signed-off-by: Harsh Desai <harsh@portworx.com>