### PR TITLE
scale down group cloud snapshot load test

### DIFF
--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -117,10 +117,20 @@ func groupSnapshotTest(t *testing.T) {
 		"group-cloud-snap-load", // volume is loaded while cloudsnap is being done
 	})
 
+	timeouts := map[string]time.Duration{
+		"mysql-localsnap-rule":  groupSnapshotWaitTimeout,
+		"mysql-cloudsnap-group": groupSnapshotWaitTimeout,
+		// below test runs fio load. Hence takes lot more time
+		"group-cloud-snap-load": 3 * groupSnapshotWaitTimeout,
+	}
+
 	ctxsToDestroy = append(ctxsToDestroy, ctxs...)
 
 	for _, ctx := range ctxs {
-		verifyGroupSnapshot(t, ctx, groupSnapshotWaitTimeout)
+		timeout, present := timeouts[ctx.App.Key]
+		require.True(t, present, "failed to get timeout for group snapshot app")
+
+		verifyGroupSnapshot(t, ctx, timeout)
 	}
 
 	// Negative

--- a/test/integration_test/specs/group-cloud-snap-load/fio-pods.yaml
+++ b/test/integration_test/specs/group-cloud-snap-load/fio-pods.yaml
@@ -9,7 +9,7 @@ spec:
   - image: ankitgd/fio_drv
     imagePullPolicy: Always
     args:
-      ["--name=random-writers", "--directory=/test","--ioengine=libaio", "--iodepth=4", "--rw=write","--bs=64k", "--direct=0","--size=4G","--nrfiles=5"]
+      ["--name=random-writers", "--directory=/test","--ioengine=libaio", "--iodepth=4", "--rw=write","--bs=64k", "--direct=0","--size=2G","--nrfiles=5"]
     name: load1
     volumeMounts:
       - name: px-data
@@ -30,7 +30,7 @@ spec:
   - image: ankitgd/fio_drv
     imagePullPolicy: Always
     args:
-      ["--name=random-writers", "--directory=/test","--ioengine=libaio", "--iodepth=4", "--rw=write","--bs=64k", "--direct=0","--size=4G","--nrfiles=5"]
+      ["--name=random-writers", "--directory=/test","--ioengine=libaio", "--iodepth=4", "--rw=write","--bs=64k", "--direct=0","--size=2G","--nrfiles=5"]
     name: load2
     volumeMounts:
       - name: px-data
@@ -51,7 +51,7 @@ spec:
   - image: ankitgd/fio_drv
     imagePullPolicy: Always
     args:
-      ["--name=random-writers", "--directory=/test","--ioengine=libaio", "--iodepth=4", "--rw=write","--bs=64k", "--direct=0","--size=4G","--nrfiles=5"]
+      ["--name=random-writers", "--directory=/test","--ioengine=libaio", "--iodepth=4", "--rw=write","--bs=64k", "--direct=0","--size=2G","--nrfiles=5"]
     name: load3
     volumeMounts:
       - name: px-data

--- a/test/integration_test/specs/group-cloud-snap-load/pvcs.yaml
+++ b/test/integration_test/specs/group-cloud-snap-load/pvcs.yaml
@@ -10,7 +10,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: 3Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -24,7 +24,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: 3Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -38,4 +38,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: 3Gi


### PR DESCRIPTION
Fixes #269

- Bump timeout for group cloud load test
- Reduce volume size and fio load size

**What type of PR is this?**: failing-test

**What this PR does / why we need it**:

Issue #269 describes the issue. Each fio jobs writes 4GB to data and there are 3 pods. In test setups, a group cloudsnapshot ends up taking > 20 minutes due to quiesce timeouts + time taken to backup the volumes.

**Does this PR change a user-facing CRD or CLI?**: no

**Is a release note needed?**: no

**Does this change need to be cherry-picked to a release branch?**: Yes. 2.1
