### PR TITLE
Check ownership of VolumeAttachment before deleting

### DIFF
--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -246,9 +246,9 @@ func (m Driver) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*storkvo
 	return volumes, nil
 }
 
-// OwnsPVC returns false since mock driver doesn't own any PVCs
+// OwnsPVC returns true because it owns all PVCs created by tests
 func (m *Driver) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
-	return false
+	return true
 }
 
 // GetSnapshotPlugin Returns nil since snapshot is not supported in the mock driver


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>
>bug

**What this PR does / why we need it**:
* Need to make sure VolumeAttachment is ours before deleting

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
2.3.0