### PR TITLE
Add quotes to the enable cluster domain flag.

### DIFF
--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -131,7 +131,7 @@ for i in $(seq 1 100) ; do
 done
 
 if [ "$run_cluster_domain_test" == "true" ] ; then
-	sed -i 's/'enable_cluster_domain'/'\"true\"'/g' /testspecs/stork-test-pod.yaml
+	sed -i 's/'enable_cluster_domain'/'\""true"\"'/g' /testspecs/stork-test-pod.yaml
 else 
 	sed -i 's/'enable_cluster_domain'/'\"\"'/g' /testspecs/stork-test-pod.yaml
 fi


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Enable cluster domain environment variables should be a string for stork-test pod

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
