### PR TITLE
Allow drivers to return resources that should be restored before volumes

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -23,6 +23,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/storage"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8shelper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
@@ -393,6 +394,12 @@ func (a *aws) UpdateMigratedPersistentVolumeSpec(
 
 func (a *aws) generatePVName() string {
 	return pvNamePrefix + string(uuid.NewUUID())
+}
+func (a *aws) GetPreRestoreResources(
+	*storkapi.ApplicationBackup,
+	[]runtime.Unstructured,
+) ([]runtime.Unstructured, error) {
+	return nil, nil
 }
 
 func (a *aws) StartRestore(

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -22,6 +22,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/storage"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	k8shelper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
@@ -393,6 +394,13 @@ func (a *azure) findExistingDisk(tags map[string]string) (*compute.Disk, error) 
 			break
 		}
 	}
+	return nil, nil
+}
+
+func (a *azure) GetPreRestoreResources(
+	*storkapi.ApplicationBackup,
+	[]runtime.Unstructured,
+) ([]runtime.Unstructured, error) {
 	return nil, nil
 }
 

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -19,6 +19,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	k8shelper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
@@ -332,6 +333,13 @@ func (g *gcp) getSnapshotResourceName(
 ) string {
 	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%v/global/snapshots/%v",
 		backupVolumeInfo.Options["projectID"], backupVolumeInfo.BackupID)
+}
+
+func (g *gcp) GetPreRestoreResources(
+	*storkapi.ApplicationBackup,
+	[]runtime.Unstructured,
+) ([]runtime.Unstructured, error) {
+	return nil, nil
 }
 
 func (g *gcp) StartRestore(

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -47,6 +48,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	v1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -94,6 +96,10 @@ const (
 
 	// pxRackLabelKey Label for rack information
 	pxRackLabelKey = "px/rack"
+	// px annotation for secret name
+	pxSecretNameAnnotation = "px/secret-name"
+	// px annotation for secret namespace
+	pxSecretNamespaceAnnotation = "px/secret-namespace"
 
 	snapshotDataNamePrefix = "k8s-volume-snapshot"
 	readySnapshotMsg       = "Snapshot created successfully and it is ready"
@@ -2626,6 +2632,54 @@ func (p *portworx) stopCloudBackupTask(volDriver volume.VolumeDriver, taskID str
 
 func (p *portworx) generatePVName() string {
 	return pvNamePrefix + string(uuid.NewUUID())
+}
+
+func (p *portworx) GetPreRestoreResources(
+	backup *storkapi.ApplicationBackup,
+	objects []runtime.Unstructured,
+) ([]runtime.Unstructured, error) {
+	secretsToRestore := make(map[string]bool)
+	objectsToRestore := make([]runtime.Unstructured, 0)
+
+	for _, o := range objects {
+		objectType, err := meta.TypeAccessor(o)
+		if err != nil {
+			return nil, err
+		}
+		if objectType.GetKind() == "PersistentVolumeClaim" {
+			metadata, err := meta.Accessor(o)
+			if err != nil {
+				return nil, err
+			}
+			annotations := metadata.GetAnnotations()
+			if annotations == nil {
+				continue
+			}
+			if secretName, present := annotations[pxSecretNameAnnotation]; present && secretName != "" {
+				// Also pick up the namespace from the annotation, if absent
+				// it'll be empty
+				secretsToRestore[filepath.Join(annotations[pxSecretNamespaceAnnotation], secretName)] = true
+			}
+		}
+	}
+	if len(secretsToRestore) > 0 {
+		for _, o := range objects {
+			objectType, err := meta.TypeAccessor(o)
+			if err != nil {
+				return nil, err
+			}
+			if objectType.GetKind() == "Secret" {
+				metadata, err := meta.Accessor(o)
+				if err != nil {
+					return nil, err
+				}
+				if secretsToRestore[filepath.Join(metadata.GetNamespace(), metadata.GetName())] {
+					objectsToRestore = append(objectsToRestore, o)
+				}
+			}
+		}
+	}
+	return objectsToRestore, nil
 }
 
 func (p *portworx) StartRestore(

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -10,6 +10,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/errors"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -139,6 +140,8 @@ type BackupRestorePluginInterface interface {
 	CancelBackup(*storkapi.ApplicationBackup) error
 	// Delete the backups specified in the status
 	DeleteBackup(*storkapi.ApplicationBackup) error
+	// Get any resources that should be created before the restore is started
+	GetPreRestoreResources(*storkapi.ApplicationBackup, []runtime.Unstructured) ([]runtime.Unstructured, error)
 	// Start restore of volumes specified by the spec. Should only restore
 	// volumes, not the specs associated with them
 	StartRestore(*storkapi.ApplicationRestore, []*storkapi.ApplicationBackupVolumeInfo) ([]*storkapi.ApplicationRestoreVolumeInfo, error)
@@ -376,6 +379,14 @@ func (b *BackupRestoreNotSupported) CancelBackup(*storkapi.ApplicationBackup) er
 // DeleteBackup returns ErrNotSupported
 func (b *BackupRestoreNotSupported) DeleteBackup(*storkapi.ApplicationBackup) error {
 	return &errors.ErrNotSupported{}
+}
+
+// GetPreRestoreResources returns ErrNotSupported
+func (b *BackupRestoreNotSupported) GetPreRestoreResources(
+	*storkapi.ApplicationBackup,
+	[]runtime.Unstructured,
+) ([]runtime.Unstructured, error) {
+	return nil, &errors.ErrNotSupported{}
 }
 
 // StartRestore returns ErrNotSupported


### PR DESCRIPTION
This allows the Portworx driver to specify any secrets that it might require to
be created before starting the volume restore.
No-op in the other drivers for now.


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
[Portworx] Fixed issue with restoring volumes that required Kubernetes secrets
```

**Does this change need to be cherry-picked to a release branch?**:
2.3, 2.4
