### PR TITLE
Add stork secrets implementation based on lsecrets.Instance()

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -27,6 +27,8 @@ import (
 	auth_secrets "github.com/libopenstorage/openstorage/pkg/auth/secrets"
 	"github.com/libopenstorage/openstorage/pkg/grpcserver"
 	"github.com/libopenstorage/openstorage/volume"
+	lsecrets "github.com/libopenstorage/secrets"
+	k8s_secrets "github.com/libopenstorage/secrets/k8s"
 	storkvolume "github.com/libopenstorage/stork/drivers/volume"
 	stork_crd "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	applicationcontrollers "github.com/libopenstorage/stork/pkg/applicationmanager/controllers"
@@ -336,6 +338,16 @@ func (p *portworx) initPortworxClients() error {
 	err = p.sdkConn.setDialOptions(isTLSEnabled())
 	if err != nil {
 		return err
+	}
+
+	// Setup secrets instance
+	k8sSecrets, err := k8s_secrets.New(nil)
+	if err != nil {
+		return fmt.Errorf("failed to initialize secrets provider: %v", err)
+	}
+	err = lsecrets.SetInstance(k8sSecrets)
+	if err != nil {
+		return fmt.Errorf("failed to set secrets provider: %v", err)
 	}
 
 	// Save the token if any was given


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>


**What type of PR is this?**
bug

**What this PR does / why we need it**:
The stork secrets implementation was lost in a recent vendor update. Openstorage now depends on lsecrets.Instance for all secrets calls. See the following in openstorage:
https://github.com/libopenstorage/openstorage/blob/7b164ed8270276bd627dca7e787ae8470db9b50c/pkg/auth/secrets/secrets.go#L40-L62

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
NONE
```

**Does this change need to be cherry-picked to a release branch?**:
Next patch release. This has been in master since
https://github.com/libopenstorage/stork/commit/dc4974e1cb9ac0abeeb7e90f8bae038fbd02bd1e

so, whichever release branches this commit is in.
