### PR TITLE
Create some default schedule policies

### DIFF
--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -290,6 +290,77 @@ func Init() error {
 		}
 	}
 
+	return createDefaultPolicy()
+}
+
+func createDefaultPolicy() error {
+	_, err := k8s.Instance().CreateSchedulePolicy(&stork_api.SchedulePolicy{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "default-migration-policy",
+		},
+		Policy: stork_api.SchedulePolicyItem{
+			Interval: &stork_api.IntervalPolicy{
+				IntervalMinutes: 1,
+			}},
+	})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	_, err = k8s.Instance().CreateSchedulePolicy(&stork_api.SchedulePolicy{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "default-interval-policy",
+		},
+		Policy: stork_api.SchedulePolicyItem{
+			Interval: &stork_api.IntervalPolicy{
+				IntervalMinutes: 15,
+				Retain:          10,
+			}},
+	})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	_, err = k8s.Instance().CreateSchedulePolicy(&stork_api.SchedulePolicy{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "default-daily-policy",
+		},
+		Policy: stork_api.SchedulePolicyItem{
+			Daily: &stork_api.DailyPolicy{
+				Time:   "12:00am",
+				Retain: 7,
+			}},
+	})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	_, err = k8s.Instance().CreateSchedulePolicy(&stork_api.SchedulePolicy{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "default-weekly-policy",
+		},
+		Policy: stork_api.SchedulePolicyItem{
+			Weekly: &stork_api.WeeklyPolicy{
+				Day:    "Sunday",
+				Time:   "12:00am",
+				Retain: 4,
+			}},
+	})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	_, err = k8s.Instance().CreateSchedulePolicy(&stork_api.SchedulePolicy{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "default-monthly-policy",
+		},
+		Policy: stork_api.SchedulePolicyItem{
+			Monthly: &stork_api.MonthlyPolicy{
+				Date:   15,
+				Time:   "12:00am",
+				Retain: 12,
+			}},
+	})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -25,12 +25,18 @@ func TestSchedule(t *testing.T) {
 	fakeKubeClient := kubernetes.NewSimpleClientset()
 
 	k8s.Instance().SetClient(fakeKubeClient, nil, fakeStorkClient, nil, nil, nil)
+	t.Run("createDefaultPoliciesTest", createDefaultPoliciesTest)
 	t.Run("triggerIntervalRequiredTest", triggerIntervalRequiredTest)
 	t.Run("triggerDailyRequiredTest", triggerDailyRequiredTest)
 	t.Run("triggerWeeklyRequiredTest", triggerWeeklyRequiredTest)
 	t.Run("triggerMonthlyRequiredTest", triggerMonthlyRequiredTest)
 	t.Run("validateSchedulePolicyTest", validateSchedulePolicyTest)
 	t.Run("policyRetainTest", policyRetainTest)
+}
+
+func createDefaultPoliciesTest(t *testing.T) {
+	err := createDefaultPolicy()
+	require.NoError(t, err, "Error creating default policies")
 }
 
 func triggerIntervalRequiredTest(t *testing.T) {

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -52,6 +52,12 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				return
 			}
 
+			_, err := k8s.Instance().GetSchedulePolicy(schedulePolicyName)
+			if err != nil {
+				util.CheckErr(fmt.Errorf("error getting schedulepolicy %v: %v", schedulePolicyName, err))
+				return
+			}
+
 			migrationSchedule := &storkv1.MigrationSchedule{
 				Spec: storkv1.MigrationScheduleSpec{
 					Template: storkv1.MigrationTemplateSpec{
@@ -71,7 +77,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 			}
 			migrationSchedule.Name = migrationScheduleName
 			migrationSchedule.Namespace = cmdFactory.GetNamespace()
-			_, err := k8s.Instance().CreateMigrationSchedule(migrationSchedule)
+			_, err = k8s.Instance().CreateMigrationSchedule(migrationSchedule)
 			if err != nil {
 				util.CheckErr(err)
 				return
@@ -87,7 +93,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 	createMigrationScheduleCommand.Flags().BoolVarP(&startApplications, "startApplications", "a", false, "Start applications on the destination cluster after migration")
 	createMigrationScheduleCommand.Flags().StringVarP(&preExecRule, "preExecRule", "", "", "Rule to run before executing migration")
 	createMigrationScheduleCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Rule to run after executing migration")
-	createMigrationScheduleCommand.Flags().StringVarP(&schedulePolicyName, "schedulePolicyName", "s", "", "Name of the schedule policy to use")
+	createMigrationScheduleCommand.Flags().StringVarP(&schedulePolicyName, "schedulePolicyName", "s", "default-migration-policy", "Name of the schedule policy to use")
 	createMigrationScheduleCommand.Flags().BoolVar(&suspend, "suspend", false, "Flag to denote whether schedule should be suspended on creation")
 
 	return createMigrationScheduleCommand

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -11,6 +11,7 @@ import (
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -39,6 +40,17 @@ func createMigrationScheduleAndVerify(
 	if postExecRule != "" {
 		cmdArgs = append(cmdArgs, "--postExecRule", postExecRule)
 	}
+
+	_, err := k8s.Instance().CreateSchedulePolicy(&storkv1.SchedulePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: schedulePolicyName,
+		},
+		Policy: storkv1.SchedulePolicyItem{
+			Interval: &storkv1.IntervalPolicy{
+				IntervalMinutes: 1,
+			}},
+	})
+	require.True(t, err == nil || errors.IsAlreadyExists(err), "Error creating schedulepolicy")
 
 	expected := "MigrationSchedule " + name + " created successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
@@ -264,5 +276,29 @@ func TestDeleteMigrationSchedules(t *testing.T) {
 	cmdArgs = []string{"delete", "migrationschedules", "-c", "clusterpair1"}
 	expected = "MigrationSchedule deletemigration1 deleted successfully\n"
 	expected += "MigrationSchedule deletemigration2 deleted successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestDefaultMigrationSchedulePolicy(t *testing.T) {
+	defer resetTest()
+	createMigrationScheduleAndVerify(t, "deletemigration", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", false)
+
+	// Create schedule without the default policy present
+	cmdArgs := []string{"create", "migrationschedules", "defaultpolicy", "-n", "test", "-c", "clusterpair", "--namespaces", "test"}
+	expected := "error: error getting schedulepolicy default-migration-policy: schedulepolicies.stork.libopenstorage.org \"default-migration-policy\" not found"
+	testCommon(t, cmdArgs, nil, expected, true)
+
+	// Create again adding default policy
+	_, err := k8s.Instance().CreateSchedulePolicy(&storkv1.SchedulePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default-migration-policy",
+		},
+		Policy: storkv1.SchedulePolicyItem{
+			Interval: &storkv1.IntervalPolicy{
+				IntervalMinutes: 1,
+			}},
+	})
+	require.NoError(t, err, "Error creating schedulepolicy")
+	expected = "MigrationSchedule defaultpolicy created successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 }


### PR DESCRIPTION
Also update strokctl to use a default policy for migration schedule

**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
* Added some default schedule policies:
  * default-migration-policy: Triggers after every minute
  * default-interval-policy: Triggers after every hour. Retains last 10
  * default-daily-policy: Triggers every day at 12:00am. Retains last 7
  * default-weekly-policy: Triggers every Sunday@12:00am. Retains last 4
  * default-monthly-policy: Triggers every 15th day of the month at 12:00am. Retains last 12.
```

**Does this change need to be cherry-picked to a release branch?**:
2.2

