### PR TITLE
specs: remove initializers field from specs

### DIFF
--- a/specs/stork-deployment.yaml
+++ b/specs/stork-deployment.yaml
@@ -80,8 +80,6 @@ metadata:
     tier: control-plane
   name: stork
   namespace: kube-system
-  initializers:
-    pending: []
 spec:
   strategy:
     rollingUpdate:

--- a/specs/stork-scheduler.yaml
+++ b/specs/stork-scheduler.yaml
@@ -77,8 +77,6 @@ metadata:
     tier: control-plane
   name: stork-scheduler
   namespace: kube-system
-  initializers:
-    pending: []
 spec:
   replicas: 3
   selector:


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:

The metadata.initializers field has been deprecated since Kubernetes
1.13, and has been completely removed in 1.16. So, when using a
Kubernetes version >=1.16, this errors out while creating the
deployment.

Fix this by just removing the key in stork-deployment.yaml and
stork-scheduler.yaml.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

