### PR TITLE
Increase wait time in snapshotschedule test

### DIFF
--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -26,7 +26,7 @@ const (
 	waitPvcRetryInterval = 5 * time.Second
 
 	snapshotScheduleRetryInterval = 10 * time.Second
-	snapshotScheduleRetryTimeout  = 2 * time.Minute
+	snapshotScheduleRetryTimeout  = 3 * time.Minute
 )
 
 func testSnapshot(t *testing.T) {


### PR DESCRIPTION
Gives it enough time to wait for the trigger and status to be updated


**What type of PR is this?**
Failing test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
2.2
