### PR TITLE
add integration test for migration cleanup feature

### DIFF
--- a/test/integration_test/specs/mysql-migration-schedule-interval/migrationschedule.yaml
+++ b/test/integration_test/specs/mysql-migration-schedule-interval/migrationschedule.yaml
@@ -14,6 +14,9 @@ spec:
       # 0 on the destination. There will be an annotation with
       # "stork.openstorage.org/migrationReplicas" to store the replica count from the source
       startApplications: false
+      # If set to true, migration will also delete resources which are no longer
+      # present on source cluster. Only resource which are earlier migrated by stork will be cleaned up
+      purgeDeletedResources: true
       # List of namespaces to migrate
       namespaces:
       - mysql-1-pvc-mysql-migration-schedule-interval


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>integration-test

**What this PR does / why we need it**:
Add integration test for migration cleanup feature #522 

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.3.0

Jenkins run:
```
 	 Scheduler Status:  Next retry in: 10s
19:50:21 2019/11/22 14:20:21 Failed to validate custom spec : remoteclusterpair of type *v1alpha1.ClusterPair due to err: Storage Status:  	 Scheduler Status:  Next retry in: 10s
19:50:31 time="2019-11-22T14:20:31Z" level=info msg="[mysql-1-pvc] Validated ClusterPair: remoteclusterpair"
19:50:31 time="2019-11-22T14:20:31Z" level=info msg="[mysql-migration-schedule-interval] Created MigrationSchedule: mysql-migration-schedule-interval"
19:50:31 time="2019-11-22T14:20:31Z" level=info msg="[mysql-migration-schedule-interval] Created SchedulePolicy: migrate-every-5m"
19:50:34 
19:50:34 
19:50:34 app key &{mysql-migration-schedule-interval 0xc420a59020 {[mysql-1-pvc] []   <nil>}}
19:50:34 
19:50:34 migr app key &{mysql-migration-schedule-interval 0xc420ac7c20 {[] []   <nil>}}--- PASS: TestSnapshotMigration (316.65s)
19:50:34     --- PASS: TestSnapshotMigration/testSnapshot (0.00s)
19:50:34     --- PASS: TestSnapshotMigration/testSnapshotRestore (0.00s)
19:50:34     --- PASS: TestSnapshotMigration/testMigration (316.65s)
19:50:34         --- PASS: TestSnapshotMigration/testMigration/intervalScheduleCleanupTest (313.65s)
19:50:34 === RUN   TestExtender
19:50:34 --- PASS: TestExtender (0.00s)
19:50:34 === RUN   TestHealthMonitor
19:50:34 --- PASS: TestHealthMonitor (0.00s)
19:50:34 PASS
19:50:34 
19:50:34 DONE 11 tests in 363.229s
19:50:44 Tests passed
```