### PR TITLE
propagate group snap annotations to child volumesnapshots

### DIFF
--- a/pkg/apis/stork/v1alpha1/groupvolumesnapshot.go
+++ b/pkg/apis/stork/v1alpha1/groupvolumesnapshot.go
@@ -34,6 +34,8 @@ type GroupVolumeSnapshotSpec struct {
 	PostExecRule string `json:"postExecRule"`
 	// PVCSelector selects the PVCs that are part of the group snapshot
 	PVCSelector PVCSelectorSpec `json:"pvcSelector"`
+	// RestoreNamespaces is a list of namespaces to which the snapshots can be restored to
+	RestoreNamespaces []string `json:"restoreNamespaces"`
 	// Options are pass-through parameters that are passed to the driver handling the group snapshot
 	Options map[string]string `json:"options"`
 }

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -300,6 +300,11 @@ func (in *GroupVolumeSnapshotList) DeepCopyObject() runtime.Object {
 func (in *GroupVolumeSnapshotSpec) DeepCopyInto(out *GroupVolumeSnapshotSpec) {
 	*out = *in
 	in.PVCSelector.DeepCopyInto(&out.PVCSelector)
+	if in.RestoreNamespaces != nil {
+		in, out := &in.RestoreNamespaces, &out.RestoreNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
 		*out = make(map[string]string, len(*in))

--- a/pkg/snapshot/provisioner.go
+++ b/pkg/snapshot/provisioner.go
@@ -23,7 +23,9 @@ import (
 // so can't vendor it in here.
 
 const (
-	storkSnapshotRestoreNamespacesAnnotation = "stork/snapshot-restore-namespaces"
+	// StorkSnapshotRestoreNamespacesAnnotation is annotation used to specify the
+	// command separated list of namespaces to which the snapshot can be restored
+	StorkSnapshotRestoreNamespacesAnnotation = "stork/snapshot-restore-namespaces"
 	// StorkSnapshotSourceNamespaceAnnotation Annotation used to specify the
 	// source of the snapshot when creating a PVC
 	StorkSnapshotSourceNamespaceAnnotation = "stork/snapshot-source-namespace"
@@ -88,7 +90,7 @@ func (p *snapshotProvisioner) isSnapshotAllowed(
 	snapshot crdv1.VolumeSnapshot,
 	namespace string,
 ) bool {
-	allowedNamespaces, ok := snapshot.Metadata.Annotations[storkSnapshotRestoreNamespacesAnnotation]
+	allowedNamespaces, ok := snapshot.Metadata.Annotations[StorkSnapshotRestoreNamespacesAnnotation]
 	if !ok {
 		return false
 	}


### PR DESCRIPTION
This is required so that we can use snapshots across namespaces ( https://docs.portworx.com/portworx-install-with-kubernetes/storage-operations/create-snapshots/snaps-single-pvc/#creating-snapshots-across-namespaces)

Signed-off-by: Harsh Desai <harsh@portworx.com>