### PR TITLE
Add debug package to dump profiles

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/cluster"
 	"github.com/libopenstorage/stork/pkg/clusterdomains"
 	"github.com/libopenstorage/stork/pkg/controller"
+	"github.com/libopenstorage/stork/pkg/dbg"
 	"github.com/libopenstorage/stork/pkg/extender"
 	"github.com/libopenstorage/stork/pkg/groupsnapshot"
 	"github.com/libopenstorage/stork/pkg/initializer"
@@ -40,6 +41,7 @@ const (
 	defaultLockObjectName      = "stork"
 	defaultLockObjectNamespace = "kube-system"
 	eventComponentName         = "stork"
+	debugFilePath              = "/var/cores"
 )
 
 var ext *extender.Extender
@@ -133,6 +135,7 @@ func main() {
 }
 
 func run(c *cli.Context) {
+	dbg.Init(c.App.Name, debugFilePath)
 
 	log.Infof("Starting stork version %v", version.Version)
 	driverName := c.String("driver")

--- a/pkg/dbg/dbg.go
+++ b/pkg/dbg/dbg.go
@@ -1,0 +1,106 @@
+package dbg
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"path"
+	"runtime"
+	"runtime/pprof"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	fnameFmt       = "2006-01-02T15:04:05.999999-0700MST"
+	stackTraceSize = 5120 * 1024 // 5MB
+)
+
+// Init Initializes the debug handlers
+func Init(name string, dir string) {
+	installSignalHandlers(name, dir)
+}
+
+func installSignalHandlers(name string, dir string) {
+	dumpChannel := make(chan os.Signal, 1)
+	cpuProfChannel := make(chan os.Signal, 1)
+	signal.Notify(dumpChannel, syscall.SIGUSR1)
+	go func() {
+		for {
+			<-dumpChannel
+			dumpGoMemoryTrace()
+			dumpHeap(generateFilename(name, dir, ".heap"))
+			dumpGoProfile(generateFilename(name, dir, ".stack"))
+		}
+	}()
+	signal.Notify(cpuProfChannel, syscall.SIGUSR2)
+	go func() {
+		started := false
+		for {
+			<-cpuProfChannel
+			if !started {
+				started = startCPUProfileDump(generateFilename(name, dir, ".cpuprof"))
+			} else {
+				pprof.StopCPUProfile()
+				started = false
+			}
+		}
+	}()
+
+}
+
+func generateFilename(name string, dir string, suffix string) string {
+	return path.Join(dir, name+"."+time.Now().Format(fnameFmt)+suffix)
+}
+
+func startCPUProfileDump(filename string) bool {
+	f, err := os.Create(filename)
+	if err != nil {
+		logrus.Errorf("could not create cpu profile: %v", err)
+		return false
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		logrus.Errorf("Error starting cpu profiling: %v", err)
+		return false
+	}
+	return true
+}
+
+// dumpGoMemoryTrace output memory profile to logs.
+func dumpGoMemoryTrace() {
+	m := &runtime.MemStats{}
+	runtime.ReadMemStats(m)
+	res := fmt.Sprintf("%#v", m)
+	logrus.Infof("==== Dumping Memory Profile ===")
+	logrus.Infof(res)
+}
+
+// dumpGoProfile output goroutines to file.
+func dumpGoProfile(filename string) {
+	trace := make([]byte, stackTraceSize)
+	len := runtime.Stack(trace, true)
+	if err := ioutil.WriteFile(filename, trace[:len], 0644); err != nil {
+		logrus.Errorf("Error dumping goroutines: %v", err)
+	}
+}
+
+// dumpHeap dumps the memory heap to a file
+func dumpHeap(filename string) {
+	f, err := os.Create(filename)
+	if err != nil {
+		logrus.Errorf("could not create memory profile: %v", err)
+		return
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			logrus.Errorf("Error closing heap file: %v", err)
+		}
+	}()
+
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		logrus.Errorf("could not write memory profile: %v", err)
+	}
+}


### PR DESCRIPTION
SIGUSR1 can be used to dump memory and goroutine info
SIGUSR2 can be used to toggle collection of cpuprofile


**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Add signal handlers to dump memory info for debugging
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

