### PR TITLE
Update cassandra version in integration test

### DIFF
--- a/test/integration_test/specs/cassandra/cassandra.yaml
+++ b/test/integration_test/specs/cassandra/cassandra.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: cassandra
-        image: gcr.io/google-samples/cassandra:v12
+        image: gcr.io/google-samples/cassandra:v14
         imagePullPolicy: Always
         ports:
         - containerPort: 7000


### PR DESCRIPTION
The older version has a bug which could lead to an empty commit log file
which causes issues during restart


**What type of PR is this?**
Integration test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

