### PR TITLE
Print N/A for volumes and resources when not migrating them

### DIFF
--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -364,19 +364,28 @@ func migrationPrinter(migrationList *storkv1.MigrationList, writer io.Writer, op
 				return err
 			}
 		}
-		totalVolumes := len(migration.Status.Volumes)
-		doneVolumes := 0
-		for _, volume := range migration.Status.Volumes {
-			if volume.Status == storkv1.MigrationStatusSuccessful {
-				doneVolumes++
+		volumeStatus := "N/A"
+		if migration.Spec.IncludeVolumes == nil || *migration.Spec.IncludeVolumes {
+			totalVolumes := len(migration.Status.Volumes)
+			doneVolumes := 0
+			for _, volume := range migration.Status.Volumes {
+				if volume.Status == storkv1.MigrationStatusSuccessful {
+					doneVolumes++
+				}
 			}
+			volumeStatus = fmt.Sprintf("%v/%v", doneVolumes, totalVolumes)
 		}
-		totalResources := len(migration.Status.Resources)
-		doneResources := 0
-		for _, resource := range migration.Status.Resources {
-			if resource.Status == storkv1.MigrationStatusSuccessful {
-				doneResources++
+
+		resourceStatus := "N/A"
+		if migration.Spec.IncludeResources == nil || *migration.Spec.IncludeResources {
+			totalResources := len(migration.Status.Resources)
+			doneResources := 0
+			for _, resource := range migration.Status.Resources {
+				if resource.Status == storkv1.MigrationStatusSuccessful {
+					doneResources++
+				}
 			}
+			resourceStatus = fmt.Sprintf("%v/%v", doneResources, totalResources)
 		}
 
 		elapsed := ""
@@ -391,15 +400,13 @@ func migrationPrinter(migrationList *storkv1.MigrationList, writer io.Writer, op
 		}
 
 		creationTime := toTimeString(migration.CreationTimestamp.Time)
-		if _, err := fmt.Fprintf(writer, "%v\t%v\t%v\t%v\t%v/%v\t%v/%v\t%v\t%v\n",
+		if _, err := fmt.Fprintf(writer, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 			name,
 			migration.Spec.ClusterPair,
 			migration.Status.Stage,
 			migration.Status.Status,
-			doneVolumes,
-			totalVolumes,
-			doneResources,
-			totalResources,
+			volumeStatus,
+			resourceStatus,
 			creationTime,
 			elapsed); err != nil {
 			return err

--- a/pkg/storkctl/migration_test.go
+++ b/pkg/storkctl/migration_test.go
@@ -9,6 +9,7 @@ import (
 
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	migration "github.com/libopenstorage/stork/pkg/migration/controllers"
+	ocpv1 "github.com/openshift/api/apps/v1"
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/stretchr/testify/require"
 	appv1 "k8s.io/api/apps/v1beta2"
@@ -213,6 +214,46 @@ func TestDeleteMigrations(t *testing.T) {
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 
+func TestExclueVolumesForMigrations(t *testing.T) {
+	defer resetTest()
+	name := "excludevolumestest"
+	namespace := "test"
+	createMigrationAndVerify(t, name, namespace, "clusterpair1", []string{"namespace1"}, "", "")
+	migration, err := k8s.Instance().GetMigration(name, namespace)
+	require.NoError(t, err, "Error getting migration")
+
+	include := false
+	migration.Spec.IncludeVolumes = &include
+	_, err = k8s.Instance().UpdateMigration(migration)
+	require.NoError(t, err, "Error updating migration")
+
+	expected := "NAME                 CLUSTERPAIR    STAGE     STATUS    VOLUMES   RESOURCES   CREATED   ELAPSED\n" +
+		name + "   clusterpair1                       N/A       0/0                   \n"
+
+	cmdArgs := []string{"get", "migrations", "-n", namespace}
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestExclueResourcesForMigrations(t *testing.T) {
+	defer resetTest()
+	name := "excluderesourcstest"
+	namespace := "test"
+	createMigrationAndVerify(t, name, namespace, "clusterpair1", []string{"namespace1"}, "", "")
+	migration, err := k8s.Instance().GetMigration(name, namespace)
+	require.NoError(t, err, "Error getting migration")
+
+	include := false
+	migration.Spec.IncludeResources = &include
+	_, err = k8s.Instance().UpdateMigration(migration)
+	require.NoError(t, err, "Error updating migration")
+
+	expected := "NAME                  CLUSTERPAIR    STAGE     STATUS    VOLUMES   RESOURCES   CREATED   ELAPSED\n" +
+		name + "   clusterpair1                       0/0       N/A                   \n"
+
+	cmdArgs := []string{"get", "migrations", "-n", namespace}
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
 func createMigratedDeployment(t *testing.T) {
 	replicas := int32(0)
 	_, err := k8s.Instance().CreateNamespace("dep", nil)
@@ -232,8 +273,8 @@ func createMigratedDeployment(t *testing.T) {
 	}
 	_, err = k8s.Instance().CreateDeployment(deployment)
 	require.NoError(t, err, "Error creating deployment")
-
 }
+
 func createMigratedStatefulSet(t *testing.T) {
 	replicas := int32(0)
 	_, err := k8s.Instance().CreateNamespace("sts", nil)
@@ -255,12 +296,39 @@ func createMigratedStatefulSet(t *testing.T) {
 	require.NoError(t, err, "Error creating statefulset")
 
 }
-func TestActivateDeactivateMigrations(t *testing.T) {
 
+func createMigratedDeploymentConfig(t *testing.T) {
+	replicas := int32(0)
+	_, err := k8s.Instance().CreateNamespace("depconf", nil)
+	require.NoError(t, err, "Error creating dep namespace")
+
+	deploymentConfig := &ocpv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "migratedDeploymentConfig",
+			Namespace: "depconf",
+			Annotations: map[string]string{
+				migration.StorkMigrationReplicasAnnotation: "1",
+			},
+		},
+		Spec: ocpv1.DeploymentConfigSpec{
+			Replicas: replicas,
+		},
+	}
+	_, err = k8s.Instance().CreateDeploymentConfig(deploymentConfig)
+	require.NoError(t, err, "Error creating deploymentconfig")
+}
+
+func TestActivateDeactivateMigrations(t *testing.T) {
 	createMigratedDeployment(t)
 	createMigratedStatefulSet(t)
+	createMigratedDeploymentConfig(t)
+
 	cmdArgs := []string{"activate", "migrations", "-n", "dep"}
 	expected := "Updated replicas for deployment dep/migratedDeployment to 1\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	cmdArgs = []string{"activate", "migrations", "-n", "depconf"}
+	expected = "Updated replicas for deploymentconfig depconf/migratedDeploymentConfig to 1\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
 	cmdArgs = []string{"activate", "migrations", "-n", "sts"}
@@ -271,6 +339,10 @@ func TestActivateDeactivateMigrations(t *testing.T) {
 	expected = "Updated replicas for deployment dep/migratedDeployment to 0\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
+	cmdArgs = []string{"deactivate", "migrations", "-n", "depconf"}
+	expected = "Updated replicas for deploymentconfig depconf/migratedDeploymentConfig to 0\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
 	cmdArgs = []string{"deactivate", "migrations", "-n", "sts"}
 	expected = "Updated replicas for statefulset sts/migratedStatefulSet to 0\n"
 	testCommon(t, cmdArgs, nil, expected, false)
@@ -278,10 +350,12 @@ func TestActivateDeactivateMigrations(t *testing.T) {
 	cmdArgs = []string{"activate", "migrations", "-a"}
 	expected = "Updated replicas for deployment dep/migratedDeployment to 1\n"
 	expected += "Updated replicas for statefulset sts/migratedStatefulSet to 3\n"
+	expected += "Updated replicas for deploymentconfig depconf/migratedDeploymentConfig to 1\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
 	cmdArgs = []string{"deactivate", "migrations", "-a"}
 	expected = "Updated replicas for deployment dep/migratedDeployment to 0\n"
 	expected += "Updated replicas for statefulset sts/migratedStatefulSet to 0\n"
+	expected += "Updated replicas for deploymentconfig depconf/migratedDeploymentConfig to 0\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 }


### PR DESCRIPTION
**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
Yes, updates output of `storkctl get migrations`

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
storkctl now prints `N/A` when volumes or resources are not being migrated
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.2

