### PR TITLE
Fix matching of clusterdomain list

### DIFF
--- a/pkg/clusterdomains/controllers/clusterdomainstatus.go
+++ b/pkg/clusterdomains/controllers/clusterdomainstatus.go
@@ -110,11 +110,15 @@ func (c *ClusterDomainsStatusController) Handle(ctx context.Context, event sdk.E
 
 func (c *ClusterDomainsStatusController) doListsMatch(domainListSDK, domainListCRD []string) bool {
 	for _, sdkDomain := range domainListSDK {
+		found := false
 		for _, crdDomain := range domainListCRD {
 			if crdDomain == sdkDomain {
-				continue
+				found = true
+				break
 			}
-			// could not find a match
+		}
+		// could not find a match
+		if !found {
 			return false
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
The clusterdomain lists weren't bein checked correctly


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Fixed comparing cluster domains to see if an update is required in the status
```

**Does this change need to be cherry-picked to a release branch?**:
2.2 (For 2.2.3)
