### PR TITLE
Add env variables for aws access to stork-test

### DIFF
--- a/test/integration_test/stork-test-pod.yaml
+++ b/test/integration_test/stork-test-pod.yaml
@@ -80,6 +80,10 @@ spec:
       value: px_shared_secret_key
     - name: BACKUP_LOCATION_PATH 
       value: backup_location_path 
+    - name: AWS_ACCESS_KEY_ID
+      value: aws_access_key_id
+    - name: AWS_SECRET_ACCESS_KEY
+      value: aws_secret_access_key
   hostNetwork: false
   hostPID: false
   volumes:

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -15,6 +15,8 @@ volume_driver="pxd"
 short_test=false
 backup_location_path="test-restore-path"
 cloud_secret=""
+aws_id=""
+aws_key=""
 for i in "$@"
 do
 case $i in
@@ -105,6 +107,18 @@ case $i in
     --cloud_secret)
         echo "Secret name for cloud provider API access: $2"
         cloud_secret=$2
+        shift
+        shift
+        ;;
+    --aws_id)
+        echo "AWS user id for API access: $2"
+        aws_id=$2
+        shift
+        shift
+        ;;
+    --aws_key)
+        echo "AWS key for API access: $2"
+        aws_key=$2
         shift
         shift
         ;;
@@ -217,6 +231,10 @@ sed -i 's/'username'/'"$SSH_USERNAME"'/g' /testspecs/stork-test-pod.yaml
 sed -i 's/'password'/'"$SSH_PASSWORD"'/g' /testspecs/stork-test-pod.yaml
 sed  -i 's|'openstorage/stork_test:.*'|'"$test_image_name"'|g'  /testspecs/stork-test-pod.yaml
 sed -i 's/'backup_location_path'/'"$backup_location_path"'/g' /testspecs/stork-test-pod.yaml
+
+# Add AWS creds to stork-test pod
+sed -i 's/'aws_access_key_id'/'"$aws_id"'/g' /testspecs/stork-test-pod.yaml
+sed -i 's/'aws_secret_access_key'/'"$aws_key"'/g' /testspecs/stork-test-pod.yaml
 
 if [ "$volume_driver" != "" ] ; then
 	sed -i 's/- -volume-driver=pxd/- -volume-driver='"$volume_driver"'/g' /testspecs/stork-test-pod.yaml


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Added awscli support to stork-test container for EKS backup tests

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.3, 2.4

