### PR TITLE
[Portworx] Don't migrate volumes which have the skipResource annotation

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -35,6 +35,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/errors"
 	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
+	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	"github.com/libopenstorage/stork/pkg/snapshot"
 	snapshotcontrollers "github.com/libopenstorage/stork/pkg/snapshot/controllers"
 	"github.com/portworx/sched-ops/k8s/core"
@@ -1981,6 +1982,9 @@ func (p *portworx) StartMigration(migration *storkapi.Migration) ([]*storkapi.Mi
 		}
 		for _, pvc := range pvcList.Items {
 			if !p.OwnsPVC(&pvc) {
+				continue
+			}
+			if resourcecollector.SkipResource(pvc.Annotations) {
 				continue
 			}
 			volumeInfo := &storkapi.MigrationVolumeInfo{

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -201,6 +201,17 @@ func (r *ResourceCollector) GetResources(namespaces []string, labelSelectors map
 	return allObjects, nil
 }
 
+// SkipResource returns whether the annotations of the object require it to be
+// skipped
+func SkipResource(annotations map[string]string) bool {
+	if value, present := annotations[skipResourceAnnotation]; present {
+		if skip, err := strconv.ParseBool(value); err == nil && skip {
+			return true
+		}
+	}
+	return false
+}
+
 // Returns whether an object should be collected or not for the requested
 // namespace
 func (r *ResourceCollector) objectToBeCollected(
@@ -216,10 +227,8 @@ func (r *ResourceCollector) objectToBeCollected(
 		return false, err
 	}
 
-	if value, present := metadata.GetAnnotations()[skipResourceAnnotation]; present {
-		if skip, err := strconv.ParseBool(value); err == nil && skip {
-			return false, err
-		}
+	if SkipResource(metadata.GetAnnotations()) {
+		return false, err
 	}
 
 	// Skip if we've already processed this object


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
- Portworx: Don't migrate volumes that have the skipResource annotation. Previously the PVC would not get migrated but the volume was still migrated
```

**Does this change need to be cherry-picked to a release branch?**:
2.3

