### PR TITLE
[portworx] Wait for volume restore api to complete

### DIFF
--- a/pkg/snapshot/controllers/snapshotrestore.go
+++ b/pkg/snapshot/controllers/snapshotrestore.go
@@ -182,7 +182,6 @@ func (c *SnapshotRestoreController) handleFinal(snapRestore *stork_api.VolumeSna
 		log.VolumeSnapshotRestoreLog(snapRestore).Errorf("unable to mark pvc for restore %v", err)
 		return err
 	}
-
 	// Do driver volume snapshot restore here
 	err = c.Driver.CompleteVolumeSnapshotRestore(snapRestore)
 	if err != nil {
@@ -193,7 +192,6 @@ func (c *SnapshotRestoreController) handleFinal(snapRestore *stork_api.VolumeSna
 		snapRestore.Status.Status = stork_api.VolumeSnapshotRestoreStatusFailed
 		return fmt.Errorf("failed to restore pvc %v", err)
 	}
-
 	err = unmarkPVCForRestore(snapRestore.Status.Volumes)
 	if err != nil {
 		log.VolumeSnapshotRestoreLog(snapRestore).Errorf("unable to unmark pvc for restore %v", err)
@@ -218,7 +216,6 @@ func markPVCForRestore(volumes []*stork_api.RestoreVolumeInfo) error {
 		if err != nil {
 			return err
 		}
-		log.PVCLog(newPvc).Debugf("Updated pvc annotation %v", newPvc.Annotations)
 		pods, err := k8s.Instance().GetPodsUsingPVC(newPvc.Name, newPvc.Namespace)
 		if err != nil {
 			return err
@@ -232,7 +229,6 @@ func markPVCForRestore(volumes []*stork_api.RestoreVolumeInfo) error {
 				log.PodLog(&pod).Errorf("Error deleting pod %v: %v", pod.Name, err)
 				return err
 			}
-			log.PodLog(&pod).Debugf("Deleted before wait pod %v", pod.Name)
 			if err := k8s.Instance().WaitForPodDeletion(pod.UID, pod.Namespace, 120*time.Second); err != nil {
 				log.PodLog(&pod).Errorf("Pod is not deleted %v:%v", pod.Name, err)
 				return err


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Px driver restore api is async, we need to wait till volume is in restore state before deleting restore snap objects

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no
**Does this change need to be cherry-picked to a release branch?**:
2.3

Integration test run:
```
time="2019-11-26T08:54:53Z" level=info msg="[mysql-cloudsnap-group-restore] Validated destroy of Deployment: mysql"
time="2019-11-26T08:54:53Z" level=info msg="[mysql-cloudsnap-group-restore] Destroyed group snapshot: mysql-group-cloudsnapshot"
time="2019-11-26T08:54:53Z" level=info msg="[mysql-cloudsnap-group-restore] Destroyed PVC: mysql-data-1"
time="2019-11-26T08:54:53Z" level=info msg="[mysql-cloudsnap-group-restore] Destroyed PVC: mysql-data-2"
time="2019-11-26T08:54:53Z" level=info msg="[mysql-cloudsnap-group-restore] Destroyed storage class: px-mysql-sc"
time="2019-11-26T08:54:53Z" level=info msg="[mysql-groupsnap-inplace-cloud-restore] Destroyed VolumeSnapshotRestore: mysql-groupsnap-cloud-inrestore"
=== RUN   TestSnapshotMigration/testMigration
--- PASS: TestSnapshotMigration (730.28s)
    --- PASS: TestSnapshotMigration/testSnapshot (0.00s)
    --- PASS: TestSnapshotMigration/testSnapshotRestore (727.27s)
        --- PASS: TestSnapshotMigration/testSnapshotRestore/simpleSnapshotRestoreTest (132.06s)
        --- PASS: TestSnapshotMigration/testSnapshotRestore/groupSnapshotRestoreTest (181.76s)
        --- PASS: TestSnapshotMigration/testSnapshotRestore/cloudSnapshotRestoreTest (111.15s)
        --- PASS: TestSnapshotMigration/testSnapshotRestore/groupCloudSnapshotRestoreTest (302.30s)
    --- PASS: TestSnapshotMigration/testMigration (3.01s)
=== RUN   TestExtender
```