### PR TITLE
Correct volume count for storkctl snaprestore output

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -777,14 +777,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d60592e3ef7b03350f15217c6cee5ed591a23730dc194cdec679c7b35fd8fb5d"
+  digest = "1:b1485ffc45798e016223b6a707cf20c5755971bf7239e32ac2c9eba3b6fb1bb2"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s",
     "task",
   ]
   pruneopts = "UT"
-  revision = "c1308b0230c046a81cbafa71ffaacdfd71af1656"
+  revision = "4773a0468a8f92fcbc3f337bc012bf090637cbf1"
 
 [[projects]]
   branch = "master"

--- a/pkg/storkctl/snapshot.go
+++ b/pkg/storkctl/snapshot.go
@@ -280,7 +280,6 @@ func newGetVolumeSnapshotRestoreCommand(cmdFactory Factory, ioStreams genericcli
 			}
 
 			if len(args) > 0 {
-				fmt.Println("Restore list")
 				snapRestoreList = new(storkv1.VolumeSnapshotRestoreList)
 				for _, restoreName := range args {
 					for _, ns := range namespaces {
@@ -293,7 +292,6 @@ func newGetVolumeSnapshotRestoreCommand(cmdFactory Factory, ioStreams genericcli
 					}
 				}
 			} else {
-				fmt.Println("Restore list else")
 				var tempRestoreList storkv1.VolumeSnapshotRestoreList
 				for _, ns := range namespaces {
 					snapRestoreList, err = k8s.Instance().ListVolumeSnapshotRestore(ns)

--- a/vendor/github.com/portworx/sched-ops/k8s/k8s.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/k8s.go
@@ -531,6 +531,8 @@ type VolumeSnapshotRestoreOps interface {
 	// CreateVolumeSnapshotRestore restore snapshot to pvc specifed in CRD, if no pvcs defined we restore to
 	// parent volumes
 	CreateVolumeSnapshotRestore(snap *v1alpha1.VolumeSnapshotRestore) (*v1alpha1.VolumeSnapshotRestore, error)
+	// UpdateVolumeSnapshotRestore updates given volumesnapshorestore CRD
+	UpdateVolumeSnapshotRestore(snap *v1alpha1.VolumeSnapshotRestore) (*v1alpha1.VolumeSnapshotRestore, error)
 	// GetVolumeSnapshotRestore returns details of given restore crd status
 	GetVolumeSnapshotRestore(name, namespace string) (*v1alpha1.VolumeSnapshotRestore, error)
 	// ListVolumeSnapshotRestore return list of volumesnapshotrestores in given namespaces
@@ -3744,6 +3746,13 @@ func (k *k8sOps) CreateVolumeSnapshotRestore(snapRestore *v1alpha1.VolumeSnapsho
 		return nil, err
 	}
 	return k.storkClient.Stork().VolumeSnapshotRestores(snapRestore.Namespace).Create(snapRestore)
+}
+
+func (k *k8sOps) UpdateVolumeSnapshotRestore(snapRestore *v1alpha1.VolumeSnapshotRestore) (*v1alpha1.VolumeSnapshotRestore, error) {
+	if err := k.initK8sClient(); err != nil {
+		return nil, err
+	}
+	return k.storkClient.Stork().VolumeSnapshotRestores(snapRestore.Namespace).Update(snapRestore)
 }
 
 func (k *k8sOps) GetVolumeSnapshotRestore(name, namespace string) (*v1alpha1.VolumeSnapshotRestore, error) {


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Fix volume count for volumesnapshotrestore 

**Does this PR change a user-facing CRD or CLI?**:
Yes
Earlier volumesnapshotrestore output always show volume to be restore as zero. This PR changes volume count as per volume which are undergoing in place restore

eg.
```
[#vsrestore]# ./storkctl get volumesnapshotrestore
NAME                         SOURCE-SNAPSHOT             SOURCE-SNAPSHOT-NAMESPACE   STATUS       VOLUMES   CREATED
mysql-snap-group-inrestore   mysql-group-localsnapshot   default                     Successful   2         16 Sep 19 04:38 PDT
```