### PR TITLE
Get the correct pluralized name of resources for the dynamic client

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-openapi/inflect"
 	"github.com/heptio/ark/pkg/discovery"
 	"github.com/libopenstorage/stork/drivers/volume"
 	"github.com/portworx/sched-ops/k8s/core"
@@ -536,7 +537,7 @@ func (r *ResourceCollector) getDynamicClient(
 		return nil, err
 	}
 	resource := &metav1.APIResource{
-		Name:       strings.ToLower(objectType.GetKind()) + "s",
+		Name:       inflect.Pluralize(strings.ToLower(objectType.GetKind())),
 		Namespaced: len(metadata.GetNamespace()) > 0,
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Fixed an issue with ApplicationRestore where some objects (like Ingress) could not be restored because an invalid name was being used for the object type
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.3
