### PR TITLE
 Suspend migration schedules if the local clusterdomain is inactive

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1684,6 +1684,15 @@ func (p *portworx) DeleteGroupSnapshot(snap *stork_crd.GroupVolumeSnapshot) erro
 
 func (p *portworx) GetClusterDomains() (*stork_crd.ClusterDomains, error) {
 
+	cluster, err := p.clusterManager.Enumerate()
+	if err != nil {
+		return nil, err
+	}
+	nodeConfig, err := p.clusterManager.GetNodeConf(cluster.NodeId)
+	if err != nil {
+		return nil, err
+	}
+
 	clusterDomainClient, err := p.getClusterDomainClient()
 	if err != nil {
 		return nil, err
@@ -1697,7 +1706,9 @@ func (p *portworx) GetClusterDomains() (*stork_crd.ClusterDomains, error) {
 		return nil, err
 	}
 
-	clusterDomainsInfo := &stork_crd.ClusterDomains{}
+	clusterDomainsInfo := &stork_crd.ClusterDomains{
+		LocalDomain: nodeConfig.ClusterDomain,
+	}
 	for _, domainName := range enumerateResp.ClusterDomainNames {
 		insCtx, insCancel := context.WithTimeout(context.Background(), clusterDomainsTimeout)
 		defer insCancel()

--- a/pkg/apis/stork/v1alpha1/clusterdomainsstatus.go
+++ b/pkg/apis/stork/v1alpha1/clusterdomainsstatus.go
@@ -16,8 +16,9 @@ const (
 // ClusterDomains provides a list of activated cluster domains and a list
 // of inactive cluster domains
 type ClusterDomains struct {
-	Active   []string `json:"active"`
-	Inactive []string `json:"inactive"`
+	LocalDomain string   `json:"localDomain"`
+	Active      []string `json:"active"`
+	Inactive    []string `json:"inactive"`
 }
 
 // +genclient

--- a/pkg/clusterdomains/controllers/clusterdomainstatus.go
+++ b/pkg/clusterdomains/controllers/clusterdomainstatus.go
@@ -86,7 +86,9 @@ func (c *ClusterDomainsStatusController) Handle(ctx context.Context, event sdk.E
 			)
 			logrus.Errorf("Failed to get cluster domain info: %v", err)
 		} else {
-			if len(clusterDomainsInfo.Active) != len(clusterDomainsStatus.Status.Active) ||
+			if clusterDomainsStatus.Status.LocalDomain != clusterDomainsInfo.LocalDomain {
+				updated = true
+			} else if len(clusterDomainsInfo.Active) != len(clusterDomainsStatus.Status.Active) ||
 				len(clusterDomainsInfo.Inactive) != len(clusterDomainsStatus.Status.Inactive) {
 				updated = true
 			} else {
@@ -98,8 +100,7 @@ func (c *ClusterDomainsStatusController) Handle(ctx context.Context, event sdk.E
 			}
 		}
 		if updated {
-			clusterDomainsStatus.Status.Active = clusterDomainsInfo.Active
-			clusterDomainsStatus.Status.Inactive = clusterDomainsInfo.Inactive
+			clusterDomainsStatus.Status = *clusterDomainsInfo
 			if err := sdk.Update(clusterDomainsStatus); err != nil {
 				return err
 			}

--- a/pkg/clusterdomains/controllers/clusterdomainupdate.go
+++ b/pkg/clusterdomains/controllers/clusterdomainupdate.go
@@ -86,6 +86,21 @@ func (c *ClusterDomainUpdateController) Handle(ctx context.Context, event sdk.Ev
 				log.ClusterDomainUpdateLog(clusterDomainUpdate).Errorf("Error updating ClusterDomainUpdate: %v", err)
 				return err
 			}
+			// Do a dummy update on the cluster domain status so that it queries
+			// the storage driver and gets updated too
+			if clusterDomainUpdate.Status.Status == storkv1.ClusterDomainUpdateStatusSuccessful {
+				cdsList, err := k8s.Instance().ListClusterDomainStatuses()
+				if err != nil {
+					return err
+				}
+				for _, cds := range cdsList.Items {
+					_, err := k8s.Instance().UpdateClusterDomainsStatus(&cds)
+					if err != nil {
+						return err
+					}
+				}
+
+			}
 			return nil
 		case storkv1.ClusterDomainUpdateStatusFailed, storkv1.ClusterDomainUpdateStatusSuccessful:
 			return nil

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -40,6 +40,7 @@ func (m *Migration) Init(migrationAdminNamespace string) error {
 		return fmt.Errorf("error initializing migration controller: %v", err)
 	}
 	m.migrationScheduleController = &controllers.MigrationScheduleController{
+		Driver:   m.Driver,
 		Recorder: m.Recorder,
 	}
 	err = m.migrationScheduleController.Init()

--- a/pkg/storkctl/clusterdomainsstatus.go
+++ b/pkg/storkctl/clusterdomainsstatus.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 )
 
-var clusterDomainsStatusColumns = []string{"NAME", "ACTIVE", "INACTIVE", "CREATED"}
+var clusterDomainsStatusColumns = []string{"NAME", "LOCAL-DOMAIN", "ACTIVE", "INACTIVE", "CREATED"}
 var clusterDomainsStatusSubcommand = "clusterdomainsstatus"
 var clusterDomainsStatusAliases = []string{"cds"}
 
@@ -64,8 +64,9 @@ func clusterDomainsStatusPrinter(cdsList *storkv1.ClusterDomainsStatusList, writ
 		name := printers.FormatResourceName(options.Kind, cds.Name, options.WithKind)
 
 		creationTime := toTimeString(cds.CreationTimestamp.Time)
-		if _, err := fmt.Fprintf(writer, "%v\t%v\t%v\t%v\n",
+		if _, err := fmt.Fprintf(writer, "%v\t%v\t%v\t%v\t%v\n",
 			name,
+			cds.Status.LocalDomain,
 			cds.Status.Active,
 			cds.Status.Inactive,
 			creationTime); err != nil {

--- a/pkg/storkctl/clusterdomainsstatus_test.go
+++ b/pkg/storkctl/clusterdomainsstatus_test.go
@@ -19,8 +19,9 @@ func createClusterDomainsStatus(t *testing.T, name string) *storkv1.ClusterDomai
 			Name: name,
 		},
 		Status: storkv1.ClusterDomains{
-			Active:   activeZones,
-			Inactive: inactiveZones,
+			LocalDomain: "zone1",
+			Active:      activeZones,
+			Inactive:    inactiveZones,
 		},
 	}
 	_, err := k8s.Instance().CreateClusterDomainsStatus(cds)
@@ -58,8 +59,8 @@ func TestGetClusterDomainsStatus(t *testing.T) {
 	createClusterDomainsStatus(t, "test1")
 	cmdArgs := []string{"get", "clusterdomainsstatus", "test1"}
 
-	expected := "NAME      ACTIVE          INACTIVE        CREATED\n" +
-		"test1     [zone1 zone2]   [zone3 zone4]   \n"
+	expected := "NAME      LOCAL-DOMAIN   ACTIVE          INACTIVE        CREATED\n" +
+		"test1     zone1          [zone1 zone2]   [zone3 zone4]   \n"
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 
@@ -68,10 +69,11 @@ func TestGetClusterDomainsStatusWithChanges(t *testing.T) {
 	cds := createClusterDomainsStatus(t, "test1")
 	cmdArgs := []string{"get", "clusterdomainsstatus", "test1"}
 
-	expected := "NAME      ACTIVE          INACTIVE        CREATED\n" +
-		"test1     [zone1 zone2]   [zone3 zone4]   \n"
+	expected := "NAME      LOCAL-DOMAIN   ACTIVE          INACTIVE        CREATED\n" +
+		"test1     zone1          [zone1 zone2]   [zone3 zone4]   \n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
+	cds.Status.LocalDomain = "zone1"
 	cds.Status.Active = []string{"zone1", "zone2", "zone3"}
 	cds.Status.Inactive = []string{"zone4"}
 	_, err := k8s.Instance().UpdateClusterDomainsStatus(cds)
@@ -79,8 +81,8 @@ func TestGetClusterDomainsStatusWithChanges(t *testing.T) {
 
 	cmdArgs = []string{"get", "clusterdomainsstatus", "test1"}
 
-	expected = "NAME      ACTIVE                INACTIVE   CREATED\n" +
-		"test1     [zone1 zone2 zone3]   [zone4]    \n"
+	expected = "NAME      LOCAL-DOMAIN   ACTIVE                INACTIVE   CREATED\n" +
+		"test1     zone1          [zone1 zone2 zone3]   [zone4]    \n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
 }


### PR DESCRIPTION
**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:
Migrations should be stopped if the local domain isn't active.

**Does this PR change a user-facing CRD or CLI?**:
Adds `localDomain` in ClusterDomainStatus
Local domain is also printed when checking the status with `storkctl`

**Is a release note needed?**:
```release-note
* Migration schedules will now be suspended if the local domain is inactive
* Updated `storkctl` to print local cluster domain
```

**Does this change need to be cherry-picked to a release branch?**:
2.2

