### PR TITLE
For azure backups add env variables from px-azure secret

### DIFF
--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -1024,7 +1024,7 @@ func waitForAppBackupToStart(name, namespace string, timeout time.Duration) erro
 		}
 		return "", false, nil
 	}
-	_, err := task.DoRetryWithTimeout(getAppBackup, timeout, defaultWaitInterval)
+	_, err := task.DoRetryWithTimeout(getAppBackup, timeout, backupWaitInterval)
 	return err
 
 }

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -68,6 +68,7 @@ const (
 	clusterDomainWaitTimeout time.Duration = 10 * time.Minute
 	groupSnapshotWaitTimeout time.Duration = 15 * time.Minute
 	defaultWaitInterval      time.Duration = 10 * time.Second
+	backupWaitInterval       time.Duration = 2 * time.Second
 
 	enableClusterDomainTests = "ENABLE_CLUSTER_DOMAIN_TESTS"
 	storageProvisioner       = "STORAGE_PROVISIONER"

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -14,6 +14,7 @@ auth_secret_configmap=""
 volume_driver="pxd"
 short_test=false
 backup_location_path="test-restore-path"
+cloud_secret=""
 for i in "$@"
 do
 case $i in
@@ -101,6 +102,12 @@ case $i in
         shift
         shift
         ;;
+    --cloud_secret)
+        echo "Secret name for cloud provider API access: $2"
+        cloud_secret=$2
+        shift
+        shift
+        ;;
 esac
 done
 
@@ -137,6 +144,10 @@ else
   echo "No environment variables passed."
 fi
 
+if [ "$volume_driver" == "azure" ] ; then
+    echo "For azure backups add environment variables to stork from existing k8s secret px-azure"
+    kubectl -n  kube-system set env --from=secret/$cloud_secret deploy/stork
+fi
 
 # Delete the pods to make sure we are waiting for the status from the
 # new pods


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
In case of azure backups, stork needs env vars as used in px-azure secret in PX

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.3
