### PR TITLE
Add suspend flag to migrationschedule spec

### DIFF
--- a/pkg/apis/stork/v1alpha1/migrationschedule.go
+++ b/pkg/apis/stork/v1alpha1/migrationschedule.go
@@ -15,6 +15,7 @@ const (
 type MigrationScheduleSpec struct {
 	Template           MigrationTemplateSpec `json:"template"`
 	SchedulePolicyName string                `json:"schedulePolicyName"`
+	Suspend            *bool                 `json:"suspend"`
 }
 
 // MigrationTemplateSpec describes the data a Migration should have when created

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -515,6 +515,11 @@ func (in *MigrationScheduleList) DeepCopyObject() runtime.Object {
 func (in *MigrationScheduleSpec) DeepCopyInto(out *MigrationScheduleSpec) {
 	*out = *in
 	in.Template.DeepCopyInto(&out.Template)
+	if in.Suspend != nil {
+		in, out := &in.Suspend, &out.Suspend
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Also update storkctl for the flag


**What type of PR is this?**
api-change

**What this PR does / why we need it**:
Added a flag to suspend migration schedules. Users don't need to delete the schedule to disable it
It is enabled by default.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
Yes

Updated Spec:
```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: MigrationSchedule
metadata:
  name: mysqlmigrationschedule
  namespace: mysql
spec:
  template:
    spec:
      clusterPair: remotecluster
      includeResources: true
      startApplications: false
      namespaces:
      - mysql
  schedulePolicyName: testpolicy
  suspend: false
```
Output of `storkctl`
```
$ storkctl get migrationschedule getmigrationschedulestatustest
NAME                             POLICYNAME   CLUSTERPAIR    SUSPEND   LAST-SUCCESS-TIME
getmigrationschedulestatustest   testpolicy   clusterpair1   false     19 Mar 19 16:51 PDT
```

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No