### PR TITLE
Optimize migrations for clusterrole

### DIFF
--- a/pkg/resourcecollector/clusterrole.go
+++ b/pkg/resourcecollector/clusterrole.go
@@ -60,6 +60,7 @@ func (r *ResourceCollector) clusterRoleBindingToBeCollected(
 func (r *ResourceCollector) clusterRoleToBeCollected(
 	labelSelectors map[string]string,
 	object runtime.Unstructured,
+	crbs *rbacv1.ClusterRoleBindingList,
 	namespace string,
 ) (bool, error) {
 	metadata, err := meta.Accessor(object)
@@ -67,10 +68,6 @@ func (r *ResourceCollector) clusterRoleToBeCollected(
 		return false, err
 	}
 	name := metadata.GetName()
-	crbs, err := k8s.Instance().ListClusterRoleBindings()
-	if err != nil {
-		return false, err
-	}
 	// Find the corresponding ClusterRoleBinding and see if it belongs to the requested namespace
 	for _, crb := range crbs.Items {
 		if crb.RoleRef.Name == name {

--- a/pkg/resourcecollector/serviceaccount.go
+++ b/pkg/resourcecollector/serviceaccount.go
@@ -15,5 +15,5 @@ func (r *ResourceCollector) serviceAccountToBeCollected(
 
 	// Don't migrate the default service account
 	name := metadata.GetName()
-	return name != "default", nil
+	return (name != "default" && name != "builder" && name != "deployer"), nil
 }


### PR DESCRIPTION
For clusterrole, get a list of crbs initially and use that to check if migration
is required

Also skip deployer and builder service accounts which are automatically created
on  OCP


**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
Use from #381 

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
No, #381 already merged for 2.2
