### PR TITLE
Don't set predicates or priorities for scheduler

### DIFF
--- a/specs/stork-deployment.yaml
+++ b/specs/stork-deployment.yaml
@@ -12,27 +12,6 @@ data:
     {
       "kind": "Policy",
       "apiVersion": "v1",
-      "predicates": [
-        {"name": "MaxAzureDiskVolumeCount"},
-        {"name": "PodToleratesNodeTaints"},
-        {"name": "CheckNodeMemoryPressure"},
-        {"name": "NoVolumeZoneConflict"},
-        {"name": "MaxEBSVolumeCount"},
-        {"name": "MaxGCEPDVolumeCount"},
-        {"name": "MatchInterPodAffinity"},
-        {"name": "NoDiskConflict"},
-        {"name": "GeneralPredicates"},
-        {"name": "CheckNodeDiskPressure"}
-      ],
-      "priorities": [
-        {"name": "NodeAffinityPriority", "weight": 1},
-        {"name": "TaintTolerationPriority", "weight": 1},
-        {"name": "SelectorSpreadPriority", "weight": 1},
-        {"name": "InterPodAffinityPriority", "weight": 1},
-        {"name": "LeastRequestedPriority", "weight": 1},
-        {"name": "BalancedResourceAllocation", "weight": 1},
-        {"name": "NodePreferAvoidPodsPriority", "weight": 1}
-      ],
       "extenders": [
         {
           "urlPrefix": "http://stork-service.kube-system.svc.cluster.local:8099",


### PR DESCRIPTION
It picks up the defaults from k8s 1.10 onwards


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
2.2, 2.1
