### PR TITLE
Vendor update for sched-ops

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -640,14 +640,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:82c0ab0c2f38fc01d4afc9ba1e154bcda581db5ebf3c8575885cd293a938043c"
+  digest = "1:6d4f14c3f750992ed26c31e73502721a5f3f2b5e8a665ba4d8d122904c95bcd2"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s",
     "task",
   ]
   pruneopts = "UT"
-  revision = "5cd739ad5470129e979a5fe4e9724decdeda091c"
+  revision = "d67339588ae8c134a2f1da52613d6abd7241b8c7"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/portworx/sched-ops/k8s/k8s.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/k8s.go
@@ -1000,6 +1000,7 @@ func (k *k8sOps) handleWatch(
 	namespace string,
 	fn WatchFunc,
 	listOptions meta_v1.ListOptions) {
+	defer watchInterface.Stop()
 	for {
 		select {
 		case event, more := <-watchInterface.ResultChan():


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
Fixes a memory leak when watches are re-established


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Fixed a memory leak when watches are re-established
```

**Does this change need to be cherry-picked to a release branch?**:
2.2
