### PR TITLE
Update test flag parsing which was broken in go 1.13

### DIFF
--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -454,7 +454,7 @@ func createApp(t *testing.T, testID string) *scheduler.Context {
 	return ctxs[0]
 }
 
-func init() {
+func TestMain(m *testing.M) {
 	flag.IntVar(&snapshotScaleCount,
 		"snapshot-scale-count",
 		10,
@@ -464,4 +464,5 @@ func init() {
 		logrus.Errorf("Setup failed with error: %v", err)
 		os.Exit(1)
 	}
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.3

