### PR TITLE
Use cassandra instead of mysql for clusterdomain migration.

### DIFF
--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -344,8 +344,7 @@ func addStorageOptions(pairInfo map[string]string) error {
 }
 
 func scheduleClusterPair(ctx *scheduler.Context, skipStorage bool) error {
-	var err error
-	err = dumpRemoteKubeConfig(remoteConfig)
+	err := dumpRemoteKubeConfig(remoteConfig)
 	if err != nil {
 		logrus.Errorf("Unable to write clusterconfig: %v", err)
 		return err

--- a/test/integration_test/specs/cassandra-clusterdomain-migration/migration.yaml
+++ b/test/integration_test/specs/cassandra-clusterdomain-migration/migration.yaml
@@ -1,0 +1,15 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: Migration
+metadata:
+  name: cassandra-migration
+spec:
+  # This should be the name of the cluster pair
+  clusterPair: remoteclusterpair
+  # If set to false this will migrate only the volumes. No PVCs, apps, etc will be migrated
+  includeResources: true
+  # If set to false, the deployments and stateful set replicas will be set to 0 on the destination. There will be an annotation with "stork.openstorage.org/migrationReplicas" to store the replica count from the source
+  startApplications: false
+  includeVolumes: false
+  # List of namespaces to migrate
+  namespaces:
+  - cassandra-cassandra-clusterdomain-migration


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Switch cluster domain migration test to cassandra from mysql

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
