### PR TITLE
Cluster pair should work with auth enabled Portworx

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -191,7 +191,6 @@ var restoreStateCallBackoff = wait.Backoff{
 }
 
 type portworx struct {
-	clusterManager  cluster.Cluster
 	store           cache.Store
 	stopChannel     chan struct{}
 	sdkConn         *portworxGrpcConnection
@@ -253,10 +252,34 @@ func (p *portworx) getCloudBackupClient() (api.OpenStorageCloudBackupClient, err
 	return api.NewOpenStorageCloudBackupClient(conn), nil
 }
 
+// getClusterManagerClient returns cluster manager client with proper configuration and updated authorization token
+// if authorization is enabled
+func (p *portworx) getClusterManagerClient() (cluster.Cluster, error) {
+	token, err := p.tokenGenerator()
+	if err != nil {
+		return nil, err
+	}
+
+	clnt, err := clusterclient.NewAuthClusterClient(p.endpoint, "v1", token, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return clusterclient.ClusterManager(clnt), nil
+}
+
 func (p *portworx) initPortworxClients() error {
 	kubeOps := core.Instance()
 
-	paramsBuilder, err := pwx.NewConnectionParamsBuilder(kubeOps, pwx.NewConnectionParamsBuilderDefaultConfig())
+	pbc := pwx.NewConnectionParamsBuilderDefaultConfig()
+
+	p.jwtSharedSecret = os.Getenv(pxSharedSecret)
+	if len(p.jwtSharedSecret) > 0 {
+		pbc.AuthTokenGenerator = p.tokenGenerator
+		pbc.AuthEnabled = true
+	}
+
+	paramsBuilder, err := pwx.NewConnectionParamsBuilder(kubeOps, pbc)
 	if err != nil {
 		return err
 	}
@@ -271,11 +294,6 @@ func (p *portworx) initPortworxClients() error {
 		return err
 	}
 
-	clnt, err := clusterclient.NewClusterClient(pxMgmtEndpoint, "v1")
-	if err != nil {
-		return err
-	}
-	p.clusterManager = clusterclient.ClusterManager(clnt)
 	p.endpoint = pxMgmtEndpoint
 
 	// Setup gRPC clients
@@ -294,9 +312,6 @@ func (p *portworx) initPortworxClients() error {
 		return fmt.Errorf("failed to set secrets provider: %v", err)
 	}
 
-	// Save the token if any was given
-	p.jwtSharedSecret = os.Getenv(pxSharedSecret)
-
 	// Create a unique identifier
 	p.id, err = os.Hostname()
 	if err != nil {
@@ -305,6 +320,49 @@ func (p *portworx) initPortworxClients() error {
 
 	p.initDone = true
 	return err
+}
+
+// 	tokenGenerator generates authorization token for system.admin
+//	when shared secret is not configured authz token is empty string
+//	this let Openstorage API clients be bootstrapped with no authorization (by accepting empty token)
+func (p *portworx) tokenGenerator() (string, error) {
+	if len(p.jwtSharedSecret) == 0 {
+		return "", nil
+	}
+
+	claims := &auth.Claims{
+		Issuer: "stork.openstorage.io",
+		Name:   "Stork",
+
+		// Unique id for stork
+		// this id must be unique across all accounts accessing the px system
+		Subject: "stork.openstorage.io." + p.id,
+
+		// Only allow certain calls
+		Roles: []string{"system.admin"},
+
+		// Be in all groups to have access to all resources
+		Groups: []string{"*"},
+	}
+
+	// This never returns an error, but just in case, check the value
+	signature, err := auth.NewSignatureSharedSecret(p.jwtSharedSecret)
+	if err != nil {
+		return "", err
+	}
+
+	// Set the token expiration
+	options := &auth.Options{
+		Expiration:  time.Now().Add(time.Hour * 1).Unix(),
+		IATSubtract: 1 * time.Minute,
+	}
+
+	token, err := auth.Token(claims, signature, options)
+	if err != nil {
+		return "", err
+	}
+
+	return token, nil
 }
 
 func (p *portworx) startNodeCache() error {
@@ -458,7 +516,13 @@ func (p *portworx) InspectNode(id string) (*storkvolume.NodeInfo, error) {
 	if id == "" {
 		return nil, fmt.Errorf("invalid node id")
 	}
-	node, err := p.clusterManager.Inspect(id)
+
+	clusterManager, err := p.getClusterManagerClient()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get cluster manager, err: %s", err.Error())
+	}
+
+	node, err := clusterManager.Inspect(id)
 	if err != nil {
 		return nil, &ErrFailedToGetNodes{
 			Cause: err.Error(),
@@ -480,7 +544,12 @@ func (p *portworx) GetNodes() ([]*storkvolume.NodeInfo, error) {
 		}
 	}
 
-	cluster, err := p.clusterManager.Enumerate()
+	clusterManager, err := p.getClusterManagerClient()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get cluster manager, err: %s", err.Error())
+	}
+
+	cluster, err := clusterManager.Enumerate()
 	if err != nil {
 		return nil, &ErrFailedToGetNodes{
 			Cause: err.Error(),
@@ -524,7 +593,12 @@ func (p *portworx) GetClusterID() (string, error) {
 		}
 	}
 
-	cluster, err := p.clusterManager.Enumerate()
+	clusterManager, err := p.getClusterManagerClient()
+	if err != nil {
+		return "", fmt.Errorf("cannot get cluster manager, err: %s", err.Error())
+	}
+
+	cluster, err := clusterManager.Enumerate()
 	if err != nil {
 		return "", &ErrFailedToGetClusterID{
 			Cause: err.Error(),
@@ -2023,7 +2097,12 @@ func (p *portworx) CreatePair(pair *storkapi.ClusterPair) (string, error) {
 		}
 	}
 
-	resp, err := p.clusterManager.CreatePair(&api.ClusterPairCreateRequest{
+	clusterManager, err := p.getClusterManagerClient()
+	if err != nil {
+		return "", fmt.Errorf("cannot get cluster manager, err: %s", err.Error())
+	}
+
+	resp, err := clusterManager.CreatePair(&api.ClusterPairCreateRequest{
 		RemoteClusterIp:    pair.Spec.Options["ip"],
 		RemoteClusterToken: pair.Spec.Options["token"],
 		RemoteClusterPort:  uint32(port),
@@ -2042,7 +2121,12 @@ func (p *portworx) DeletePair(pair *storkapi.ClusterPair) error {
 		}
 	}
 
-	return p.clusterManager.DeletePair(pair.Status.RemoteStorageID)
+	clusterManager, err := p.getClusterManagerClient()
+	if err != nil {
+		return fmt.Errorf("cannot get cluster manager, err: %s", err.Error())
+	}
+
+	return clusterManager.DeletePair(pair.Status.RemoteStorageID)
 }
 
 func (p *portworx) StartMigration(migration *storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error) {
@@ -2333,8 +2417,13 @@ func (p *portworx) GetClusterDomains() (*storkapi.ClusterDomains, error) {
 		}
 	}
 
+	clusterManager, err := p.getClusterManagerClient()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get cluster manager, err: %s", err.Error())
+	}
+
 	// get the cluster details
-	cluster, err := p.clusterManager.Enumerate()
+	cluster, err := clusterManager.Enumerate()
 	if err != nil {
 		return nil, err
 	}
@@ -2479,9 +2568,14 @@ func (p *portworx) DeactivateClusterDomain(cdu *storkapi.ClusterDomainUpdate) er
 }
 
 func (p *portworx) getNodesToDomainMap(nodes []api.Node) (map[string]string, error) {
+	clusterManager, err := p.getClusterManagerClient()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get cluster manager, err: %s", err.Error())
+	}
+
 	nodeToDomainMap := make(map[string]string)
 	for _, node := range nodes {
-		nodeConfig, err := p.clusterManager.GetNodeConf(node.Id)
+		nodeConfig, err := clusterManager.GetNodeConf(node.Id)
 		if err != nil {
 			return nil, err
 		}
@@ -3249,7 +3343,12 @@ func (p *portworx) ensureNodesHaveMinVersion(minVersionStr string) (bool, string
 		return false, "", err
 	}
 
-	result, err := p.clusterManager.Enumerate()
+	clusterManager, err := p.getClusterManagerClient()
+	if err != nil {
+		return false, "", fmt.Errorf("cannot get cluster manager, err: %s", err.Error())
+	}
+
+	result, err := clusterManager.Enumerate()
 	if err != nil {
 		return false, "", err
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:

bug
>feature
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

