### PR TITLE
Disable auto-updating app scheduler as stork for app based on annotations

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -141,6 +141,10 @@ func main() {
 			Name:  "webhook-controller",
 			Usage: "Enable webhook controller to start driver apps with scheduler as stork (default: true)",
 		},
+		cli.StringFlag{
+			Name:  "webhook-skip-resources-annotation",
+			Usage: "Application annotation to be used to disable auto updating app scheduler as stork",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -197,8 +201,9 @@ func run(c *cli.Context) {
 		}
 		if c.Bool("webhook-controller") {
 			webhook = &webhookadmission.Controller{
-				Driver:   d,
-				Recorder: recorder,
+				Driver:       d,
+				Recorder:     recorder,
+				SkipResource: c.String("webhook-skip-resources-annotation"),
 			}
 			if err := webhook.Start(); err != nil {
 				log.Fatalf("error starting webhook controller: %v", err)

--- a/pkg/webhookadmission/webhook.go
+++ b/pkg/webhookadmission/webhook.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,17 +34,19 @@ const (
 	secretName               = "servercert-secret"
 	privKey                  = "privKey"
 	privCert                 = "privCert"
+	defaultSkipAnnotation    = "stork.libopenstorage.org/disable-admission-controller"
 )
 
 // Controller for admission mutating webhook to initialise resources
 // with stork as scheduler, if given resources are using driver supported
 // by stork
 type Controller struct {
-	Recorder record.EventRecorder
-	Driver   volume.Driver
-	server   *http.Server
-	lock     sync.Mutex
-	started  bool
+	Recorder     record.EventRecorder
+	Driver       volume.Driver
+	server       *http.Server
+	lock         sync.Mutex
+	started      bool
+	SkipResource string
 }
 
 // Serve method for webhook server
@@ -61,7 +64,10 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 	var schedPath string
 	admissionReview := v1beta1.AdmissionReview{}
 	isStorkResource := false
-
+	skipHookAnnotation := defaultSkipAnnotation
+	if c.SkipResource != "" {
+		skipHookAnnotation = c.SkipResource
+	}
 	webhookConfig := &admissionv1beta1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: storkAdmissionController,
@@ -91,13 +97,15 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 			http.Error(w, "Decode error", http.StatusBadRequest)
 			return
 		}
-		isStorkResource, err = c.checkVolumeOwner(ss.Spec.Template.Spec.Volumes, arReq.Namespace)
-		if err != nil {
-			c.Recorder.Event(&ss, v1.EventTypeWarning, "Could not get volume owner info for ss: %v", err.Error())
-			http.Error(w, "Could not get volume owner info", http.StatusInternalServerError)
-			return
+		if !skipSchedulerUpdate(skipHookAnnotation, ss.ObjectMeta.Annotations) {
+			isStorkResource, err = c.checkVolumeOwner(ss.Spec.Template.Spec.Volumes, arReq.Namespace)
+			if err != nil {
+				c.Recorder.Event(&ss, v1.EventTypeWarning, "Could not get volume owner info for ss: %v", err.Error())
+				http.Error(w, "Could not get volume owner info", http.StatusInternalServerError)
+				return
+			}
+			schedPath = appSchedPrefix + podSpecSchedPath
 		}
-		schedPath = appSchedPrefix + podSpecSchedPath
 	case "Deployment":
 		var deployment appv1.Deployment
 		if err := json.Unmarshal(arReq.Object.Raw, &deployment); err != nil {
@@ -106,13 +114,15 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 			http.Error(w, "Decode error", http.StatusBadRequest)
 			return
 		}
-		isStorkResource, err = c.checkVolumeOwner(deployment.Spec.Template.Spec.Volumes, arReq.Namespace)
-		if err != nil {
-			c.Recorder.Event(&deployment, v1.EventTypeWarning, "Could not get volume owner info deployment: %v", err.Error())
-			http.Error(w, "Could not get volume owner info", http.StatusInternalServerError)
-			return
+		if !skipSchedulerUpdate(skipHookAnnotation, deployment.ObjectMeta.Annotations) {
+			isStorkResource, err = c.checkVolumeOwner(deployment.Spec.Template.Spec.Volumes, arReq.Namespace)
+			if err != nil {
+				c.Recorder.Event(&deployment, v1.EventTypeWarning, "Could not get volume owner info deployment: %v", err.Error())
+				http.Error(w, "Could not get volume owner info", http.StatusInternalServerError)
+				return
+			}
+			schedPath = appSchedPrefix + podSpecSchedPath
 		}
-		schedPath = appSchedPrefix + podSpecSchedPath
 	case "Pod":
 		var pod v1.Pod
 		if err := json.Unmarshal(arReq.Object.Raw, &pod); err != nil {
@@ -121,13 +131,15 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 			http.Error(w, "Decode error", http.StatusBadRequest)
 			return
 		}
-		isStorkResource, err = c.checkVolumeOwner(pod.Spec.Volumes, arReq.Namespace)
-		if err != nil {
-			c.Recorder.Event(&pod, v1.EventTypeWarning, "Could not get volume owner info for pod: %v", err.Error())
-			http.Error(w, "Could not get volume owner info", http.StatusInternalServerError)
-			return
+		if !skipSchedulerUpdate(skipHookAnnotation, pod.ObjectMeta.Annotations) {
+			isStorkResource, err = c.checkVolumeOwner(pod.Spec.Volumes, arReq.Namespace)
+			if err != nil {
+				c.Recorder.Event(&pod, v1.EventTypeWarning, "Could not get volume owner info for pod: %v", err.Error())
+				http.Error(w, "Could not get volume owner info", http.StatusInternalServerError)
+				return
+			}
+			schedPath = podSpecSchedPath
 		}
-		schedPath = podSpecSchedPath
 	}
 
 	if !isStorkResource {
@@ -283,4 +295,15 @@ func createPatch(schedpath string) []byte {
 		log.Errorf("could not marshal patch: %v", err)
 	}
 	return b
+}
+
+func skipSchedulerUpdate(skipHookAnnotation string, annotations map[string]string) bool {
+	if annotations != nil {
+		if value, ok := annotations[skipHookAnnotation]; ok {
+			if skip, err := strconv.ParseBool(value); err == nil && skip {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
**What type of PR is this?**
> enhancement

**What this PR does / why we need it**:
Skip updating application scheduler to stork based on annotations. If stork started with `webhook-skip-resources` flag , we will skip updating scheduler for resources with `webhook-skip-resources` annotation 

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.4.3