### PR TITLE
Fix pre exec rule failure in application backup

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2506,7 +2506,6 @@ func (p *portworx) StartBackup(backup *storkapi.ApplicationBackup,
 	}
 	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 	for _, pvc := range pvcs {
-		log.ApplicationBackupLog(backup).Infof("PVC %v in portworx", pvc.Name)
 		if pvc.DeletionTimestamp != nil {
 			log.ApplicationBackupLog(backup).Warnf("Ignoring PVC %v which is being deleted", pvc.Name)
 			continue


### PR DESCRIPTION
Multiple updates were failing because of conflicts. Fetching latest object
before updating in pre exec path
Also if the pre exec rule fails the backup will be marked as Failed instead of
retrying


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Fixed handling of error during Pre-Exec rule in `ApplicationBackup`
```

**Does this change need to be cherry-picked to a release branch?**:
2.4

