### PR TITLE
Import k8s client auth in integration tests

### DIFF
--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -4,7 +4,28 @@ FROM golang:1.11.2
 RUN apt-get update && \ 
     /usr/local/go/bin/go get -u gotest.tools/gotestsum
 
+RUN apt-get update && apt-get install -y python-pip
+
+RUN pip install --upgrade pip 
+
+ARG GCLOUD_SDK=google-cloud-sdk-269.0.0-linux-x86_64.tar.gz
+# Remove the test directories
+# Also don't need gsutil
+RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
+    tar xf $GCLOUD_SDK && rm -rf $GCLOUD_SDK && \
+    cp -r google-cloud-sdk/bin/* /usr/local/bin/  && \
+    cp -r google-cloud-sdk/lib/* /usr/local/lib/  && \
+    rm -rf /google-cloud-sdk/platform/gsutil/third_party/oauth2client/tests \
+        /google-cloud-sdk/platform/gsutil/third_party/rsa/tests \
+        /google-cloud-sdk/platform/gsutil/third_party/httplib2/python2/httplib2/test \
+        /google-cloud-sdk/platform/gsutil && \
+    pip install pyyaml>=5.1 rsa>=4.0 urllib3>=1.24.2 --upgrade -t /google-cloud-sdk/lib/third_party
+
+RUN wget -O /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
+    chmod +x /usr/local/bin/aws-iam-authenticator
+
 WORKDIR /
 
 COPY stork.test /
 COPY specs /specs/
+

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -40,6 +40,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -144,22 +144,24 @@ for i in $(seq 1 100) ; do
     fi
 done
 
-echo "Creating stork scheduler"
-kubectl apply -f /specs/stork-scheduler.yaml
+if [ "$volume_driver" == "pxd" ] ; then
+	echo "Creating stork scheduler"
+	kubectl apply -f /specs/stork-scheduler.yaml
 # Delete the pods to make sure we are waiting for the status from the
 # new pods
-kubectl delete pods -n kube-system -l name=stork-scheduler
+	kubectl delete pods -n kube-system -l name=stork-scheduler
 
-echo "Waiting for stork-scheduler to be in running state"
-for i in $(seq 1 100) ; do
-    replicas=$(kubectl get deployment -n kube-system stork-scheduler -o json | jq ".status.readyReplicas")
-    if [ "$replicas" == "3" ]; then
-        break
-    else
-        echo "Stork scheduler is not ready yet"
-        sleep 10
-    fi
-done
+	echo "Waiting for stork-scheduler to be in running state"
+	for i in $(seq 1 100) ; do
+		replicas=$(kubectl get deployment -n kube-system stork-scheduler -o json | jq ".status.readyReplicas")
+		if [ "$replicas" == "3" ]; then
+			break
+		else
+			echo "Stork scheduler is not ready yet"
+			sleep 10
+		fi
+	done
+fi
 
 if [ "$run_cluster_domain_test" == "true" ] ; then
 	sed -i 's/'enable_cluster_domain'/'\""true"\"'/g' /testspecs/stork-test-pod.yaml


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
When running integration tests on cloud platforms need to init auth plugins

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.3
