### PR TITLE
Use name from the existing secret object as new obj might be nil.

### DIFF
--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -163,7 +163,7 @@ func createBackupLocation(
 	newSecretObj := secretObj.DeepCopy()
 	newSecretObj.Namespace = namespace
 	newSecretObj.ResourceVersion = ""
-	newSecret, err := k8s.Instance().CreateSecret(newSecretObj)
+	_, err = k8s.Instance().CreateSecret(newSecretObj)
 	// Ignore if secret already exists
 	if err != nil && !errors.IsAlreadyExists(err) {
 		require.NoError(t, err, "Failed to copy secret %s  to namespace %s", name, namespace)
@@ -178,7 +178,7 @@ func createBackupLocation(
 		Location: storkv1.BackupLocationItem{
 			Type:         locationtype,
 			Path:         "test-restore-path",
-			SecretConfig: newSecret.Name,
+			SecretConfig: secretObj.Name,
 		},
 	}
 	return k8s.Instance().CreateBackupLocation(backupLocation)


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
In case of an existing secret, the new secret object might have null values, including it's name

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

