### PR TITLE
Fail migrations if domain is inactive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(BUILD_TYPE),debug)
 BUILDFLAGS += -gcflags "-N -l"
 endif
 
-RELEASE_VER := 2.2.3
+RELEASE_VER := 2.2.4
 BASE_DIR    := $(shell git rev-parse --show-toplevel)
 GIT_SHA     := $(shell git rev-parse --short HEAD)
 BIN         :=$(BASE_DIR)/bin

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1739,6 +1739,9 @@ func (p *portworx) GetClusterDomains() (*stork_crd.ClusterDomains, error) {
 	// get the domain to state (active/inactive) map
 	domainStateMap, err := p.getDomainStateMap()
 	if err != nil {
+		if strings.HasSuffix(err.Error(), "node is not initialized with cluster domains") {
+			return &stork_crd.ClusterDomains{}, nil
+		}
 		logrus.Errorf("Failed to get domain name to state map: %v", err)
 		return nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
* Migrations will be marked as Failed if the local cluster domain is inactive
* Updated migration behavior for PVs
  * Setting reclaim policy to Retain if volumes aren't being migrated
  * Updating PV if it already exists instead of deleting and creating
```

**Does this change need to be cherry-picked to a release branch?**:
No, this is for 2.2 branch. Will send separate PR for master since code has changed there.
