### PR TITLE
Increase wait time for groupsnapshot restore PVC to be bound

### DIFF
--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -24,7 +24,7 @@ import (
 var storkStorageClass = "stork-snapshot-sc"
 
 const (
-	waitPvcBound         = 120 * time.Second
+	waitPvcBound         = 300 * time.Second
 	waitPvcRetryInterval = 5 * time.Second
 
 	snapshotScheduleRetryInterval = 10 * time.Second


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
We need wait for restore to get completed before PVC gets bound. So we need more wait time for PVC to be bound

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.3

