### PR TITLE
Return status for failed cloudsnapshots

### DIFF
--- a/pkg/groupsnapshot/controllers/groupsnapshot.go
+++ b/pkg/groupsnapshot/controllers/groupsnapshot.go
@@ -305,8 +305,14 @@ func (m *GroupSnapshotController) handleSnap(groupSnap *stork_api.GroupVolumeSna
 		return !updateCRD, err
 	}
 
-	if isAnySnapshotFailed(response.Snapshots) {
-		log.GroupSnapshotLog(groupSnap).Infof("Some snapshots in group have failed")
+	if isFailed, failedTasks := isAnySnapshotFailed(response.Snapshots); isFailed {
+		err = fmt.Errorf("Some snapshots in group have failed: %s."+
+			" Resetting group snapshot to retry.", failedTasks)
+		log.GroupSnapshotLog(groupSnap).Errorf(err.Error())
+		m.Recorder.Event(groupSnap,
+			v1.EventTypeWarning,
+			string(stork_api.GroupSnapshotFailed),
+			err.Error())
 		response.Snapshots = nil // so that snapshots are retried
 		stage = stork_api.GroupSnapshotStageSnapshot
 		status = stork_api.GroupSnapshotPending
@@ -556,22 +562,21 @@ func (m *GroupSnapshotController) handleDelete(groupSnap *stork_api.GroupVolumeS
 	return nil
 }
 
-// isAnySnapshotFailed checks if any of the given snapshots is in error state
-func isAnySnapshotFailed(snapshots []*stork_api.VolumeSnapshotStatus) bool {
-	failed := false
-
+// isAnySnapshotFailed checks if any of the given snapshots is in error state and returns
+// task IDs of failed snapshots
+func isAnySnapshotFailed(snapshots []*stork_api.VolumeSnapshotStatus) (bool, []string) {
+	failedTasks := make([]string, 0)
 	for _, snapshot := range snapshots {
 		conditions := snapshot.Conditions
 		if len(conditions) > 0 {
 			lastCondition := conditions[0]
 			if lastCondition.Status == v1.ConditionTrue && lastCondition.Type == crdv1.VolumeSnapshotConditionError {
-				failed = true
-				break
+				failedTasks = append(failedTasks, snapshot.TaskID)
 			}
 		}
 	}
 
-	return failed
+	return len(failedTasks) > 0, failedTasks
 }
 
 func areAllSnapshotsStarted(snapshots []*stork_api.VolumeSnapshotStatus) bool {


### PR DESCRIPTION
If any cloudsnap has failed, the get status API should not fail. Rather it should return the failed tasks in the response so controller can log an event and then reset and retry the group snapshot.

The PR also handles all failed cloud snapshot statues (stopped and aborted).

Signed-off-by: Harsh Desai <harsh@portworx.com>