### PR TITLE
Fix schedule to trigger if next trigger is exactly at current time

### DIFF
--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -135,9 +135,9 @@ func checkTrigger(
 		return false, nil
 	}
 
-	// If we are within one hour after the next trigger time, trigger a new
+	// If we are within one hour after/at the next trigger time, trigger a new
 	// schedule
-	if now.After(nextTrigger) && now.Sub(nextTrigger).Hours() < 1 {
+	if now.Equal(nextTrigger) || (now.After(nextTrigger) && now.Sub(nextTrigger).Hours() < 1) {
 		return true, nil
 	}
 	return false, nil

--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -178,6 +178,13 @@ func triggerWeeklyRequiredTest(t *testing.T) {
 	required, err = TriggerRequired("weeklypolicy", stork_api.SchedulePolicyTypeWeekly, meta.Date(2019, time.February, 6, 23, 16, 0, 0, time.Local))
 	require.NoError(t, err, "Error checking if trigger required")
 	require.True(t, required, "Trigger should have been required")
+
+	newTime = time.Date(2019, time.February, 17, 23, 15, 0, 0, time.Local) // Current day: Sunday
+	setMockTime(&newTime)
+	// LastTriggered last Sunday at 11:16pm
+	required, err = TriggerRequired("weeklypolicy", stork_api.SchedulePolicyTypeWeekly, meta.Date(2019, time.February, 10, 23, 16, 0, 0, time.Local))
+	require.NoError(t, err, "Error checking if trigger required")
+	require.True(t, required, "Trigger should have been required")
 }
 
 func triggerMonthlyRequiredTest(t *testing.T) {


### PR DESCRIPTION
Also added UT


**What type of PR is this?**
Bug

**What this PR does / why we need it**:
The schedule would not get triggered if the current time was exactly at the next trigger time


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Fixed schedules not getting triggered if the current time is exactly at next trigger time
```

**Does this change need to be cherry-picked to a release branch?**:
2.2 (For 2.2.3)
