### PR TITLE
Store finish timestamp for migration

### DIFF
--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -25,10 +25,11 @@ type MigrationSpec struct {
 
 // MigrationStatus is the status of a migration operation
 type MigrationStatus struct {
-	Stage     MigrationStageType  `json:"stage"`
-	Status    MigrationStatusType `json:"status"`
-	Resources []*ResourceInfo     `json:"resources"`
-	Volumes   []*VolumeInfo       `json:"volumes"`
+	Stage           MigrationStageType  `json:"stage"`
+	Status          MigrationStatusType `json:"status"`
+	Resources       []*ResourceInfo     `json:"resources"`
+	Volumes         []*VolumeInfo       `json:"volumes"`
+	FinishTimestamp meta.Time           `json:"finishTimestamp"`
 }
 
 // ResourceInfo is the info for the migration of a resource

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -817,6 +817,7 @@ func (in *MigrationStatus) DeepCopyInto(out *MigrationStatus) {
 			}
 		}
 	}
+	in.FinishTimestamp.DeepCopyInto(&out.FinishTimestamp)
 	return
 }
 

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -191,6 +191,7 @@ func (m *MigrationController) Handle(ctx context.Context, event sdk.Event) error
 				if err != nil {
 					migration.Status.Status = stork_api.MigrationStatusFailed
 					migration.Status.Stage = stork_api.MigrationStageFinal
+					migration.Status.FinishTimestamp = metav1.Now()
 					err = fmt.Errorf("Error getting namespace %v: %v", ns, err)
 					log.MigrationLog(migration).Errorf(err.Error())
 					m.Recorder.Event(migration,
@@ -368,6 +369,7 @@ func (m *MigrationController) migrateVolumes(migration *stork_api.Migration, ter
 					log.MigrationLog(migration).Errorf("Error cancelling migration: %v", err)
 				}
 				migration.Status.Stage = stork_api.MigrationStageFinal
+				migration.Status.FinishTimestamp = metav1.Now()
 				migration.Status.Status = stork_api.MigrationStatusFailed
 				err = sdk.Update(migration)
 				if err != nil {
@@ -408,6 +410,7 @@ func (m *MigrationController) migrateVolumes(migration *stork_api.Migration, ter
 					string(vInfo.Status),
 					fmt.Sprintf("Error migrating volume %v: %v", vInfo.Volume, vInfo.Reason))
 				migration.Status.Stage = stork_api.MigrationStageFinal
+				migration.Status.FinishTimestamp = metav1.Now()
 				migration.Status.Status = stork_api.MigrationStatusFailed
 			} else if vInfo.Status == stork_api.MigrationStatusSuccessful {
 				m.Recorder.Event(migration,
@@ -441,6 +444,7 @@ func (m *MigrationController) migrateVolumes(migration *stork_api.Migration, ter
 			}
 		} else {
 			migration.Status.Stage = stork_api.MigrationStageFinal
+			migration.Status.FinishTimestamp = metav1.Now()
 			migration.Status.Status = stork_api.MigrationStatusSuccessful
 		}
 	}
@@ -711,6 +715,7 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration) e
 	}
 
 	migration.Status.Stage = stork_api.MigrationStageFinal
+	migration.Status.FinishTimestamp = metav1.Now()
 	migration.Status.Status = stork_api.MigrationStatusSuccessful
 	for _, resource := range migration.Status.Resources {
 		if resource.Status != stork_api.MigrationStatusSuccessful {


### PR DESCRIPTION
Also display elapesed time using storkctl


**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:
Helps display more user friendly info for migration

**Does this PR change a user-facing CRD or CLI?**:
Yes, adds a FinishTimestamp in migration status and displays migration times with `storkctl`

**Is a release note needed?**:
```release-note
* Added FinishTimestamp field in Migration status
* `storkctl` now displays elapsed time for migration and migrationschedule objects
```

**Does this change need to be cherry-picked to a release branch?**:
No
