### PR TITLE
Add the old parameter for cluster-admin-namespace

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -122,6 +122,11 @@ func main() {
 			Value: defaultAdminNamespace,
 			Usage: "Namespace to be used by a cluster admin which can migrate and backup all other namespaces",
 		},
+		cli.StringFlag{
+			Name:  "migration-admin-namespace",
+			Value: defaultAdminNamespace,
+			Usage: "Namespace to be used by a cluster admin which can migrate all other namespaces (Deprecated, please use admin-namespace)",
+		},
 		cli.BoolTFlag{
 			Name:  "cluster-domain-controllers",
 			Usage: "Start the cluster domain controllers (default: true)",
@@ -311,6 +316,10 @@ func runStork(d volume.Driver, recorder record.EventRecorder, c *cli.Context) {
 	}
 
 	adminNamespace := c.String("admin-namespace")
+	if adminNamespace == "" {
+		adminNamespace = c.String("migration-admin-namespace")
+	}
+
 	if c.Bool("migration-controller") {
 		migration := migration.Migration{
 			Driver:            d,

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2433,6 +2433,10 @@ func (p *portworx) StartBackup(backup *stork_crd.ApplicationBackup) ([]*stork_cr
 			if !p.OwnsPVC(&pvc) {
 				continue
 			}
+			if pvc.DeletionTimestamp != nil {
+				log.ApplicationBackupLog(backup).Warnf("Ignoring PVC %v which is being deleted", pvc.Name)
+				continue
+			}
 			volumeInfo := &stork_crd.ApplicationBackupVolumeInfo{}
 			volumeInfo.PersistentVolumeClaim = pvc.Name
 			volumeInfo.Namespace = pvc.Namespace

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -290,9 +290,9 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 						v1.EventTypeWarning,
 						string(stork_api.ApplicationBackupStatusFailed),
 						message)
-					return true, err
+					return false, nil
 				}
-				return false, nil
+				return true, nil
 			}); err != nil {
 				message := fmt.Sprintf("Error cancelling ApplicationBackup for volumes, will not retry further: %v", err)
 				log.ApplicationBackupLog(backup).Errorf(message)


### PR DESCRIPTION
Added the message that it is deprecated


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
`migration-admin-namespace` parameter for stork has been deprecated. Please use `admin-namespace` instead.
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.3
