### PR TITLE
Ability to skip restore tests even when running individually.

### DIFF
--- a/test/integration_test/snapshot_restore_test.go
+++ b/test/integration_test/snapshot_restore_test.go
@@ -72,6 +72,9 @@ func groupSnapshotRestoreTest(t *testing.T) {
 }
 
 func cloudSnapshotRestoreTest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test: cloudSnapshotRestoreTest.")
+	}
 	snapCtx, err := schedulerDriver.Schedule("cslocal",
 		scheduler.ScheduleOptions{AppKeys: []string{"mysql-cloudsnap-restore"}})
 	require.NoError(t, err, "Error scheduling task")
@@ -90,6 +93,9 @@ func cloudSnapshotRestoreTest(t *testing.T) {
 }
 
 func groupCloudSnapshotRestoreTest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test: groupCloudSnapshotRestoreTest.")
+	}
 	snapCtx, err := schedulerDriver.Schedule("csgroup",
 		scheduler.ScheduleOptions{AppKeys: []string{"mysql-cloudsnap-group-restore"}})
 	require.NoError(t, err, "Error scheduling task")


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Currently snap restore tests won't be skipped if required, when running individually.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

