### PR TITLE
Check the scale factor of the application after scaling it down.

### DIFF
--- a/test/integration_test/clusterdomain_test.go
+++ b/test/integration_test/clusterdomain_test.go
@@ -159,6 +159,14 @@ func testClusterDomainsFailover(
 	err = schedulerDriver.ScaleApplication(ctxs[0], scaleFactor)
 	require.NoError(t, err, "Unexpected error on ScaleApplication")
 
+	// check if the app is scaled down.
+	updatedScaleFactor, err := schedulerDriver.GetScaleFactorMap(ctxs[0])
+	require.NoError(t, err, "Unexpected error on GetScaleFactorMap")
+
+	for k := range updatedScaleFactor {
+		require.Equal(t, updatedScaleFactor[k], 0, "Expected scale to be 0")
+	}
+
 	// start the app on cluster 2
 	err = setRemoteConfig(remoteFilePath)
 	require.NoError(t, err, "Error setting remote config")


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
We found in cluster domain tests, that even after scaling down the cassandra stateful set, the pods were still running. By adding this extra check, we will make sure that the stateful set is completely scaled down before we migrate cassandra.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

