### PR TITLE
Add check in monitor to skip duplicate offline nodes with same IP

### DIFF
--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -166,6 +166,18 @@ func (m *Driver) UpdateNodeStatus(
 	return nil
 }
 
+// UpdateNodeIP Update IP for a node
+func (m *Driver) UpdateNodeIP(
+	nodeIndex int,
+	ip string,
+) error {
+	if len(m.nodes) <= nodeIndex {
+		return fmt.Errorf("node %v not found", nodeIndex)
+	}
+	m.nodes[nodeIndex].IPs[0] = ip
+	return nil
+}
+
 // SetInterfaceError to the specified error. Used for negative testing
 func (m *Driver) SetInterfaceError(err error) {
 	m.interfaceError = err

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -160,6 +160,7 @@ func (m *Monitor) driverMonitor() {
 				log.Errorf("Error getting nodes: %v", err)
 				time.Sleep(2 * time.Second)
 			}
+			nodes = volume.RemoveDuplicateOfflineNodes(nodes)
 			for _, node := range nodes {
 				// Check if nodes are reported online by the storage driver
 				// If not online, look at all the pods on that node


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
It is possible for the storage driver to return information for 2 nodes with the
same IP if a new node was re-using the IP from a node that was removed.
In that case the health monitor would incorrectly determine that the storage
driver was offline on the node.

This change removes offline nodes with duplicate IPs


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Fixed issue in health monitor to ignore duplicate node IPs which would cause pods to be deleted from nodes where storage was online
```

**Does this change need to be cherry-picked to a release branch?**:
2.2

