### PR TITLE
Add a reason field for the overall backup and restore status

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -48,6 +48,7 @@ const (
 type ApplicationBackupStatus struct {
 	Stage            ApplicationBackupStageType       `json:"stage"`
 	Status           ApplicationBackupStatusType      `json:"status"`
+	Reason           string                           `json:"reason"`
 	Resources        []*ApplicationBackupResourceInfo `json:"resources"`
 	Volumes          []*ApplicationBackupVolumeInfo   `json:"volumes"`
 	BackupPath       string                           `json:"backupPath"`

--- a/pkg/apis/stork/v1alpha1/applicationrestore.go
+++ b/pkg/apis/stork/v1alpha1/applicationrestore.go
@@ -52,6 +52,7 @@ const (
 type ApplicationRestoreStatus struct {
 	Stage           ApplicationRestoreStageType       `json:"stage"`
 	Status          ApplicationRestoreStatusType      `json:"status"`
+	Reason          string                            `json:"reason"`
 	Resources       []*ApplicationRestoreResourceInfo `json:"resources"`
 	Volumes         []*ApplicationRestoreVolumeInfo   `json:"volumes"`
 	FinishTimestamp metav1.Time                       `json:"finishTimestamp"`


### PR DESCRIPTION
**What type of PR is this?**
Improvement

**What this PR does / why we need it**:

**Does this PR change a user-facing CRD or CLI?**:
Yes, Status is updated, no backward compatibility issue

**Is a release note needed?**:
```
* The status for `ApplicationBackup` and `ApplicationRestore` now has an overall status reason field
```

**Does this change need to be cherry-picked to a release branch?**:
2.3

