### PR TITLE
[portworx] bump px version for in place restore feature

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1150,7 +1150,7 @@ func (p *portworx) GetVolumeSnapshotRestoreStatus(snapRestore *stork_crd.VolumeS
 		switch snapType {
 		case "", crdv1.PortworxSnapshotTypeLocal:
 			vol.RestoreStatus = stork_crd.VolumeSnapshotRestoreStatusStaged
-			vol.Reason = fmt.Sprintf("Restore object is ready")
+			vol.Reason = "Restore object is ready"
 		case crdv1.PortworxSnapshotTypeCloud:
 			uid := getUidforRestore(vol.Volume, string(snapRestore.GetUID()))
 			taskID := restoreTaskPrefix + uid
@@ -1173,7 +1173,7 @@ func (p *portworx) GetVolumeSnapshotRestoreStatus(snapRestore *stork_crd.VolumeS
 					vol.Reason = "Volume is in resync state"
 				}
 				vol.RestoreStatus = stork_crd.VolumeSnapshotRestoreStatusStaged
-				vol.Reason = fmt.Sprintf("Restore object is ready")
+				vol.Reason = "Restore object is ready"
 			}
 		default:
 			vol.Reason = fmt.Sprintf("invalid SourceType for snapshot(local/cloud), found: %v", snapType)
@@ -1625,7 +1625,7 @@ func (p *portworx) waitForCloudSnapCompletion(
 
 	csStatus := cloudSnapStatus{
 		status: api.CloudBackupStatusFailed,
-		msg:    fmt.Sprintf("cloudsnap status unknown"),
+		msg:    "cloudsnap status unknown",
 	}
 
 	err := wait.ExponentialBackoff(cloudsnapBackoff, func() (bool, error) {
@@ -1983,7 +1983,7 @@ func (p *portworx) StartMigration(migration *stork_crd.Migration) ([]*stork_crd.
 				}
 			}
 			volumeInfo.Status = stork_crd.MigrationStatusInProgress
-			volumeInfo.Reason = fmt.Sprintf("Volume migration has started. Backup in progress.")
+			volumeInfo.Reason = "Volume migration has started. Backup in progress."
 		}
 	}
 
@@ -2034,7 +2034,7 @@ func (p *portworx) GetMigrationStatus(migration *stork_crd.Migration) ([]*stork_
 				} else if mInfo.CurrentStage == api.CloudMigrate_Done &&
 					mInfo.Status == api.CloudMigrate_Complete {
 					vInfo.Status = stork_crd.MigrationStatusSuccessful
-					vInfo.Reason = fmt.Sprintf("Migration successful for volume")
+					vInfo.Reason = "Migration successful for volume"
 				} else if mInfo.Status == api.CloudMigrate_InProgress {
 					vInfo.Reason = fmt.Sprintf("Volume migration has started. %v in progress. BytesDone: %v BytesTotal: %v ETA: %v seconds",
 						mInfo.CurrentStage.String(),
@@ -2520,7 +2520,7 @@ func (p *portworx) GetBackupStatus(backup *stork_crd.ApplicationBackup) ([]*stor
 		} else {
 			vInfo.BackupID = csStatus.cloudSnapID
 			vInfo.Status = stork_crd.ApplicationBackupStatusSuccessful
-			vInfo.Reason = fmt.Sprintf("Backup successful for volume")
+			vInfo.Reason = "Backup successful for volume"
 		}
 	}
 
@@ -2654,7 +2654,7 @@ func (p *portworx) GetRestoreStatus(restore *stork_crd.ApplicationRestore) ([]*s
 			vInfo.Reason = fmt.Sprintf("Restore failed for volume: %v", csStatus.msg)
 		} else {
 			vInfo.Status = stork_crd.ApplicationRestoreStatusSuccessful
-			vInfo.Reason = fmt.Sprintf("Restore successful for volume")
+			vInfo.Reason = "Restore successful for volume"
 		}
 	}
 

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -1068,7 +1068,7 @@ func (p *portworx) StartVolumeSnapshotRestore(snapRestore *stork_crd.VolumeSnaps
 	case "", crdv1.PortworxSnapshotTypeLocal:
 		return nil
 	case crdv1.PortworxSnapshotTypeCloud:
-		ok, msg, err := p.ensureNodesHaveMinVersion("2.3.0")
+		ok, msg, err := p.ensureNodesHaveMinVersion("2.3.2")
 		if err != nil {
 			return err
 		}
@@ -1076,7 +1076,7 @@ func (p *portworx) StartVolumeSnapshotRestore(snapRestore *stork_crd.VolumeSnaps
 		if !ok {
 			err = &errors.ErrNotSupported{
 				Feature: "VolumeSnapshotRestore for Cloudsnaps",
-				Reason:  "Only supported on PX version 2.3.0 onwards: " + msg,
+				Reason:  "Only supported on PX version 2.3.2 onwards: " + msg,
 			}
 
 			return err

--- a/pkg/clusterdomains/controllers/clusterdomainstatus.go
+++ b/pkg/clusterdomains/controllers/clusterdomainstatus.go
@@ -82,7 +82,7 @@ func (c *ClusterDomainsStatusController) Handle(ctx context.Context, event sdk.E
 				apiClusterDomainsStatus,
 				v1.EventTypeWarning,
 				err.Error(),
-				fmt.Sprintf("Failed to update ClusterDomainsStatuses"),
+				"Failed to update ClusterDomainsStatuses",
 			)
 			logrus.Errorf("Failed to get cluster domain info: %v", err)
 		} else {

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -186,7 +186,7 @@ func (m *MigrationController) Handle(ctx context.Context, event sdk.Event) error
 					migration.Status.Status = stork_api.MigrationStatusFailed
 					migration.Status.Stage = stork_api.MigrationStageFinal
 					migration.Status.FinishTimestamp = metav1.Now()
-					msg := fmt.Sprintf("Failing migration since local clusterdomain is inactive")
+					msg := "Failing migration since local clusterdomain is inactive"
 					m.Recorder.Event(migration,
 						v1.EventTypeWarning,
 						string(stork_api.MigrationStatusFailed),

--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -92,7 +92,7 @@ func (m *MigrationScheduleController) Handle(ctx context.Context, event sdk.Even
 						domainInfo.State == stork_api.ClusterDomainInactive {
 						suspend := true
 						migrationSchedule.Spec.Suspend = &suspend
-						msg := fmt.Sprintf("Suspending migration schedule since local clusterdomain is inactive")
+						msg := "Suspending migration schedule since local clusterdomain is inactive"
 						m.Recorder.Event(migrationSchedule,
 							v1.EventTypeWarning,
 							"Suspended",

--- a/pkg/storkctl/common.go
+++ b/pkg/storkctl/common.go
@@ -14,7 +14,7 @@ func toTimeString(t time.Time) string {
 }
 
 func handleEmptyList(out io.Writer) {
-	msg := fmt.Sprintf("No resources found.")
+	msg := "No resources found."
 	printMsg(msg, out)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
Ensure px driver has 2.3.2 version for in place cloud snapshot restore feature

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no
**Does this change need to be cherry-picked to a release branch?**:
2.3.0
