### PR TITLE
Add wait options for storkctl create migrations

### DIFF
--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -3,16 +3,26 @@ package storkctl
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"strconv"
 	"time"
 
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	migration "github.com/libopenstorage/stork/pkg/migration/controllers"
 	"github.com/portworx/sched-ops/k8s"
+	"github.com/portworx/sched-ops/task"
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/printers"
+)
+
+const (
+	migrRetryTimeout = 30 * time.Second
+	migrTimeout      = 6 * time.Hour
+	stage            = "STAGE"
+	status           = "STATUS"
 )
 
 var migrationColumns = []string{"NAME", "CLUSTERPAIR", "STAGE", "STATUS", "VOLUMES", "RESOURCES", "CREATED", "ELAPSED"}
@@ -28,6 +38,7 @@ func newCreateMigrationCommand(cmdFactory Factory, ioStreams genericclioptions.I
 	var preExecRule string
 	var postExecRule string
 	var includeVolumes bool
+	var waitForCompletion bool
 
 	createMigrationCommand := &cobra.Command{
 		Use:     migrationSubcommand,
@@ -47,7 +58,6 @@ func newCreateMigrationCommand(cmdFactory Factory, ioStreams genericclioptions.I
 				util.CheckErr(fmt.Errorf("need to provide atleast one namespace to migrate"))
 				return
 			}
-
 			migration := &storkv1.Migration{
 				Spec: storkv1.MigrationSpec{
 					ClusterPair:       clusterPair,
@@ -66,14 +76,25 @@ func newCreateMigrationCommand(cmdFactory Factory, ioStreams genericclioptions.I
 				util.CheckErr(err)
 				return
 			}
-			msg := fmt.Sprintf("Migration %v created successfully", migration.Name)
-			printMsg(msg, ioStreams.Out)
+
+			if waitForCompletion {
+				msg, err := waitForMigration(migration.Name, migration.Namespace, ioStreams)
+				if err != nil {
+					util.CheckErr(err)
+					return
+				}
+				printMsg(msg, ioStreams.Out)
+			} else {
+				msg := "Migration " + migrationName + " created successfully"
+				printMsg(msg, ioStreams.Out)
+			}
 		},
 	}
 	createMigrationCommand.Flags().StringSliceVarP(&namespaceList, "namespaces", "", nil, "Comma separated list of namespaces to migrate")
 	createMigrationCommand.Flags().StringVarP(&clusterPair, "clusterPair", "c", "", "ClusterPair name for migration")
 	createMigrationCommand.Flags().BoolVarP(&includeResources, "includeResources", "r", true, "Include resources in the migration")
 	createMigrationCommand.Flags().BoolVarP(&includeVolumes, "includeVolumes", "", true, "Include volumees in the migration")
+	createMigrationCommand.Flags().BoolVarP(&waitForCompletion, "wait", "w", false, "Wait for migration to complete")
 	createMigrationCommand.Flags().BoolVarP(&startApplications, "startApplications", "a", true, "Start applications on the destination cluster after migration")
 	createMigrationCommand.Flags().StringVarP(&preExecRule, "preExecRule", "", "", "Rule to run before executing migration")
 	createMigrationCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Rule to run after executing migration")
@@ -413,4 +434,41 @@ func migrationPrinter(migrationList *storkv1.MigrationList, writer io.Writer, op
 		}
 	}
 	return nil
+}
+
+func waitForMigration(name, namespace string, ioStreams genericclioptions.IOStreams) (string, error) {
+	var msg string
+	var err error
+
+	log.SetFlags(0)
+	log.SetOutput(ioutil.Discard)
+	heading := fmt.Sprintf("%s\t\t%-20s", stage, status)
+	printMsg(heading, ioStreams.Out)
+	t := func() (interface{}, bool, error) {
+		migrResp, err := k8s.Instance().GetMigration(name, namespace)
+		if err != nil {
+			util.CheckErr(err)
+			return "", false, err
+		}
+		stat := fmt.Sprintf("%s\t\t%-20s", migrResp.Status.Stage, migrResp.Status.Status)
+		printMsg(stat, ioStreams.Out)
+		if migrResp.Status.Status == storkv1.MigrationStatusSuccessful ||
+			migrResp.Status.Status == storkv1.MigrationStatusPartialSuccess {
+			msg = fmt.Sprintf("Migration %v completed successfully", name)
+			return "", false, nil
+		}
+		if migrResp.Status.Status == storkv1.MigrationStatusFailed {
+			msg = fmt.Sprintf("Migration %v failed", name)
+			return "", false, nil
+		}
+		return "", true, fmt.Errorf("%v", migrResp.Status.Status)
+	}
+	// sleep just so that instead of blank initial stage/status,
+	// we have something at start
+	time.Sleep(5 * time.Second)
+	if _, err = task.DoRetryWithTimeout(t, migrTimeout, migrRetryTimeout); err != nil {
+		msg = "Timed out performing task"
+	}
+
+	return msg, err
 }


### PR DESCRIPTION
**What type of PR is this?**
> enhancement

**What this PR does / why we need it**:
Add wait support for storkctl ```create migrations```

**Does this PR change a user-facing CRD or CLI?**:
Yes, with -w/wait option to storkctl create migration,  user can wait till operation completes

eg output :-
```
# ./storkctl create migration  -c testclusterpair -a --namespaces default ngnixmigration14 -w
STAGE		STATUS
Volumes		InProgress
Volumes		InProgress
Final		Failed
Migration ngnixmigration14 failed
```
**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note

```

**Does this change need to be cherry-picked to a release branch?**:
yes
