### PR TITLE
Add deploymentconfig to activate migrations for storkctl

### DIFF
--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -107,6 +107,7 @@ func newActivateMigrationsCommand(cmdFactory Factory, ioStreams genericclioption
 			for _, ns := range activationNamespaces {
 				updateStatefulSets(ns, true, ioStreams)
 				updateDeployments(ns, true, ioStreams)
+				updateDeploymentConfigs(ns, true, ioStreams)
 			}
 
 		},


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Storkctl: Activating DeploymentConfig for migrations
```

**Does this change need to be cherry-picked to a release branch?**:
2.2
