### PR TITLE
Use retain policy for label selector test.

### DIFF
--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -122,12 +122,8 @@ func triggerBackupRestoreTest(
 			require.NoError(t, err, "Error waiting for back-up to complete.")
 			logrus.Infof("Backup completed.")
 
-			appBackup, err := k8s.Instance().GetApplicationBackup(appKey+"-backup", ctx.GetID())
-			require.NoError(t, err, "Error fetching app backup.")
-			if appBackup.Spec.ReclaimPolicy != storkv1.ApplicationBackupReclaimPolicyDelete {
-				// Destroy apps only if reclaim policy if NOT delete
-				destroyAndWait(t, []*scheduler.Context{preRestoreCtx})
-			}
+			// Delete apps so that they can be restored
+			destroyAndWait(t, []*scheduler.Context{preRestoreCtx})
 
 			logrus.Infof("Starting Restore.")
 			// Restore application


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
It serves 2 purposes:
1. We will delete all apps created as part of the test
2. Also tests "Retain" policy for application backups. 

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

