### PR TITLE
Fix import path of golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ install:
 	go install -tags "$(TAGS)" $(PKGS)
 
 lint:
-	go get -v github.com/golang/lint/golint
+	go get -v golang.org/x/lint/golint
 	for file in $$(find . -name '*.go' | grep -v vendor | \
                                        grep -v '\.pb\.go' | \
                                        grep -v '\.pb\.gw\.go' | \


### PR DESCRIPTION
According to this stackoverflow post:
https://stackoverflow.com/questions/52784861/cannot-install-golint-package-wrong-import-path

the import path of golint is here:
https://github.com/golang/lint#installation

and changed recently due to this:
due to this: https://github.com/golang/lint/commit/9a272034dedb2a3ed05231d5604ce17fb40f0e58