### PR TITLE
Background command fixes

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -445,17 +445,18 @@ func (p *portworx) SnapshotCreate(
 	}
 
 	backgroundCommandTermChan, err := rule.ExecutePreSnapRule(pvcsForSnapshot, snap)
-	if err != nil {
-		err = fmt.Errorf("failed to run pre-snap rule due to: %v", err)
-		log.SnapshotLog(snap).Errorf(err.Error())
-		return nil, getErrorSnapshotConditions(err), err
-	}
 
 	defer func() {
 		if backgroundCommandTermChan != nil {
 			backgroundCommandTermChan <- true // regardless of what happens, always terminate commands
 		}
 	}()
+
+	if err != nil {
+		err = fmt.Errorf("failed to run pre-snap rule due to: %v", err)
+		log.SnapshotLog(snap).Errorf(err.Error())
+		return nil, getErrorSnapshotConditions(err), err
+	}
 
 	snapStatusConditions := []crdv1.VolumeSnapshotCondition{}
 	var snapshotID, snapshotDataName, snapshotCredID string

--- a/pkg/snapshot/rule/rule.go
+++ b/pkg/snapshot/rule/rule.go
@@ -208,7 +208,6 @@ func executeSnapRule(pvcs []v1.PersistentVolumeClaim, snap *crdv1.VolumeSnapshot
 		return nil, err
 	}
 
-	backgroundCommandTermChan := make(chan bool, 1)
 	if snap.Metadata.Annotations != nil {
 		ruleName, present := snap.Metadata.Annotations[ruleAnnotationKeys[rType]]
 		if present && len(ruleName) > 0 {
@@ -236,6 +235,14 @@ func executeSnapRule(pvcs []v1.PersistentVolumeClaim, snap *crdv1.VolumeSnapshot
 					return nil, err
 				}
 
+				// start a watcher thread that will accumulate pods which have background commands to
+				// terminate and also watch a signal channel that indicates when to terminate them
+				backgroundCommandTermChan := make(chan bool, 1)
+				backgroundPodListChan := make(chan v1.Pod)
+				go cmdTerminationWatcher(backgroundPodListChan, backgroundCommandTermChan, snap, taskID.String())
+
+				// backgroundActionPresent is used to track if there is atleast one background action
+				backgroundActionPresent := false
 				for _, item := range rule.Spec {
 					filteredPods := make([]v1.Pod, 0)
 					// filter pods and only uses the ones that match this selector
@@ -251,19 +258,35 @@ func executeSnapRule(pvcs []v1.PersistentVolumeClaim, snap *crdv1.VolumeSnapshot
 					}
 
 					for _, action := range item.Actions {
+						if action.Background {
+							backgroundActionPresent = true
+						}
+
 						if action.Type == apis_stork.StorkRuleActionCommand {
-							err := executeCommandAction(filteredPods, rule, snap, action, backgroundCommandTermChan, rType, taskID)
+							err := executeCommandAction(filteredPods, rule, snap, action, backgroundPodListChan, rType, taskID)
 							if err != nil {
-								return backgroundCommandTermChan, err
+								if backgroundActionPresent {
+									return backgroundCommandTermChan, err
+								}
+
+								backgroundCommandTermChan <- false
+								return nil, err
 							}
 						}
 					}
 				}
+
+				if backgroundActionPresent {
+					return backgroundCommandTermChan, nil
+				}
+
+				backgroundCommandTermChan <- false
+				return nil, nil
 			}
 		}
 	}
 
-	return backgroundCommandTermChan, nil
+	return nil, nil
 }
 
 // executeCommandAction executes the command type action on given pods:
@@ -272,7 +295,7 @@ func executeCommandAction(
 	rule *apis_stork.StorkRule,
 	snap *crdv1.VolumeSnapshot,
 	action apis_stork.StorkRuleAction,
-	backgroundCommandTermChan chan bool,
+	backgroundPodNotifyChan chan v1.Pod,
 	rType ruleType, taskID *uuid.UUID) error {
 	if len(pods) == 0 {
 		return nil
@@ -294,16 +317,9 @@ func executeCommandAction(
 	}
 
 	if action.Background {
-		go func() {
-			if len(podsForAction) > 0 {
-				terminate := <-backgroundCommandTermChan
-				if terminate {
-					if err := terminateCommandInPods(snap, podsForAction, taskID.String()); err != nil {
-						log.SnapshotLog(snap).Warnf("failed to terminate background command in pods due to: %v", err)
-					}
-				}
-			}
-		}()
+		for _, podToTerminate := range podsForAction {
+			backgroundPodNotifyChan <- podToTerminate
+		}
 
 		// regardless of the outcome of running the background command, we first update the
 		// snapshot to track pods which might have a running background command
@@ -562,6 +578,36 @@ func waitForExecPodCompletion(pod *v1.Pod) error {
 
 		return false, nil
 	})
+}
+
+// cmdTerminationWatcher accumulates pods supplied to the given podListChan and when
+// the terminationSignalChan is sent a true signal, it terminates commands on the accumulated
+// pods
+func cmdTerminationWatcher(
+	podListChan chan v1.Pod,
+	terminationSignalChan chan bool,
+	snap *crdv1.VolumeSnapshot,
+	id string) {
+	// For tracking, use a map/set keyed by uid to handle duplicates
+	podsToTerminate := make(map[string]v1.Pod)
+	for {
+		select {
+		case pod := <-podListChan:
+			podsToTerminate[string(pod.GetUID())] = pod
+		case terminate := <-terminationSignalChan:
+			if terminate {
+				podList := make([]v1.Pod, 0)
+				for _, pod := range podsToTerminate {
+					podList = append(podList, pod)
+				}
+
+				if err := terminateCommandInPods(snap, podList, id); err != nil {
+					log.SnapshotLog(snap).Warnf("failed to terminate background command in pods due to: %v", err)
+				}
+			}
+			break
+		}
+	}
 }
 
 func hasSubset(set map[string]string, subset map[string]string) bool {

--- a/pkg/snapshot/rule/rule.go
+++ b/pkg/snapshot/rule/rule.go
@@ -265,8 +265,11 @@ func executeSnapRule(pvcs []v1.PersistentVolumeClaim, snap *crdv1.VolumeSnapshot
 						if action.Type == apis_stork.StorkRuleActionCommand {
 							err := executeCommandAction(filteredPods, rule, snap, action, backgroundPodListChan, rType, taskID)
 							if err != nil {
+								// if any action fails, terminate all background jobs and don't depend on caller
+								// to clean them up
 								if backgroundActionPresent {
-									return backgroundCommandTermChan, err
+									backgroundCommandTermChan <- true
+									return nil, err
 								}
 
 								backgroundCommandTermChan <- false

--- a/test/integration_test/specs/mysql-3d-snap/px-presnap-rule.yaml
+++ b/test/integration_test/specs/mysql-3d-snap/px-presnap-rule.yaml
@@ -14,4 +14,10 @@ spec:
       runInSinglePod: true
     - type: command
       background: true
+      runInSinglePod: true
+      # this command is just to test multiple background commands
+      value: mysql --user=root --password=$MYSQL_ROOT_PASSWORD -Bse 'show databases;system ${WAIT_CMD};'
+    - type: command
+      background: true
+      # this command will flush tables with read lock
       value: mysql --user=root --password=$MYSQL_ROOT_PASSWORD -Bse 'flush tables with read lock;system ${WAIT_CMD};'


### PR DESCRIPTION
1) Don't send the background termination channel if there are no background commands
2) Handle situations where there could be more than one background actions and the first one has a single pod

Fixes #131

Signed-off-by: Harsh Desai <harsh@portworx.com>