### PR TITLE
When uploading objects don't close writer async

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -501,15 +501,18 @@ func (a *ApplicationBackupController) uploadObject(
 	if err != nil {
 		return err
 	}
-	defer func() {
-		err := writer.Close()
-		if err != nil {
-			log.ApplicationBackupLog(backup).Errorf("Error closing writer for objectstore: %v", err)
-		}
-	}()
 
 	_, err = writer.Write(data)
 	if err != nil {
+		closeErr := writer.Close()
+		if closeErr != nil {
+			log.ApplicationBackupLog(backup).Errorf("Error closing writer for objectstore: %v", closeErr)
+		}
+		return err
+	}
+	err = writer.Close()
+	if err != nil {
+		log.ApplicationBackupLog(backup).Errorf("Error closing writer for objectstore: %v", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
It can return errors which should be reported back


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

