### PR TITLE
Add support to use labels to select resources during migration

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1151,10 +1151,6 @@ func (p *portworx) StartMigration(migration *stork_crd.Migration) ([]*stork_crd.
 		return nil, err
 	}
 
-	if len(migration.Spec.Selectors) != 0 {
-		return nil, fmt.Errorf("selectors are not supported yet")
-	}
-
 	if len(migration.Spec.Namespaces) == 0 {
 		return nil, fmt.Errorf("namespaces for migration cannot be empty")
 	}
@@ -1244,9 +1240,9 @@ func (p *portworx) GetMigrationStatus(migration *stork_crd.Migration) ([]*stork_
 					vInfo.Reason = fmt.Sprintf("Migration successful for volume")
 				} else if mInfo.Status == api.CloudMigrate_InProgress {
 					vInfo.Reason = fmt.Sprintf("Volume migration has started. %v in progress. BytesDone: %v BytesTotal: %v ETA: %v seconds",
+						mInfo.CurrentStage.String(),
 						mInfo.BytesDone,
 						mInfo.BytesTotal,
-						mInfo.CurrentStage.String(),
 						mInfo.EtaSeconds)
 				}
 				break

--- a/test/integration_test/specs/cassandra/cassandra.yaml
+++ b/test/integration_test/specs/cassandra/cassandra.yaml
@@ -24,6 +24,8 @@ apiVersion: "apps/v1beta2"
 kind: StatefulSet
 metadata:
   name: cassandra
+  labels:
+    app: cassandra
 spec:
   serviceName: cassandra
   replicas: 3

--- a/test/integration_test/specs/label-selector-migration/migration.yaml
+++ b/test/integration_test/specs/label-selector-migration/migration.yaml
@@ -1,0 +1,16 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: Migration
+metadata:
+  name: cassandra-migration
+spec:
+  # This should be the name of the cluster pair created above
+  clusterPair: remoteclusterpair
+  # If set to false this will migrate only the Portworx volumes. No PVCs, apps, etc will be migrated
+  includeResources: true
+  # If set to false, the deployments and stateful set replicas will be set to 0 on the destination. There will be an annotation with "stork.openstorage.org/migrationReplicas" to store the replica count from the source
+  startApplications: true
+  # List of namespaces to migrate
+  namespaces:
+  - cassandra-migration-label-selector-test
+  selectors:
+     app: cassandra


### PR DESCRIPTION
**What type of PR is this?**
feature

**What this PR does / why we need it**:
Adds support to use label selectors during migration

**Does this PR change a user-facing CRD or CLI?**:
The label selector field present in the CRD is implemented

**Is a release note needed?**:
```release-note
Added support to use label selectors during migration
```

**Does this change need to be cherry-picked to a release branch?**:
No
