### PR TITLE
Update bool in migration specs to pointers so that we can set defaults

### DIFF
--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -15,9 +15,9 @@ const (
 type MigrationSpec struct {
 	ClusterPair       string            `json:"clusterPair"`
 	Namespaces        []string          `json:"namespaces"`
-	IncludeResources  bool              `json:"includeResources"`
-	IncludeVolumes    bool              `json:"includeVolumes"`
-	StartApplications bool              `json:"startApplications"`
+	IncludeResources  *bool             `json:"includeResources"`
+	IncludeVolumes    *bool             `json:"includeVolumes"`
+	StartApplications *bool             `json:"startApplications"`
 	Selectors         map[string]string `json:"selectors"`
 	PreExecRule       string            `json:"preExecRule"`
 	PostExecRule      string            `json:"postExecRule"`

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -573,6 +573,21 @@ func (in *MigrationSpec) DeepCopyInto(out *MigrationSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IncludeResources != nil {
+		in, out := &in.IncludeResources, &out.IncludeResources
+		*out = new(bool)
+		**out = **in
+	}
+	if in.IncludeVolumes != nil {
+		in, out := &in.IncludeVolumes, &out.IncludeVolumes
+		*out = new(bool)
+		**out = **in
+	}
+	if in.StartApplications != nil {
+		in, out := &in.StartApplications, &out.StartApplications
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Selectors != nil {
 		in, out := &in.Selectors, &out.Selectors
 		*out = make(map[string]string, len(*in))

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -26,6 +26,7 @@ func newCreateMigrationCommand(cmdFactory Factory, ioStreams genericclioptions.I
 	var startApplications bool
 	var preExecRule string
 	var postExecRule string
+	var includeVolumes bool
 
 	createMigrationCommand := &cobra.Command{
 		Use:     migrationSubcommand,
@@ -50,8 +51,9 @@ func newCreateMigrationCommand(cmdFactory Factory, ioStreams genericclioptions.I
 				Spec: storkv1.MigrationSpec{
 					ClusterPair:       clusterPair,
 					Namespaces:        namespaceList,
-					IncludeResources:  includeResources,
-					StartApplications: startApplications,
+					IncludeResources:  &includeResources,
+					IncludeVolumes:    &includeVolumes,
+					StartApplications: &startApplications,
 					PreExecRule:       preExecRule,
 					PostExecRule:      postExecRule,
 				},
@@ -70,6 +72,7 @@ func newCreateMigrationCommand(cmdFactory Factory, ioStreams genericclioptions.I
 	createMigrationCommand.Flags().StringSliceVarP(&namespaceList, "namespaces", "", nil, "Comma separated list of namespaces to migrate")
 	createMigrationCommand.Flags().StringVarP(&clusterPair, "clusterPair", "c", "", "ClusterPair name for migration")
 	createMigrationCommand.Flags().BoolVarP(&includeResources, "includeResources", "r", true, "Include resources in the migration")
+	createMigrationCommand.Flags().BoolVarP(&includeVolumes, "includeVolumes", "", true, "Include volumees in the migration")
 	createMigrationCommand.Flags().BoolVarP(&startApplications, "startApplications", "a", true, "Start applications on the destination cluster after migration")
 	createMigrationCommand.Flags().StringVarP(&preExecRule, "preExecRule", "", "", "Rule to run before executing migration")
 	createMigrationCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Rule to run after executing migration")

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -22,6 +22,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 	var clusterPair string
 	var namespaceList []string
 	var includeResources bool
+	var includeVolumes bool
 	var startApplications bool
 	var preExecRule string
 	var postExecRule string
@@ -56,8 +57,9 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 						Spec: storkv1.MigrationSpec{
 							ClusterPair:       clusterPair,
 							Namespaces:        namespaceList,
-							IncludeResources:  includeResources,
-							StartApplications: startApplications,
+							IncludeResources:  &includeResources,
+							IncludeVolumes:    &includeVolumes,
+							StartApplications: &startApplications,
 							PreExecRule:       preExecRule,
 							PostExecRule:      postExecRule,
 						},
@@ -79,6 +81,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 	createMigrationScheduleCommand.Flags().StringSliceVarP(&namespaceList, "namespaces", "", nil, "Comma separated list of namespaces to migrate")
 	createMigrationScheduleCommand.Flags().StringVarP(&clusterPair, "clusterPair", "c", "", "ClusterPair name for migration")
 	createMigrationScheduleCommand.Flags().BoolVarP(&includeResources, "includeResources", "r", true, "Include resources in the migration")
+	createMigrationScheduleCommand.Flags().BoolVarP(&includeVolumes, "includeVolumes", "", true, "Include volumees in the migration")
 	createMigrationScheduleCommand.Flags().BoolVarP(&startApplications, "startApplications", "a", false, "Start applications on the destination cluster after migration")
 	createMigrationScheduleCommand.Flags().StringVarP(&preExecRule, "preExecRule", "", "", "Rule to run before executing migration")
 	createMigrationScheduleCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Rule to run after executing migration")


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
Bug

**What this PR does / why we need it**:
The `includeVolumes` field was defaulting to `false` if not specified in the spec

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
Yes

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
No

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Yes, 2.1

