### PR TITLE
Explicitly reset kubeconfig after every migration-backup loop

### DIFF
--- a/test/integration_test/migration_backup_test.go
+++ b/test/integration_test/migration_backup_test.go
@@ -133,5 +133,8 @@ func deploymentMigrationBackupTest(t *testing.T) {
 		require.NoError(t, err, "Failed to delete  backup location %s on source cluster: %v.", currBackupLocation.Name, err)
 
 		logrus.Infoln("Completed cleanup on destination cluster")
+
+		err = setRemoteConfig("")
+		require.NoError(t, err, "Error resetting remote config")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Reset kubeconfig to source cluster after every loop in the mig-backup test

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.3
