### PR TITLE
 Add test to load volumes while group cloudsnap is being done

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -586,14 +586,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b13b21b698826bfca38bf489b14ee0571b440498bfd15d90f2a947f867e75141"
+  digest = "1:4e75f297e0e75ecc4df1917c939d67e0887e129d0229c0512104a8060211efde"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s",
     "task",
   ]
   pruneopts = "UT"
-  revision = "76210daaf3f669121d3adc29b6936aef152bc0d4"
+  revision = "10d259768eb3b40dd1ce8a557920722cf237ed59"
 
 [[projects]]
   branch = "master"

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -44,8 +44,9 @@ const (
 	zoneScore   = 25
 	regionScore = 10
 
-	defaultWaitTimeout  time.Duration = 5 * time.Minute
-	defaultWaitInterval time.Duration = 10 * time.Second
+	defaultWaitTimeout       time.Duration = 5 * time.Minute
+	groupSnapshotWaitTimeout time.Duration = 8 * time.Minute
+	defaultWaitInterval      time.Duration = 10 * time.Second
 )
 
 var nodeDriver node.Driver

--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -115,7 +115,7 @@ func groupSnapshotTest(t *testing.T) {
 	ctxsToDestroy = append(ctxsToDestroy, ctxs...)
 
 	for _, ctx := range ctxs {
-		verifyGroupSnapshot(t, ctx, defaultWaitTimeout)
+		verifyGroupSnapshot(t, ctx, groupSnapshotWaitTimeout)
 	}
 
 	// Negative
@@ -145,7 +145,7 @@ func groupSnapshotScaleTest(t *testing.T) {
 		allContexts = append(allContexts, ctxs...)
 	}
 
-	timeout := defaultWaitTimeout
+	timeout := groupSnapshotWaitTimeout
 	// Increase the timeout if scale is more than or equal 10
 	if snapshotScaleCount >= 10 {
 		timeout *= time.Duration((snapshotScaleCount / 10) + 1)
@@ -163,9 +163,10 @@ func createGroupsnaps(t *testing.T) []*scheduler.Context {
 		scheduler.ScheduleOptions{AppKeys: []string{
 			"mysql-localsnap-rule",  // tests local group snapshots with a pre exec rule
 			"mysql-cloudsnap-group", // tests cloud group snapshots
+			"group-cloud-snap-load", // volume is loaded while cloudsnap is being done
 		}})
 	require.NoError(t, err, "Error scheduling task")
-	require.Len(t, ctxs, 2, "Only one task should have started")
+	require.Len(t, ctxs, 3, "Only one task should have started")
 
 	return ctxs
 }

--- a/test/integration_test/specs/group-cloud-snap-load/fio-pods.yaml
+++ b/test/integration_test/specs/group-cloud-snap-load/fio-pods.yaml
@@ -1,0 +1,62 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: loadvolumes1
+spec:
+  schedulerName: stork
+  restartPolicy: Never
+  containers:
+  - image: ankitgd/fio_drv
+    imagePullPolicy: Always
+    args:
+      ["--name=random-writers", "--directory=/test","--ioengine=libaio", "--iodepth=4", "--rw=write","--bs=64k", "--direct=0","--size=4G","--nrfiles=5"]
+    name: load1
+    volumeMounts:
+      - name: px-data
+        mountPath: /test
+  volumes:
+  - name: px-data
+    persistentVolumeClaim:
+      claimName: vol1
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: loadvolumes2
+spec:
+  schedulerName: stork
+  restartPolicy: Never
+  containers:
+  - image: ankitgd/fio_drv
+    imagePullPolicy: Always
+    args:
+      ["--name=random-writers", "--directory=/test","--ioengine=libaio", "--iodepth=4", "--rw=write","--bs=64k", "--direct=0","--size=4G","--nrfiles=5"]
+    name: load2
+    volumeMounts:
+      - name: px-data
+        mountPath: /test
+  volumes:
+  - name: px-data
+    persistentVolumeClaim:
+      claimName: vol2
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: loadvolumes3
+spec:
+  schedulerName: stork
+  restartPolicy: Never
+  containers:
+  - image: ankitgd/fio_drv
+    imagePullPolicy: Always
+    args:
+      ["--name=random-writers", "--directory=/test","--ioengine=libaio", "--iodepth=4", "--rw=write","--bs=64k", "--direct=0","--size=4G","--nrfiles=5"]
+    name: load3
+    volumeMounts:
+      - name: px-data
+        mountPath: /test
+  volumes:
+  - name: px-data
+    persistentVolumeClaim:
+      claimName: vol3

--- a/test/integration_test/specs/group-cloud-snap-load/group-cloud-snap.yaml
+++ b/test/integration_test/specs/group-cloud-snap-load/group-cloud-snap.yaml
@@ -1,0 +1,14 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: GroupVolumeSnapshot
+metadata:
+  annotations:
+  name: load-snapshot-cloud
+  namespace: load-harsh
+spec:
+  options:
+    portworx/snapshot-type: cloud
+  postExecRule: ""
+  preExecRule: ""
+  pvcSelector:
+    matchLabels:
+      app: loadvol

--- a/test/integration_test/specs/group-cloud-snap-load/pvcs.yaml
+++ b/test/integration_test/specs/group-cloud-snap-load/pvcs.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vol1
+  labels:
+    app: loadvol
+spec:
+  storageClassName: portworx-repl2
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vol2
+  labels:
+    app: loadvol
+spec:
+  storageClassName: portworx-repl2
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vol3
+  labels:
+    app: loadvol
+spec:
+  storageClassName: portworx-repl2
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/test/integration_test/specs/group-cloud-snap-load/sc.yaml
+++ b/test/integration_test/specs/group-cloud-snap-load/sc.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-repl2
+parameters:
+  repl: "2"
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Delete


### PR DESCRIPTION
On stork:2.1.0-rc1, this catches the group snapshot issue with failure

```
=== RUN   TestMain/Snapshot/groupSnapshotTest
time="2019-02-17T00:04:18Z" level=info msg="[group-cloud-snap-load] Created Group snapshot: load-snapshot-cloud"
time="2019-02-17T00:04:18Z" level=info msg="[group-cloud-snap-load] Created PVC: vol1"
time="2019-02-17T00:04:18Z" level=info msg="[group-cloud-snap-load] Created PVC: vol2"
time="2019-02-17T00:04:18Z" level=info msg="[group-cloud-snap-load] Created PVC: vol3"
time="2019-02-17T00:04:18Z" level=info msg="[group-cloud-snap-load] Found existing storage class: portworx-repl2"
time="2019-02-17T00:04:18Z" level=info msg="[group-cloud-snap-load] Created Pod: loadvolumes1"
time="2019-02-17T00:04:19Z" level=info msg="[group-cloud-snap-load] Created Pod: loadvolumes2"
time="2019-02-17T00:04:19Z" level=info msg="[group-cloud-snap-load] Created Pod: loadvolumes3"
time="2019-02-17T00:04:19Z" level=info msg="[group-cloud-snap-load] Skipping validate for *v1alpha1.GroupVolumeSnapshot"
time="2019-02-17T00:04:19Z" level=info msg="[group-cloud-snap-load] Skipping validate for *v1.PersistentVolumeClaim"
time="2019-02-17T00:04:19Z" level=info msg="[group-cloud-snap-load] Skipping validate for *v1.PersistentVolumeClaim"
time="2019-02-17T00:04:19Z" level=info msg="[group-cloud-snap-load] Skipping validate for *v1.PersistentVolumeClaim"
time="2019-02-17T00:04:19Z" level=info msg="[group-cloud-snap-load] Skipping validate for *v1.StorageClass"
2019/02/17 00:04:19 Pod loadvolumes1, ID: 924578a3-3247-11e9-ad83-000c29fa7c89  is not ready. Status Pending Next retry in: 10s
2019/02/17 00:04:29 Pod loadvolumes1, ID: 924578a3-3247-11e9-ad83-000c29fa7c89  is not ready. Status Pending Next retry in: 10s
2019/02/17 00:04:39 Pod loadvolumes1, ID: 924578a3-3247-11e9-ad83-000c29fa7c89  is not ready. Status Pending Next retry in: 10s
2019/02/17 00:04:49 Pod loadvolumes1, ID: 924578a3-3247-11e9-ad83-000c29fa7c89  is not ready. Status Pending Next retry in: 10s
time="2019-02-17T00:04:59Z" level=info msg="[group-cloud-snap-load] Validated pod: loadvolumes1"
time="2019-02-17T00:04:59Z" level=info msg="[group-cloud-snap-load] Validated pod: loadvolumes2"
time="2019-02-17T00:04:59Z" level=info msg="[group-cloud-snap-load] Validated pod: loadvolumes3"
2019/02/17 00:04:59 Snapshot load-snapshot-cloud is not ready yet. Cause: group snapshot has 0 child snapshots yet Next retry in: 10s
2019/02/17 00:05:09 Snapshot load-snapshot-cloud is not ready yet. Cause: group snapshot has 0 child snapshots yet Next retry in: 10s
2019/02/17 00:05:19 Snapshot load-snapshot-cloud is not ready yet. Cause: group snapshot has 0 child snapshots yet Next retry in: 10s
2019/02/17 00:05:29 Snapshot load-snapshot-cloud is not ready yet. Cause: group snapshot has 0 child snapshots yet Next retry in: 10s
2019/02/17 00:05:39 Snapshot load-snapshot-cloud is not ready yet. Cause: group snapshot has 0 child snapshots yet Next retry in: 10s
2019/02/17 00:05:49 Snapshot load-snapshot-cloud is not ready yet. Cause: stage: Snapshot status: InProgress Next retry in: 10s
2019/02/17 00:05:59 Snapshot load-snapshot-cloud is not ready yet. Cause: stage: Snapshot status: InProgress Next retry in: 10s
2019/02/17 00:06:09 Snapshot load-snapshot-cloud is not ready yet. Cause: stage: Snapshot status: InProgress Next retry in: 10s
--- FAIL: TestMain (123.58s)
    --- PASS: TestMain/setup (1.83s)
    --- FAIL: TestMain/Snapshot (121.76s)
        --- FAIL: TestMain/Snapshot/groupSnapshotTest (121.75s)
                require.go:794:
                                Error Trace:    snapshot_test.go:179
                                                                        snapshot_test.go:118
                                Error:          Received unexpected error:
                                                Failed to validate storage for app: group-cloud-snap-load due to err: Failed to validate group snapshot: load-snapshot-cloud. Err: Snapshot load-snapshot-cloud has failed. Cause: group snapshot is marked as successfull  but following child volumesnapshots are not done: [load-snapshot-cloud-vol2-91cc3ccc-3247-11e9-ad83-000c29fa7c89 load-snapshot-cloud-vol3-91cc3ccc-3247-11e9-ad83-000c29fa7c89 load-snapshot-cloud-vol1-91cc3ccc-3247-11e9-ad83-000c29fa7c89]
                                Test:           TestMain/Snapshot/groupSnapshotTest
                                Messages:       Error validating storage components
FAIL
```

Will update vendor to use sched-ops master once https://github.com/portworx/sched-ops/pull/104 is merged