### PR TITLE
[Azure] Store the resource group for volumes during snapshot

### DIFF
--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -210,6 +210,9 @@ func (a *azure) StartBackup(backup *storkapi.ApplicationBackup,
 		volumeInfo.PersistentVolumeClaim = pvc.Name
 		volumeInfo.Namespace = pvc.Namespace
 		volumeInfo.DriverName = driverName
+		volumeInfo.Options = map[string]string{
+			resourceGroupKey: a.resourceGroup,
+		}
 		volumeInfos = append(volumeInfos, volumeInfo)
 
 		pvName, err := k8s.Instance().GetVolumeForPersistentVolumeClaim(&pvc)
@@ -331,7 +334,15 @@ func (a *azure) StartRestore(
 
 	volumeInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
 	for _, backupVolumeInfo := range volumeBackupInfos {
-		snapshot, err := a.snapshotClient.Get(context.TODO(), a.resourceGroup, backupVolumeInfo.BackupID)
+		var resourceGroup string
+		if val, present := backupVolumeInfo.Options[resourceGroupKey]; present {
+			resourceGroup = val
+		} else {
+			resourceGroup = a.resourceGroup
+			logrus.Warnf("missing resource group in snapshot %v, will use current resource group", backupVolumeInfo.BackupID)
+		}
+
+		snapshot, err := a.snapshotClient.Get(context.TODO(), resourceGroup, backupVolumeInfo.BackupID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Use it during restore so that it can be restored across resource groups


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
