### PR TITLE
Cleanup deleted objects from destination during migration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -777,14 +777,14 @@
 
 [[projects]]
   branch = "kubernetes-1.11"
-  digest = "1:fbc0b6405af4b9578157aadf843bedab8074bbe20986e99d84881b7355a34564"
+  digest = "1:cd1e41248a08329610f7859cb1768f7dbee3fead77c937b0b9a3c54d1413c1d8"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s",
     "task",
   ]
   pruneopts = "UT"
-  revision = "57be5866c9371831429d7fc929dedc957cadba27"
+  revision = "80b302640aeb98ce531cb85a01e7c79a12df1261"
 
 [[projects]]
   branch = "master"

--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -311,7 +311,7 @@ func runStork(d volume.Driver, recorder record.EventRecorder, c *cli.Context) {
 	resourceCollector := resourcecollector.ResourceCollector{
 		Driver: d,
 	}
-	if err := resourceCollector.Init(); err != nil {
+	if err := resourceCollector.Init(nil); err != nil {
 		log.Fatalf("Error initializing ResourceCollector: %v", err)
 	}
 

--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -13,16 +13,16 @@ const (
 
 // MigrationSpec is the spec used to migrate apps between clusterpairs
 type MigrationSpec struct {
-	ClusterPair            string            `json:"clusterPair"`
-	AdminClusterPair       string            `json:"adminClusterPair"`
-	Namespaces             []string          `json:"namespaces"`
-	IncludeResources       *bool             `json:"includeResources"`
-	IncludeVolumes         *bool             `json:"includeVolumes"`
-	StartApplications      *bool             `json:"startApplications"`
-	AllowCleaningResources *bool             `json:"allowCleaningResources"`
-	Selectors              map[string]string `json:"selectors"`
-	PreExecRule            string            `json:"preExecRule"`
-	PostExecRule           string            `json:"postExecRule"`
+	ClusterPair           string            `json:"clusterPair"`
+	AdminClusterPair      string            `json:"adminClusterPair"`
+	Namespaces            []string          `json:"namespaces"`
+	IncludeResources      *bool             `json:"includeResources"`
+	IncludeVolumes        *bool             `json:"includeVolumes"`
+	StartApplications     *bool             `json:"startApplications"`
+	PurgeDeletedResources *bool             `json:"purgeDeletedResources"`
+	Selectors             map[string]string `json:"selectors"`
+	PreExecRule           string            `json:"preExecRule"`
+	PostExecRule          string            `json:"postExecRule"`
 }
 
 // MigrationStatus is the status of a migration operation
@@ -81,8 +81,8 @@ const (
 	MigrationStatusPartialSuccess MigrationStatusType = "PartialSuccess"
 	// MigrationStatusSuccessful for when migration has completed successfully
 	MigrationStatusSuccessful MigrationStatusType = "Successful"
-	// MigrationStatusCleaned for when migration objects has been deleted
-	MigrationStatusCleaned MigrationStatusType = "Cleaned"
+	// MigrationStatusPurged for when migration objects has been deleted
+	MigrationStatusPurged MigrationStatusType = "Purged"
 )
 
 // MigrationStageType is the stage of the migration

--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -13,15 +13,16 @@ const (
 
 // MigrationSpec is the spec used to migrate apps between clusterpairs
 type MigrationSpec struct {
-	ClusterPair       string            `json:"clusterPair"`
-	AdminClusterPair  string            `json:"adminClusterPair"`
-	Namespaces        []string          `json:"namespaces"`
-	IncludeResources  *bool             `json:"includeResources"`
-	IncludeVolumes    *bool             `json:"includeVolumes"`
-	StartApplications *bool             `json:"startApplications"`
-	Selectors         map[string]string `json:"selectors"`
-	PreExecRule       string            `json:"preExecRule"`
-	PostExecRule      string            `json:"postExecRule"`
+	ClusterPair            string            `json:"clusterPair"`
+	AdminClusterPair       string            `json:"adminClusterPair"`
+	Namespaces             []string          `json:"namespaces"`
+	IncludeResources       *bool             `json:"includeResources"`
+	IncludeVolumes         *bool             `json:"includeVolumes"`
+	StartApplications      *bool             `json:"startApplications"`
+	AllowCleaningResources *bool             `json:"allowCleaningResources"`
+	Selectors              map[string]string `json:"selectors"`
+	PreExecRule            string            `json:"preExecRule"`
+	PostExecRule           string            `json:"postExecRule"`
 }
 
 // MigrationStatus is the status of a migration operation

--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -81,6 +81,8 @@ const (
 	MigrationStatusPartialSuccess MigrationStatusType = "PartialSuccess"
 	// MigrationStatusSuccessful for when migration has completed successfully
 	MigrationStatusSuccessful MigrationStatusType = "Successful"
+	// MigrationStatusCleaned for when migration objects has been deleted
+	MigrationStatusCleaned MigrationStatusType = "Cleaned"
 )
 
 // MigrationStageType is the stage of the migration

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -1433,8 +1433,8 @@ func (in *MigrationSpec) DeepCopyInto(out *MigrationSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.AllowCleaningResources != nil {
-		in, out := &in.AllowCleaningResources, &out.AllowCleaningResources
+	if in.PurgeDeletedResources != nil {
+		in, out := &in.PurgeDeletedResources, &out.PurgeDeletedResources
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -1433,6 +1433,11 @@ func (in *MigrationSpec) DeepCopyInto(out *MigrationSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AllowCleaningResources != nil {
+		in, out := &in.AllowCleaningResources, &out.AllowCleaningResources
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Selectors != nil {
 		in, out := &in.Selectors, &out.Selectors
 		*out = make(map[string]string, len(*in))

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -597,7 +597,7 @@ func (a *ApplicationBackupController) preparePVResource(
 func (a *ApplicationBackupController) backupResources(
 	backup *stork_api.ApplicationBackup,
 ) error {
-	allObjects, err := a.ResourceCollector.GetResources(backup.Spec.Namespaces, backup.Spec.Selectors, nil, false)
+	allObjects, err := a.ResourceCollector.GetResources(backup.Spec.Namespaces, backup.Spec.Selectors)
 	if err != nil {
 		log.ApplicationBackupLog(backup).Errorf("Error getting resources: %v", err)
 		return err

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -22,7 +22,7 @@ import (
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/gcerrors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -597,7 +597,7 @@ func (a *ApplicationBackupController) preparePVResource(
 func (a *ApplicationBackupController) backupResources(
 	backup *stork_api.ApplicationBackup,
 ) error {
-	allObjects, err := a.ResourceCollector.GetResources(backup.Spec.Namespaces, backup.Spec.Selectors)
+	allObjects, err := a.ResourceCollector.GetResources(backup.Spec.Namespaces, backup.Spec.Selectors, nil, false)
 	if err != nil {
 		log.ApplicationBackupLog(backup).Errorf("Error getting resources: %v", err)
 		return err

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -632,7 +632,7 @@ func (a *ApplicationCloneController) applyResources(
 func (a *ApplicationCloneController) cloneResources(
 	clone *stork_api.ApplicationClone,
 ) error {
-	allObjects, err := a.ResourceCollector.GetResources([]string{clone.Spec.SourceNamespace}, clone.Spec.Selectors, nil, false)
+	allObjects, err := a.ResourceCollector.GetResources([]string{clone.Spec.SourceNamespace}, clone.Spec.Selectors)
 	if err != nil {
 		log.ApplicationCloneLog(clone).Errorf("Error getting resources: %v", err)
 		return err

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -15,7 +15,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -632,7 +632,7 @@ func (a *ApplicationCloneController) applyResources(
 func (a *ApplicationCloneController) cloneResources(
 	clone *stork_api.ApplicationClone,
 ) error {
-	allObjects, err := a.ResourceCollector.GetResources([]string{clone.Spec.SourceNamespace}, clone.Spec.Selectors)
+	allObjects, err := a.ResourceCollector.GetResources([]string{clone.Spec.SourceNamespace}, clone.Spec.Selectors, nil, false)
 	if err != nil {
 		log.ApplicationCloneLog(clone).Errorf("Error getting resources: %v", err)
 		return err

--- a/pkg/resourcecollector/clusterrole.go
+++ b/pkg/resourcecollector/clusterrole.go
@@ -3,7 +3,6 @@ package resourcecollector
 import (
 	"strings"
 
-	"github.com/portworx/sched-ops/k8s"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -177,10 +176,10 @@ func (r *ResourceCollector) mergeAndUpdateClusterRoleBinding(
 		return err
 	}
 
-	currentCRB, err := k8s.Instance().GetClusterRoleBinding(newCRB.Name)
+	currentCRB, err := r.k8sOps.GetClusterRoleBinding(newCRB.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			_, err = k8s.Instance().CreateClusterRoleBinding(&newCRB)
+			_, err = r.k8sOps.CreateClusterRoleBinding(&newCRB)
 		}
 		return err
 	}
@@ -204,6 +203,6 @@ func (r *ResourceCollector) mergeAndUpdateClusterRoleBinding(
 		currentCRB.Subjects = append(currentCRB.Subjects, subject)
 	}
 
-	_, err = k8s.Instance().UpdateClusterRoleBinding(currentCRB)
+	_, err = r.k8sOps.UpdateClusterRoleBinding(currentCRB)
 	return err
 }

--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -3,8 +3,7 @@ package resourcecollector
 import (
 	"fmt"
 
-	"github.com/portworx/sched-ops/k8s"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -37,7 +36,7 @@ func (r *ResourceCollector) pvToBeCollected(
 			return false, nil
 		}
 
-		pvc, err := k8s.Instance().GetPersistentVolumeClaim(pvcName, pvcNamespace)
+		pvc, err := r.k8sOps.GetPersistentVolumeClaim(pvcName, pvcNamespace)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/resourcecollector/persistentvolumeclaim.go
+++ b/pkg/resourcecollector/persistentvolumeclaim.go
@@ -3,8 +3,7 @@ package resourcecollector
 import (
 	"fmt"
 
-	"github.com/portworx/sched-ops/k8s"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -19,7 +18,7 @@ func (r *ResourceCollector) pvcToBeCollected(
 	}
 
 	pvcName := metadata.GetName()
-	pvc, err := k8s.Instance().GetPersistentVolumeClaim(pvcName, namespace)
+	pvc, err := r.k8sOps.GetPersistentVolumeClaim(pvcName, namespace)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -27,10 +27,9 @@ import (
 
 const (
 	// Annotation to use when the resource shouldn't be collected
-	skipResourceAnnotation   = "stork.libopenstorage.org/skipresource"
-	storkMigrationAnnotation = "stork.libopenstorage.org/storkMigration"
-	deletedMaxRetries        = 12
-	deletedRetryInterval     = 10 * time.Second
+	skipResourceAnnotation = "stork.libopenstorage.org/skipresource"
+	deletedMaxRetries      = 12
+	deletedRetryInterval   = 10 * time.Second
 )
 
 // ResourceCollector is used to collect and process unstructured objects in namespaces and using label selectors
@@ -38,14 +37,11 @@ type ResourceCollector struct {
 	Driver           volume.Driver
 	discoveryHelper  discovery.Helper
 	dynamicInterface dynamic.Interface
+	k8sOps           k8s.Ops
 }
 
 // Init initializes the resource collector
-func (r *ResourceCollector) Init() error {
-	return r.initClusterConfig(nil)
-}
-
-func (r *ResourceCollector) initClusterConfig(config *restclient.Config) error {
+func (r *ResourceCollector) Init(config *restclient.Config) error {
 	var err error
 	if config == nil {
 		config, err = restclient.InClusterConfig()
@@ -71,7 +67,10 @@ func (r *ResourceCollector) initClusterConfig(config *restclient.Config) error {
 	}
 
 	// reset k8s instance to given cluster config
-	k8s.Instance().SetConfig(config)
+	r.k8sOps, err = k8s.NewInstanceFromRestConfig(config)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -102,13 +101,8 @@ func resourceToBeCollected(resource metav1.APIResource) bool {
 }
 
 // GetResources gets all the resources in the given list of namespaces which match the labelSelectors
-func (r *ResourceCollector) GetResources(namespaces []string, labelSelectors map[string]string, remoteConfig *restclient.Config, destCluster bool) ([]runtime.Unstructured, error) {
-	err := r.initClusterConfig(remoteConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	err = r.discoveryHelper.Refresh()
+func (r *ResourceCollector) GetResources(namespaces []string, labelSelectors map[string]string) ([]runtime.Unstructured, error) {
+	err := r.discoveryHelper.Refresh()
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +111,7 @@ func (r *ResourceCollector) GetResources(namespaces []string, labelSelectors map
 	// Map to prevent collection of duplicate objects
 	resourceMap := make(map[types.UID]bool)
 
-	crbs, err := k8s.Instance().ListClusterRoleBindings()
+	crbs, err := r.k8sOps.ListClusterRoleBindings()
 	if err != nil {
 		return nil, err
 	}
@@ -130,11 +124,6 @@ func (r *ResourceCollector) GetResources(namespaces []string, labelSelectors map
 
 		for _, resource := range group.APIResources {
 			if !resourceToBeCollected(resource) {
-				continue
-			}
-			// skip collecting non-namespaced resources for
-			// destination cluster
-			if destCluster && !resource.Namespaced {
 				continue
 			}
 			for _, ns := range namespaces {
@@ -172,7 +161,7 @@ func (r *ResourceCollector) GetResources(namespaces []string, labelSelectors map
 						return nil, fmt.Errorf("error casting object: %v", o)
 					}
 
-					collect, err := r.objectToBeCollected(labelSelectors, resourceMap, runtimeObject, crbs, ns, destCluster)
+					collect, err := r.objectToBeCollected(labelSelectors, resourceMap, runtimeObject, crbs, ns)
 					if err != nil {
 						return nil, fmt.Errorf("error processing object %v: %v", runtimeObject, err)
 					}
@@ -205,22 +194,10 @@ func (r *ResourceCollector) objectToBeCollected(
 	object runtime.Unstructured,
 	crbs *rbacv1.ClusterRoleBindingList,
 	namespace string,
-	destCluster bool,
 ) (bool, error) {
 	metadata, err := meta.Accessor(object)
 	if err != nil {
 		return false, err
-	}
-
-	// check migration resources
-	if destCluster {
-		if val, ok := metadata.GetAnnotations()[storkMigrationAnnotation]; ok {
-			if skip, err := strconv.ParseBool(val); err == nil && !skip {
-				return true, err
-			}
-		} else {
-			return false, nil
-		}
 	}
 
 	if value, present := metadata.GetAnnotations()[skipResourceAnnotation]; present {

--- a/vendor/github.com/portworx/sched-ops/k8s/k8s.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/k8s.go
@@ -995,6 +995,19 @@ func (k *k8sOps) initK8sClient() error {
 	return nil
 }
 
+// NewInstanceFromRestConfig returns new instance of k8sOps by using given
+// k8s rest client config
+func NewInstanceFromRestConfig(config *rest.Config) (Ops, error) {
+	newInstance := &k8sOps{}
+	newInstance.config = config
+	err := newInstance.loadClientFor(config)
+	if err != nil {
+		logrus.Errorf("Unable to set new instance: %v", err)
+		return nil, err
+	}
+	return newInstance, nil
+}
+
 func (k *k8sOps) GetVersion() (*version.Info, error) {
 	if err := k.initK8sClient(); err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**\
>feature


**What this PR does / why we need it**:
With this user can able to cleanup deleted objects from destination during migration

**Does this PR change a user-facing CRD or CLI?**:
yes, we have `AllowCleaningResources` flag to cleanup resources
**Is a release note needed?**:
no


**Does this change need to be cherry-picked to a release branch?**:
yes, 2.30

