### PR TITLE
Add support for configurable retry count

### DIFF
--- a/pkg/apis/stork/v1alpha1/groupvolumesnapshot.go
+++ b/pkg/apis/stork/v1alpha1/groupvolumesnapshot.go
@@ -36,6 +36,8 @@ type GroupVolumeSnapshotSpec struct {
 	PVCSelector PVCSelectorSpec `json:"pvcSelector"`
 	// RestoreNamespaces is a list of namespaces to which the snapshots can be restored to
 	RestoreNamespaces []string `json:"restoreNamespaces"`
+	// MaxRetries is the number of times to retry the groupvolumesnapshot on failure. default: 0
+	MaxRetries int `json:"maxRetries"`
 	// Options are pass-through parameters that are passed to the driver handling the group snapshot
 	Options map[string]string `json:"options"`
 }
@@ -59,6 +61,7 @@ type GroupVolumeSnapshotList struct {
 type GroupVolumeSnapshotStatus struct {
 	Stage           GroupVolumeSnapshotStageType  `json:"stage"`
 	Status          GroupVolumeSnapshotStatusType `json:"status"`
+	NumRetries      int                           `json:"numRetries"`
 	VolumeSnapshots []*VolumeSnapshotStatus       `json:"volumeSnapshots"`
 }
 

--- a/test/integration_test/specs/group-cloud-snap-load/group-cloud-snap.yaml
+++ b/test/integration_test/specs/group-cloud-snap-load/group-cloud-snap.yaml
@@ -3,10 +3,10 @@ kind: GroupVolumeSnapshot
 metadata:
   annotations:
   name: load-snapshot-cloud
-  namespace: load-harsh
 spec:
   options:
     portworx/snapshot-type: cloud
+  maxRetries: 2
   postExecRule: ""
   preExecRule: ""
   pvcSelector:


### PR DESCRIPTION
The PR adds a new field maxRetries in the group volume snapshot spec that allows users to set a max retry count if a group snapshot fails. 

By default, the max retries is 0 and hence the controller will mark the group snapshot as failed if it's fails after it was triggered.

```release-note
Don't retry by default if a group snapshot fails after it is triggered. Allows users to set max retry count.
```

Signed-off-by: Harsh Desai <harsh@portworx.com>