### PR TITLE
Portworx ClusterDomainsStatus: Do not fail on volume enumerate errors.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1743,19 +1743,25 @@ func (p *portworx) GetClusterDomains() (*stork_crd.ClusterDomains, error) {
 		LocalDomain: nodeToDomainMap[cluster.NodeId],
 	}
 
+	var (
+		vols []*api.Volume
+	)
+
+	syncStatusUnknown := true
 	volDriver, err := p.getAdminVolDriver()
 	if err != nil {
 		logrus.Errorf("Failed to get a volumeDriver: %v", err)
-		return nil, err
+		goto cluster_domain_info
 	}
 
 	// get all the volumes in this cluster
-	vols, err := volDriver.Enumerate(&api.VolumeLocator{}, nil)
+	vols, err = volDriver.Enumerate(&api.VolumeLocator{}, nil)
 	if err != nil {
 		logrus.Errorf("Failed to enumerate volumes: %v", err)
-		return nil, err
+		goto cluster_domain_info
 	}
 
+	syncStatusUnknown = false
 	for _, vol := range vols {
 		// get the node (replicas) which are not in the current set
 		// but exist in the create set. These are the replica nodes
@@ -1773,9 +1779,14 @@ func (p *portworx) GetClusterDomains() (*stork_crd.ClusterDomains, error) {
 		}
 	}
 
+cluster_domain_info:
+
 	// Build the cluster domain infos object
 	for domain, isActive := range domainStateMap {
-		syncStatus := domainSyncStatusMap[domain]
+		syncStatus := stork_crd.ClusterDomainSyncStatusUnknown
+		if !syncStatusUnknown {
+			syncStatus = domainSyncStatusMap[domain]
+		}
 		clusterDomainState := stork_crd.ClusterDomainInactive
 		if isActive {
 			clusterDomainState = stork_crd.ClusterDomainActive

--- a/pkg/apis/stork/v1alpha1/clusterdomainsstatus.go
+++ b/pkg/apis/stork/v1alpha1/clusterdomainsstatus.go
@@ -34,6 +34,8 @@ const (
 	ClusterDomainSyncStatusInProgress ClusterDomainSyncStatus = "SyncInProgress"
 	// ClusterDomainSyncStatusNotInSync indicates the cluster domain is not in sync
 	ClusterDomainSyncStatusNotInSync ClusterDomainSyncStatus = "NotInSync"
+	// ClusterDomainSyncStatusUnknown indicates the cluster domain sync status is currently not known
+	ClusterDomainSyncStatusUnknown ClusterDomainSyncStatus = "SyncStatusUnknown"
 )
 
 // ClusterDomains provides a list of activated cluster domains and a list


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
Portworx Driver
- Change the GetClusterDomains API to not return an error when it fails to fetch the volume list
- Add a new status SyncStatusUnknown


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Yes
```release-note
Add a new SyncStatus Unknown when the driver fails to fetch the storage sync status
```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.2

