### PR TITLE
Fixes for migration schedule tests

### DIFF
--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -316,6 +316,7 @@ func migrationScheduleInvalidTest(t *testing.T) {
 	)
 
 	namespace := preMigrationCtx.GetID()
+	time.Sleep(90 * time.Second)
 
 	// **** TEST ensure 0 migrations since the schedule is invalid. Also check events for invalid specs
 	for _, migrationScheduleName := range migrationSchedules {
@@ -382,7 +383,17 @@ func migrationScheduleTest(
 		require.True(t, found, fmt.Sprintf("failed to find date from given schedule day: %s", scheduleDay))
 	}
 
-	nextTrigger := time.Date(time.Now().Year(), time.Now().Month(), date, 12, 4, 0, 0, time.Local)
+	month := time.Now().Month()
+	// Increment the month if we went to the next
+	if date < time.Now().Day() {
+		month++
+	}
+	// Increment the year if we went to the next
+	year := time.Now().Year()
+	if month < time.Now().Month() {
+		year++
+	}
+	nextTrigger := time.Date(year, month, date, 12, 4, 0, 0, time.Local)
 	// Set time 2 hours before the scheduled time so no migrations run
 	mockNow := nextTrigger.Add(-2 * time.Hour)
 


### PR DESCRIPTION
- Sleep before checking for error message for invalid schedule. There could be
an error because the policy was not found since they are applied in a different
order. The next reconciliation will be after a minute
- Rollover to the next month/year when finding the right day


**What type of PR is this?**
Integration-test fix

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

