### PR TITLE
Move resource collection logic from migration controller

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -618,14 +618,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:22ac8319516a9b6413cdedc84af6e5790b0fb30e78df26e2397a5d1a6a81b454"
+  digest = "1:0da6b28d5321520c5371c173b91a79a2173139fc6e58343ad5a6f27aeff8f359"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s",
     "task",
   ]
   pruneopts = "UT"
-  revision = "7dfac52795f4d95ac7bef74e6ab4f3f20d1d1620"
+  revision = "a6c2439fe523728558d12346a2c5a944794631bc"
 
 [[projects]]
   branch = "master"
@@ -1538,6 +1538,7 @@
     "k8s.io/api/apps/v1beta1",
     "k8s.io/api/apps/v1beta2",
     "k8s.io/api/core/v1",
+    "k8s.io/api/rbac/v1",
     "k8s.io/api/storage/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
@@ -1555,6 +1556,7 @@
     "k8s.io/apimachinery/pkg/util/strategicpatch",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/apiserver/pkg/authentication/serviceaccount",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/dynamic",

--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -17,6 +17,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/migration"
 	"github.com/libopenstorage/stork/pkg/monitor"
 	"github.com/libopenstorage/stork/pkg/pvcwatcher"
+	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	"github.com/libopenstorage/stork/pkg/rule"
 	"github.com/libopenstorage/stork/pkg/schedule"
 	"github.com/libopenstorage/stork/pkg/snapshot"
@@ -294,11 +295,19 @@ func runStork(d volume.Driver, recorder record.EventRecorder, c *cli.Context) {
 		}
 	}
 
+	resourceCollector := resourcecollector.ResourceCollector{
+		Driver: d,
+	}
+	if err := resourceCollector.Init(); err != nil {
+		log.Fatalf("Error initializing ResourceCollector: %v", err)
+	}
+
 	if c.Bool("migration-controller") {
 		migrationAdminNamespace := c.String("migration-admin-namespace")
 		migration := migration.Migration{
-			Driver:   d,
-			Recorder: recorder,
+			Driver:            d,
+			Recorder:          recorder,
+			ResourceCollector: resourceCollector,
 		}
 		if err := migration.Init(migrationAdminNamespace); err != nil {
 			log.Fatalf("Error initializing migration: %v", err)

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/libopenstorage/stork/drivers/volume"
 	"github.com/libopenstorage/stork/pkg/migration/controllers"
+	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -12,6 +13,7 @@ import (
 type Migration struct {
 	Driver                      volume.Driver
 	Recorder                    record.EventRecorder
+	ResourceCollector           resourcecollector.ResourceCollector
 	clusterPairController       *controllers.ClusterPairController
 	migrationController         *controllers.MigrationController
 	migrationScheduleController *controllers.MigrationScheduleController
@@ -29,8 +31,9 @@ func (m *Migration) Init(migrationAdminNamespace string) error {
 	}
 
 	m.migrationController = &controllers.MigrationController{
-		Driver:   m.Driver,
-		Recorder: m.Recorder,
+		Driver:            m.Driver,
+		Recorder:          m.Recorder,
+		ResourceCollector: m.ResourceCollector,
 	}
 	err = m.migrationController.Init(migrationAdminNamespace)
 	if err != nil {

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/pkg/util/node"
@@ -139,7 +140,7 @@ func (m *Monitor) podMonitor() error {
 		return nil
 	}
 
-	if err := k8s.Instance().WatchPods("", fn); err != nil {
+	if err := k8s.Instance().WatchPods("", fn, metav1.ListOptions{}); err != nil {
 		log.Errorf("failed to watch pods due to: %v", err)
 		return err
 	}

--- a/pkg/resourcecollector/clusterrole.go
+++ b/pkg/resourcecollector/clusterrole.go
@@ -1,0 +1,205 @@
+package resourcecollector
+
+import (
+	"strings"
+
+	"github.com/portworx/sched-ops/k8s"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+)
+
+// Checks if the subject is in the specified namespace
+func (r *ResourceCollector) subjectInNamespace(subject *rbacv1.Subject, namespace string) (bool, error) {
+	switch subject.Kind {
+	case rbacv1.ServiceAccountKind:
+		// For ServiceAccount the namespace is in the spec
+		if subject.Namespace == namespace {
+			return true, nil
+		}
+	case rbacv1.UserKind:
+		// For User we need to parse the username to get the namespace
+		userNamespace, _, err := serviceaccount.SplitUsername(subject.Name)
+		if err != nil {
+			return false, nil
+		}
+		if userNamespace == namespace {
+			return true, nil
+		}
+	case rbacv1.GroupKind:
+		// For Group  we need to parse the username to get the namespace
+		groupNamespace := strings.TrimPrefix(subject.Name, serviceaccount.ServiceAccountUsernamePrefix)
+		if groupNamespace == namespace {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *ResourceCollector) clusterRoleBindingToBeCollected(
+	labelSelectors map[string]string,
+	object runtime.Unstructured,
+	namespace string,
+) (bool, error) {
+	var crb rbacv1.ClusterRoleBinding
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &crb); err != nil {
+		return false, err
+	}
+	// Check if there is a subject for the namespace which is requested
+	for _, subject := range crb.Subjects {
+		collect, err := r.subjectInNamespace(&subject, namespace)
+		if err != nil || collect {
+			return collect, err
+		}
+	}
+	return false, nil
+}
+
+func (r *ResourceCollector) clusterRoleToBeCollected(
+	labelSelectors map[string]string,
+	object runtime.Unstructured,
+	namespace string,
+) (bool, error) {
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return false, err
+	}
+	name := metadata.GetName()
+	crbs, err := k8s.Instance().ListClusterRoleBindings()
+	if err != nil {
+		return false, err
+	}
+	// Find the corresponding ClusterRoleBinding and see if it belongs to the requested namespace
+	for _, crb := range crbs.Items {
+		if crb.RoleRef.Name == name {
+			for _, subject := range crb.Subjects {
+				collect, err := r.subjectInNamespace(&subject, namespace)
+				if err != nil || collect {
+					return collect, err
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+func (r *ResourceCollector) prepareClusterRoleBindingForCollection(
+	object runtime.Unstructured,
+	namespaces []string,
+) error {
+	var crb rbacv1.ClusterRoleBinding
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &crb); err != nil {
+		return err
+	}
+	subjectsToCollect := make([]rbacv1.Subject, 0)
+	// Check if there is a subject for the namespace which is requested
+	for _, subject := range crb.Subjects {
+		for _, ns := range namespaces {
+			collect, err := r.subjectInNamespace(&subject, ns)
+			if err != nil {
+				return err
+			}
+
+			if collect {
+				subjectsToCollect = append(subjectsToCollect, subject)
+			}
+		}
+	}
+	crb.Subjects = subjectsToCollect
+	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&crb)
+	if err != nil {
+		return err
+	}
+	object.SetUnstructuredContent(o)
+
+	return nil
+}
+
+func (r *ResourceCollector) prepareClusterRoleBindingForApply(
+	object runtime.Unstructured,
+	namespaceMappings map[string]string,
+) error {
+	var crb rbacv1.ClusterRoleBinding
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &crb); err != nil {
+		return err
+	}
+	subjectsToApply := make([]rbacv1.Subject, 0)
+	for sourceNamespace, destNamespace := range namespaceMappings {
+		// Check if there is a subject for the namespace which is requested
+		for _, subject := range crb.Subjects {
+			collect, err := r.subjectInNamespace(&subject, sourceNamespace)
+			if err != nil {
+				return err
+			}
+			if !collect {
+				continue
+			}
+
+			switch subject.Kind {
+			case rbacv1.UserKind:
+				_, username, err := serviceaccount.SplitUsername(subject.Name)
+				if err != nil {
+					return err
+				}
+				// Regnerate the Username for the destination namespace
+				subject.Name = serviceaccount.MakeUsername(destNamespace, username)
+			case rbacv1.GroupKind:
+				// Regnerate the Group name for the destination namespace
+				subject.Name = serviceaccount.MakeNamespaceGroupName(destNamespace)
+			case rbacv1.ServiceAccountKind:
+				// Update the Namespace in the spec for ServiceAccounts
+				subject.Namespace = destNamespace
+			}
+			subjectsToApply = append(subjectsToApply, subject)
+		}
+	}
+	crb.Subjects = subjectsToApply
+	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&crb)
+	if err != nil {
+		return err
+	}
+	object.SetUnstructuredContent(o)
+
+	return nil
+}
+
+func (r *ResourceCollector) mergeAndUpdateClusterRoleBinding(
+	object runtime.Unstructured,
+) error {
+	var newCRB rbacv1.ClusterRoleBinding
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &newCRB); err != nil {
+		return err
+	}
+
+	currentCRB, err := k8s.Instance().GetClusterRoleBinding(newCRB.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err = k8s.Instance().CreateClusterRoleBinding(&newCRB)
+		}
+		return err
+	}
+
+	// Map which will help eliminate duplicate subjects since the subject string
+	// will be unique for different subjects
+	updatedSubjects := make(map[string]rbacv1.Subject)
+
+	// First add the current subjects to the map
+	for _, subject := range currentCRB.Subjects {
+		updatedSubjects[subject.String()] = subject
+	}
+	// Then add the new subjects to be merged
+	for _, subject := range newCRB.Subjects {
+		updatedSubjects[subject.String()] = subject
+	}
+
+	// Then get the updated list of subjects from the map to apply
+	currentCRB.Subjects = make([]rbacv1.Subject, 0)
+	for _, subject := range updatedSubjects {
+		currentCRB.Subjects = append(currentCRB.Subjects, subject)
+	}
+
+	_, err = k8s.Instance().UpdateClusterRoleBinding(currentCRB)
+	return err
+}

--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -1,0 +1,103 @@
+package resourcecollector
+
+import (
+	"fmt"
+
+	"github.com/heptio/ark/pkg/util/collections"
+	"github.com/portworx/sched-ops/k8s"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) pvToBeCollected(
+	labelSelectors map[string]string,
+	object runtime.Unstructured,
+	namespace string,
+) (bool, error) {
+	phase, err := collections.GetString(object.UnstructuredContent(), "status.phase")
+	if err != nil {
+		return false, err
+	}
+	// Only collect Bound PVs
+	if phase != string(v1.ClaimBound) {
+		return false, nil
+	}
+
+	// Collect only PVs which have a reference to a PVC in the namespace requested
+	pvcName, err := collections.GetString(object.UnstructuredContent(), "spec.claimRef.name")
+	if err != nil {
+		return false, err
+	}
+	if pvcName == "" {
+		return false, nil
+	}
+
+	pvcNamespace, err := collections.GetString(object.UnstructuredContent(), "spec.claimRef.namespace")
+	if err != nil {
+		return false, err
+	}
+	if pvcNamespace != namespace {
+		return false, nil
+	}
+
+	pvc, err := k8s.Instance().GetPersistentVolumeClaim(pvcName, pvcNamespace)
+	if err != nil {
+		return false, err
+	}
+	// Collect only if the PVC bound to the PV is owned by the driver
+	if !r.Driver.OwnsPVC(pvc) {
+		return false, nil
+	}
+
+	// Also check the labels on the PVC since the PV doesn't inherit the labels
+	if len(pvc.Labels) == 0 && len(labelSelectors) > 0 {
+		return false, nil
+	}
+
+	if !labels.AreLabelsInWhiteList(labels.Set(labelSelectors),
+		labels.Set(pvc.Labels)) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (r *ResourceCollector) preparePVResourceForCollection(
+	object runtime.Unstructured,
+) error {
+	spec, err := collections.GetMap(object.UnstructuredContent(), "spec")
+	if err != nil {
+		return err
+	}
+
+	// Delete the claimRef so that the collected resource can be rebound
+	delete(spec, "claimRef")
+
+	// Storage class needs to be removed so that it can rebind to an existing PV
+	delete(spec, "storageClassName")
+
+	return nil
+}
+
+// Updates the PV by pointing to the new volume. Also updated the name of the PV
+// itself. The restored PVC will point to this new PV name.
+func (r *ResourceCollector) preparePVResourceForApply(
+	object runtime.Unstructured,
+	pvNameMappings map[string]string,
+) error {
+	var updatedName string
+	var present bool
+
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return err
+	}
+
+	if updatedName, present = pvNameMappings[metadata.GetName()]; !present {
+		return fmt.Errorf("PV name mapping not found for %v", metadata.GetName())
+	}
+	metadata.SetName(updatedName)
+	_, err = r.Driver.UpdateMigratedPersistentVolumeSpec(object)
+	return err
+}

--- a/pkg/resourcecollector/persistentvolumeclaim.go
+++ b/pkg/resourcecollector/persistentvolumeclaim.go
@@ -1,0 +1,67 @@
+package resourcecollector
+
+import (
+	"fmt"
+
+	"github.com/portworx/sched-ops/k8s"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) pvcToBeCollected(
+	object runtime.Unstructured,
+	namespace string,
+) (bool, error) {
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return false, err
+	}
+
+	pvcName := metadata.GetName()
+	pvc, err := k8s.Instance().GetPersistentVolumeClaim(pvcName, namespace)
+	if err != nil {
+		return false, err
+	}
+	// Only collect Bound PVCs
+	if pvc.Status.Phase != v1.ClaimBound {
+		return false, nil
+	}
+
+	// Don't collect PVCs not owned by the driver
+	if !r.Driver.OwnsPVC(pvc) {
+		return false, nil
+	}
+	return true, nil
+}
+
+// Updates the PVC by pointing to the new PV that it should refer to
+// pvNameMappings has the map of the original PV name to the new PV name
+func (r *ResourceCollector) preparePVCResourceForApply(
+	object runtime.Unstructured,
+	pvNameMappings map[string]string,
+) error {
+	var pvc v1.PersistentVolumeClaim
+	var updatedName string
+	var present bool
+
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return err
+	}
+
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &pvc); err != nil {
+		return fmt.Errorf("error converting PVC object: %v: %v", object, err)
+	}
+
+	if updatedName, present = pvNameMappings[pvc.Spec.VolumeName]; !present {
+		return fmt.Errorf("PV name mapping not found for %v", metadata.GetName())
+	}
+	pvc.Spec.VolumeName = updatedName
+	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pvc)
+	if err != nil {
+		return err
+	}
+	object.SetUnstructuredContent(o)
+	return nil
+}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -1,0 +1,383 @@
+package resourcecollector
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/heptio/ark/pkg/discovery"
+	"github.com/heptio/ark/pkg/util/collections"
+	"github.com/libopenstorage/stork/drivers/volume"
+	"github.com/sirupsen/logrus"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
+)
+
+const (
+	// Annotation to use when the resource shouldn't be collected
+	skipResourceAnnotation = "stork.libopenstorage.ord/skipresource"
+)
+
+// ResourceCollector is used to collect and process unstructured objects in namespaces and using label selectors
+type ResourceCollector struct {
+	Driver           volume.Driver
+	discoveryHelper  discovery.Helper
+	dynamicInterface dynamic.Interface
+}
+
+// Init initializes the resource collector
+func (r *ResourceCollector) Init() error {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("error getting cluster config: %v", err)
+	}
+
+	aeclient, err := apiextensionsclient.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("error getting apiextension client, %v", err)
+	}
+
+	discoveryClient := aeclient.Discovery()
+	r.discoveryHelper, err = discovery.NewHelper(discoveryClient, logrus.New())
+	if err != nil {
+		return err
+	}
+	err = r.discoveryHelper.Refresh()
+	if err != nil {
+		return err
+	}
+	r.dynamicInterface, err = dynamic.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceToBeCollected(resource metav1.APIResource) bool {
+	// Deployment is present in "apps" and "extensions" group, so ignore
+	// "extensions"
+	if resource.Group == "extensions" && resource.Kind == "Deployment" {
+		return false
+	}
+
+	switch resource.Kind {
+	case "PersistentVolumeClaim",
+		"PersistentVolume",
+		"Deployment",
+		"StatefulSet",
+		"ConfigMap",
+		"Service",
+		"Secret",
+		"DaemonSet",
+		"ServiceAccount",
+		"ClusterRole",
+		"ClusterRoleBinding":
+		return true
+	default:
+		return false
+	}
+}
+
+// GetResources gets all the resources in the given list of namespaces which match the labelSelectors
+func (r *ResourceCollector) GetResources(namespaces []string, labelSelectors map[string]string) ([]runtime.Unstructured, error) {
+	err := r.discoveryHelper.Refresh()
+	if err != nil {
+		return nil, err
+	}
+	allObjects := make([]runtime.Unstructured, 0)
+
+	for _, group := range r.discoveryHelper.Resources() {
+		groupVersion, err := schema.ParseGroupVersion(group.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+		if groupVersion.Group == "extensions" {
+			continue
+		}
+
+		// Map to prevent collection of duplicate objects
+		resourceMap := make(map[types.UID]bool)
+		for _, resource := range group.APIResources {
+			if !resourceToBeCollected(resource) {
+				continue
+			}
+
+			for _, ns := range namespaces {
+				var dynamicClient dynamic.ResourceInterface
+				if !resource.Namespaced {
+					dynamicClient = r.dynamicInterface.Resource(groupVersion.WithResource(resource.Name))
+				} else {
+					dynamicClient = r.dynamicInterface.Resource(groupVersion.WithResource(resource.Name)).Namespace(ns)
+				}
+
+				var selectors string
+				// PVs don't get the labels from their PVCs, so don't use the label selector
+				// Also skip for some other resources that aren't necessarily tied to an application
+				switch resource.Kind {
+				case "PersistentVolume",
+					"ClusterRoleBinding",
+					"ClusterRole",
+					"ServiceAccount":
+				default:
+					selectors = labels.Set(labelSelectors).String()
+				}
+				objectsList, err := dynamicClient.List(metav1.ListOptions{
+					LabelSelector: selectors,
+				})
+				if err != nil {
+					return nil, err
+				}
+				objects, err := meta.ExtractList(objectsList)
+				if err != nil {
+					return nil, err
+				}
+				for _, o := range objects {
+					runtimeObject, ok := o.(runtime.Unstructured)
+					if !ok {
+						return nil, fmt.Errorf("error casting object: %v", o)
+					}
+
+					collect, err := r.objectToBeCollected(labelSelectors, resourceMap, runtimeObject, ns)
+					if err != nil {
+						return nil, fmt.Errorf("error processing object %v: %v", runtimeObject, err)
+					}
+					if !collect {
+						continue
+					}
+					metadata, err := meta.Accessor(runtimeObject)
+					if err != nil {
+						return nil, err
+					}
+					allObjects = append(allObjects, runtimeObject)
+					resourceMap[metadata.GetUID()] = true
+				}
+			}
+		}
+	}
+
+	err = r.prepareResourcesForCollection(allObjects, namespaces)
+	if err != nil {
+		return nil, err
+	}
+	return allObjects, nil
+}
+
+// Returns whether an object should be collected or not for the requested
+// namespace
+func (r *ResourceCollector) objectToBeCollected(
+	labelSelectors map[string]string,
+	resourceMap map[types.UID]bool,
+	object runtime.Unstructured,
+	namespace string,
+) (bool, error) {
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return false, err
+	}
+
+	if value, present := metadata.GetAnnotations()[skipResourceAnnotation]; present {
+		if skip, err := strconv.ParseBool(value); err == nil && skip {
+			return false, err
+		}
+	}
+
+	// Skip if we've already processed this object
+	if _, ok := resourceMap[metadata.GetUID()]; ok {
+		return false, nil
+	}
+
+	objectType, err := meta.TypeAccessor(object)
+	if err != nil {
+		return false, err
+	}
+
+	switch objectType.GetKind() {
+	case "Service":
+		return r.serviceToBeCollected(object)
+	case "PersistentVolumeClaim":
+		return r.pvcToBeCollected(object, namespace)
+	case "PersistentVolume":
+		return r.pvToBeCollected(labelSelectors, object, namespace)
+	case "ClusterRoleBinding":
+		return r.clusterRoleBindingToBeCollected(labelSelectors, object, namespace)
+	case "ClusterRole":
+		return r.clusterRoleToBeCollected(labelSelectors, object, namespace)
+	case "ServiceAccount":
+		return r.serviceAccountToBeCollected(object)
+	case "Secret":
+		return r.secretToBeCollected(object)
+	}
+
+	return true, nil
+}
+
+func (r *ResourceCollector) prepareResourcesForCollection(
+	objects []runtime.Unstructured,
+	namespaces []string,
+) error {
+	for _, o := range objects {
+		metadata, err := meta.Accessor(o)
+		if err != nil {
+			return err
+		}
+
+		switch o.GetObjectKind().GroupVersionKind().Kind {
+		case "PersistentVolume":
+			err := r.preparePVResourceForCollection(o)
+			if err != nil {
+				return fmt.Errorf("error preparing PV resource %v: %v", metadata.GetName(), err)
+			}
+		case "Service":
+			err := r.prepareServiceResourceForCollection(o)
+			if err != nil {
+				return fmt.Errorf("error preparing Service resource %v/%v: %v", metadata.GetNamespace(), metadata.GetName(), err)
+			}
+		case "ClusterRoleBinding":
+			err := r.prepareClusterRoleBindingForCollection(o, namespaces)
+			if err != nil {
+				return fmt.Errorf("error preparing ClusterRoleBindings resource %v: %v", metadata.GetName(), err)
+			}
+		}
+
+		content := o.UnstructuredContent()
+		// Status shouldn't be retained when collecting resources
+		delete(content, "status")
+		metadataMap, err := collections.GetMap(content, "metadata")
+		if err != nil {
+			return fmt.Errorf("error getting metadata for resource %v: %v", metadata.GetName(), err)
+		}
+		// Remove all metadata except some well-known ones
+		for key := range metadataMap {
+			switch key {
+			case "name", "namespace", "labels", "annotations":
+			default:
+				delete(metadataMap, key)
+			}
+		}
+	}
+	return nil
+}
+
+func (r *ResourceCollector) prepareResourceForApply(
+	object runtime.Unstructured,
+	namespaceMappings map[string]string,
+	pvNameMappings map[string]string,
+) error {
+	objectType, err := meta.TypeAccessor(object)
+	if err != nil {
+		return err
+	}
+
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return err
+	}
+	if metadata.GetNamespace() != "" {
+		// Update the namepsace of the object, will be no-op for clustered resources
+		metadata.SetNamespace(namespaceMappings[metadata.GetNamespace()])
+	}
+
+	switch objectType.GetKind() {
+	case "PersistentVolume":
+		return r.preparePVResourceForApply(object, pvNameMappings)
+	case "PersistentVolumeClaim":
+		return r.preparePVCResourceForApply(object, pvNameMappings)
+	case "ClusterRoleBinding":
+		err := r.prepareClusterRoleBindingForApply(object, namespaceMappings)
+		if err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (r *ResourceCollector) mergeSupportedForResource(
+	resourceName string,
+) bool {
+	switch resourceName {
+	case "ClusterRoleBindings":
+		return true
+	}
+	return false
+}
+
+func (r *ResourceCollector) mergeAndUpdateResource(
+	object runtime.Unstructured,
+) error {
+	objectType, err := meta.TypeAccessor(object)
+	if err != nil {
+		return err
+	}
+
+	switch objectType.GetKind() {
+	case "ClusterRoleBinding":
+		return r.mergeAndUpdateClusterRoleBinding(object)
+	}
+	return nil
+}
+
+// ApplyResource applies a given resource using the provided client interface
+func (r *ResourceCollector) ApplyResource(
+	dynamicInterface dynamic.Interface,
+	object *unstructured.Unstructured,
+	pvNameMappings map[string]string,
+	namespaceMappings map[string]string,
+	deleteIfPresent bool,
+) error {
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return err
+	}
+	objectType, err := meta.TypeAccessor(object)
+	if err != nil {
+		return err
+	}
+	resource := &metav1.APIResource{
+		Name:       strings.ToLower(objectType.GetKind()) + "s",
+		Namespaced: len(metadata.GetNamespace()) > 0,
+	}
+
+	destNamespace := ""
+	if resource.Namespaced {
+		destNamespace = namespaceMappings[metadata.GetNamespace()]
+	}
+	dynamicClient := dynamicInterface.Resource(
+		object.GetObjectKind().GroupVersionKind().GroupVersion().WithResource(resource.Name)).Namespace(destNamespace)
+
+	err = r.prepareResourceForApply(object, namespaceMappings, pvNameMappings)
+	if err != nil {
+		return err
+	}
+
+	_, err = dynamicClient.Create(object)
+	if err != nil && (apierrors.IsAlreadyExists(err) || strings.Contains(err.Error(), portallocator.ErrAllocated.Error())) {
+		if r.mergeSupportedForResource(resource.Name) {
+			err := r.mergeAndUpdateResource(object)
+			if err != nil {
+				return err
+			}
+		} else if deleteIfPresent {
+			// Delete the resource if it already exists on the destination
+			// cluster and try creating again
+			err = dynamicClient.Delete(metadata.GetName(), &metav1.DeleteOptions{})
+			if err == nil {
+				_, err = dynamicClient.Create(object)
+			} else {
+				return err
+			}
+		}
+	}
+
+	return err
+}

--- a/pkg/resourcecollector/secret.go
+++ b/pkg/resourcecollector/secret.go
@@ -1,0 +1,25 @@
+package resourcecollector
+
+import (
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) secretToBeCollected(
+	object runtime.Unstructured,
+) (bool, error) {
+	var secret v1.Secret
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &secret); err != nil {
+		logrus.Errorf("Error converting Secret object %v: %v", object, err)
+		return false, err
+	}
+	// Don't collect secret which store the default service account token
+	if secret.Type == v1.SecretTypeServiceAccountToken {
+		if accountName, ok := secret.Annotations[v1.ServiceAccountNameKey]; ok && accountName == "default" {
+			return false, nil
+		}
+	}
+	return true, nil
+
+}

--- a/pkg/resourcecollector/service.go
+++ b/pkg/resourcecollector/service.go
@@ -1,0 +1,37 @@
+package resourcecollector
+
+import (
+	"github.com/heptio/ark/pkg/util/collections"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) serviceToBeCollected(
+	object runtime.Unstructured,
+) (bool, error) {
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return false, err
+	}
+
+	// Don't migrate the kubernetes service
+	if metadata.GetName() == "kubernetes" {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (r *ResourceCollector) prepareServiceResourceForCollection(
+	object runtime.Unstructured,
+) error {
+	spec, err := collections.GetMap(object.UnstructuredContent(), "spec")
+	if err != nil {
+		return err
+	}
+	// Don't delete clusterIP for headless services
+	if ip, err := collections.GetString(spec, "clusterIP"); err == nil && ip != "None" {
+		delete(spec, "clusterIP")
+	}
+
+	return nil
+}

--- a/pkg/resourcecollector/serviceaccount.go
+++ b/pkg/resourcecollector/serviceaccount.go
@@ -1,0 +1,19 @@
+package resourcecollector
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) serviceAccountToBeCollected(
+	object runtime.Unstructured,
+) (bool, error) {
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return false, err
+	}
+
+	// Don't migrate the default service account
+	name := metadata.GetName()
+	return name != "default", nil
+}


### PR DESCRIPTION
Can be used by other modules to get unstructured objects from a namepsace
and matching label selectors


**What type of PR is this?**
Cleanup

**What this PR does / why we need it**:
Refactored code so that same code can be shared by multiple modules


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
