### PR TITLE
Use correct namespace when checking status of adminClusterPair

### DIFF
--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -132,7 +132,7 @@ func (c *ClusterPairController) Handle(ctx context.Context, event sdk.Event) err
 func getClusterPairSchedulerConfig(clusterPairName string, namespace string) (*restclient.Config, error) {
 	clusterPair, err := k8s.Instance().GetClusterPair(clusterPairName, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("error getting clusterpair: %v", err)
+		return nil, fmt.Errorf("error getting clusterpair (%v/%v): %v", namespace, clusterPairName, err)
 	}
 	remoteClientConfig := clientcmd.NewNonInteractiveClientConfig(
 		clusterPair.Spec.Config,

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -671,7 +671,7 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration) e
 	}
 
 	if migration.Spec.AdminClusterPair != "" {
-		schedulerStatus, err = getClusterPairSchedulerStatus(migration.Spec.AdminClusterPair, migration.Namespace)
+		schedulerStatus, err = getClusterPairSchedulerStatus(migration.Spec.AdminClusterPair, m.migrationAdminNamespace)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Fixed issue where the wrong namespace was being used when checking the admin cluster pair during migration
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.3

