### PR TITLE
Update golang version in travis to 1.11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: go
 go:
-  - 1.10.4
+  - 1.11.2
 before_install:
   - sudo apt-get update -yq
   - sudo apt-get install go-md2man -y


### PR DESCRIPTION
go 1.11.2 has more improvements to `go vet`, so use that for travis