### PR TITLE
Collect jobs from resource collector

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1852,7 +1852,7 @@
   version = "kubernetes-1.16.6"
 
 [[projects]]
-  digest = "1:025f785d59f3327d14f9ef94b0fe0a044d67a1615dde354e763947457d4463db"
+  digest = "1:3d4d9153f2d42a04e7bb52a67600679e554a88210ad6e2bbc88979a92fee45d2"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/api/legacyscheme",
@@ -1871,6 +1871,7 @@
     "pkg/util/goroutinemap/exponentialbackoff",
     "pkg/util/node",
     "pkg/util/parsers",
+    "pkg/util/slice",
   ]
   pruneopts = "UT"
   revision = "72c30166b2105cd7d3350f2c28a219e6abcd79eb"
@@ -2070,6 +2071,7 @@
     "k8s.io/api/apps/v1",
     "k8s.io/api/apps/v1beta1",
     "k8s.io/api/apps/v1beta2",
+    "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/api/storage/v1",
@@ -2134,6 +2136,7 @@
     "k8s.io/kubernetes/pkg/registry/core/service/portallocator",
     "k8s.io/kubernetes/pkg/scheduler/api",
     "k8s.io/kubernetes/pkg/util/node",
+    "k8s.io/kubernetes/pkg/util/slice",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/handler",

--- a/pkg/apis/stork/v1alpha1/applicationclone.go
+++ b/pkg/apis/stork/v1alpha1/applicationclone.go
@@ -36,7 +36,8 @@ type ApplicationCloneSpec struct {
 	PreExecRule  string            `json:"preExecRule"`
 	PostExecRule string            `json:"postExecRule"`
 	// ReplacePolicy to decide how to react when a object conflict occurs in the cloning process
-	ReplacePolicy ApplicationCloneReplacePolicyType `json:"replacePolicy"`
+	ReplacePolicy                ApplicationCloneReplacePolicyType `json:"replacePolicy"`
+	IncludeOptionalResourceTypes []string                          `json:"includeOptionalResourceTypes"`
 }
 
 // ApplicationCloneStatus defines the status of the clone

--- a/pkg/apis/stork/v1alpha1/applicationrestore.go
+++ b/pkg/apis/stork/v1alpha1/applicationrestore.go
@@ -25,12 +25,13 @@ type ApplicationRestore struct {
 
 // ApplicationRestoreSpec is the spec used to restore applications
 type ApplicationRestoreSpec struct {
-	BackupName       string                              `json:"backupName"`
-	BackupLocation   string                              `json:"backupLocation"`
-	NamespaceMapping map[string]string                   `json:"namespaceMapping"`
-	Selectors        map[string]string                   `json:"selectors"`
-	EncryptionKey    *corev1.EnvVarSource                `json:"encryptionKey"`
-	ReplacePolicy    ApplicationRestoreReplacePolicyType `json:"replacePolicy"`
+	BackupName                   string                              `json:"backupName"`
+	BackupLocation               string                              `json:"backupLocation"`
+	NamespaceMapping             map[string]string                   `json:"namespaceMapping"`
+	Selectors                    map[string]string                   `json:"selectors"`
+	EncryptionKey                *corev1.EnvVarSource                `json:"encryptionKey"`
+	ReplacePolicy                ApplicationRestoreReplacePolicyType `json:"replacePolicy"`
+	IncludeOptionalResourceTypes []string                            `json:"includeOptionalResourceTypes"`
 }
 
 // ApplicationRestoreReplacePolicyType is the replace policy for the application restore

--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -13,16 +13,17 @@ const (
 
 // MigrationSpec is the spec used to migrate apps between clusterpairs
 type MigrationSpec struct {
-	ClusterPair           string            `json:"clusterPair"`
-	AdminClusterPair      string            `json:"adminClusterPair"`
-	Namespaces            []string          `json:"namespaces"`
-	IncludeResources      *bool             `json:"includeResources"`
-	IncludeVolumes        *bool             `json:"includeVolumes"`
-	StartApplications     *bool             `json:"startApplications"`
-	PurgeDeletedResources *bool             `json:"purgeDeletedResources"`
-	Selectors             map[string]string `json:"selectors"`
-	PreExecRule           string            `json:"preExecRule"`
-	PostExecRule          string            `json:"postExecRule"`
+	ClusterPair                  string            `json:"clusterPair"`
+	AdminClusterPair             string            `json:"adminClusterPair"`
+	Namespaces                   []string          `json:"namespaces"`
+	IncludeResources             *bool             `json:"includeResources"`
+	IncludeVolumes               *bool             `json:"includeVolumes"`
+	StartApplications            *bool             `json:"startApplications"`
+	PurgeDeletedResources        *bool             `json:"purgeDeletedResources"`
+	Selectors                    map[string]string `json:"selectors"`
+	PreExecRule                  string            `json:"preExecRule"`
+	PostExecRule                 string            `json:"postExecRule"`
+	IncludeOptionalResourceTypes []string          `json:"includeOptionalResourceTypes"`
 }
 
 // MigrationStatus is the status of a migration operation

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -426,6 +426,11 @@ func (in *ApplicationCloneSpec) DeepCopyInto(out *ApplicationCloneSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.IncludeOptionalResourceTypes != nil {
+		in, out := &in.IncludeOptionalResourceTypes, &out.IncludeOptionalResourceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -593,6 +598,11 @@ func (in *ApplicationRestoreSpec) DeepCopyInto(out *ApplicationRestoreSpec) {
 		in, out := &in.EncryptionKey, &out.EncryptionKey
 		*out = new(v1.EnvVarSource)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.IncludeOptionalResourceTypes != nil {
+		in, out := &in.IncludeOptionalResourceTypes, &out.IncludeOptionalResourceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }
@@ -1600,6 +1610,11 @@ func (in *MigrationSpec) DeepCopyInto(out *MigrationSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.IncludeOptionalResourceTypes != nil {
+		in, out := &in.IncludeOptionalResourceTypes, &out.IncludeOptionalResourceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -510,7 +510,8 @@ func (a *ApplicationCloneController) prepareResources(
 		_, err = a.resourceCollector.PrepareResourceForApply(
 			o,
 			namespaceMapping,
-			pvNameMappings)
+			pvNameMappings,
+			clone.Spec.IncludeOptionalResourceTypes)
 		if err != nil {
 			return nil, err
 		}
@@ -692,7 +693,11 @@ func (a *ApplicationCloneController) applyResources(
 func (a *ApplicationCloneController) cloneResources(
 	clone *stork_api.ApplicationClone,
 ) error {
-	allObjects, err := a.resourceCollector.GetResources([]string{clone.Spec.SourceNamespace}, clone.Spec.Selectors, false)
+	allObjects, err := a.resourceCollector.GetResources(
+		[]string{clone.Spec.SourceNamespace},
+		clone.Spec.Selectors,
+		clone.Spec.IncludeOptionalResourceTypes,
+		false)
 	if err != nil {
 		log.ApplicationCloneLog(clone).Errorf("Error getting resources: %v", err)
 		return err

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -537,7 +537,8 @@ func (a *ApplicationRestoreController) applyResources(
 		skip, err := a.resourceCollector.PrepareResourceForApply(
 			o,
 			restore.Spec.NamespaceMapping,
-			pvNameMappings)
+			pvNameMappings,
+			restore.Spec.IncludeOptionalResourceTypes)
 		if err != nil {
 			return err
 		}

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -362,7 +362,11 @@ func (m *MigrationController) purgeMigratedResources(migration *stork_api.Migrat
 		log.MigrationLog(migration).Errorf("Error initializing resource collector: %v", err)
 		return err
 	}
-	destObjects, err := rc.GetResources(migration.Spec.Namespaces, migration.Spec.Selectors, false)
+	destObjects, err := rc.GetResources(
+		migration.Spec.Namespaces,
+		migration.Spec.Selectors,
+		migration.Spec.IncludeOptionalResourceTypes,
+		false)
 	if err != nil {
 		m.recorder.Event(migration,
 			v1.EventTypeWarning,
@@ -371,7 +375,11 @@ func (m *MigrationController) purgeMigratedResources(migration *stork_api.Migrat
 		log.MigrationLog(migration).Errorf("Error getting resources: %v", err)
 		return err
 	}
-	srcObjects, err := m.resourceCollector.GetResources(migration.Spec.Namespaces, migration.Spec.Selectors, false)
+	srcObjects, err := m.resourceCollector.GetResources(
+		migration.Spec.Namespaces,
+		migration.Spec.Selectors,
+		migration.Spec.IncludeOptionalResourceTypes,
+		false)
 	if err != nil {
 		m.recorder.Event(migration,
 			v1.EventTypeWarning,
@@ -722,7 +730,11 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration) e
 		}
 	}
 
-	allObjects, err := m.resourceCollector.GetResources(migration.Spec.Namespaces, migration.Spec.Selectors, false)
+	allObjects, err := m.resourceCollector.GetResources(
+		migration.Spec.Namespaces,
+		migration.Spec.Selectors,
+		migration.Spec.IncludeOptionalResourceTypes,
+		false)
 	if err != nil {
 		m.recorder.Event(migration,
 			v1.EventTypeWarning,

--- a/pkg/resourcecollector/job.go
+++ b/pkg/resourcecollector/job.go
@@ -1,0 +1,37 @@
+package resourcecollector
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	controllerUIDLabel = "controller-uid"
+)
+
+func (r *ResourceCollector) prepareJobForCollection(
+	object runtime.Unstructured,
+	namespaces []string,
+) error {
+	var job batchv1.Job
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &job); err != nil {
+		return err
+	}
+
+	if job.Labels != nil {
+		delete(job.Labels, controllerUIDLabel)
+	}
+	if job.Spec.Selector != nil && job.Spec.Selector.MatchLabels != nil {
+		delete(job.Spec.Selector.MatchLabels, controllerUIDLabel)
+	}
+	if job.Spec.Template.Labels != nil {
+		delete(job.Spec.Template.Labels, controllerUIDLabel)
+	}
+	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&job)
+	if err != nil {
+		return err
+	}
+	object.SetUnstructuredContent(o)
+
+	return nil
+}

--- a/vendor/k8s.io/kubernetes/pkg/util/slice/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/util/slice/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["slice.go"],
+    importpath = "k8s.io/kubernetes/pkg/util/slice",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["slice_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/util/slice/slice.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/slice/slice.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package slice provides utility methods for common operations on slices.
+package slice
+
+import (
+	"sort"
+)
+
+// CopyStrings copies the contents of the specified string slice
+// into a new slice.
+func CopyStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	c := make([]string, len(s))
+	copy(c, s)
+	return c
+}
+
+// SortStrings sorts the specified string slice in place. It returns the same
+// slice that was provided in order to facilitate method chaining.
+func SortStrings(s []string) []string {
+	sort.Strings(s)
+	return s
+}
+
+// ContainsString checks if a given slice of strings contains the provided string.
+// If a modifier func is provided, it is called with the slice item before the comparation.
+func ContainsString(slice []string, s string, modifier func(s string) string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+		if modifier != nil && modifier(item) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveString returns a newly created []string that contains all items from slice that
+// are not equal to s and modifier(s) in case modifier func is provided.
+func RemoveString(slice []string, s string, modifier func(s string) string) []string {
+	newSlice := make([]string, 0)
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		if modifier != nil && modifier(item) == s {
+			continue
+		}
+		newSlice = append(newSlice, item)
+	}
+	if len(newSlice) == 0 {
+		// Sanitize for unit tests so we don't need to distinguish empty array
+		// and nil.
+		newSlice = nil
+	}
+	return newSlice
+}


### PR DESCRIPTION
Since jobs might not be idempotent, restoring/cloning/migrating them are
optional. They will always be backed up


**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
Yes, it adds `includeOptionalResourceTypes` field to Migration, ApplicationClone and ApplicationRestore specs

**Is a release note needed?**:
```release-note
Added support to optionally migrate, clone, and restore `Jobs`. This can be done by specifying `Jobs` in the `includeOptionalResourceTypes` field in the specs. This is made optional since jobs might not be idempotent.
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.4
