### PR TITLE
Remove owner ref from synced backups

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -99,6 +99,12 @@ func (a *ApplicationRestoreController) verifyNamespaces(restore *stork_api.Appli
 
 	for _, ns := range restore.Spec.NamespaceMapping {
 		if _, err := k8s.Instance().GetNamespace(ns); err != nil {
+
+			if errors.IsNotFound(err) {
+				if _, err := k8s.Instance().CreateNamespace(ns, nil); err != nil {
+					return err
+				}
+			}
 			return err
 		}
 	}

--- a/pkg/applicationmanager/controllers/backupsync.go
+++ b/pkg/applicationmanager/controllers/backupsync.go
@@ -137,6 +137,7 @@ func (b *BackupSyncController) syncBackupsFromLocation(location *storkv1.BackupL
 				backupInfo.UID = ""
 				backupInfo.ResourceVersion = ""
 				backupInfo.SelfLink = ""
+				backupInfo.OwnerReferences = nil
 				backupInfo.Spec.ReclaimPolicy = storkv1.ApplicationBackupReclaimPolicyRetain
 				_, err = k8s.Instance().CreateApplicationBackup(&backupInfo)
 				if err != nil {


### PR DESCRIPTION
This was causing backups to be deleted by the k8s because the owner,
which is the backup schedule, won't be present on remote cluster


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
