### PR TITLE
Remove gosimple as it is no longer available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(BUILD_TYPE),debug)
 BUILDFLAGS += -gcflags "-N -l"
 endif
 
-RELEASE_VER := 2.2.4
+RELEASE_VER := 2.2.5
 BASE_DIR    := $(shell git rev-parse --show-toplevel)
 GIT_SHA     := $(shell git rev-parse --short HEAD)
 BIN         :=$(BASE_DIR)/bin

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BUILD_OPTIONS := -ldflags=$(LDFLAGS)
 .DEFAULT_GOAL=all
 .PHONY: test clean vendor vendor-update
 
-all: stork storkctl cmdexecutor vet lint simple
+all: stork storkctl cmdexecutor vet lint
 
 vendor-update:
 	dep ensure -update
@@ -50,12 +50,6 @@ lint:
 vet:
 	go vet $(PKGS)
 
-$(GOPATH)/bin/gosimple:
-	go get -u honnef.co/go/tools/cmd/gosimple
-
-simple: $(GOPATH)/bin/gosimple
-	$(GOPATH)/bin/gosimple $(PKGS)
-
 errcheck:
 	go get -v github.com/kisielk/errcheck
 	errcheck -verbose -blank $(PKGS)
@@ -66,7 +60,7 @@ check-fmt:
 do-fmt:
 	 gofmt -s -w $(GO_FILES)
 
-pretest: check-fmt lint vet errcheck simple
+pretest: check-fmt lint vet errcheck
 
 test:
 	echo "" > coverage.txt


### PR DESCRIPTION
Also update version to 2.2.5

**What type of PR is this?**
Cleanup

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

