### PR TITLE
Add apt-get install jq for ubuntu base images

### DIFF
--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -99,6 +99,7 @@ done
 
 apk update
 apk add jq
+apt-get -y install jq
 
 KUBEVERSION=$(kubectl version -o json | jq ".serverVersion.gitVersion" -r)
 sed -i 's/<kube_version>/'"$KUBEVERSION"'/g' /specs/stork-scheduler.yaml

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -105,6 +105,9 @@ KUBEVERSION=$(kubectl version -o json | jq ".serverVersion.gitVersion" -r)
 sed -i 's/<kube_version>/'"$KUBEVERSION"'/g' /specs/stork-scheduler.yaml
 sed -i 's|'openstorage/stork:.*'|'"$image_name"'|g'  /specs/stork-deployment.yaml
 
+if [ "$volume_driver" != "pxd" ] ; then
+	sed -i 's/- --driver=pxd//g' /testspecs/stork-test-pod.yaml
+fi
 # For integration test mock times
 kubectl delete cm stork-mock-time  -n kube-system || true
 kubectl create cm stork-mock-time  -n kube-system --from-literal=time=""


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
For Ubuntu base images need 'jq' when running integration tests

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.3
