### PR TITLE
Set all configmap after default config map is correctly set

### DIFF
--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -47,11 +47,6 @@ func TestApplicationBackup(t *testing.T) {
 
 	allConfigMap = configMap.Data
 
-	// If running on COLO backup to all locations
-	if volumeDriverName != "pxd" {
-		allConfigMap = defaultConfigMap
-	}
-
 	// Default backup location
 	defaultBackupLocation, err = getBackupLocationForVolumeDriver(volumeDriverName)
 	require.NoError(t, err, "Failed to get default backuplocation for %s: %v", volumeDriverName, err)
@@ -59,6 +54,11 @@ func TestApplicationBackup(t *testing.T) {
 	require.NoError(t, err, "Failed to get default secret name for %s: %v", volumeDriverName, err)
 	logrus.Infof("Default backup location set to %v", defaultBackupLocation)
 	defaultConfigMap = getBackupConfigMapForType(allConfigMap, defaultBackupLocation)
+
+	// If running pxd driver backup to all locations
+	if volumeDriverName != "pxd" {
+		allConfigMap = defaultConfigMap
+	}
 
 	t.Run("applicationBackupRestoreTest", applicationBackupRestoreTest)
 	t.Run("applicationBackupDelBackupLocation", applicationBackupDelBackupLocation)


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Set allconfig currently gets set to blank

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.3
