### PR TITLE
Add node start and create separate storageclass for pvcownership test

### DIFF
--- a/test/integration_test/extender_test.go
+++ b/test/integration_test/extender_test.go
@@ -213,5 +213,11 @@ func pvcOwnershipTest(t *testing.T) {
 	}
 	require.Equal(t, true, errUnscheduledPod, "Pod should not have been schedule.")
 
+	err = volumeDriver.StartDriver(scheduledNodes[0])
+	require.NoError(t, err, "Error starting driver on scheduled Node %+v", scheduledNodes[0])
+
+	err = volumeDriver.WaitDriverUpOnNode(scheduledNodes[0])
+	require.NoError(t, err, "Volume driver is not up on Node %+v", scheduledNodes[0])
+
 	destroyAndWait(t, ctxs)
 }

--- a/test/integration_test/specs/mysql-repl-1/mysql.yaml
+++ b/test/integration_test/specs/mysql-repl-1/mysql.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
    name: mysql-data
    annotations:
-     volume.beta.kubernetes.io/storage-class: px-mysql-sc
+     volume.beta.kubernetes.io/storage-class: px-mysql-sc-repl1
 spec:
    accessModes:
      - ReadWriteOnce
@@ -14,7 +14,7 @@ spec:
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-    name: px-mysql-sc
+    name: px-mysql-sc-repl1
 provisioner: kubernetes.io/portworx-volume
 parameters:
    repl: "1"


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
We need to start PX on the node where it was stopped

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.1

