### PR TITLE
Fix bumping time in migration schedule test

### DIFF
--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -457,20 +457,18 @@ func migrationScheduleTest(
 	require.Equal(t, firstMigrationCreationTime, migrations[0].CreationTimestamp,
 		"timestamps of first and most recent migrations don't match")
 
-	// **** TEST 4 bump time by 1 day + 5 minutes. Should cause one new migration
-	oneDay := 24 * time.Hour
-	var bumpPeriod time.Duration
+	// **** TEST 4 bump time by (1 day / 1 week / 1 month) + 5 minutes. Should cause one new migration
 	switch scheduleType {
 	case v1alpha1.SchedulePolicyTypeDaily:
-		bumpPeriod = oneDay
+		mockNow = nextTrigger.AddDate(0, 0, 1)
 	case v1alpha1.SchedulePolicyTypeWeekly:
-		bumpPeriod = 7 * oneDay
+		mockNow = nextTrigger.AddDate(0, 0, 7)
 	case v1alpha1.SchedulePolicyTypeMonthly:
-		bumpPeriod = 31 * oneDay
+		mockNow = nextTrigger.AddDate(0, 1, 0)
 	default:
 		t.Fatalf("this testcase only supports daily, weekly and monthly intervals")
 	}
-	mockNow = nextTrigger.Add(bumpPeriod + 5*time.Minute)
+	mockNow = mockNow.Add(5 * time.Minute)
 	setMockTime(&mockNow)
 
 	// Give time for new migration to trigger


### PR DESCRIPTION
Adding 31 days for the monthly schedule test can cause the schedule to be
skipped for months with 30 days since the date of the month will be one ahead

**What type of PR is this?**
Failing-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
