### PR TITLE
Reset remote config

### DIFF
--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -702,6 +702,10 @@ func commonApplicationBackupScheduleTests(
 
 func applicationBackupSyncControllerTest(t *testing.T) {
 	var err error
+	defer func() {
+		err = setRemoteConfig("")
+		require.NoError(t, err, "Error resetting remote config")
+	}()
 	backupLocationName := appKey + "-backup-location-sync"
 
 	// Create myqsl app deployment


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Need to set kubeconfig to source cluster after backup sync controller test.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

