### PR TITLE
storkctl support for group snapshots

### DIFF
--- a/pkg/storkctl/create.go
+++ b/pkg/storkctl/create.go
@@ -17,6 +17,7 @@ func newCreateCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams)
 		newCreateMigrationScheduleCommand(cmdFactory, ioStreams),
 		newCreatePVCCommand(cmdFactory, ioStreams),
 		newCreateSnapshotScheduleCommand(cmdFactory, ioStreams),
+		newCreateGroupSnapshotCommand(cmdFactory, ioStreams),
 	)
 
 	return createCommands

--- a/pkg/storkctl/delete.go
+++ b/pkg/storkctl/delete.go
@@ -16,6 +16,7 @@ func newDeleteCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams)
 		newDeleteMigrationCommand(cmdFactory, ioStreams),
 		newDeleteMigrationScheduleCommand(cmdFactory, ioStreams),
 		newDeleteSnapshotScheduleCommand(cmdFactory, ioStreams),
+		newDeleteGroupVolumeSnapshotCommand(cmdFactory, ioStreams),
 	)
 	return deleteCommands
 }

--- a/pkg/storkctl/get.go
+++ b/pkg/storkctl/get.go
@@ -23,6 +23,7 @@ func newGetCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *c
 		newGetSchedulePolicyCommand(cmdFactory, ioStreams),
 		newGetMigrationScheduleCommand(cmdFactory, ioStreams),
 		newGetSnapshotScheduleCommand(cmdFactory, ioStreams),
+		newGetGroupVolumeSnapshotCommand(cmdFactory, ioStreams),
 	)
 
 	return getCommands

--- a/pkg/storkctl/groupsnapshot.go
+++ b/pkg/storkctl/groupsnapshot.go
@@ -1,0 +1,241 @@
+package storkctl
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s"
+	"github.com/spf13/cobra"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
+	"k8s.io/kubernetes/pkg/printers"
+)
+
+var groupSnapshotColumns = []string{"NAME", "STATUS", "STAGE", "SNAPSHOTS", "CREATED"}
+var groupSnapshotSubcommand = "groupsnapshots"
+var groupSnapshotAliases = []string{"groupsnapshot"}
+
+func newCreateGroupSnapshotCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	var groupSnapshotName string
+	var restoreNamespaces []string
+	var opts []string
+	var pvcSelectors []string
+	var preExecRule string
+	var postExecRule string
+	var maxRetries int
+
+	createGroupVolumeSnapshotCommand := &cobra.Command{
+		Use:     groupSnapshotSubcommand,
+		Aliases: groupSnapshotAliases,
+		Short:   "Create a group volume snapshot",
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) != 1 {
+				util.CheckErr(fmt.Errorf("Exactly one name needs to be provided for groupsnapshot name"))
+				return
+			}
+			groupSnapshotName = args[0]
+			if len(pvcSelectors) == 0 {
+				util.CheckErr(fmt.Errorf("PVC label selectors must be provided"))
+				return
+			}
+
+			labelSelector, err := parseKeyValueList(pvcSelectors)
+			if err != nil {
+				util.CheckErr(err)
+				return
+			}
+
+			pvcSelectorSpec := storkv1.PVCSelectorSpec{
+				LabelSelector: meta.LabelSelector{
+					MatchLabels: labelSelector,
+				},
+			}
+
+			var optsMap map[string]string
+			if len(opts) > 0 {
+				optsMap, err = parseKeyValueList(opts)
+				if err != nil {
+					util.CheckErr(err)
+					return
+				}
+			}
+
+			groupSnapshot := &storkv1.GroupVolumeSnapshot{
+				Spec: storkv1.GroupVolumeSnapshotSpec{
+					PreExecRule:       preExecRule,
+					PostExecRule:      postExecRule,
+					PVCSelector:       pvcSelectorSpec,
+					RestoreNamespaces: restoreNamespaces,
+					MaxRetries:        maxRetries,
+					Options:           optsMap,
+				},
+			}
+			groupSnapshot.Name = groupSnapshotName
+			groupSnapshot.Namespace = cmdFactory.GetNamespace()
+			_, err = k8s.Instance().CreateGroupSnapshot(groupSnapshot)
+			if err != nil {
+				util.CheckErr(err)
+				return
+			}
+			msg := fmt.Sprintf("GroupVolumeSnapshot %v created successfully", groupSnapshot.Name)
+			printMsg(msg, ioStreams.Out)
+		},
+	}
+
+	createGroupVolumeSnapshotCommand.Flags().StringSliceVarP(
+		&pvcSelectors, "pvcSelectors", "", nil,
+		"Comma-separated list of PVC selectors in the format key1=value1,key2=value2. "+" e.g app=mysql,tier=db")
+
+	createGroupVolumeSnapshotCommand.Flags().StringVarP(
+		&preExecRule, "preExecRule", "", "", "Rule to run before triggering group volume snapshot")
+
+	createGroupVolumeSnapshotCommand.Flags().StringVarP(
+		&postExecRule, "postExecRule", "", "", "Rule to run after triggering group volume snapshot")
+
+	createGroupVolumeSnapshotCommand.Flags().StringSliceVarP(
+		&restoreNamespaces, "restoreNamespaces", "", nil,
+		"List of namespaces to which the snapshots can be restored to")
+
+	createGroupVolumeSnapshotCommand.Flags().IntVarP(
+		&maxRetries, "maxRetries", "", 0, "Number of times to retry the groupvolumesnapshot on failure")
+
+	createGroupVolumeSnapshotCommand.Flags().StringSliceVarP(
+		&opts, "opts", "", nil,
+		"Comma-separated list of options to provide to the storage driver. These "+
+			"are in the format key1=value1,key2=value2. e.g portworx/snapshot-type=cloud")
+
+	return createGroupVolumeSnapshotCommand
+}
+
+func newGetGroupVolumeSnapshotCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	getGroupVolumeSnapshotCommand := &cobra.Command{
+		Use:     groupSnapshotSubcommand,
+		Aliases: groupSnapshotAliases,
+		Short:   "Get group volume snapshots",
+		Run: func(c *cobra.Command, args []string) {
+			var groupSnapshots *storkv1.GroupVolumeSnapshotList
+			var err error
+
+			namespaces, err := cmdFactory.GetAllNamespaces()
+			if err != nil {
+				util.CheckErr(err)
+				return
+			}
+
+			groupSnapshots = new(storkv1.GroupVolumeSnapshotList)
+
+			if len(args) > 0 {
+				for _, groupSnapshotName := range args {
+					for _, ns := range namespaces {
+						groupSnapshot, err := k8s.Instance().GetGroupSnapshot(groupSnapshotName, ns)
+						if err != nil {
+							util.CheckErr(err)
+							return
+						}
+						groupSnapshots.Items = append(groupSnapshots.Items, *groupSnapshot)
+					}
+				}
+			} else {
+				// Get all
+				for _, ns := range namespaces {
+					groupSnapshotsInNamespace, err := k8s.Instance().ListGroupSnapshots(ns)
+					if err != nil {
+						util.CheckErr(err)
+						return
+					}
+					groupSnapshots.Items = append(groupSnapshots.Items, groupSnapshotsInNamespace.Items...)
+				}
+			}
+
+			if len(groupSnapshots.Items) == 0 {
+				handleEmptyList(ioStreams.Out)
+				return
+			}
+
+			if err := printObjects(c, groupSnapshots, cmdFactory, groupSnapshotColumns, groupSnapshotPrinter, ioStreams.Out); err != nil {
+				util.CheckErr(err)
+				return
+			}
+		},
+	}
+
+	cmdFactory.BindGetFlags(getGroupVolumeSnapshotCommand.Flags())
+	return getGroupVolumeSnapshotCommand
+}
+
+func newDeleteGroupVolumeSnapshotCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	deleteGroupVolumeSnapshotCommand := &cobra.Command{
+		Use:     groupSnapshotSubcommand,
+		Aliases: groupSnapshotAliases,
+		Short:   "Delete group volume snapshots",
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) == 0 {
+				util.CheckErr(fmt.Errorf("At least one argument needs to be provided for groupsnapshot name"))
+				return
+			}
+
+			deleteGroupVolumeSnapshots(args, cmdFactory.GetNamespace(), ioStreams)
+		},
+	}
+
+	return deleteGroupVolumeSnapshotCommand
+}
+
+func deleteGroupVolumeSnapshots(groupSnapshots []string, namespace string, ioStreams genericclioptions.IOStreams) {
+	for _, groupSnapshot := range groupSnapshots {
+		err := k8s.Instance().DeleteGroupSnapshot(groupSnapshot, namespace)
+		if err != nil {
+			util.CheckErr(err)
+			return
+		}
+		msg := fmt.Sprintf("GroupVolumeSnapshot %v deleted successfully", groupSnapshot)
+		printMsg(msg, ioStreams.Out)
+	}
+}
+
+func groupSnapshotPrinter(groupSnapshotList *storkv1.GroupVolumeSnapshotList, writer io.Writer, options printers.PrintOptions) error {
+	if groupSnapshotList == nil {
+		return nil
+	}
+
+	for _, groupSnapshot := range groupSnapshotList.Items {
+		name := printers.FormatResourceName(options.Kind, groupSnapshot.Name, options.WithKind)
+
+		if options.WithNamespace {
+			if _, err := fmt.Fprintf(writer, "%v\t", groupSnapshot.Namespace); err != nil {
+				return err
+			}
+		}
+
+		creationTime := toTimeString(groupSnapshot.CreationTimestamp.Time)
+		if _, err := fmt.Fprintf(writer, "%v\t%v\t%v\t%d\t%v\n",
+			name,
+			groupSnapshot.Status.Status,
+			groupSnapshot.Status.Stage,
+			len(groupSnapshot.Status.VolumeSnapshots),
+			creationTime,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseKeyValueList parses a list of key values into a map
+func parseKeyValueList(expressions []string) (map[string]string, error) {
+	matchLabels := make(map[string]string)
+	for _, e := range expressions {
+		entry := strings.SplitN(e, "=", 2)
+		if len(entry) != 2 {
+			return nil, fmt.Errorf("Invalid key value: %s provided. "+
+				"Example format: app=mysql", e)
+		}
+
+		matchLabels[entry[0]] = entry[1]
+	}
+
+	return matchLabels, nil
+}

--- a/pkg/storkctl/groupsnapshot_test.go
+++ b/pkg/storkctl/groupsnapshot_test.go
@@ -1,0 +1,232 @@
+// +build unittest
+
+package storkctl
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOneGroupSnapshot(t *testing.T) {
+	defer resetTest()
+	name := "test-group-snap"
+	namespace := "test"
+	selectors := map[string]string{"app": "mysql"}
+	preRuleName := "mysql-pre-snap"
+	postRuleName := "mysql-post-snap"
+	restoreNamespaces := []string{namespace, "prod"}
+
+	createGroupSnapshotAndVerify(t, name, namespace,
+		selectors, preRuleName, postRuleName, restoreNamespaces, nil, 99)
+
+	expected := fmt.Sprintf("NAME              STATUS    STAGE     SNAPSHOTS   CREATED\n"+
+		"%s                       0           \n", name)
+	cmdArgs := []string{"get", "groupsnapshots", "-n", namespace, name}
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestGroupSnapshotWithStatus(t *testing.T) {
+	defer resetTest()
+
+	name := "test-group-snap-status"
+	namespace := "default"
+	selectors := map[string]string{"app": "mysql"}
+
+	createGroupSnapshotAndVerify(t, name, namespace, selectors, "", "", nil, nil, 0)
+
+	groupSnap, err := k8s.Instance().GetGroupSnapshot(name, namespace)
+	require.NoError(t, err, "failed to get group snapshot")
+	require.NotNil(t, groupSnap, "got nil group snapshot after get call")
+
+	groupSnap.Status.Status = storkv1.GroupSnapshotSuccessful
+	groupSnap.Status.Stage = storkv1.GroupSnapshotStageFinal
+	groupSnap.Status.VolumeSnapshots = []*storkv1.VolumeSnapshotStatus{
+		{
+			VolumeSnapshotName: fmt.Sprintf("%s-child-1", name),
+			TaskID:             "123",
+			ParentVolumeID:     "mysql-data-1",
+			// rest of fields not relevant for unit test
+		},
+		{
+			VolumeSnapshotName: fmt.Sprintf("%s-child-2", name),
+			TaskID:             "456",
+			ParentVolumeID:     "mysql-data-2",
+			// rest of fields not relevant for unit test
+		},
+	}
+
+	_, err = k8s.Instance().UpdateGroupSnapshot(groupSnap)
+	require.NoError(t, err, "failed to update group snapshot")
+
+	expected := fmt.Sprintf("NAME                     STATUS       STAGE     SNAPSHOTS   CREATED\n"+
+		"%s   Successful   Final     2           \n", name)
+	cmdArgs := []string{"get", "groupsnapshots", "-n", namespace, name}
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestGroupSnapshotWithNoSelector(t *testing.T) {
+	name := "test-group-snap-no-selector"
+	expected := "error: PVC label selectors must be provided"
+	cmdArgs := []string{"create", "groupsnapshots", name}
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestGroupSnapshotWithNoName(t *testing.T) {
+	expected := "error: Exactly one name needs to be provided for groupsnapshot name"
+	cmdArgs := []string{"create", "groupsnapshots"}
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestDuplicateGroupSnapshots(t *testing.T) {
+	defer resetTest()
+
+	name := "test-group-snap-duplicate"
+	namespace := "default"
+	selectors, err := parseKeyValueList([]string{"app=mysql"})
+	require.NoError(t, err, "failed to parse selectors")
+
+	createGroupSnapshotAndVerify(t, name, namespace, selectors, "", "", nil, nil, 0)
+
+	// create another with the same name. should fail
+	cmdArgs := []string{"create", "groupsnapshots", "-n", namespace, "--pvcSelectors", "app=mysql", name}
+	expected := fmt.Sprintf("Error from server (AlreadyExists): groupvolumesnapshots.stork.libopenstorage.org \"%s\" already exists", name)
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestMultipleGroupSnapshots(t *testing.T) {
+	defer resetTest()
+
+	name1 := "test-group-snap-1"
+	name2 := "test-group-snap-2"
+	namespace := "default"
+	selectors := map[string]string{"app": "mysql"}
+
+	_, err := k8s.Instance().CreateNamespace(namespace, nil)
+	require.NoError(t, err, "Error creating namespace")
+
+	createGroupSnapshotAndVerify(t, name1, namespace, selectors, "", "", nil, nil, 0)
+	createGroupSnapshotAndVerify(t, name2, namespace, selectors, "", "", nil, nil, 0)
+
+	expected := fmt.Sprintf("NAME                STATUS    STAGE     SNAPSHOTS   CREATED\n"+
+		"%s                       0           \n%s                       0           \n",
+		name1, name2)
+	cmdArgs := []string{"get", "groupsnapshots", "-n", namespace, name1, name2}
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// Should get all group snapshots if no name given
+	cmdArgs = []string{"get", "groupsnapshots"}
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	name3 := "test-group-snap-3"
+	customNamespace := "ns1"
+	_, err = k8s.Instance().CreateNamespace(customNamespace, nil)
+	require.NoError(t, err, "Error creating namespace")
+
+	createGroupSnapshotAndVerify(t, name3, customNamespace, selectors, "", "", nil, nil, 0)
+
+	// get from all namespaces
+	expected = fmt.Sprintf("NAMESPACE   NAME                STATUS    STAGE     SNAPSHOTS   CREATED\n"+
+		"%s     %s                       0           \n%s     %s                       0           \n"+
+		"%s         %s                       0           \n",
+		namespace, name1, namespace, name2, customNamespace, name3)
+	cmdArgs = []string{"get", "groupsnapshots", "--all-namespaces"}
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestDeleteGroupSnapshots(t *testing.T) {
+	defer resetTest()
+
+	name := "test-group-snap-delete"
+	namespace := "default"
+	selectors := map[string]string{"app": "mysql"}
+	createGroupSnapshotAndVerify(t, name, namespace, selectors, "", "", nil, nil, 0)
+
+	cmdArgs := []string{"delete", "groupsnapshots", name}
+	expected := fmt.Sprintf("GroupVolumeSnapshot %s deleted successfully\n", name)
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// delete again. should fail
+	cmdArgs = []string{"delete", "groupsnapshots", name}
+	expected = fmt.Sprintf("Error from server (NotFound): groupvolumesnapshots.stork.libopenstorage.org \"%s\" not found", name)
+	testCommon(t, cmdArgs, nil, expected, true)
+
+	// delete multiple
+	name1 := "test-group-snap-delete-1"
+	name2 := "test-group-snap-delete-2"
+	createGroupSnapshotAndVerify(t, name1, namespace, selectors, "", "", nil, nil, 0)
+	createGroupSnapshotAndVerify(t, name2, namespace, selectors, "", "", nil, nil, 0)
+	cmdArgs = []string{"delete", "groupsnapshots", name1, name2}
+	expected = fmt.Sprintf("GroupVolumeSnapshot %s deleted successfully\n", name1)
+	expected += fmt.Sprintf("GroupVolumeSnapshot %s deleted successfully\n", name2)
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestDeleteNoName(t *testing.T) {
+	cmdArgs := []string{"delete", "groupsnapshots"}
+	expected := "error: At least one argument needs to be provided for groupsnapshot name"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func createGroupSnapshotAndVerify(
+	t *testing.T,
+	name string,
+	namespace string,
+	pvcSelectors map[string]string,
+	preExecRule string,
+	postExecRule string,
+	restoreNamespaces []string,
+	opts map[string]string,
+	maxRetries int,
+) {
+	selectorList := make([]string, 0)
+	for k, v := range pvcSelectors {
+		selectorList = append(selectorList, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	cmdArgs := []string{"create", "groupsnapshots", "-n", namespace, "--pvcSelectors", strings.Join(selectorList, ","), name}
+
+	if preExecRule != "" {
+		cmdArgs = append(cmdArgs, "--preExecRule", preExecRule)
+	}
+	if postExecRule != "" {
+		cmdArgs = append(cmdArgs, "--postExecRule", postExecRule)
+	}
+
+	if len(restoreNamespaces) > 0 {
+		cmdArgs = append(cmdArgs, "--restoreNamespaces", strings.Join(restoreNamespaces, ","))
+	}
+
+	if len(opts) > 0 {
+		optsList := make([]string, 0)
+		for k, v := range opts {
+			optsList = append(optsList, fmt.Sprintf("%s=%s", k, v))
+		}
+		cmdArgs = append(cmdArgs, "--opts", strings.Join(optsList, ","))
+	}
+
+	if maxRetries > 0 {
+		cmdArgs = append(cmdArgs, "--maxRetries", fmt.Sprintf("%d", maxRetries))
+	}
+
+	expected := "GroupVolumeSnapshot " + name + " created successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// Make sure it's created correctly
+	groupSnap, err := k8s.Instance().GetGroupSnapshot(name, namespace)
+	require.NoError(t, err, "failed to get group snapshot")
+	require.NotNil(t, groupSnap, "got nil group snapshot after get call")
+
+	require.Equal(t, name, groupSnap.Name, "name mismatch")
+	require.Equal(t, namespace, groupSnap.Namespace, "namespace mismatch")
+	require.Equal(t, pvcSelectors, groupSnap.Spec.PVCSelector.MatchLabels, "selectors mismatch")
+	require.Equal(t, preExecRule, groupSnap.Spec.PreExecRule, "preRuleName mismatch")
+	require.Equal(t, postExecRule, groupSnap.Spec.PostExecRule, "postRuleName mismatch")
+	require.Equal(t, restoreNamespaces, groupSnap.Spec.RestoreNamespaces, "restoreNamespaces mismatch")
+	require.Equal(t, maxRetries, groupSnap.Spec.MaxRetries, "maxRetries mismatch")
+	require.Equal(t, opts, groupSnap.Spec.Options, "restoreNamespaces mismatch")
+}


### PR DESCRIPTION
Fixes #226

Signed-off-by: Harsh Desai <harsh@portworx.com>


**What type of PR is this?**
feature
unit-test

**What this PR does / why we need it**: Add storkctl support for group snapshots


**Does this PR change a user-facing CRD or CLI?**:  yes

create
```
storkctl create groupsnapshots --help
Create a group snapshot

Usage:
  storkctl create groupsnapshots [flags]

Aliases:
  groupsnapshots, groupsnapshot

Flags:
  -h, --help                        help for groupsnapshots
      --maxRetries int              Number of times to retry the groupvolumesnapshot on failure
      --opts strings                Comma-separated list of options to provide to the storage driver. These are in the format key1=value1,key2=value2. e.g portworx/snapshot-type=cloud
      --postExecRule string         Rule to run after executing migration
      --preExecRule string          Rule to run before executing migration
      --pvcSelectors strings        Comma-separated list of PVC selectors in the format key1=value1,key2=value2.  e.g app=mysql,tier=db
```

get
```
storkctl get groupsnapshots --help
Get group snapshots

Usage:
  storkctl get groupsnapshots [flags]

Aliases:
  groupsnapshots, groupsnapshot

Flags:
      --all-namespaces   If present, list the requested object(s) across all namespaces.
                         Namespace in current context is ignored even if specified with --namespace.
```

delete
```
storkctl delete groupsnapshots --help
Delete group snapshots

Usage:
  storkctl delete groupsnapshots [flags]

Aliases:
  groupsnapshots, groupsnapshot

Flags:
  -h, --help   help for groupsnapshots
```

**Is a release note needed?**:
```release-note
Add storkctl support for group snapshots 
```

**Does this change need to be cherry-picked to a release branch?**: no

