### PR TITLE
Create annotations for app during migration if it doesn't exist

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -518,8 +518,6 @@ func (p *portworx) GetNodes() ([]*storkvolume.NodeInfo, error) {
 			if region, ok := labels[kubeletapis.LabelZoneRegion]; ok {
 				nodeInfo.Region = region
 			}
-		} else {
-			logrus.Warnf("Error getting labels for node %v: %v", nodeInfo.Hostname, err)
 		}
 
 		nodes = append(nodes, nodeInfo)

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -790,7 +790,7 @@ func (m *MigrationController) prepareApplicationResource(
 		return err
 	}
 	if !found {
-		return fmt.Errorf("annotations not found in application")
+		annotations = make(map[string]string)
 	}
 	annotations[StorkMigrationReplicasAnnotation] = strconv.FormatInt(replicas, 10)
 	return unstructured.SetNestedStringMap(content, annotations, "metadata", "annotations")


### PR DESCRIPTION
Also remove noisy log message


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Fixed issue during migration when an application didn't have annotations. This would cause failures when trying to add the replica count as an annotation
```

**Does this change need to be cherry-picked to a release branch?**:
Yes, 2.2, but need to make separate changes since code has changed

