### PR TITLE
Don't block driver registration if init fails

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -172,6 +172,12 @@ func isCsiProvisioner(provisioner string) bool {
 func (a *aws) StartBackup(backup *storkapi.ApplicationBackup,
 	pvcs []v1.PersistentVolumeClaim,
 ) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
+	if a.client == nil {
+		if err := a.Init(nil); err != nil {
+			return nil, err
+		}
+	}
+
 	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 
 	for _, pvc := range pvcs {
@@ -326,6 +332,12 @@ func (a *aws) getFiltersFromMap(filters map[string]string) []*ec2.Filter {
 }
 
 func (a *aws) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
+	if a.client == nil {
+		if err := a.Init(nil); err != nil {
+			return nil, err
+		}
+	}
+
 	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 
 	for _, vInfo := range backup.Status.Volumes {
@@ -358,6 +370,12 @@ func (a *aws) CancelBackup(backup *storkapi.ApplicationBackup) error {
 }
 
 func (a *aws) DeleteBackup(backup *storkapi.ApplicationBackup) error {
+	if a.client == nil {
+		if err := a.Init(nil); err != nil {
+			return err
+		}
+	}
+
 	for _, vInfo := range backup.Status.Volumes {
 		if vInfo.DriverName != driverName {
 			continue
@@ -406,6 +424,11 @@ func (a *aws) StartRestore(
 	restore *storkapi.ApplicationRestore,
 	volumeBackupInfos []*storkapi.ApplicationBackupVolumeInfo,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
+	if a.client == nil {
+		if err := a.Init(nil); err != nil {
+			return nil, err
+		}
+	}
 
 	volumeInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
 	for _, backupVolumeInfo := range volumeBackupInfos {
@@ -475,6 +498,12 @@ func (a *aws) CancelRestore(*storkapi.ApplicationRestore) error {
 }
 
 func (a *aws) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
+	if a.client == nil {
+		if err := a.Init(nil); err != nil {
+			return nil, err
+		}
+	}
+
 	volumeInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
 	for _, vInfo := range restore.Status.Volumes {
 		if vInfo.DriverName != driverName {
@@ -541,7 +570,6 @@ func init() {
 	err := a.Init(nil)
 	if err != nil {
 		logrus.Debugf("Error init'ing aws driver: %v", err)
-		return
 	}
 	if err := storkvolume.Register(driverName, a); err != nil {
 		logrus.Panicf("Error registering aws volume driver: %v", err)

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -147,6 +147,12 @@ func isCsiProvisioner(provisioner string) bool {
 func (g *gcp) StartBackup(backup *storkapi.ApplicationBackup,
 	pvcs []v1.PersistentVolumeClaim,
 ) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
+	if g.service == nil {
+		if err := g.Init(nil); err != nil {
+			return nil, err
+		}
+	}
+
 	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 
 	for _, pvc := range pvcs {
@@ -267,6 +273,12 @@ func (g *gcp) getZoneURLs(zones []string) ([]string, error) {
 }
 
 func (g *gcp) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
+	if g.service == nil {
+		if err := g.Init(nil); err != nil {
+			return nil, err
+		}
+	}
+
 	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 
 	for _, vInfo := range backup.Status.Volumes {
@@ -300,6 +312,12 @@ func (g *gcp) CancelBackup(backup *storkapi.ApplicationBackup) error {
 }
 
 func (g *gcp) DeleteBackup(backup *storkapi.ApplicationBackup) error {
+	if g.service == nil {
+		if err := g.Init(nil); err != nil {
+			return err
+		}
+	}
+
 	for _, vInfo := range backup.Status.Volumes {
 		if vInfo.DriverName != driverName {
 			continue
@@ -346,6 +364,12 @@ func (g *gcp) StartRestore(
 	restore *storkapi.ApplicationRestore,
 	volumeBackupInfos []*storkapi.ApplicationBackupVolumeInfo,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
+	if g.service == nil {
+		if err := g.Init(nil); err != nil {
+			return nil, err
+		}
+	}
+
 	var err error
 
 	volumeInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
@@ -412,6 +436,12 @@ func (g *gcp) CancelRestore(restore *storkapi.ApplicationRestore) error {
 }
 
 func (g *gcp) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
+	if g.service == nil {
+		if err := g.Init(nil); err != nil {
+			return nil, err
+		}
+	}
+
 	volumeInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
 	for _, vInfo := range restore.Status.Volumes {
 		if vInfo.DriverName != driverName {
@@ -494,7 +524,6 @@ func init() {
 	err := g.Init(nil)
 	if err != nil {
 		logrus.Debugf("Error init'ing gcp driver: %v", err)
-		return
 	}
 	if err := storkvolume.Register(driverName, g); err != nil {
 		logrus.Panicf("Error registering gcp volume driver: %v", err)


### PR DESCRIPTION
The init will be tried again when the APIs are called if init had failed


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.4

