### PR TITLE
Migrate image pull secrets associated with default service account

### DIFF
--- a/pkg/resourcecollector/serviceaccount.go
+++ b/pkg/resourcecollector/serviceaccount.go
@@ -1,6 +1,9 @@
 package resourcecollector
 
 import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -15,5 +18,12 @@ func (r *ResourceCollector) serviceAccountToBeCollected(
 
 	// Don't migrate the default service account
 	name := metadata.GetName()
+	var serviceAccount v1.ServiceAccount
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &serviceAccount); err != nil {
+		return false, fmt.Errorf("error converting to serviceAccount: %v", err)
+	}
+	if name == "default" && len(serviceAccount.ImagePullSecrets) > 0 {
+		return true, nil
+	}
 	return (name != "default" && name != "builder" && name != "deployer"), nil
 }


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
We don't maintain link between secrets while migrating `default` service account. This PR check and update imagepullSecrets for default service account

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

**Does this change need to be cherry-picked to a release branch?**:
yes
