### PR TITLE
Parameterize stork volume driver for integration tests.

### DIFF
--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	nodeDriverName        = "ssh"
-	volumeDriverName      = "pxd"
 	schedulerDriverName   = "k8s"
 	remotePairName        = "remoteclusterpair"
 	remoteConfig          = "remoteconfigmap"
@@ -68,6 +67,7 @@ var snapshotScaleCount int
 var migrationScaleCount int
 var authToken string
 var authTokenConfigMap string
+var volumeDriverName string
 
 func TestSnapshotMigration(t *testing.T) {
 	t.Run("testSnapshot", testSnapshot)
@@ -80,8 +80,9 @@ func TestSnapshotMigration(t *testing.T) {
 func setup() error {
 	var err error
 
+	logrus.Infof("Using stork volume driver: %s", volumeDriverName)
 	if storkVolumeDriver, err = storkdriver.Get(volumeDriverName); err != nil {
-		return fmt.Errorf("Error getting stork driver %v: %v", volumeDriverName, err)
+		return fmt.Errorf("Error getting stork driver %s: %v", volumeDriverName, err)
 	}
 
 	if err = storkVolumeDriver.Init(nil); err != nil {
@@ -475,6 +476,10 @@ func TestMain(m *testing.M) {
 		"migration-scale-count",
 		10,
 		"Number of migrations to use for migration test")
+	flag.StringVar(&volumeDriverName,
+		"volume-driver",
+		"pxd",
+		"Stork volume driver to be used for stork integration tests")
 	flag.Parse()
 	if err := setup(); err != nil {
 		logrus.Errorf("Setup failed with error: %v", err)

--- a/test/integration_test/stork-test-pod.yaml
+++ b/test/integration_test/stork-test-pod.yaml
@@ -54,6 +54,7 @@ spec:
     FOCUS_TESTS
     - -snapshot-scale-count=10
     - -migration-scale-count=10
+    - -volume-driver=pxd
     imagePullPolicy: Always
     image: openstorage/stork_test:latest
     securityContext:

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -11,6 +11,7 @@ environment_variables=""
 storage_provisioner="portworx"
 focus_tests=""
 auth_secret_configmap=""
+volume_driver="pxd"
 for i in "$@"
 do
 case $i in
@@ -76,6 +77,12 @@ case $i in
     --auth_secret_configmap)
         echo "K8s secret name to use for test: $2"
         auth_secret_configmap=$2
+        shift
+        shift
+        ;;
+    --volume_driver)
+        echo "K8s secret name to use for test: $2"
+        volume_driver=$2
         shift
         shift
         ;;
@@ -182,6 +189,10 @@ sed -i 's/'username'/'"$SSH_USERNAME"'/g' /testspecs/stork-test-pod.yaml
 sed -i 's/'password'/'"$SSH_PASSWORD"'/g' /testspecs/stork-test-pod.yaml
 sed -i 's/'stork_test:.*'/'"$test_image_name"'/g' /testspecs/stork-test-pod.yaml
 
+if [ "$volume_driver" != "" ] ; then
+	sed -i 's/- -volume-driver=pxd/- -volume-driver='"$volume_driver"'/g' /testspecs/stork-test-pod.yaml
+fi
+
 if [ "$remote_config_path" != "" ]; then
     kubectl create configmap remoteconfigmap --from-file=$remote_config_path -n kube-system
 fi
@@ -206,6 +217,7 @@ for i in $(seq 1 100) ; do
         echo "Test is still running, status: $test_status"
         kubectl logs stork-test  -n kube-system -f
     else
+        sleep 5
         break
     fi
 done


### PR DESCRIPTION
 Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
The stork volume driver used in integration tests needs to be parameterized.
This way we can support other drivers as well.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

