### PR TITLE
Validate name and namespace when generating clusterpair

### DIFF
--- a/pkg/storkctl/clusterpair_test.go
+++ b/pkg/storkctl/clusterpair_test.go
@@ -111,28 +111,16 @@ func TestGetClusterPairsWithStatus(t *testing.T) {
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 
-/*
-func TestGenerateClusterPair(t *testing.T) {
-	cmdArgs := []string{"clusterpair", "pair1"}
+func TestGenerateClusterPairInvalidName(t *testing.T) {
+	cmdArgs := []string{"generate", "clusterpair", "pair_test", "-n", "test"}
 
-	var clusterPairs storkv1.ClusterPairList
-	clusterPair := &storkv1.ClusterPair{
-		TypeMeta: meta.TypeMeta{
-			Kind:       reflect.TypeOf(storkv1.ClusterPair{}).Name(),
-			APIVersion: storkv1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: meta.ObjectMeta{
-			Name: "pair1",
-		},
-
-		Spec: storkv1.ClusterPairSpec{
-			Options: map[string]string{},
-		},
-	}
-
-	clusterPairs.Items = append(clusterPairs.Items, *clusterPair)
-
-	expected := ""
-	testCommon(t, newGenerateCommand, cmdArgs, &clusterPairs, expected, false)
+	expected := "error: the Name \"pair_test\" is not valid: [a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]"
+	testCommon(t, cmdArgs, nil, expected, true)
 }
-*/
+
+func TestGenerateClusterPairInvalidNamespace(t *testing.T) {
+	cmdArgs := []string{"generate", "clusterpair", "pair1", "-n", "test_namespace"}
+
+	expected := "error: the Namespace \"test_namespace\" is not valid: [a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]"
+	testCommon(t, cmdArgs, nil, expected, true)
+}


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
Yes, adds validation for name and namespace for `storkctl generate clusterpair` command

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
* Added validation for `name` and `namespace` in the clusterpair generated with `storkctl generate clusterpair`
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.2
