### PR TITLE
Print an error log when the controller fails to fetch cluster domain info

### DIFF
--- a/pkg/clusterdomains/controllers/clusterdomainstatus.go
+++ b/pkg/clusterdomains/controllers/clusterdomainstatus.go
@@ -84,6 +84,7 @@ func (c *ClusterDomainsStatusController) Handle(ctx context.Context, event sdk.E
 				err.Error(),
 				fmt.Sprintf("Failed to update ClusterDomainsStatuses"),
 			)
+			logrus.Errorf("Failed to get cluster domain info: %v", err)
 		} else {
 			if len(clusterDomainsInfo.Active) != len(clusterDomainsStatus.Status.Active) ||
 				len(clusterDomainsInfo.Inactive) != len(clusterDomainsStatus.Status.Inactive) {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
Prints a log line when the cluster domain controller fails to fetch cluster domain info from the driver.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

