### PR TITLE
Add monitor for pods in unknown state

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1537,7 +1537,9 @@
     "k8s.io/kubernetes/pkg/kubelet/apis",
     "k8s.io/kubernetes/pkg/printers",
     "k8s.io/kubernetes/pkg/registry/core/service/portallocator",
+    "k8s.io/kubernetes/pkg/scheduler/algorithm",
     "k8s.io/kubernetes/pkg/scheduler/api",
+    "k8s.io/kubernetes/pkg/util/node",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,13 @@ errcheck:
 	go get -v github.com/kisielk/errcheck
 	errcheck -verbose -blank $(PKGS)
 
-fmt:
+check-fmt:
 	bash -c "diff -u <(echo -n) <(gofmt -l -d -s -e $(GO_FILES))"
 
-pretest: fmt lint vet errcheck simple
+do-fmt:
+	 gofmt -s -w $(GO_FILES)
+
+pretest: check-fmt lint vet errcheck simple
 
 test:
 	echo "" > coverage.txt

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	driverName       = "MockDriver"
+	driverName = "MockDriver"
+	// storageClassName is the storage class for mock driver PVCs
 	storageClassName = "mockDriverStorageClass"
 	provisionerName  = "kubernetes.io/mock-volume"
 	// RackLabel Label used for the mock driver to set rack information

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -1,0 +1,238 @@
+// +build unittest
+
+package monitor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/libopenstorage/stork/drivers/volume"
+	"github.com/libopenstorage/stork/drivers/volume/mock"
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	fakeclient "github.com/libopenstorage/stork/pkg/client/clientset/versioned/fake"
+	"github.com/portworx/sched-ops/k8s"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubernetes "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest/fake"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm"
+	"k8s.io/kubernetes/pkg/util/node"
+)
+
+const (
+	mockDriverName   = "MockDriver"
+	driverVolumeName = "singleVolume"
+	nodeForPod       = "node1.domain"
+)
+
+var (
+	fakeStorkClient *fakeclient.Clientset
+	fakeRestClient  *fake.RESTClient
+	driver          *mock.Driver
+	monitor         *Monitor
+)
+
+func init() {
+	resetTest()
+}
+
+func resetTest() {
+	scheme := runtime.NewScheme()
+	stork_api.AddToScheme(scheme)
+	fakeStorkClient = fakeclient.NewSimpleClientset()
+	fakeKubeClient := kubernetes.NewSimpleClientset()
+
+	k8s.Instance().SetClient(fakeKubeClient, nil, fakeStorkClient, nil, nil)
+}
+
+func TestMonitor(t *testing.T) {
+	t.Run("setup", setup)
+	t.Run("testUnknownDriverPod", testUnknownDriverPod)
+	t.Run("testUnknownOtherDriverPod", testUnknownOtherDriverPod)
+	t.Run("testEvictedDriverPod", testEvictedDriverPod)
+	t.Run("testEvictedOtherDriverPod", testEvictedOtherDriverPod)
+}
+
+func setup(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+
+	storkdriver, err := volume.Get(mockDriverName)
+	require.NoError(t, err, "Error getting mock volume driver")
+
+	var ok bool
+	driver, ok = storkdriver.(*mock.Driver)
+	require.True(t, ok, "Error casting mockdriver")
+
+	err = storkdriver.Init(nil)
+	require.NoError(t, err, "Error initializing mock volume driver")
+
+	monitor = &Monitor{
+		Driver: storkdriver,
+	}
+
+	err = monitor.Start()
+	require.NoError(t, err, "failed to start monitor")
+
+	nodes := &v1.NodeList{}
+	nodes.Items = append(nodes.Items, *newNode(nodeForPod, nodeForPod, "192.168.0.1", "rack1", "", ""))
+	nodes.Items = append(nodes.Items, *newNode("node2.domain", "node2.domain", "192.168.0.2", "rack2", "", ""))
+	nodes.Items = append(nodes.Items, *newNode("node3.domain", "node3.domain", "192.168.0.3", "rack1", "", ""))
+	nodes.Items = append(nodes.Items, *newNode("node4.domain", "node4.domain", "192.168.0.4", "rack2", "", ""))
+	nodes.Items = append(nodes.Items, *newNode("node5.domain", "node5.domain", "192.168.0.5", "rack3", "", ""))
+
+	for _, n := range nodes.Items {
+		node, err := k8s.Instance().CreateNode(&n)
+		require.NoError(t, err, "failed to create fake node")
+		require.NotNil(t, node, "got nil node from create node api")
+	}
+
+	provNodes := []int{0, 1}
+	err = driver.CreateCluster(5, nodes)
+	require.NoError(t, err, "Error creating cluster")
+
+	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1)
+	require.NoError(t, err, "Error provisioning volume")
+}
+
+func testUnknownDriverPod(t *testing.T) {
+	pod := newPod("driverPod", []string{driverVolumeName})
+	testLostPod(t, pod, true, true, false)
+}
+
+func testUnknownOtherDriverPod(t *testing.T) {
+	pod := newPod("otherDriverPod", nil)
+	podVolume := v1.Volume{}
+	podVolume.PersistentVolumeClaim = &v1.PersistentVolumeClaimVolumeSource{
+		ClaimName: "noDriverPVC",
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, podVolume)
+
+	testLostPod(t, pod, false, true, false)
+}
+
+func testEvictedOtherDriverPod(t *testing.T) {
+	pod := newPod("otherDriverPod", nil)
+	podVolume := v1.Volume{}
+	podVolume.PersistentVolumeClaim = &v1.PersistentVolumeClaimVolumeSource{
+		ClaimName: "noDriverPVC",
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, podVolume)
+
+	testLostPod(t, pod, false, false, true)
+}
+
+func testEvictedDriverPod(t *testing.T) {
+	pod := newPod("driverPod", []string{driverVolumeName})
+	testLostPod(t, pod, true, false, true)
+}
+
+func testLostPod(
+	t *testing.T,
+	pod *v1.Pod,
+	driverPod bool,
+	testUnknownPod bool,
+	testTaintBasedEviction bool,
+) {
+	pod, err := k8s.Instance().CreatePod(pod)
+	require.NoError(t, err, "failed to create pod")
+	require.NotNil(t, pod, "got nil pod back from create pod")
+
+	pod, err = k8s.Instance().GetPodByName(pod.Name, "")
+	require.NoError(t, err, "failed to get pod from fake API")
+	require.NotNil(t, pod, "got nil pod back from get pod")
+
+	info, err := driver.GetPodVolumes(&pod.Spec, "")
+	if driverPod {
+		require.NoError(t, err, "failed to get pod from fake API")
+		require.NotNil(t, info, "got nil pod volumes from driver")
+	} else {
+		require.Error(t, err, "expected error when getting pod volumes from mock driver")
+		require.Nil(t, info, "expected empty pod volumes from driver")
+	}
+
+	if testUnknownPod {
+		// make pod unknown
+		pod.Status = v1.PodStatus{
+			Reason: node.NodeUnreachablePodReason,
+		}
+	}
+
+	if testTaintBasedEviction {
+		pod.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		node, err := k8s.Instance().GetNodeByName(nodeForPod)
+		require.NoError(t, err, "failed to get node for pod")
+		node.Spec.Taints = []v1.Taint{
+			{
+				Key:    algorithm.TaintNodeUnreachable,
+				Effect: v1.TaintEffectNoExecute,
+			},
+		}
+
+		_, err = k8s.Instance().UpdateNode(node)
+		require.NoError(t, err, "failed to taint fake node")
+	}
+
+	pod, err = k8s.Instance().UpdatePod(pod)
+	require.NoError(t, err, "failed to update pod")
+	require.NotNil(t, pod, "got nil pod back from update pod")
+
+	time.Sleep(2 * time.Second)
+
+	if driverPod {
+		// pod should be deleted
+		pod, err = k8s.Instance().GetPodByName(pod.Name, "")
+		require.Error(t, err, "expected error from get pod as pod should be deleted")
+	} else {
+		// pod should still be present
+		pod, err = k8s.Instance().GetPodByName(pod.Name, "")
+		require.NoError(t, err, "failed to get pod")
+		require.NotNil(t, pod, "got nil pod back from get pod")
+
+		// cleanup pod
+		err = k8s.Instance().DeletePod(pod.Name, pod.Namespace, false)
+		require.NoError(t, err, "failed to delete pod")
+	}
+}
+
+func newPod(podName string, volumes []string) *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName},
+	}
+	for _, volume := range volumes {
+		pvc := driver.NewPVC(volume)
+		podVolume := v1.Volume{}
+		podVolume.PersistentVolumeClaim = &v1.PersistentVolumeClaimVolumeSource{
+			ClaimName: pvc.Name,
+		}
+		pod.Spec.Volumes = append(pod.Spec.Volumes, podVolume)
+	}
+
+	pod.Spec.NodeName = nodeForPod
+	return pod
+}
+
+func newNode(name, hostname, ip, rack, zone, region string) *v1.Node {
+	node := v1.Node{}
+
+	node.Name = name
+	node.Labels = make(map[string]string)
+	node.Labels[mock.RackLabel] = rack
+	node.Labels[mock.ZoneLabel] = zone
+	node.Labels[mock.RegionLabel] = region
+
+	hostNameAddress := v1.NodeAddress{
+		Type:    v1.NodeHostName,
+		Address: hostname,
+	}
+	node.Status.Addresses = append(node.Status.Addresses, hostNameAddress)
+	IPAddress := v1.NodeAddress{
+		Type:    v1.NodeInternalIP,
+		Address: ip,
+	}
+	node.Status.Addresses = append(node.Status.Addresses, IPAddress)
+
+	return &node
+}

--- a/test/integration_test/health_monitor_test.go
+++ b/test/integration_test/health_monitor_test.go
@@ -3,15 +3,18 @@
 package integrationtest
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/portworx/sched-ops/k8s"
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/stretchr/testify/require"
 )
 
 func testHealthMonitor(t *testing.T) {
 	t.Run("stopDriverTest", stopDriverTest)
+	t.Run("stopKubeletTest", stopKubeletTest)
 }
 
 func stopDriverTest(t *testing.T) {
@@ -60,4 +63,55 @@ func stopDriverTest(t *testing.T) {
 	require.NoError(t, err, "Error waiting for Node to start %+v", scheduledNodes[0])
 
 	destroyAndWait(t, ctxs)
+}
+
+func stopKubeletTest(t *testing.T) {
+	// Cordon node where the test is running. This is so that we don't end up stopping
+	// kubelet on the node where the stork-test pod is running
+	testPodNode := ""
+	testPod, err := k8s.Instance().GetPodByName("stork-test", "kube-system")
+	if err == nil { // if this hits an error, skip below logic to allow running tests outside a pod
+		testPodNode = testPod.Spec.NodeName
+		err = k8s.Instance().CordonNode(testPodNode, defaultWaitTimeout, defaultWaitInterval)
+		require.NoError(t, err, "Error cordorning k8s node for stork test pod")
+	}
+
+	defer func() {
+		if len(testPodNode) > 0 {
+			err = k8s.Instance().UnCordonNode(testPodNode, defaultWaitTimeout, defaultWaitInterval)
+			require.NoError(t, err, "Error uncordorning k8s node for stork test pod")
+		}
+	}()
+
+	ctxs, err := schedulerDriver.Schedule(generateInstanceID(t, "stopkubelettest"),
+		scheduler.ScheduleOptions{AppKeys: []string{"mysql-ss"}})
+	require.NoError(t, err, "Error scheduling task")
+	require.Equal(t, 1, len(ctxs), "Only one task should have started")
+
+	err = schedulerDriver.WaitForRunning(ctxs[0], defaultWaitTimeout, defaultWaitInterval)
+	require.NoError(t, err, "Error waiting for pod to get to running state")
+
+	scheduledNodes, err := schedulerDriver.GetNodesForApp(ctxs[0])
+	require.NoError(t, err, "Error getting node for app")
+	require.Equal(t, 1, len(scheduledNodes), "App should be scheduled on one node")
+
+	scheduledNode := scheduledNodes[0]
+	err = schedulerDriver.StopSchedOnNode(scheduledNode)
+	require.NoError(t, err, fmt.Sprintf("failed to stop scheduler on node: %s", scheduledNode.Name))
+
+	defer func() {
+		// restore scheduler
+		err = schedulerDriver.StartSchedOnNode(scheduledNode)
+		require.NoError(t, err, fmt.Sprintf("failed to start scheduler on node: %s", scheduledNode.Name))
+
+	}()
+
+	// wait for the scheduler daemon on node to stop and pod to get into unknown state
+	time.Sleep(6 * time.Minute)
+
+	err = schedulerDriver.WaitForRunning(ctxs[0], defaultWaitTimeout, defaultWaitInterval)
+	require.NoError(t, err, "Error waiting for pod to get to running state")
+
+	destroyAndWait(t, ctxs)
+
 }

--- a/test/integration_test/specs/mysql-ss/mysql-ss.yaml
+++ b/test/integration_test/specs/mysql-ss/mysql-ss.yaml
@@ -1,0 +1,83 @@
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: portworx-repl2
+provisioner: kubernetes.io/portworx-volume
+parameters:
+   repl: "2"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-01
+  labels:
+    app: mysql
+spec:
+  ports:
+  - port: 3306
+    name: mysql
+  clusterIP: None
+  selector:
+    app: mysql
+---
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: mysql-sset
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  serviceName: "mysql"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: mysql
+        image: mysql:5.6
+        env:
+          # Use secret in real usage
+        - name: MYSQL_ROOT_PASSWORD
+          value: password
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-vol
+          mountPath: /var/lib/mysql
+        livenessProbe:
+          exec:
+            command: ["sh", "-c", "mysqladmin -u root -p$MYSQL_ROOT_PASSWORD ping"]
+          initialDelaySeconds: 70
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "mysql -u root -p$MYSQL_ROOT_PASSWORD -e \"select 1\""]
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+  volumeClaimTemplates:
+  - metadata:
+      name: mysql-vol
+      annotations:
+        volume.beta.kubernetes.io/storage-class: portworx-repl2
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 2Gi


### PR DESCRIPTION
**What type of PR is this?**

feature
integration-test
unit-test

**What this PR does / why we need it**:

When kubelet is down on a node, pods go into node lost (< 1.13) or terminating (> 1.13) state. By default, for statefulsets, new pods aren't created. This results in manual recovery for operators.

This PR adds a monitor for pods in such a state and force deletes them so that a new replacement pod is spun up.

**Does this PR change a user-facing CRD or CLI?**: no

**Is a release note needed?**:
```release-note
Add support to force delete pods in unknown state that can happen when kubelet goes down on a node.
```

**Does this change need to be cherry-picked to a release branch?**:
no
