### PR TITLE
Increase wait time when waiting for cluster domain list.

### DIFF
--- a/test/integration_test/clusterdomain_test.go
+++ b/test/integration_test/clusterdomain_test.go
@@ -41,7 +41,7 @@ func testClusterDomains(t *testing.T) {
 		return "", false, nil
 
 	}
-	_, err := task.DoRetryWithTimeout(listCdsTask, defaultWaitTimeout, defaultWaitInterval)
+	_, err := task.DoRetryWithTimeout(listCdsTask, clusterDomainWaitTimeout, defaultWaitInterval)
 	require.NoError(t, err, "expected list cluster domains status to succeed")
 
 	require.NotEqual(t, 0, len(cds.Status.ClusterDomainInfos), "Found 0 cluster domains in the cluster.")

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -51,6 +51,7 @@ const (
 	regionScore = 10
 
 	defaultWaitTimeout       time.Duration = 5 * time.Minute
+	clusterDomainWaitTimeout time.Duration = 10 * time.Minute
 	groupSnapshotWaitTimeout time.Duration = 15 * time.Minute
 	defaultWaitInterval      time.Duration = 10 * time.Second
 


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Integration test failed as the wait time to check if cluster domain list is valid, was not enough.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
