### PR TITLE
Update go version for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: go
 go:
-  - 1.11.2
+  - 1.11.13
 before_install:
   - sudo apt-get update -yq
   - sudo apt-get install go-md2man -y


### PR DESCRIPTION
**What type of PR is this?**
Build update

**What this PR does / why we need it**:
Updating go version to fix a vulnerability in the older version

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Update go version to 1.11.13 to fix [vulnerabilities](https://thenewstack.io/netflix-discovers-severe-kubernetes-http-2-vulnerabilities/) that were recently discovered
```

**Does this change need to be cherry-picked to a release branch?**:
2.2
