### PR TITLE
Use created config map for watch on mock time

### DIFF
--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -263,7 +263,7 @@ func Init() error {
 					MockTimeConfigMapKey: "",
 				}
 
-				cm := &v1.ConfigMap{
+				cm = &v1.ConfigMap{
 					ObjectMeta: meta.ObjectMeta{
 						Name:      MockTimeConfigMapName,
 						Namespace: MockTimeConfigMapNamespace,
@@ -271,7 +271,7 @@ func Init() error {
 					Data: data,
 				}
 
-				_, err = k8s.Instance().CreateConfigMap(cm)
+				cm, err = k8s.Instance().CreateConfigMap(cm)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Previously if the mock time config map was not created we would end up using the
empty config map to start the watch


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
No

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.3
