### PR TITLE
 Recreate service during migration for conflicting node port

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1274,7 +1274,7 @@
   revision = "ced9eb3070a5f1c548ef46e8dfe2a97c208d9f03"
 
 [[projects]]
-  digest = "1:12a13d641a3564d82f36273a2bb8150dc00d9ba0349a053655d9e67518c53bd8"
+  digest = "1:a979d09283bc1ad4a99cee68eee2aba987fa4f4499c57136e638154b12521750"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/api/events",
@@ -1400,6 +1400,8 @@
     "pkg/master/ports",
     "pkg/printers",
     "pkg/printers/internalversion",
+    "pkg/registry/core/service/allocator",
+    "pkg/registry/core/service/portallocator",
     "pkg/registry/rbac/validation",
     "pkg/scheduler/algorithm",
     "pkg/scheduler/algorithm/priorities/util",
@@ -1531,6 +1533,7 @@
     "k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource",
     "k8s.io/kubernetes/pkg/kubelet/apis",
     "k8s.io/kubernetes/pkg/printers",
+    "k8s.io/kubernetes/pkg/registry/core/service/portallocator",
     "k8s.io/kubernetes/pkg/scheduler/api",
   ]
   solver-name = "gps-cdcl"

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
 )
 
 const (
@@ -960,7 +961,7 @@ func (m *MigrationController) applyResources(
 			return fmt.Errorf("Unable to cast object to unstructured: %v", o)
 		}
 		_, err = dynamicClient.Create(unstructured)
-		if err != nil && apierrors.IsAlreadyExists(err) {
+		if err != nil && (apierrors.IsAlreadyExists(err) || strings.Contains(err.Error(), portallocator.ErrAllocated.Error())) {
 			switch objectType.GetKind() {
 			// Don't want to delete the Volume resources
 			case "PersistentVolumeClaim", "PersistentVolume":

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/service/allocator/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/service/allocator/BUILD
@@ -1,0 +1,43 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "bitmap.go",
+        "interfaces.go",
+        "utils.go",
+    ],
+    importpath = "k8s.io/kubernetes/pkg/registry/core/service/allocator",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "bitmap_test.go",
+        "utils_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//pkg/registry/core/service/allocator/storage:all-srcs",
+    ],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/service/allocator/bitmap.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/service/allocator/bitmap.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import (
+	"errors"
+	"math/big"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// AllocationBitmap is a contiguous block of resources that can be allocated atomically.
+//
+// Each resource has an offset.  The internal structure is a bitmap, with a bit for each offset.
+//
+// If a resource is taken, the bit at that offset is set to one.
+// r.count is always equal to the number of set bits and can be recalculated at any time
+// by counting the set bits in r.allocated.
+//
+// TODO: use RLE and compact the allocator to minimize space.
+type AllocationBitmap struct {
+	// strategy carries the details of how to choose the next available item out of the range
+	strategy bitAllocator
+	// max is the maximum size of the usable items in the range
+	max int
+	// rangeSpec is the range specifier, matching RangeAllocation.Range
+	rangeSpec string
+
+	// lock guards the following members
+	lock sync.Mutex
+	// count is the number of currently allocated elements in the range
+	count int
+	// allocated is a bit array of the allocated items in the range
+	allocated *big.Int
+}
+
+// AllocationBitmap implements Interface and Snapshottable
+var _ Interface = &AllocationBitmap{}
+var _ Snapshottable = &AllocationBitmap{}
+
+// bitAllocator represents a search strategy in the allocation map for a valid item.
+type bitAllocator interface {
+	AllocateBit(allocated *big.Int, max, count int) (int, bool)
+}
+
+// NewAllocationMap creates an allocation bitmap using the random scan strategy.
+func NewAllocationMap(max int, rangeSpec string) *AllocationBitmap {
+	a := AllocationBitmap{
+		strategy: randomScanStrategy{
+			rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+		},
+		allocated: big.NewInt(0),
+		count:     0,
+		max:       max,
+		rangeSpec: rangeSpec,
+	}
+	return &a
+}
+
+// NewContiguousAllocationMap creates an allocation bitmap using the contiguous scan strategy.
+func NewContiguousAllocationMap(max int, rangeSpec string) *AllocationBitmap {
+	a := AllocationBitmap{
+		strategy:  contiguousScanStrategy{},
+		allocated: big.NewInt(0),
+		count:     0,
+		max:       max,
+		rangeSpec: rangeSpec,
+	}
+	return &a
+}
+
+// Allocate attempts to reserve the provided item.
+// Returns true if it was allocated, false if it was already in use
+func (r *AllocationBitmap) Allocate(offset int) (bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.allocated.Bit(offset) == 1 {
+		return false, nil
+	}
+	r.allocated = r.allocated.SetBit(r.allocated, offset, 1)
+	r.count++
+	return true, nil
+}
+
+// AllocateNext reserves one of the items from the pool.
+// (0, false, nil) may be returned if there are no items left.
+func (r *AllocationBitmap) AllocateNext() (int, bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	next, ok := r.strategy.AllocateBit(r.allocated, r.max, r.count)
+	if !ok {
+		return 0, false, nil
+	}
+	r.count++
+	r.allocated = r.allocated.SetBit(r.allocated, next, 1)
+	return next, true, nil
+}
+
+// Release releases the item back to the pool. Releasing an
+// unallocated item or an item out of the range is a no-op and
+// returns no error.
+func (r *AllocationBitmap) Release(offset int) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.allocated.Bit(offset) == 0 {
+		return nil
+	}
+
+	r.allocated = r.allocated.SetBit(r.allocated, offset, 0)
+	r.count--
+	return nil
+}
+
+const (
+	// Find the size of a big.Word in bytes.
+	notZero   = uint64(^big.Word(0))
+	wordPower = (notZero>>8)&1 + (notZero>>16)&1 + (notZero>>32)&1
+	wordSize  = 1 << wordPower
+)
+
+// ForEach calls the provided function for each allocated bit.  The
+// AllocationBitmap may not be modified while this loop is running.
+func (r *AllocationBitmap) ForEach(fn func(int)) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	words := r.allocated.Bits()
+	for wordIdx, word := range words {
+		bit := 0
+		for word > 0 {
+			if (word & 1) != 0 {
+				fn((wordIdx * wordSize * 8) + bit)
+				word = word &^ 1
+			}
+			bit++
+			word = word >> 1
+		}
+	}
+}
+
+// Has returns true if the provided item is already allocated and a call
+// to Allocate(offset) would fail.
+func (r *AllocationBitmap) Has(offset int) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.allocated.Bit(offset) == 1
+}
+
+// Free returns the count of items left in the range.
+func (r *AllocationBitmap) Free() int {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	return r.max - r.count
+}
+
+// Snapshot saves the current state of the pool.
+func (r *AllocationBitmap) Snapshot() (string, []byte) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.rangeSpec, r.allocated.Bytes()
+}
+
+// Restore restores the pool to the previously captured state.
+func (r *AllocationBitmap) Restore(rangeSpec string, data []byte) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.rangeSpec != rangeSpec {
+		return errors.New("the provided range does not match the current range")
+	}
+
+	r.allocated = big.NewInt(0).SetBytes(data)
+	r.count = countBits(r.allocated)
+
+	return nil
+}
+
+// randomScanStrategy chooses a random address from the provided big.Int, and then
+// scans forward looking for the next available address (it will wrap the range if
+// necessary).
+type randomScanStrategy struct {
+	rand *rand.Rand
+}
+
+func (rss randomScanStrategy) AllocateBit(allocated *big.Int, max, count int) (int, bool) {
+	if count >= max {
+		return 0, false
+	}
+	offset := rss.rand.Intn(max)
+	for i := 0; i < max; i++ {
+		at := (offset + i) % max
+		if allocated.Bit(at) == 0 {
+			return at, true
+		}
+	}
+	return 0, false
+}
+
+var _ bitAllocator = randomScanStrategy{}
+
+// contiguousScanStrategy tries to allocate starting at 0 and filling in any gaps
+type contiguousScanStrategy struct{}
+
+func (contiguousScanStrategy) AllocateBit(allocated *big.Int, max, count int) (int, bool) {
+	if count >= max {
+		return 0, false
+	}
+	for i := 0; i < max; i++ {
+		if allocated.Bit(i) == 0 {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+var _ bitAllocator = contiguousScanStrategy{}

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/service/allocator/interfaces.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/service/allocator/interfaces.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+// Interface manages the allocation of items out of a range. Interface
+// should be threadsafe.
+type Interface interface {
+	Allocate(int) (bool, error)
+	AllocateNext() (int, bool, error)
+	Release(int) error
+	ForEach(func(int))
+
+	// For testing
+	Has(int) bool
+
+	// For testing
+	Free() int
+}
+
+// Snapshottable is an Interface that can be snapshotted and restored. Snapshottable
+// should be threadsafe.
+type Snapshottable interface {
+	Interface
+	Snapshot() (string, []byte)
+	Restore(string, []byte) error
+}
+
+type AllocatorFactory func(max int, rangeSpec string) Interface

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/service/allocator/utils.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/service/allocator/utils.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import "math/big"
+
+// countBits returns the number of set bits in n
+func countBits(n *big.Int) int {
+	var count int = 0
+	for _, b := range n.Bytes() {
+		count += int(bitCounts[b])
+	}
+	return count
+}
+
+// bitCounts is all of the bits counted for each number between 0-255
+var bitCounts = []int8{
+	0, 1, 1, 2, 1, 2, 2, 3,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	1, 2, 2, 3, 2, 3, 3, 4,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	2, 3, 3, 4, 3, 4, 4, 5,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	3, 4, 4, 5, 4, 5, 5, 6,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	4, 5, 5, 6, 5, 6, 6, 7,
+	5, 6, 6, 7, 6, 7, 7, 8,
+}

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/service/portallocator/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/service/portallocator/BUILD
@@ -1,0 +1,49 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "allocator.go",
+        "operation.go",
+    ],
+    importpath = "k8s.io/kubernetes/pkg/registry/core/service/portallocator",
+    deps = [
+        "//pkg/apis/core:go_default_library",
+        "//pkg/registry/core/service/allocator:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["allocator_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/core:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//pkg/registry/core/service/portallocator/controller:all-srcs",
+    ],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/service/portallocator/allocator.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/service/portallocator/allocator.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portallocator
+
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/net"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/registry/core/service/allocator"
+
+	"github.com/golang/glog"
+)
+
+// Interface manages the allocation of ports out of a range. Interface
+// should be threadsafe.
+type Interface interface {
+	Allocate(int) error
+	AllocateNext() (int, error)
+	Release(int) error
+	ForEach(func(int))
+
+	// For testing
+	Has(int) bool
+}
+
+var (
+	ErrFull              = errors.New("range is full")
+	ErrAllocated         = errors.New("provided port is already allocated")
+	ErrMismatchedNetwork = errors.New("the provided port range does not match the current port range")
+)
+
+type ErrNotInRange struct {
+	ValidPorts string
+}
+
+func (e *ErrNotInRange) Error() string {
+	return fmt.Sprintf("provided port is not in the valid range. The range of valid ports is %s", e.ValidPorts)
+}
+
+type PortAllocator struct {
+	portRange net.PortRange
+
+	alloc allocator.Interface
+}
+
+// PortAllocator implements Interface and Snapshottable
+var _ Interface = &PortAllocator{}
+
+// NewPortAllocatorCustom creates a PortAllocator over a net.PortRange, calling allocatorFactory to construct the backing store.
+func NewPortAllocatorCustom(pr net.PortRange, allocatorFactory allocator.AllocatorFactory) *PortAllocator {
+	max := pr.Size
+	rangeSpec := pr.String()
+
+	a := &PortAllocator{
+		portRange: pr,
+	}
+	a.alloc = allocatorFactory(max, rangeSpec)
+	return a
+}
+
+// Helper that wraps NewPortAllocatorCustom, for creating a range backed by an in-memory store.
+func NewPortAllocator(pr net.PortRange) *PortAllocator {
+	return NewPortAllocatorCustom(pr, func(max int, rangeSpec string) allocator.Interface {
+		return allocator.NewAllocationMap(max, rangeSpec)
+	})
+}
+
+// NewFromSnapshot allocates a PortAllocator and initializes it from a snapshot.
+func NewFromSnapshot(snap *api.RangeAllocation) (*PortAllocator, error) {
+	pr, err := net.ParsePortRange(snap.Range)
+	if err != nil {
+		return nil, err
+	}
+	r := NewPortAllocator(*pr)
+	if err := r.Restore(*pr, snap.Data); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// Free returns the count of port left in the range.
+func (r *PortAllocator) Free() int {
+	return r.alloc.Free()
+}
+
+// Used returns the count of ports used in the range.
+func (r *PortAllocator) Used() int {
+	return r.portRange.Size - r.alloc.Free()
+}
+
+// Allocate attempts to reserve the provided port. ErrNotInRange or
+// ErrAllocated will be returned if the port is not valid for this range
+// or has already been reserved.  ErrFull will be returned if there
+// are no ports left.
+func (r *PortAllocator) Allocate(port int) error {
+	ok, offset := r.contains(port)
+	if !ok {
+		// include valid port range in error
+		validPorts := r.portRange.String()
+		return &ErrNotInRange{validPorts}
+	}
+
+	allocated, err := r.alloc.Allocate(offset)
+	if err != nil {
+		return err
+	}
+	if !allocated {
+		return ErrAllocated
+	}
+	return nil
+}
+
+// AllocateNext reserves one of the ports from the pool. ErrFull may
+// be returned if there are no ports left.
+func (r *PortAllocator) AllocateNext() (int, error) {
+	offset, ok, err := r.alloc.AllocateNext()
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return 0, ErrFull
+	}
+	return r.portRange.Base + offset, nil
+}
+
+// ForEach calls the provided function for each allocated port.
+func (r *PortAllocator) ForEach(fn func(int)) {
+	r.alloc.ForEach(func(offset int) {
+		fn(r.portRange.Base + offset)
+	})
+}
+
+// Release releases the port back to the pool. Releasing an
+// unallocated port or a port out of the range is a no-op and
+// returns no error.
+func (r *PortAllocator) Release(port int) error {
+	ok, offset := r.contains(port)
+	if !ok {
+		glog.Warningf("port is not in the range when release it. port: %v", port)
+		return nil
+	}
+
+	return r.alloc.Release(offset)
+}
+
+// Has returns true if the provided port is already allocated and a call
+// to Allocate(port) would fail with ErrAllocated.
+func (r *PortAllocator) Has(port int) bool {
+	ok, offset := r.contains(port)
+	if !ok {
+		return false
+	}
+
+	return r.alloc.Has(offset)
+}
+
+// Snapshot saves the current state of the pool.
+func (r *PortAllocator) Snapshot(dst *api.RangeAllocation) error {
+	snapshottable, ok := r.alloc.(allocator.Snapshottable)
+	if !ok {
+		return fmt.Errorf("not a snapshottable allocator")
+	}
+	rangeString, data := snapshottable.Snapshot()
+	dst.Range = rangeString
+	dst.Data = data
+	return nil
+}
+
+// Restore restores the pool to the previously captured state. ErrMismatchedNetwork
+// is returned if the provided port range doesn't exactly match the previous range.
+func (r *PortAllocator) Restore(pr net.PortRange, data []byte) error {
+	if pr.String() != r.portRange.String() {
+		return ErrMismatchedNetwork
+	}
+	snapshottable, ok := r.alloc.(allocator.Snapshottable)
+	if !ok {
+		return fmt.Errorf("not a snapshottable allocator")
+	}
+	return snapshottable.Restore(pr.String(), data)
+}
+
+// contains returns true and the offset if the port is in the range, and false
+// and nil otherwise.
+func (r *PortAllocator) contains(port int) (bool, int) {
+	if !r.portRange.Contains(port) {
+		return false, 0
+	}
+
+	offset := port - r.portRange.Base
+	return true, offset
+}

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/service/portallocator/operation.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/service/portallocator/operation.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portallocator
+
+// Encapsulates the semantics of a port allocation 'transaction':
+// It is better to leak ports than to double-allocate them,
+// so we allocate immediately, but defer release.
+// On commit we best-effort release the deferred releases.
+// On rollback we best-effort release any allocations we did.
+//
+// Pattern for use:
+//   op := StartPortAllocationOperation(...)
+//   defer op.Finish
+//   ...
+//   write(updatedOwner)
+///  op.Commit()
+type PortAllocationOperation struct {
+	pa              Interface
+	allocated       []int
+	releaseDeferred []int
+	shouldRollback  bool
+}
+
+// Creates a portAllocationOperation, tracking a set of allocations & releases
+func StartOperation(pa Interface) *PortAllocationOperation {
+	op := &PortAllocationOperation{}
+	op.pa = pa
+	op.allocated = []int{}
+	op.releaseDeferred = []int{}
+	op.shouldRollback = true
+	return op
+}
+
+// Will rollback unless marked as shouldRollback = false by a Commit().  Call from a defer block
+func (op *PortAllocationOperation) Finish() {
+	if op.shouldRollback {
+		op.Rollback()
+	}
+}
+
+// (Try to) undo any operations we did
+func (op *PortAllocationOperation) Rollback() []error {
+	errors := []error{}
+
+	for _, allocated := range op.allocated {
+		err := op.pa.Release(allocated)
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+// (Try to) perform any deferred operations.
+// Note that even if this fails, we don't rollback; we always want to err on the side of over-allocation,
+// and Commit should be called _after_ the owner is written
+func (op *PortAllocationOperation) Commit() []error {
+	errors := []error{}
+
+	for _, release := range op.releaseDeferred {
+		err := op.pa.Release(release)
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	// Even on error, we don't rollback
+	// Problems should be fixed by an eventual reconciliation / restart
+	op.shouldRollback = false
+
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// Allocates a port, and record it for future rollback
+func (op *PortAllocationOperation) Allocate(port int) error {
+	err := op.pa.Allocate(port)
+	if err == nil {
+		op.allocated = append(op.allocated, port)
+	}
+	return err
+}
+
+// Allocates a port, and record it for future rollback
+func (op *PortAllocationOperation) AllocateNext() (int, error) {
+	port, err := op.pa.AllocateNext()
+	if err == nil {
+		op.allocated = append(op.allocated, port)
+	}
+	return port, err
+}
+
+// Marks a port so that it will be released if this operation Commits
+func (op *PortAllocationOperation) ReleaseDeferred(port int) {
+	op.releaseDeferred = append(op.releaseDeferred, port)
+}


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
Re-migrating a svc fails when a node port is defined. We should be able to re-create the svc in this scenario


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Fixed continuous migration of service objects with NodePort defined
```

**Does this change need to be cherry-picked to a release branch?**:
2.1

