### PR TITLE
Add storcktl cmd for volumesnapshotrestore crd's

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -753,14 +753,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8dea5f278f7935c01a6cb1757a6b10c2b9dbab5306b14b644c16bb168406b391"
+  digest = "1:2277c50cc404f9b12bd3d8286d806cc95fda65b3d0eb08c82ce9cb7118b4f03c"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s",
     "task",
   ]
   pruneopts = "UT"
-  revision = "5ad42621478d99aa5b313ab00c7d706c0407313b"
+  revision = "465f2f0585413db8efdfebd781778cc9d0e940ce"
 
 [[projects]]
   branch = "master"

--- a/pkg/storkctl/create.go
+++ b/pkg/storkctl/create.go
@@ -18,6 +18,7 @@ func newCreateCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams)
 		newCreatePVCCommand(cmdFactory, ioStreams),
 		newCreateSnapshotScheduleCommand(cmdFactory, ioStreams),
 		newCreateGroupSnapshotCommand(cmdFactory, ioStreams),
+		newCreateVolumeSnapshotRestoreCommand(cmdFactory, ioStreams),
 	)
 
 	return createCommands

--- a/pkg/storkctl/delete.go
+++ b/pkg/storkctl/delete.go
@@ -17,6 +17,7 @@ func newDeleteCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams)
 		newDeleteMigrationScheduleCommand(cmdFactory, ioStreams),
 		newDeleteSnapshotScheduleCommand(cmdFactory, ioStreams),
 		newDeleteGroupVolumeSnapshotCommand(cmdFactory, ioStreams),
+		newDeleteVolumeSnapshotRestoreCommand(cmdFactory, ioStreams),
 	)
 	return deleteCommands
 }

--- a/pkg/storkctl/get.go
+++ b/pkg/storkctl/get.go
@@ -26,6 +26,7 @@ func newGetCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *c
 		newGetGroupVolumeSnapshotCommand(cmdFactory, ioStreams),
 		newGetClusterDomainsStatusCommand(cmdFactory, ioStreams),
 		newGetClusterDomainUpdateCommand(cmdFactory, ioStreams),
+		newGetVolumeSnapshotRestoreCommand(cmdFactory, ioStreams),
 	)
 
 	return getCommands

--- a/pkg/storkctl/snapshot.go
+++ b/pkg/storkctl/snapshot.go
@@ -7,9 +7,10 @@ import (
 
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 	"github.com/libopenstorage/stork/drivers/volume"
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
@@ -18,7 +19,9 @@ import (
 
 var snapshotColumns = []string{"NAME", "PVC", "STATUS", "CREATED", "COMPLETED", "TYPE"}
 var snapSubcommand = "volumesnapshots"
+var restoreSubCommand = "volumesnapshotrestore"
 var snapAliases = []string{"volumesnapshot", "snapshots", "snapshot", "snap"}
+var snapRestoreColumns = []string{"NAME", "SOURCE-SNAPSHOT", "SOURCE-SNAPSHOT-NAMESPACE", "STATUS", "VOLUMES", "CREATED"}
 
 func newCreateSnapshotCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	var snapName string
@@ -219,4 +222,156 @@ func getSnapshotStatusAndTime(snap *snapv1.VolumeSnapshot) (string, string) {
 		}
 	}
 	return string(snapv1.VolumeSnapshotConditionPending), toTimeString(time.Time{})
+}
+
+func newCreateVolumeSnapshotRestoreCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	var snapName string
+	var snapNamespace string
+	var snapGroup bool
+
+	restoreSnapshotCommand := &cobra.Command{
+		Use:     restoreSubCommand,
+		Aliases: []string{"restore"},
+		Short:   "Restore snapshot to source PVC",
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) != 1 {
+				util.CheckErr(fmt.Errorf("exactly one argument needs to be provided for volumesnapshotrestore name"))
+				return
+			}
+			restoreCRDName := args[0]
+			snapRestore := &storkv1.VolumeSnapshotRestore{
+				Spec: storkv1.VolumeSnapshotRestoreSpec{
+					SourceName:      snapName,
+					SourceNamespace: snapNamespace,
+					GroupSnapshot:   snapGroup,
+				},
+			}
+			snapRestore.Name = restoreCRDName
+			snapRestore.Namespace = cmdFactory.GetNamespace()
+			_, err := k8s.Instance().CreateVolumeSnapshotRestore(snapRestore)
+			if err != nil {
+				util.CheckErr(err)
+				return
+			}
+
+			msg := fmt.Sprintf("Snapshot restore %v started successfully", restoreCRDName)
+			printMsg(msg, ioStreams.Out)
+		},
+	}
+	restoreSnapshotCommand.Flags().StringVarP(&snapName, "snapname", "", "", "Snapshot name to be restored")
+	restoreSnapshotCommand.Flags().StringVarP(&snapNamespace, "sourcenamepace", "", "default", "Namespace of snapshot")
+	restoreSnapshotCommand.Flags().BoolVarP(&snapGroup, "groupsnapshot", "g", false, "True if snapshot is group, default false")
+	return restoreSnapshotCommand
+}
+
+func newGetVolumeSnapshotRestoreCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	restoreSnapshotCommand := &cobra.Command{
+		Use:     restoreSubCommand,
+		Aliases: []string{"restore"},
+		Short:   "Get snapshot restore status",
+		Run: func(c *cobra.Command, args []string) {
+			var snapRestoreList *storkv1.VolumeSnapshotRestoreList
+			var err error
+
+			namespaces, err := cmdFactory.GetAllNamespaces()
+			if err != nil {
+				util.CheckErr(err)
+				return
+			}
+
+			if len(args) > 0 {
+				fmt.Println("Restore list")
+				snapRestoreList = new(storkv1.VolumeSnapshotRestoreList)
+				for _, restoreName := range args {
+					for _, ns := range namespaces {
+						snapRestore, err := k8s.Instance().GetVolumeSnapshotRestore(restoreName, ns)
+						if err != nil {
+							util.CheckErr(err)
+							return
+						}
+						snapRestoreList.Items = append(snapRestoreList.Items, *snapRestore)
+					}
+				}
+			} else {
+				fmt.Println("Restore list else")
+				var tempRestoreList storkv1.VolumeSnapshotRestoreList
+				for _, ns := range namespaces {
+					snapRestoreList, err = k8s.Instance().ListVolumeSnapshotRestore(ns)
+					if err != nil {
+						util.CheckErr(err)
+						return
+					}
+					tempRestoreList.Items = append(tempRestoreList.Items, snapRestoreList.Items...)
+				}
+				snapRestoreList = &tempRestoreList
+			}
+
+			if len(snapRestoreList.Items) == 0 {
+				handleEmptyList(ioStreams.Out)
+				return
+			}
+
+			if err := printObjects(c, snapRestoreList, cmdFactory, snapRestoreColumns, snapshotRestorePrinter, ioStreams.Out); err != nil {
+				util.CheckErr(err)
+				return
+			}
+		},
+	}
+
+	cmdFactory.BindGetFlags(restoreSnapshotCommand.Flags())
+	return restoreSnapshotCommand
+}
+
+func newDeleteVolumeSnapshotRestoreCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	restoreSnapshotCommand := &cobra.Command{
+		Use:     restoreSubCommand,
+		Aliases: []string{"restore"},
+		Short:   "Delete Volume snapshot restore",
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) == 0 {
+				util.CheckErr(fmt.Errorf("at least one argument needs to be provided for volumesnapshotrestore name"))
+				return
+			}
+			name := args[0]
+			err := k8s.Instance().DeleteVolumeSnapshotRestore(name, cmdFactory.GetNamespace())
+			if err != nil {
+				util.CheckErr(err)
+				return
+			}
+
+			msg := fmt.Sprintf("Volume snapshot restore %v deleted successfully", name)
+			printMsg(msg, ioStreams.Out)
+		},
+	}
+
+	return restoreSnapshotCommand
+}
+
+func snapshotRestorePrinter(snapRestoreList *storkv1.VolumeSnapshotRestoreList, writer io.Writer, options printers.PrintOptions) error {
+	if snapRestoreList == nil {
+		return nil
+	}
+
+	for _, snapRestore := range snapRestoreList.Items {
+		name := printers.FormatResourceName(options.Kind, snapRestore.Name, options.WithKind)
+
+		if options.WithNamespace {
+			if _, err := fmt.Fprintf(writer, "%v\t", snapRestore.Namespace); err != nil {
+				return err
+			}
+		}
+
+		creationTime := toTimeString(snapRestore.CreationTimestamp.Time)
+		if _, err := fmt.Fprintf(writer, "%v\t%v\t%v\t%v\t%d\t%v\n",
+			name,
+			snapRestore.Spec.SourceName,
+			snapRestore.Spec.SourceNamespace,
+			snapRestore.Status.Status,
+			len(snapRestore.Status.Volumes),
+			creationTime,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/storkctl/snapshot_test.go
+++ b/pkg/storkctl/snapshot_test.go
@@ -3,9 +3,11 @@
 package storkctl
 
 import (
+	"strconv"
 	"testing"
 
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,4 +140,99 @@ func TestDeleteSnapshotsNoSnapshots(t *testing.T) {
 
 	expected := "No resources found.\n"
 	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestGetVolumeSnapshotRestoreNoRestores(t *testing.T) {
+	cmdArgs := []string{"get", "volumesnapshotrestore"}
+
+	var snapshots storkv1.VolumeSnapshotRestoreList
+	expected := "No resources found.\n"
+	testCommon(t, cmdArgs, &snapshots, expected, false)
+}
+
+func TestGetVolumeSnapshotRestoreAllRestores(t *testing.T) {
+
+	_, err := k8s.Instance().CreateNamespace("ns", nil)
+	require.NoError(t, err, "Error creating ns namespace")
+	_, err = k8s.Instance().CreateNamespace("default", nil)
+	require.NoError(t, err, "Error creating ns1 namespace")
+
+	cmdArgs := []string{"get", "volumesnapshotrestore", "--all-namespaces"}
+	createSnapshotRestoreAndVerify(t, "test1", "asdf", "sourceSnapName1", "default", false)
+	createSnapshotRestoreAndVerify(t, "test2", "default", "sourceSnapName2", "default", false)
+	createSnapshotRestoreAndVerify(t, "test3", "ns", "sourceSnapName3", "ns", false)
+
+	var snapshots storkv1.VolumeSnapshotRestoreList
+	expected := "NAMESPACE   NAME      SOURCE-SNAPSHOT   SOURCE-SNAPSHOT-NAMESPACE   STATUS    VOLUMES   CREATED\n" +
+		"ns          test3     sourceSnapName3   ns                                    0         \n" +
+		"default     test2     sourceSnapName2   default                               0         \n"
+	testCommon(t, cmdArgs, &snapshots, expected, false)
+}
+
+func TestGetVolumeSnapshotsOneRestore(t *testing.T) {
+	crdRestore := "crd-restore-test"
+	cmdArgs := []string{"get", "volumesnapshotrestore", crdRestore}
+	namespace := "default"
+	createSnapshotRestoreAndVerify(t, crdRestore, namespace, "sourceSnapName", "sourceSnapnamespace", false)
+	expected := "NAME               SOURCE-SNAPSHOT   SOURCE-SNAPSHOT-NAMESPACE   STATUS    VOLUMES   CREATED\n" +
+		"crd-restore-test   sourceSnapName    sourceSnapnamespace                   0         \n"
+
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestGetVolumeSnapshotMultipleRestore(t *testing.T) {
+	crdRestore1 := "crd-restore1"
+	crdRestore2 := "crd-restore2"
+	namespace := "default"
+
+	createSnapshotRestoreAndVerify(t, crdRestore1, namespace, "sourceName1", "sourceNamespace1", false)
+	createSnapshotRestoreAndVerify(t, crdRestore2, namespace, "sourceName2", "sourceNamespace2", false)
+
+	expected := "NAME               SOURCE-SNAPSHOT   SOURCE-SNAPSHOT-NAMESPACE   STATUS    VOLUMES   CREATED\n" +
+		"test2              sourceSnapName2   default                               0         \n" +
+		"crd-restore-test   sourceSnapName    sourceSnapnamespace                   0         \n" +
+		"crd-restore1       sourceName1       sourceNamespace1                      0         \n" +
+		"crd-restore2       sourceName2       sourceNamespace2                      0         \n"
+
+	cmdArgs := []string{"get", "volumesnapshotrestore"}
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestDeleteVolumeSnapshotRestore(t *testing.T) {
+	crdRestore := "crd-restore"
+	namespace := "default"
+
+	createSnapshotRestoreAndVerify(t, crdRestore, namespace, "sourceName1", "sourceNamespace1", false)
+
+	expected := "Volume snapshot restore " + crdRestore + " deleted successfully\n"
+
+	cmdArgs := []string{"delete", "volumesnapshotrestore", crdRestore}
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestVolumeSnapshotRestoreWithNoName(t *testing.T) {
+	expected := "error: exactly one argument needs to be provided for volumesnapshotrestore name"
+	cmdArgs := []string{"create", "volumesnapshotrestore"}
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func createSnapshotRestoreAndVerify(
+	t *testing.T,
+	name string,
+	namespace string,
+	sourceName string,
+	sourceNamespace string,
+	isGroup bool,
+) {
+	cmdArgs := []string{"create", "volumesnapshotrestore", "-n", namespace, "--snapname", sourceName, "--sourcenamepace", sourceNamespace, "-g=" + strconv.FormatBool(isGroup), name}
+	expected := "Snapshot restore " + name + " started successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// Make sure it was created correctly
+	snapRestore, err := k8s.Instance().GetVolumeSnapshotRestore(name, namespace)
+	require.NoError(t, err, "Error getting volumesnapshotrestores")
+	require.Equal(t, name, snapRestore.Name, "VolumeSnapshotRestore name mismatch")
+	require.Equal(t, sourceName, snapRestore.Spec.SourceName, "VolumeSnapshotRestore sourceName mismatch")
+	require.Equal(t, sourceNamespace, snapRestore.Spec.SourceNamespace, "VolumeSnapshotRestore sourceNamespace mismatch")
+	require.Equal(t, isGroup, snapRestore.Spec.GroupSnapshot, "VolumeSnapshotRestore isGroupSnapshot mismatch")
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/k8s.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/k8s.go
@@ -92,6 +92,7 @@ type Ops interface {
 	BackupLocationOps
 	ApplicationBackupRestoreOps
 	ApplicationCloneOps
+	VolumeSnapshotRestoreOps
 	GetVersion() (*version.Info, error)
 	SetConfig(config *rest.Config)
 	SetClient(
@@ -479,6 +480,19 @@ type GroupSnapshotOps interface {
 	ValidateGroupSnapshot(name, namespace string, retry bool, timeout, retryInterval time.Duration) error
 	// GetSnapshotsForGroupSnapshot returns all child snapshots for the group snapshot
 	GetSnapshotsForGroupSnapshot(name, namespace string) ([]*snap_v1.VolumeSnapshot, error)
+}
+
+// VolumeSnapshotRestoreOps is interface to perform snapshot restore using CRD
+type VolumeSnapshotRestoreOps interface {
+	// CreateVolumeSnapshotRestore restore snapshot to pvc specifed in CRD, if no pvcs defined we restore to
+	// parent volumes
+	CreateVolumeSnapshotRestore(snap *v1alpha1.VolumeSnapshotRestore) (*v1alpha1.VolumeSnapshotRestore, error)
+	// GetVolumeSnapshotRestore returns details of given restore crd status
+	GetVolumeSnapshotRestore(name, namespace string) (*v1alpha1.VolumeSnapshotRestore, error)
+	// ListVolumeSnapshotRestore return list of snapshot in given namespaces
+	ListVolumeSnapshotRestore(namespace string) (*v1alpha1.VolumeSnapshotRestoreList, error)
+	// DeleteVolumeSnapshotRestore delete CRD for restore
+	DeleteVolumeSnapshotRestore(name, namespace string) error
 }
 
 // RuleOps is an interface to perform operations for k8s stork rule
@@ -3532,6 +3546,37 @@ func (k *k8sOps) GetSnapshotsForGroupSnapshot(name, namespace string) ([]*snap_v
 }
 
 // GroupSnapshot APIs - END
+
+// Restore Snapshot APIs - BEGIN
+func (k *k8sOps) CreateVolumeSnapshotRestore(snapRestore *v1alpha1.VolumeSnapshotRestore) (*v1alpha1.VolumeSnapshotRestore, error) {
+	if err := k.initK8sClient(); err != nil {
+		return nil, err
+	}
+	return k.storkClient.Stork().VolumeSnapshotRestores(snapRestore.Namespace).Create(snapRestore)
+}
+
+func (k *k8sOps) GetVolumeSnapshotRestore(name, namespace string) (*v1alpha1.VolumeSnapshotRestore, error) {
+	if err := k.initK8sClient(); err != nil {
+		return nil, err
+	}
+	return k.storkClient.Stork().VolumeSnapshotRestores(namespace).Get(name, meta_v1.GetOptions{})
+}
+
+func (k *k8sOps) ListVolumeSnapshotRestore(namespace string) (*v1alpha1.VolumeSnapshotRestoreList, error) {
+	if err := k.initK8sClient(); err != nil {
+		return nil, err
+	}
+	return k.storkClient.Stork().VolumeSnapshotRestores(namespace).List(meta_v1.ListOptions{})
+}
+
+func (k *k8sOps) DeleteVolumeSnapshotRestore(name, namespace string) error {
+	if err := k.initK8sClient(); err != nil {
+		return err
+	}
+	return k.storkClient.Stork().VolumeSnapshotRestores(namespace).Delete(name, &meta_v1.DeleteOptions{})
+}
+
+// Restore Snapshot APIs - END
 
 // Rule APIs - BEGIN
 func (k *k8sOps) GetRule(name, namespace string) (*v1alpha1.Rule, error) {

--- a/vendor/github.com/portworx/sched-ops/k8s/k8s.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/k8s.go
@@ -482,16 +482,16 @@ type GroupSnapshotOps interface {
 	GetSnapshotsForGroupSnapshot(name, namespace string) ([]*snap_v1.VolumeSnapshot, error)
 }
 
-// VolumeSnapshotRestoreOps is interface to perform snapshot restore using CRD
+// VolumeSnapshotRestoreOps is interface to perform isnapshot restore using CRD
 type VolumeSnapshotRestoreOps interface {
 	// CreateVolumeSnapshotRestore restore snapshot to pvc specifed in CRD, if no pvcs defined we restore to
 	// parent volumes
 	CreateVolumeSnapshotRestore(snap *v1alpha1.VolumeSnapshotRestore) (*v1alpha1.VolumeSnapshotRestore, error)
 	// GetVolumeSnapshotRestore returns details of given restore crd status
 	GetVolumeSnapshotRestore(name, namespace string) (*v1alpha1.VolumeSnapshotRestore, error)
-	// ListVolumeSnapshotRestore return list of snapshot in given namespaces
+	// ListVolumeSnapshotRestore return list of volumesnapshotrestores in given namespaces
 	ListVolumeSnapshotRestore(namespace string) (*v1alpha1.VolumeSnapshotRestoreList, error)
-	// DeleteVolumeSnapshotRestore delete CRD for restore
+	// DeleteVolumeSnapshotRestore delete given volumesnapshotrestore CRD
 	DeleteVolumeSnapshotRestore(name, namespace string) error
 }
 


### PR DESCRIPTION
**What type of PR is this?**
>feature
>unit-test

**What this PR does / why we need it**:
PR add storctl support for in place volume restore. Consecutive PR for  https://github.com/libopenstorage/stork/pull/353

**Does this PR change a user-facing CRD or CLI?**:
yes, add support for `volumesnapshotrestore` crd in storkctl.

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

