### PR TITLE
Wait for snapshot to complete in in-place restore tests

### DIFF
--- a/test/integration_test/snapshot_restore_test.go
+++ b/test/integration_test/snapshot_restore_test.go
@@ -79,6 +79,7 @@ func cloudSnapshotRestoreTest(t *testing.T) {
 		scheduler.ScheduleOptions{AppKeys: []string{"mysql-cloudsnap-restore"}})
 	require.NoError(t, err, "Error scheduling task")
 	require.Equal(t, 1, len(snapCtx), "Only one task should have started")
+	verifyGroupSnapshot(t, snapCtx[0], defaultWaitTimeout)
 
 	err = schedulerDriver.WaitForRunning(snapCtx[0], defaultWaitTimeout, defaultWaitInterval)
 	require.NoError(t, err, "Error waiting for pod to get to running state")
@@ -100,6 +101,8 @@ func groupCloudSnapshotRestoreTest(t *testing.T) {
 		scheduler.ScheduleOptions{AppKeys: []string{"mysql-cloudsnap-group-restore"}})
 	require.NoError(t, err, "Error scheduling task")
 	require.Equal(t, 1, len(snapCtx), "Only one task should have started")
+
+	verifyGroupSnapshot(t, snapCtx[0], defaultWaitTimeout)
 
 	err = schedulerDriver.WaitForRunning(snapCtx[0], defaultWaitTimeout, defaultWaitInterval)
 	require.NoError(t, err, "Error waiting for pod to get to running state")

--- a/test/integration_test/snapshot_restore_test.go
+++ b/test/integration_test/snapshot_restore_test.go
@@ -79,7 +79,7 @@ func cloudSnapshotRestoreTest(t *testing.T) {
 		scheduler.ScheduleOptions{AppKeys: []string{"mysql-cloudsnap-restore"}})
 	require.NoError(t, err, "Error scheduling task")
 	require.Equal(t, 1, len(snapCtx), "Only one task should have started")
-	verifyGroupSnapshot(t, snapCtx[0], defaultWaitTimeout)
+	verifySnapshot(t, snapCtx, "mysql-data", defaultWaitTimeout)
 
 	err = schedulerDriver.WaitForRunning(snapCtx[0], defaultWaitTimeout, defaultWaitInterval)
 	require.NoError(t, err, "Error waiting for pod to get to running state")

--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -253,6 +253,7 @@ func createSnapshot(t *testing.T, appKeys []string) []*scheduler.Context {
 }
 
 func verifySnapshot(t *testing.T, ctxs []*scheduler.Context, pvcInUseByTest string, waitTimeout time.Duration) {
+	logrus.Info("Now verifying volume snapshot")
 	err := schedulerDriver.WaitForRunning(ctxs[0], waitTimeout, defaultWaitInterval)
 	require.NoError(t, err, fmt.Sprintf("Error waiting for app to get to running state in context: %s-%s", ctxs[0].App.Key, ctxs[0].UID))
 

--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -209,6 +209,7 @@ func createGroupsnaps(t *testing.T, apps []string) []*scheduler.Context {
 }
 
 func verifyGroupSnapshot(t *testing.T, ctx *scheduler.Context, waitTimeout time.Duration) {
+	logrus.Info("Now verifying group volume snapshot")
 	err := schedulerDriver.WaitForRunning(ctx, waitTimeout, defaultWaitInterval)
 	require.NoError(t, err, fmt.Sprintf("Error waiting for app to get to running state in context: %s-%s", ctx.App.Key, ctx.UID))
 


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Currently, inplace restore tests don't wait on volume snaps to complete before proceeding to
volume restore

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

