### PR TITLE
Update spec version for deployments

### DIFF
--- a/specs/stork-deployment.yaml
+++ b/specs/stork-deployment.yaml
@@ -66,7 +66,7 @@ spec:
       port: 8099
       targetPort: 8099
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -83,6 +83,9 @@ spec:
       maxSurge: 1
       maxUnavailable: 1
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: stork
   replicas: 3
   template:
     metadata:

--- a/specs/stork-scheduler.yaml
+++ b/specs/stork-scheduler.yaml
@@ -53,7 +53,7 @@ rules:
     resources: ["persistentvolumeclaims", "persistentvolumes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
+    resources: ["storageclasses", "csinodes"]
     verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -69,7 +69,7 @@ roleRef:
   name: stork-scheduler-role
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -81,11 +81,15 @@ metadata:
     pending: []
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      name: stork-scheduler
   template:
     metadata:
       labels:
         component: scheduler
         tier: control-plane
+        name: stork-scheduler
       name: stork-scheduler
     spec:
       containers:


### PR DESCRIPTION
Also add csinodes permission for scheduler clusterrole,
required for k8s 1.16 onwards


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

