### PR TITLE
[Portworx] Fail Portworx driver init if service doesn't have required ports

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -71,9 +71,6 @@ const (
 	// default API port
 	defaultAPIPort = 9001
 
-	// default SDK port
-	defaultSDKPort = 9020
-
 	// provisioner names for portworx volumes
 	provisionerName    = "kubernetes.io/portworx-volume"
 	csiProvisionerName = "com.openstorage.pxd"
@@ -270,9 +267,6 @@ func (p *portworx) initPortworxClients() error {
 		return fmt.Errorf("failed to get endpoint for portworx volume driver")
 	}
 
-	p.restPort = defaultAPIPort
-	p.sdkPort = defaultSDKPort
-
 	// Get the ports from service
 	for _, svcPort := range svc.Spec.Ports {
 		if svcPort.Name == pxSdkPort &&
@@ -282,6 +276,16 @@ func (p *portworx) initPortworxClients() error {
 			svcPort.Port != 0 {
 			p.restPort = int(svcPort.Port)
 		}
+	}
+
+	// check if the ports were parsed
+	if p.sdkPort == 0 || p.restPort == 0 {
+		err := fmt.Errorf("%s in %s namespace has been not updated to the latest spec. "+
+			"%s and/or %s ports are missing. Follow "+
+			"https://docs.portworx.com/portworx-install-with-kubernetes/operate-and-maintain-on-kubernetes/upgrade/"+
+			" to upgrade Portworx", serviceName, namespace, pxSdkPort, pxRestPort)
+		logrus.Errorf(err.Error())
+		return err
 	}
 
 	logrus.Infof("Using %v:%v as endpoint for portworx REST endpoint", endpoint, p.restPort)


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>


**What type of PR is this?**
>bug

**What this PR does / why we need it**:

If the Portworx driver doesn't find the ports it needs in the k8s service, fail the initialization. These ports on the service are required for the Portworx driver to function. So it's safer to explicitly fail the init if the ports are missing.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Fixed an issue where Portworx driver would attempt to make API calls to a non-existing portworx service port.
```

**Does this change need to be cherry-picked to a release branch?**: 2.1.3, 2.2.5

