### PR TITLE
Portworx: Return an error when clusterID is empty

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -502,7 +502,7 @@ func (p *portworx) GetNodes() ([]*storkvolume.NodeInfo, error) {
 
 func (p *portworx) GetClusterID() (string, error) {
 	clusterID := p.clusterManager.Uuid()
-	if len(clusterID) > 0 {
+	if len(clusterID) == 0 {
 		return "", &ErrFailedToGetClusterID{
 			Cause: "Portworx driver returned empty cluster UUID",
 		}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
GetClusterID for portworx will return an error if it gets an empty clusterID.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

