### PR TITLE
Fix flag for enabling cluster domain tests in integration tests.

### DIFF
--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -131,9 +131,9 @@ for i in $(seq 1 100) ; do
 done
 
 if [ "$run_cluster_domain_test" == "true" ] ; then
-	sed -i 's/'enable_cluster_domain'/'"true"'/g' /testspecs/stork-test-pod.yaml
+	sed -i 's/'enable_cluster_domain'/'\"true\"'/g' /testspecs/stork-test-pod.yaml
 else 
-	sed -i 's/'enable_cluster_domain'/'""'/g' /testspecs/stork-test-pod.yaml
+	sed -i 's/'enable_cluster_domain'/'\"\"'/g' /testspecs/stork-test-pod.yaml
 fi
 
 sed -i 's/'storage_provisioner'/'"$storage_provisioner"'/g' /testspecs/stork-test-pod.yaml


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Add escape characters for quotes in the enable cluster domain flag

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

