### PR TITLE
ClusterDomains controller changes.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -501,13 +501,18 @@ func (p *portworx) GetNodes() ([]*storkvolume.NodeInfo, error) {
 }
 
 func (p *portworx) GetClusterID() (string, error) {
-	clusterID := p.clusterManager.Uuid()
-	if len(clusterID) == 0 {
+	cluster, err := p.clusterManager.Enumerate()
+	if err != nil {
+		return "", &ErrFailedToGetClusterID{
+			Cause: err.Error(),
+		}
+	}
+	if len(cluster.Id) == 0 {
 		return "", &ErrFailedToGetClusterID{
 			Cause: "Portworx driver returned empty cluster UUID",
 		}
 	}
-	return clusterID, nil
+	return cluster.Id, nil
 }
 
 func (p *portworx) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {

--- a/pkg/clusterdomains/controllers/clusterdomainstatus.go
+++ b/pkg/clusterdomains/controllers/clusterdomainstatus.go
@@ -127,7 +127,7 @@ func (c *ClusterDomainsStatusController) createClusterDomainsStatusObject() {
 				Name: clusterID,
 			},
 		}
-		if _, err := k8s.Instance().CreateClusterDomainsStatus(clusterDomainStatus); err != nil {
+		if _, err := k8s.Instance().CreateClusterDomainsStatus(clusterDomainStatus); err != nil && !errors.IsAlreadyExists(err) {
 			return nil, true, fmt.Errorf("Failed to create cluster domain"+
 				" status object for driver %v: %v", c.Driver.String(), err)
 		}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
- cluster.Uuid is not implemented on Portworx REST client. Use cluster.Enumerate to get the clusterID
- Ignore already exists error while creating ClusterDomainsStatus

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

