### PR TITLE
Avoid adding duplicate volume to restore status

### DIFF
--- a/pkg/snapshot/controllers/snapshotrestore.go
+++ b/pkg/snapshot/controllers/snapshotrestore.go
@@ -92,7 +92,7 @@ func (c *SnapshotRestoreController) Handle(ctx context.Context, event sdk.Event)
 				c.Recorder.Event(snapRestore,
 					v1.EventTypeNormal,
 					string(snapRestore.Status.Status),
-					"Snapshot in-Place  Restore completed")
+					"Snapshot in-Place Restore completed")
 			}
 		case stork_api.VolumeSnapshotRestoreStatusFailed:
 			err = c.Driver.CleanupSnapshotRestoreObjects(snapRestore)
@@ -279,24 +279,26 @@ func initRestoreVolumesInfo(snapshotList []*snap_v1.VolumeSnapshot, snapRestore 
 		if err != nil {
 			return fmt.Errorf("failed to get pvc details for snapshot %v", err)
 		}
-
 		volInfo := &stork_api.RestoreVolumeInfo{}
 		// check whether we have volInfo already processed for given
 		// pvc. If so update existing vol info
+		isPresent := false
 		for _, vol := range snapRestore.Status.Volumes {
-			if pvc.Spec.VolumeName == vol.PVC {
+			if pvc.Name == vol.PVC {
 				volInfo = vol
+				isPresent = true
 				break
 			}
 		}
-		volInfo.Volume = pvc.Spec.VolumeName
-		volInfo.PVC = pvc.Name
-		volInfo.Namespace = pvc.Namespace
-		volInfo.Snapshot = snapData
-		volInfo.RestoreStatus = stork_api.VolumeSnapshotRestoreStatusInitial
-		snapRestore.Status.Volumes = append(snapRestore.Status.Volumes, volInfo)
+		if !isPresent {
+			volInfo.Volume = pvc.Spec.VolumeName
+			volInfo.PVC = pvc.Name
+			volInfo.Namespace = pvc.Namespace
+			volInfo.Snapshot = snapData
+			volInfo.RestoreStatus = stork_api.VolumeSnapshotRestoreStatusInitial
+			snapRestore.Status.Volumes = append(snapRestore.Status.Volumes, volInfo)
+		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
We keep adding volume entries into restore status in case of failure, this PR fix adding duplicate volume to snapshot restore status

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:


**Does this change need to be cherry-picked to a release branch?**:
yes, 2.3.3

**Example Restore output**:
```
# storkctl get volumesnapshotrestore
NAME                         SOURCE-SNAPSHOT             SOURCE-SNAPSHOT-NAMESPACE   STATUS   VOLUMES   CREATED
mysql-snap-group-inrestore   mysql-group-cloudsnapshot   default                              1         25 Mar 20 23:05 PDT
# date
Wed Mar 25 23:11:40 PDT 2020
```


**kubectl describe volumesnapshotrestore.stork.libopenstorage.org/mysql-snap-group-inrestore**
```
Name:         mysql-snap-group-inrestore
Namespace:    default
Labels:       <none>
Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                {"apiVersion":"stork.libopenstorage.org/v1alpha1","kind":"VolumeSnapshotRestore","metadata":{"annotations":{},"name":"mysql-snap-group-inr...
API Version:  stork.libopenstorage.org/v1alpha1
Kind:         VolumeSnapshotRestore
Metadata:
  Creation Timestamp:  2020-03-26T06:05:15Z
  Generation:          2
  Resource Version:    560783
  Self Link:           /apis/stork.libopenstorage.org/v1alpha1/namespaces/default/volumesnapshotrestores/mysql-snap-group-inrestore
  UID:                 c31cdd6a-6f27-11ea-92e2-000c29343860
Spec:
  Group Snapshot:    true
  Source Name:       mysql-group-cloudsnapshot
  Source Namespace:  default
Status:
  Status:
  Volumes:
    Namespace:  default
    Pvc:        mysql-data-1
    Reason:
    Snapshot:   mysql-group-cloudsnapshot-mysql-data-1-5deff7ee-6ec1-11ea-816a-000c29343860
    Status:
    Volume:     pvc-09a5f2c8-6ec1-11ea-816a-000c29343860
Events:
  Type     Reason  Age                From   Message
  ----     ------  ----               ----   -------
  Warning  Failed  8s (x12 over 10m)  stork  failed to get pvc details for snapshot persistentvolumeclaims "mysql-data-2" not found
```