### PR TITLE
Store snapshot schedule info in annotations instead of labels

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -726,15 +726,17 @@ func (p *portworx) addCloudsnapInfo(
 	request *api.CloudBackupCreateRequest,
 	snap *crdv1.VolumeSnapshot,
 ) {
-	if scheduleName, exists := snap.Metadata.Labels[snapshotcontrollers.SnapshotScheduleNameLabel]; exists {
-		if policyType, exists := snap.Metadata.Labels[snapshotcontrollers.SnapshotSchedulePolicyTypeLabel]; exists {
-			request.Labels[cloudBackupExternalManagerLabel] = "Stork-" + scheduleName + "-" + snap.Metadata.Namespace + "-" + policyType
-			// Use full backups for weekly and montly snaps
-			if policyType == string(stork_crd.SchedulePolicyTypeWeekly) ||
-				policyType == string(stork_crd.SchedulePolicyTypeMonthly) {
-				request.Full = true
+	if snap.Metadata.Annotations != nil {
+		if scheduleName, exists := snap.Metadata.Annotations[snapshotcontrollers.SnapshotScheduleNameAnnotation]; exists {
+			if policyType, exists := snap.Metadata.Annotations[snapshotcontrollers.SnapshotSchedulePolicyTypeAnnotation]; exists {
+				request.Labels[cloudBackupExternalManagerLabel] = "Stork-" + scheduleName + "-" + snap.Metadata.Namespace + "-" + policyType
+				// Use full backups for weekly and monthly snaps
+				if policyType == string(stork_crd.SchedulePolicyTypeWeekly) ||
+					policyType == string(stork_crd.SchedulePolicyTypeMonthly) {
+					request.Full = true
+				}
+				return
 			}
-			return
 		}
 	}
 	request.Labels[cloudBackupExternalManagerLabel] = "StorkManual"

--- a/pkg/snapshot/controllers/snapshotschedule.go
+++ b/pkg/snapshot/controllers/snapshotschedule.go
@@ -28,12 +28,12 @@ const (
 	validateCRDInterval  time.Duration = 5 * time.Second
 	validateCRDTimeout   time.Duration = 1 * time.Minute
 
-	// SnapshotScheduleNameLabel Label used to specify the name of schedule that
+	// SnapshotScheduleNameAnnotation Annotation used to specify the name of schedule that
 	// created the snapshot
-	SnapshotScheduleNameLabel = "stork.libopenstorage.org/snapshotScheduleName"
-	// SnapshotSchedulePolicyTypeLabel Label used to specify the type of the
+	SnapshotScheduleNameAnnotation = "stork.libopenstorage.org/snapshotScheduleName"
+	// SnapshotSchedulePolicyTypeAnnotation Annotation used to specify the type of the
 	// policy that triggered the snapshot
-	SnapshotSchedulePolicyTypeLabel = "stork.libopenstorage.org/snapshotSchedulePolicyType"
+	SnapshotSchedulePolicyTypeAnnotation = "stork.libopenstorage.org/snapshotSchedulePolicyType"
 )
 
 // SnapshotScheduleController reconciles VolumeSnapshotSchedule objects
@@ -269,11 +269,11 @@ func (s *SnapshotScheduleController) startVolumeSnapshot(snapshotSchedule *stork
 		},
 		Spec: snapshotSchedule.Spec.Template.Spec,
 	}
-	if snapshot.Metadata.Labels == nil {
-		snapshot.Metadata.Labels = make(map[string]string)
+	if snapshot.Metadata.Annotations == nil {
+		snapshot.Metadata.Annotations = make(map[string]string)
 	}
-	snapshot.Metadata.Labels[SnapshotScheduleNameLabel] = snapshotSchedule.Name
-	snapshot.Metadata.Labels[SnapshotSchedulePolicyTypeLabel] = string(policyType)
+	snapshot.Metadata.Annotations[SnapshotScheduleNameAnnotation] = snapshotSchedule.Name
+	snapshot.Metadata.Annotations[SnapshotSchedulePolicyTypeAnnotation] = string(policyType)
 
 	log.VolumeSnapshotScheduleLog(snapshotSchedule).Infof("Starting snapshot %v", snapshotName)
 	// If reclaim policy is set to Delete, this will delete the snapshots


### PR DESCRIPTION
Values in labels have a smaller length limit and the info should be an
annotation anyways

Fixes #415


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Fixed issue with failing scheduled snapshots if the snapshot schedule name was longer than 64 characters
```

**Does this change need to be cherry-picked to a release branch?**:
2.2
