### PR TITLE
Set defaults for the spec in migration schedule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
       export DOCKER_HUB_STORK_TEST_TAG=`git rev-parse --short HEAD`
       export DOCKER_HUB_CMD_EXECUTOR_TAG=`git rev-parse --short HEAD`
     fi
-    make && make test && make container && make integration-test && make integration-test-container &&
+    make -j 2 && make test && make container && make integration-test && make integration-test-container &&
     if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
       docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}";
       make deploy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_install:
   - sudo apt-get update -yq
   - sudo apt-get install go-md2man -y
   - sudo apt-get install -y awscli
+cache:
+  directories:
+    - $HOME/.cache/go-build
 script:
   - |
     if [ "${TRAVIS_BRANCH}" == "master" ]; then

--- a/pkg/applicationmanager/controllers/applicationbackupschedule.go
+++ b/pkg/applicationmanager/controllers/applicationbackupschedule.go
@@ -126,7 +126,7 @@ func (s *ApplicationBackupScheduleController) Handle(ctx context.Context, event 
 
 func (s *ApplicationBackupScheduleController) setDefaults(backupSchedule *stork_api.ApplicationBackupSchedule) {
 	if backupSchedule.Spec.ReclaimPolicy == "" {
-		backupSchedule.Spec.ReclaimPolicy = stork_api.ReclaimPolicyDelete
+		backupSchedule.Spec.ReclaimPolicy = stork_api.ReclaimPolicyRetain
 	}
 }
 

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -113,24 +113,24 @@ func (m *MigrationController) performRuleRecovery() error {
 	return lastError
 }
 
-func setDefaults(migration *stork_api.Migration) *stork_api.Migration {
-	if migration.Spec.IncludeVolumes == nil {
+func setDefaults(spec stork_api.MigrationSpec) stork_api.MigrationSpec {
+	if spec.IncludeVolumes == nil {
 		defaultBool := true
-		migration.Spec.IncludeVolumes = &defaultBool
+		spec.IncludeVolumes = &defaultBool
 	}
-	if migration.Spec.IncludeResources == nil {
+	if spec.IncludeResources == nil {
 		defaultBool := true
-		migration.Spec.IncludeResources = &defaultBool
+		spec.IncludeResources = &defaultBool
 	}
-	if migration.Spec.StartApplications == nil {
+	if spec.StartApplications == nil {
 		defaultBool := false
-		migration.Spec.StartApplications = &defaultBool
+		spec.StartApplications = &defaultBool
 	}
-	if migration.Spec.PurgeDeletedResources == nil {
+	if spec.PurgeDeletedResources == nil {
 		defaultBool := false
-		migration.Spec.PurgeDeletedResources = &defaultBool
+		spec.PurgeDeletedResources = &defaultBool
 	}
-	return migration
+	return spec
 }
 
 // Handle updates for Migration objects
@@ -144,7 +144,7 @@ func (m *MigrationController) Handle(ctx context.Context, event sdk.Event) error
 			}
 			return nil
 		}
-		migration = setDefaults(migration)
+		migration.Spec = setDefaults(migration.Spec)
 
 		if migration.Spec.ClusterPair == "" {
 			err := fmt.Errorf("clusterPair to migrate to cannot be empty")

--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -63,6 +63,7 @@ func (m *MigrationScheduleController) Handle(ctx context.Context, event sdk.Even
 			return m.deleteMigrations(migrationSchedule)
 		}
 
+		migrationSchedule.Spec.Template.Spec = setDefaults(migrationSchedule.Spec.Template.Spec)
 		// First update the status of any pending migrations
 		err := m.updateMigrationStatus(migrationSchedule)
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
* The defaults are now set in the MigrationScheduleSpec if not provided
* The default ReclaimPolicy for ApplicationBackupSchedule has been changed to `Retain` so that the backups don't get deleted when the schedule object is deleted
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.3
