### PR TITLE
Some optimizations for migration

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -125,7 +125,10 @@ func (m *MigrationController) Handle(ctx context.Context, event sdk.Event) error
 	case *stork_api.Migration:
 		migration := o
 		if event.Deleted {
-			return m.Driver.CancelMigration(migration)
+			if migration.Status.Stage != stork_api.MigrationStageFinal {
+				return m.Driver.CancelMigration(migration)
+			}
+			return nil
 		}
 		migration = setDefaults(migration)
 

--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -300,6 +300,7 @@ func (m *MigrationScheduleController) startMigration(
 }
 
 func (m *MigrationScheduleController) pruneMigrations(migrationSchedule *stork_api.MigrationSchedule) error {
+	updated := false
 	for policyType, policyMigration := range migrationSchedule.Status.Items {
 		// Keep only one successful migration status and all failed migrations
 		// until there is a successful one
@@ -320,9 +321,16 @@ func (m *MigrationScheduleController) pruneMigrations(migrationSchedule *stork_a
 				}
 			}
 			migrationSchedule.Status.Items[policyType] = policyMigration[deleteBefore:]
+			if deleteBefore > 0 {
+				updated = true
+			}
 		}
 	}
-	return sdk.Update(migrationSchedule)
+	if updated {
+		return sdk.Update(migrationSchedule)
+	}
+	return nil
+
 }
 
 func (m *MigrationScheduleController) deleteMigrations(migrationSchedule *stork_api.MigrationSchedule) error {


### PR DESCRIPTION
- Don't cancel migrations that are in Final stage
- Don't update migration schedule after prune if the object wasn't updated


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Optimized some operations for migration and migrationschedule to reduce K8s API calls
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.3 
