### PR TITLE
Add storageclass to s3 config in BackupLocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN microdnf clean all && microdnf install -y yum
 
 RUN yum install -y wget python3 ca-certificates tar gzip
 
-RUN wget -O /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
+RUN wget -q -O /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
 RUN python3 -m pip install awscli && python3 -m pip install rsa --upgrade
@@ -22,7 +22,7 @@ RUN python3 -m pip install awscli && python3 -m pip install rsa --upgrade
 ARG GCLOUD_SDK=google-cloud-sdk-269.0.0-linux-x86_64.tar.gz
 # Remove the test directories
 # Also don't need gsutil
-RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
     tar xf $GCLOUD_SDK && rm -rf $GCLOUD_SDK && \
     rm -rf /google-cloud-sdk/platform/gsutil/third_party/oauth2client/tests \
         /google-cloud-sdk/platform/gsutil/third_party/rsa/tests \

--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -66,6 +66,9 @@ type S3Config struct {
 	// Disable SSL option if using with a non-AWS S3 objectstore which doesn't
 	// have SSL enabled
 	DisableSSL bool `json:"disableSSL"`
+	// The S3 Storage Class to use when uploading objects. Glacier storage
+	// classes are not supported
+	StorageClass string `json:"storageClass"`
 }
 
 // AzureConfig specifies the config required to connect to Azure Blob Storage
@@ -145,6 +148,9 @@ func (bl *BackupLocation) getMergedS3Config(client kubernetes.Interface) error {
 			if err != nil {
 				return fmt.Errorf("error parding disableSSL from Secret: %v", err)
 			}
+		}
+		if val, ok := secretConfig.Data["storageClass"]; ok && val != nil {
+			bl.Location.S3Config.StorageClass = strings.TrimSuffix(string(val), "\n")
 		}
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
Adds `storageClass` in the s3Config in `BackupLocation` CRD

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Users can now specify the S3 storage class to be used for backups
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.4
