### PR TITLE
pass poolids to Nodeid for ha update api

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1246,7 +1246,7 @@ func (p *portworx) checkAndUpdateHaLevel(volID, uid string, params map[string]st
 		logrus.Infof("Updating HA Level of volume %v", restoreVol.GetLocator().GetName())
 		spec := &api.VolumeSpec{
 			HaLevel:    restoreVol.GetSpec().GetHaLevel() + 1,
-			ReplicaSet: &api.ReplicaSet{PoolUuids: pools},
+			ReplicaSet: &api.ReplicaSet{Nodes: pools},
 		}
 		if err := volDriver.Set(restoreVol.GetId(), restoreVol.GetLocator(), spec); err != nil {
 			return false, fmt.Errorf("failed to perform ha-update: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
HA update api need `pool uuids` passed in as `Nodes` of Replicasets

for starting restore we do the same
https://github.com/libopenstorage/stork/blob/d9e7b18d2bd63597f699b818f404b80070307856/drivers/volume/portworx/portworx.go#L1108

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.3.0