### PR TITLE
Updates for health monitor

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -285,6 +285,7 @@ func runStork(mgr manager.Manager, d volume.Driver, recorder record.EventRecorde
 	monitor := &monitor.Monitor{
 		Driver:      d,
 		IntervalSec: c.Int64("health-monitor-interval"),
+		Recorder:    recorder,
 	}
 	snapshot := &snapshot.Snapshot{
 		Driver:   d,

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -384,8 +384,6 @@ func (p *portworx) inspectVolume(volDriver volume.VolumeDriver, volumeID string)
 
 func (p *portworx) mapNodeStatus(status api.Status) storkvolume.NodeStatus {
 	switch status {
-	case api.Status_STATUS_NONE:
-		fallthrough
 	case api.Status_STATUS_INIT:
 		fallthrough
 	case api.Status_STATUS_OFFLINE:
@@ -401,6 +399,8 @@ func (p *portworx) mapNodeStatus(status api.Status) storkvolume.NodeStatus {
 	case api.Status_STATUS_NEEDS_REBOOT:
 		return storkvolume.NodeOffline
 
+	case api.Status_STATUS_NONE:
+		fallthrough
 	case api.Status_STATUS_OK:
 		fallthrough
 	case api.Status_STATUS_STORAGE_DOWN:
@@ -459,6 +459,7 @@ func (p *portworx) InspectNode(id string) (*storkvolume.NodeInfo, error) {
 		SchedulerID: node.SchedulerNodeName,
 		Hostname:    strings.ToLower(node.Hostname),
 		Status:      p.mapNodeStatus(node.Status),
+		RawStatus:   node.Status.String(),
 	}, nil
 }
 
@@ -483,6 +484,7 @@ func (p *portworx) GetNodes() ([]*storkvolume.NodeInfo, error) {
 			SchedulerID: n.SchedulerNodeName,
 			Hostname:    strings.ToLower(n.Hostname),
 			Status:      p.mapNodeStatus(n.Status),
+			RawStatus:   n.Status.String(),
 		}
 		nodeInfo.IPs = append(nodeInfo.IPs, n.MgmtIp)
 		nodeInfo.IPs = append(nodeInfo.IPs, n.DataIp)

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -223,6 +223,8 @@ type NodeInfo struct {
 	Region string
 	// Status of the node
 	Status NodeStatus
+	// RawStatus as returned by the driver
+	RawStatus string
 }
 
 var (


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
* [Portworx] Map node status None to Online
* Add events when deleting pods from health monitor

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
* [Portworx] Fix issue with mapping node status which could cause pods to be deleted from the HealthMonitor when not required
* Added events to the pod when deleting them from the HealthMonitor
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.4
