### PR TITLE
Support generic CRD migration, backup/restore

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -827,7 +827,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b37682af267432318e0f30746339f826280c2876d33e0abc1c985f8fb6396e78"
+  digest = "1:3e11dbea9e1e2cdeb11252efbda51144b208667b55b23b1a8be9fcfc7be47d86"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s/admissionregistration",
@@ -848,7 +848,7 @@
     "task",
   ]
   pruneopts = "UT"
-  revision = "30fe0dc403445ed92659f59a1954da1cc8a86697"
+  revision = "7b23c232a58f815546b86e2498091335fb6847b7"
 
 [[projects]]
   branch = "master"

--- a/pkg/apis/stork/v1alpha1/applicationregistration.go
+++ b/pkg/apis/stork/v1alpha1/applicationregistration.go
@@ -31,6 +31,8 @@ type ApplicationResource struct {
 	KeepStatus bool `json:"keepStatus"`
 	// SuspendOptions to disable CRD upon migration/restore/clone
 	SuspendOptions SuspendOptions `json:"suspendOptions"`
+	// PodsPath to help activate/deactivate crd upon migration
+	PodsPath string `json:"podsPath`
 }
 
 // SuspendOptions to disable CRD upon migration/restore/clone

--- a/pkg/apis/stork/v1alpha1/register.go
+++ b/pkg/apis/stork/v1alpha1/register.go
@@ -54,6 +54,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ApplicationBackupList{},
 		&ApplicationRestore{},
 		&ApplicationRestoreList{},
+		&ApplicationRegistration{},
+		&ApplicationRegistrationList{},
 		&BackupLocation{},
 		&BackupLocationList{},
 		&VolumeSnapshotRestore{},
@@ -62,8 +64,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ApplicationBackupScheduleList{},
 		&DataExport{},
 		&DataExportList{},
-		&ApplicationRegistration{},
-		&ApplicationRegistrationList{},
 	)
 
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/applicationmanager/applicationmanager.go
+++ b/pkg/applicationmanager/applicationmanager.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libopenstorage/stork/drivers/volume"
+	stork_crd "github.com/libopenstorage/stork/pkg/apis/stork"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/applicationmanager/controllers"
 	"github.com/libopenstorage/stork/pkg/resourcecollector"
@@ -60,6 +61,10 @@ func (a *ApplicationManager) Init(mgr manager.Manager, adminNamespace string, st
 	if err := syncController.Init(stopChannel); err != nil {
 		return err
 	}
+
+	if err := controllers.RegisterDefaultCRDs(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -83,9 +88,9 @@ func (a *ApplicationManager) createCRD() error {
 	appReg := apiextensions.CustomResource{
 		Name:    stork_api.ApplicationRegistrationResourceName,
 		Plural:  stork_api.ApplicationRegistrationResourcePlural,
-		Group:   stork_api.SchemeGroupVersion.Group,
+		Group:   stork_crd.GroupName,
 		Version: stork_api.SchemeGroupVersion.Version,
-		Scope:   apiextensionsv1beta1.NamespaceScoped,
+		Scope:   apiextensionsv1beta1.ClusterScoped,
 		Kind:    reflect.TypeOf(stork_api.ApplicationRegistration{}).Name(),
 	}
 	err = apiextensions.Instance().CreateCRD(appReg)

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -42,7 +42,7 @@ const (
 	validateCRDTimeout  time.Duration = 1 * time.Minute
 
 	resourceObjectName = "resources.json"
-	resourceCRDName    = "crds.json"
+	crdObjectName      = "crds.json"
 	metadataObjectName = "metadata.json"
 
 	backupCancelBackoffInitialDelay = 5 * time.Second
@@ -733,7 +733,7 @@ func (a *ApplicationBackupController) uploadCRDResources(backup *stork_api.Appli
 	if err != nil {
 		return err
 	}
-	if err := a.uploadObject(backup, resourceCRDName, jsonBytes); err != nil {
+	if err := a.uploadObject(backup, crdObjectName, jsonBytes); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -723,6 +723,9 @@ func (a *ApplicationBackupController) uploadCRDResources(backup *stork_api.Appli
 		for _, v := range crd.Resources {
 			res, err := apiextensions.Instance().GetCRD(v.Group, metav1.GetOptions{ResourceVersion: v.Version})
 			if err != nil {
+				if k8s_errors.IsNotFound(err) {
+					continue
+				}
 				log.ApplicationBackupLog(backup).Errorf("Unable to get customresourcedefination for %s, err: %v", v.Kind, err)
 				return err
 			}

--- a/pkg/applicationmanager/controllers/applicationregistration.go
+++ b/pkg/applicationmanager/controllers/applicationregistration.go
@@ -94,6 +94,7 @@ func getSupportedCRD() map[string][]stork_api.ApplicationResource {
 				Path: "spec.suspend",
 				Type: "bool",
 			},
+			PodsPath: "status.members.ready",
 		},
 		{
 			GroupVersionKind: metav1.GroupVersionKind{

--- a/pkg/applicationmanager/controllers/applicationregistration.go
+++ b/pkg/applicationmanager/controllers/applicationregistration.go
@@ -5,6 +5,7 @@ import (
 
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/stork"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -44,15 +45,16 @@ func getSupportedCRD() map[string][]string {
 	// datastax/Cassandra CRD's
 	defCRD[CassandraApp] = []string{"CassandraDatacenter,cassandradatacenters.cassandra.datastax.com,spec.stopped,bool"}
 	// redis cluster CRD's
-	defCRD[RedisClusterApp] = []string{"RedisEnterpriseCluster,redisenterpriseclusters.app.redislabs.com"}
+	defCRD[RedisClusterApp] = []string{"RedisEnterpriseCluster,redisenterpriseclusters.app.redislabs.com",
+		"RedisEnterpriseDatabase,redisenterprisedatabases.app.redislabs.com"}
 
 	return defCRD
 }
 
 // RegisterDefaultCRDs  registered already supported CRDs
 func RegisterDefaultCRDs() error {
-	var resources []stork_api.ApplicationResource
 	for name, res := range getSupportedCRD() {
+		var resources []stork_api.ApplicationResource
 		for _, reg := range res {
 			cr := strings.Split(reg, ",")
 			if len(cr) < 2 {
@@ -72,6 +74,7 @@ func RegisterDefaultCRDs() error {
 		}
 		appReg.Name = name
 		if _, err := stork.Instance().CreateApplicationRegistration(appReg); err != nil && !errors.IsAlreadyExists(err) {
+			logrus.Errorf("unable to register app %v, err: %v", appReg, err)
 			return err
 		}
 	}

--- a/pkg/applicationmanager/controllers/applicationregistration.go
+++ b/pkg/applicationmanager/controllers/applicationregistration.go
@@ -1,0 +1,79 @@
+package controllers
+
+import (
+	"strings"
+
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s/stork"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	// IBMApp registration name
+	IBMApp = "ibm-app-reg"
+	// CouchBaseApp registration name
+	CouchBaseApp = "couchbase-app-reg"
+	// RedisClusterApp registration name
+	RedisClusterApp = "redis-app-reg"
+	// CassandraApp registration name
+	CassandraApp = "cassandra-app-reg"
+)
+
+func getSupportedCRD() map[string][]string {
+	// Default CRD registration of format,
+	// {kind, crdName, suspendPath,suspendType(bool/int)}
+	defCRD := make(map[string][]string)
+	// IBM CRD's
+	defCRD[IBMApp] = []string{"IBPCA,ibpcas.ibp.com",
+		"IBPConsole,ibpconsoles.ibp.com",
+		"IBPOrderer,ibporderers.ibp.com",
+		"IBPPeer,ibppeers.ibp.com",
+	}
+	//CouchBase CRD's
+	defCRD[CouchBaseApp] = []string{"CouchbaseBucket,couchbasebuckets.couchbase.com",
+		"CouchbaseCluster,couchbaseclusters.couchbase.com,spec.suspend,true",
+		"CouchbaseEphemeralBucket,couchbaseephemeralbuckets.couchbase.com",
+		"CouchbaseMemcachedBucket,couchbasememcachedbuckets.couchbase.com",
+		"CouchbaseReplication,couchbasereplications.couchbase.com",
+		"CouchbaseUser,couchbaseusers.couchbase.com",
+		"CouchbaseGroup,couchbasegroups.couchbase.com",
+		"CouchbaseRoleBinding,couchbaserolebindings.couchbase.com",
+		"CouchbaseBackup,couchbasebackups.couchbase.com",
+		"CouchbaseBackupRestore,couchbasebackuprestores.couchbase.com",
+	}
+	// datastax/Cassandra CRD's
+	defCRD[CassandraApp] = []string{"CassandraDatacenter,cassandradatacenters.cassandra.datastax.com,spec.stopped,bool"}
+	// redis cluster CRD's
+	defCRD[RedisClusterApp] = []string{"RedisEnterpriseCluster,redisenterpriseclusters.app.redislabs.com"}
+
+	return defCRD
+}
+
+// RegisterDefaultCRDs  registered already supported CRDs
+func RegisterDefaultCRDs() error {
+	var resources []stork_api.ApplicationResource
+	for name, res := range getSupportedCRD() {
+		for _, reg := range res {
+			cr := strings.Split(reg, ",")
+			if len(cr) < 2 {
+				continue
+			}
+			var appReg stork_api.ApplicationResource
+			appReg.Kind = cr[0]
+			appReg.Group = cr[1]
+			if len(cr) == 4 {
+				appReg.SuspendOptions = stork_api.SuspendOptions{Path: cr[2], Type: cr[3]}
+			}
+			resources = append(resources, appReg)
+		}
+
+		appReg := &stork_api.ApplicationRegistration{
+			Resources: resources,
+		}
+		appReg.Name = name
+		if _, err := stork.Instance().CreateApplicationRegistration(appReg); err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/applicationmanager/controllers/applicationregistration.go
+++ b/pkg/applicationmanager/controllers/applicationregistration.go
@@ -1,12 +1,11 @@
 package controllers
 
 import (
-	"strings"
-
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -20,33 +19,182 @@ const (
 	CassandraApp = "cassandra-app-reg"
 )
 
-func getSupportedCRD() map[string][]string {
-	// Default CRD registration of format,
-	// {kind, crdName, suspendPath,suspendType(bool/int)}
-	defCRD := make(map[string][]string)
+func getSupportedCRD() map[string][]stork_api.ApplicationResource {
+	// supported CRD registration
+	defCRD := make(map[string][]stork_api.ApplicationResource)
 	// IBM CRD's
-	defCRD[IBMApp] = []string{"IBPCA,ibpcas.ibp.com",
-		"IBPConsole,ibpconsoles.ibp.com",
-		"IBPOrderer,ibporderers.ibp.com",
-		"IBPPeer,ibppeers.ibp.com",
+	defCRD[IBMApp] = []stork_api.ApplicationResource{
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "IBPCA",
+				Group:   "ibp.com",
+				Version: "v1alpha1",
+			},
+			KeepStatus: false,
+			SuspendOptions: stork_api.SuspendOptions{
+				Path: "spec.replicas",
+				Type: "int",
+			},
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "IBPConsole",
+				Group:   "ibp.com",
+				Version: "v1alpha1",
+			},
+			KeepStatus: false,
+			SuspendOptions: stork_api.SuspendOptions{
+				Path: "spec.replicas",
+				Type: "int",
+			},
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "IBPOrderer",
+				Group:   "ibp.com",
+				Version: "v1alpha1",
+			},
+			KeepStatus: false,
+			SuspendOptions: stork_api.SuspendOptions{
+				Path: "spec.replicas",
+				Type: "int",
+			},
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "IBPPeer",
+				Group:   "ibp.com",
+				Version: "v1alpha1",
+			},
+			KeepStatus: false,
+			SuspendOptions: stork_api.SuspendOptions{
+				Path: "spec.replicas",
+				Type: "int",
+			},
+		},
 	}
 	//CouchBase CRD's
-	defCRD[CouchBaseApp] = []string{"CouchbaseBucket,couchbasebuckets.couchbase.com",
-		"CouchbaseCluster,couchbaseclusters.couchbase.com,spec.suspend,true",
-		"CouchbaseEphemeralBucket,couchbaseephemeralbuckets.couchbase.com",
-		"CouchbaseMemcachedBucket,couchbasememcachedbuckets.couchbase.com",
-		"CouchbaseReplication,couchbasereplications.couchbase.com",
-		"CouchbaseUser,couchbaseusers.couchbase.com",
-		"CouchbaseGroup,couchbasegroups.couchbase.com",
-		"CouchbaseRoleBinding,couchbaserolebindings.couchbase.com",
-		"CouchbaseBackup,couchbasebackups.couchbase.com",
-		"CouchbaseBackupRestore,couchbasebackuprestores.couchbase.com",
+	defCRD[CouchBaseApp] = []stork_api.ApplicationResource{
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CouchbaseBucket",
+				Group:   "couchbase.com",
+				Version: "v2",
+			},
+			KeepStatus: false,
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CouchbaseCluster",
+				Group:   "couchbase.com",
+				Version: "v2",
+			},
+			KeepStatus: false,
+			SuspendOptions: stork_api.SuspendOptions{
+				Path: "spec.suspend",
+				Type: "bool",
+			},
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CouchbaseEphemeralBucket",
+				Group:   "couchbase.com",
+				Version: "v2",
+			},
+			KeepStatus: false,
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CouchbaseMemcachedBucket",
+				Group:   "couchbase.com",
+				Version: "v2",
+			},
+			KeepStatus: false,
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CouchbaseReplication",
+				Group:   "couchbase.com",
+				Version: "v2",
+			},
+			KeepStatus: false,
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CouchbaseUser",
+				Group:   "couchbase.com",
+				Version: "v2",
+			},
+			KeepStatus: false,
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CouchbaseGroup",
+				Group:   "couchbase.com",
+				Version: "v2",
+			},
+			KeepStatus: false,
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CouchbaseRoleBinding",
+				Group:   "couchbase.com",
+				Version: "v2",
+			},
+			KeepStatus: false,
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CouchbaseBackup",
+				Group:   "couchbase.com",
+				Version: "v2",
+			},
+			KeepStatus: false,
+		},
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CouchbaseBackupRestore",
+				Group:   "ouchbase.com",
+				Version: "v2",
+			},
+			KeepStatus: false,
+		},
 	}
 	// datastax/Cassandra CRD's
-	defCRD[CassandraApp] = []string{"CassandraDatacenter,cassandradatacenters.cassandra.datastax.com,spec.stopped,bool"}
+	defCRD[CassandraApp] = []stork_api.ApplicationResource{
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "CassandraDatacenter",
+				Group:   "cassandra.datastax.com",
+				Version: "v1beta1",
+			},
+			KeepStatus: false,
+			SuspendOptions: stork_api.SuspendOptions{
+				Path: "spec.stopped",
+				Type: "bool",
+			},
+		},
+	}
 	// redis cluster CRD's
-	defCRD[RedisClusterApp] = []string{"RedisEnterpriseCluster,redisenterpriseclusters.app.redislabs.com",
-		"RedisEnterpriseDatabase,redisenterprisedatabases.app.redislabs.com"}
+	defCRD[RedisClusterApp] =
+		[]stork_api.ApplicationResource{
+			{
+				GroupVersionKind: metav1.GroupVersionKind{
+					Kind:    "RedisEnterpriseCluster",
+					Group:   "app.redislabs.com",
+					Version: "v1",
+				},
+				KeepStatus: false,
+			},
+			{
+				GroupVersionKind: metav1.GroupVersionKind{
+					Kind:    "RedisEnterpriseDatabase",
+					Group:   "app.redislabs.com",
+					Version: "v1",
+				},
+				KeepStatus: false,
+			},
+		}
 
 	return defCRD
 }
@@ -54,23 +202,8 @@ func getSupportedCRD() map[string][]string {
 // RegisterDefaultCRDs  registered already supported CRDs
 func RegisterDefaultCRDs() error {
 	for name, res := range getSupportedCRD() {
-		var resources []stork_api.ApplicationResource
-		for _, reg := range res {
-			cr := strings.Split(reg, ",")
-			if len(cr) < 2 {
-				continue
-			}
-			var appReg stork_api.ApplicationResource
-			appReg.Kind = cr[0]
-			appReg.Group = cr[1]
-			if len(cr) == 4 {
-				appReg.SuspendOptions = stork_api.SuspendOptions{Path: cr[2], Type: cr[3]}
-			}
-			resources = append(resources, appReg)
-		}
-
 		appReg := &stork_api.ApplicationRegistration{
-			Resources: resources,
+			Resources: res,
 		}
 		appReg.Name = name
 		if _, err := stork.Instance().CreateApplicationRegistration(appReg); err != nil && !errors.IsAlreadyExists(err) {

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -489,7 +489,7 @@ func (a *ApplicationRestoreController) downloadCRD(
 	namespace string,
 ) error {
 	var crds []*apiextensionsv1beta1.CustomResourceDefinition
-	crdData, err := a.downloadObject(backup, backupLocation, namespace, resourceCRDName)
+	crdData, err := a.downloadObject(backup, backupLocation, namespace, crdObjectName)
 	if err != nil {
 		return err
 	}

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -463,6 +463,10 @@ func (a *ApplicationRestoreController) downloadResources(
 	backupLocation string,
 	namespace string,
 ) ([]runtime.Unstructured, error) {
+	// create CRD resource first
+	if err := a.downloadCRD(backup, backupLocation, namespace); err != nil {
+		return nil, err
+	}
 	data, err := a.downloadObject(backup, backupLocation, namespace, resourceObjectName)
 	if err != nil {
 		return nil, err
@@ -477,6 +481,33 @@ func (a *ApplicationRestoreController) downloadResources(
 		runtimeObjects = append(runtimeObjects, o)
 	}
 	return runtimeObjects, nil
+}
+
+func (a *ApplicationRestoreController) downloadCRD(
+	backup *storkapi.ApplicationBackup,
+	backupLocation string,
+	namespace string,
+) error {
+	var crds []*apiextensionsv1beta1.CustomResourceDefinition
+	crdData, err := a.downloadObject(backup, backupLocation, namespace, resourceCRDName)
+	if err != nil {
+		return err
+	}
+	if err = json.Unmarshal(crdData, &crds); err != nil {
+		return err
+	}
+	for _, crd := range crds {
+		crd.ResourceVersion = ""
+		if err := apiextensions.Instance().RegisterCRD(crd); err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+		if err := apiextensions.Instance().ValidateCRD(apiextensions.CustomResource{
+			Plural: crd.Spec.Names.Plural,
+			Group:  crd.Spec.Group}, validateCRDTimeout, validateCRDInterval); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (a *ApplicationRestoreController) updateResourceStatus(

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1097,6 +1097,9 @@ func (m *MigrationController) applyResources(
 		for _, v := range crd.Resources {
 			res, err := apiextensions.Instance().GetCRD(v.Group, metav1.GetOptions{ResourceVersion: v.Version})
 			if err != nil {
+				if errors.IsNotFound(err) {
+					continue
+				}
 				log.MigrationLog(migration).Errorf("unable to get customresourcedefination for %s, err: %v", v.Kind, err)
 				return err
 			}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -427,21 +427,6 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 							delete(metadataMap, key)
 						}
 					}
-					fields := strings.Split(kind.SuspendOptions.Path, ".")
-					if len(fields) > 1 {
-						var disableVersion interface{}
-						disableVersion = 0
-						if kind.SuspendOptions.Type == "bool" {
-							disableVersion = true
-						} else if kind.SuspendOptions.Type == "int" {
-							disableVersion = 0
-						} else {
-							return fmt.Errorf("invalid type %v to suspend cr", kind.SuspendOptions.Type)
-						}
-						if err := unstructured.SetNestedField(content, disableVersion, fields...); err != nil {
-							return err
-						}
-					}
 				}
 			}
 		}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -86,9 +86,10 @@ func (r *ResourceCollector) Init(config *restclient.Config) error {
 	return nil
 }
 
-func resourceToBeCollected(resource metav1.APIResource, crdKinds, optionalResourceTypes []string) bool {
-	for _, kind := range crdKinds {
-		if kind == resource.Kind {
+func resourceToBeCollected(resource metav1.APIResource, grp schema.GroupVersion, crdKinds []metav1.GroupVersionKind, optionalResourceTypes []string) bool {
+	for _, res := range crdKinds {
+		if res.Kind == resource.Kind &&
+			res.Group == grp.Group && res.Version == grp.Version {
 			return true
 		}
 	}
@@ -135,15 +136,14 @@ func (r *ResourceCollector) GetResources(
 
 	// Map to prevent collection of duplicate objects
 	resourceMap := make(map[types.UID]bool)
-
-	var crdResources []string
+	var crdResources []metav1.GroupVersionKind
 	crdList, err := storkops.Instance().ListApplicationRegistrations()
 	if err != nil {
 		return nil, err
 	}
 	for _, crd := range crdList.Items {
 		for _, kind := range crd.Resources {
-			crdResources = append(crdResources, kind.Kind)
+			crdResources = append(crdResources, kind.GroupVersionKind)
 		}
 	}
 
@@ -159,7 +159,7 @@ func (r *ResourceCollector) GetResources(
 		}
 
 		for _, resource := range group.APIResources {
-			if !resourceToBeCollected(resource, crdResources, optionalResourceTypes) {
+			if !resourceToBeCollected(resource, groupVersion, crdResources, optionalResourceTypes) {
 				continue
 			}
 			for _, ns := range namespaces {
@@ -409,10 +409,11 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 		if err != nil {
 			return err
 		}
-		resourceKind := o.GetObjectKind().GroupVersionKind().Kind
+		resourceKind := o.GetObjectKind().GroupVersionKind()
 		for _, crd := range crdList.Items {
 			for _, kind := range crd.Resources {
-				if kind.Kind == resourceKind {
+				if kind.Kind == resourceKind.Kind && kind.Group == resourceKind.Group &&
+					kind.Version == resourceKind.Version {
 					// remove status from crd
 					if !kind.KeepStatus {
 						delete(content, "status")

--- a/pkg/storkctl/applicationregistration.go
+++ b/pkg/storkctl/applicationregistration.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 )
 
-var applicationRegistrationColumns = []string{"NAME", "KIND", "CRD_NAME", "SUSPEND_OPTIONS", "KEEP_STATUS"}
+var applicationRegistrationColumns = []string{"NAME", "KIND", "CRD-NAME", "VERSION", "SUSPEND-OPTIONS", "KEEP-STATUS"}
 var applicationRegistrationSubcommand = "applicationregistrations"
 var applicationRegistrationAliases = []string{"applicationregistration", "appreg", "appregs"}
 
@@ -78,6 +78,7 @@ func applicationRegistrationPrinter(
 				[]interface{}{app.Name,
 					res.Kind,
 					res.Group,
+					res.Version,
 					suspendOptions,
 					res.KeepStatus},
 			)

--- a/pkg/storkctl/applicationregistration.go
+++ b/pkg/storkctl/applicationregistration.go
@@ -1,0 +1,94 @@
+package storkctl
+
+import (
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/spf13/cobra"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubernetes/pkg/printers"
+)
+
+var applicationRegistrationColumns = []string{"NAME", "KIND", "CRD_NAME", "SUSPEND_OPTIONS", "KEEP_STATUS"}
+var applicationRegistrationSubcommand = "applicationregistrations"
+var applicationRegistrationAliases = []string{"applicationregistration", "appreg", "appregs"}
+
+func newGetapplicationRegistrationCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	getapplicationRegistrationCommand := &cobra.Command{
+		Use:     applicationRegistrationSubcommand,
+		Aliases: applicationRegistrationAliases,
+		Short:   "Get applicationRegistration resources",
+		Run: func(c *cobra.Command, args []string) {
+			var appRegList *storkv1.ApplicationRegistrationList
+			var err error
+
+			if len(args) > 0 {
+				for _, name := range args {
+					reg, err := storkops.Instance().GetApplicationRegistration(name)
+					if err != nil {
+						util.CheckErr(err)
+						return
+					}
+					appRegList.Items = append(appRegList.Items, *reg)
+				}
+			} else {
+				var tmpAppReg storkv1.ApplicationRegistrationList
+				appRegs, err := storkops.Instance().ListApplicationRegistrations()
+				if err != nil {
+					util.CheckErr(err)
+					return
+				}
+				tmpAppReg.Items = append(tmpAppReg.Items, appRegs.Items...)
+				appRegList = &tmpAppReg
+
+			}
+			applicationRegistrations, err := storkops.Instance().ListApplicationRegistrations()
+			if err != nil {
+				util.CheckErr(err)
+				return
+			}
+
+			if len(applicationRegistrations.Items) == 0 {
+				handleEmptyList(ioStreams.Out)
+				return
+			}
+
+			if err := printObjects(c, applicationRegistrations, cmdFactory, applicationRegistrationColumns, applicationRegistrationPrinter, ioStreams.Out); err != nil {
+				util.CheckErr(err)
+				return
+			}
+		},
+	}
+	cmdFactory.BindGetFlags(getapplicationRegistrationCommand.Flags())
+
+	return getapplicationRegistrationCommand
+}
+
+func applicationRegistrationPrinter(
+	applicationRegistrationList *storkv1.ApplicationRegistrationList,
+	options printers.GenerateOptions,
+) ([]metav1beta1.TableRow, error) {
+	if applicationRegistrationList == nil {
+		return nil, nil
+	}
+
+	rows := make([]metav1beta1.TableRow, 0)
+	for _, app := range applicationRegistrationList.Items {
+		for _, res := range app.Resources {
+			suspendOptions := ""
+			if res.SuspendOptions.Path != "" {
+				suspendOptions = res.SuspendOptions.Path + "," + res.SuspendOptions.Type
+			}
+			row := getRow(&app,
+				[]interface{}{app.Name,
+					res.Kind,
+					res.Group,
+					suspendOptions,
+					res.KeepStatus},
+			)
+			rows = append(rows, row)
+		}
+	}
+	return rows, nil
+}

--- a/pkg/storkctl/applicationregistration.go
+++ b/pkg/storkctl/applicationregistration.go
@@ -21,10 +21,10 @@ func newGetapplicationRegistrationCommand(cmdFactory Factory, ioStreams genericc
 		Short:   "Get applicationRegistration resources",
 		Run: func(c *cobra.Command, args []string) {
 			var appRegList *storkv1.ApplicationRegistrationList
-			var err error
 
 			if len(args) > 0 {
 				for _, name := range args {
+					appRegList = new(storkv1.ApplicationRegistrationList)
 					reg, err := storkops.Instance().GetApplicationRegistration(name)
 					if err != nil {
 						util.CheckErr(err)
@@ -41,20 +41,14 @@ func newGetapplicationRegistrationCommand(cmdFactory Factory, ioStreams genericc
 				}
 				tmpAppReg.Items = append(tmpAppReg.Items, appRegs.Items...)
 				appRegList = &tmpAppReg
-
-			}
-			applicationRegistrations, err := storkops.Instance().ListApplicationRegistrations()
-			if err != nil {
-				util.CheckErr(err)
-				return
 			}
 
-			if len(applicationRegistrations.Items) == 0 {
+			if len(appRegList.Items) == 0 {
 				handleEmptyList(ioStreams.Out)
 				return
 			}
 
-			if err := printObjects(c, applicationRegistrations, cmdFactory, applicationRegistrationColumns, applicationRegistrationPrinter, ioStreams.Out); err != nil {
+			if err := printObjects(c, appRegList, cmdFactory, applicationRegistrationColumns, applicationRegistrationPrinter, ioStreams.Out); err != nil {
 				util.CheckErr(err)
 				return
 			}

--- a/pkg/storkctl/applicationregistration_test.go
+++ b/pkg/storkctl/applicationregistration_test.go
@@ -43,8 +43,8 @@ func TestGetApplicationRegistrations(t *testing.T) {
 	createApplicationRegistrationAndVerify(t, "cassandra-app-reg", "CassandraDatacenter",
 		"cassandradatacenters.cassandra.datastax.com", "", false, "spec.stopped", "bool")
 
-	expected := "NAME                KIND                  CRD_NAME                                      SUSPEND_OPTIONS     KEEP_STATUS\n" +
-		"cassandra-app-reg   CassandraDatacenter   cassandradatacenters.cassandra.datastax.com   spec.stopped,bool   false\n"
+	expected := "NAME                KIND                  CRD-NAME                                      VERSION   SUSPEND-OPTIONS     KEEP-STATUS\n" +
+		"cassandra-app-reg   CassandraDatacenter   cassandradatacenters.cassandra.datastax.com             spec.stopped,bool   false\n"
 	cmdArgs := []string{"get", "appreg", "cassandra-app-reg"}
 	testCommon(t, cmdArgs, nil, expected, false)
 
@@ -55,11 +55,11 @@ func TestGetApplicationRegistrations(t *testing.T) {
 	createApplicationRegistrationAndVerify(t, "test-app-reg3", "TestCustomCRD3",
 		"CRD_NAME3", "Version", true, "spec.path", "spec.path.type")
 
-	expected = "NAME                KIND                  CRD_NAME                                      SUSPEND_OPTIONS            KEEP_STATUS\n" +
-		"cassandra-app-reg   CassandraDatacenter   cassandradatacenters.cassandra.datastax.com   spec.stopped,bool          false\n" +
-		"test-app-reg1       TestCustomCRD1        CRD_NAME1                                     spec.path,spec.path.type   true\n" +
-		"test-app-reg2       TestCustomCRD2        CRD_NAME2                                     spec.path,spec.path.type   true\n" +
-		"test-app-reg3       TestCustomCRD3        CRD_NAME3                                     spec.path,spec.path.type   true\n"
+	expected = "NAME                KIND                  CRD-NAME                                      VERSION   SUSPEND-OPTIONS            KEEP-STATUS\n" +
+		"cassandra-app-reg   CassandraDatacenter   cassandradatacenters.cassandra.datastax.com             spec.stopped,bool          false\n" +
+		"test-app-reg1       TestCustomCRD1        CRD_NAME1                                     Version   spec.path,spec.path.type   true\n" +
+		"test-app-reg2       TestCustomCRD2        CRD_NAME2                                     Version   spec.path,spec.path.type   true\n" +
+		"test-app-reg3       TestCustomCRD3        CRD_NAME3                                     Version   spec.path,spec.path.type   true\n"
 	cmdArgs = []string{"get", "appreg"}
 	testCommon(t, cmdArgs, nil, expected, false)
 

--- a/pkg/storkctl/applicationregistration_test.go
+++ b/pkg/storkctl/applicationregistration_test.go
@@ -1,0 +1,66 @@
+// +build unittest
+
+package storkctl
+
+import (
+	"testing"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/stretchr/testify/require"
+)
+
+func createApplicationRegistrationAndVerify(
+	t *testing.T,
+	name string,
+	kind string,
+	crdName string,
+	version string,
+	keepStatus bool,
+	path string,
+	pathType string,
+) {
+	res := storkv1.ApplicationResource{
+		KeepStatus: keepStatus,
+		SuspendOptions: storkv1.SuspendOptions{
+			Path: path,
+			Type: pathType,
+		},
+	}
+	res.Kind = kind
+	res.Group = crdName
+	res.Version = version
+	appReg := &storkv1.ApplicationRegistration{Resources: []storkv1.ApplicationResource{res}}
+
+	appReg.Name = name
+	// Make sure it was created correctly
+	resp, err := storkops.Instance().CreateApplicationRegistration(appReg)
+	require.NoError(t, err, "Error getting clone")
+	require.NotNil(t, resp)
+}
+func TestGetApplicationRegistrations(t *testing.T) {
+
+	createApplicationRegistrationAndVerify(t, "cassandra-app-reg", "CassandraDatacenter",
+		"cassandradatacenters.cassandra.datastax.com", "", false, "spec.stopped", "bool")
+
+	expected := "NAME                KIND                  CRD_NAME                                      SUSPEND_OPTIONS     KEEP_STATUS\n" +
+		"cassandra-app-reg   CassandraDatacenter   cassandradatacenters.cassandra.datastax.com   spec.stopped,bool   false\n"
+	cmdArgs := []string{"get", "appreg", "cassandra-app-reg"}
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	createApplicationRegistrationAndVerify(t, "test-app-reg1", "TestCustomCRD1",
+		"CRD_NAME1", "Version", true, "spec.path", "spec.path.type")
+	createApplicationRegistrationAndVerify(t, "test-app-reg2", "TestCustomCRD2",
+		"CRD_NAME2", "Version", true, "spec.path", "spec.path.type")
+	createApplicationRegistrationAndVerify(t, "test-app-reg3", "TestCustomCRD3",
+		"CRD_NAME3", "Version", true, "spec.path", "spec.path.type")
+
+	expected = "NAME                KIND                  CRD_NAME                                      SUSPEND_OPTIONS            KEEP_STATUS\n" +
+		"cassandra-app-reg   CassandraDatacenter   cassandradatacenters.cassandra.datastax.com   spec.stopped,bool          false\n" +
+		"test-app-reg1       TestCustomCRD1        CRD_NAME1                                     spec.path,spec.path.type   true\n" +
+		"test-app-reg2       TestCustomCRD2        CRD_NAME2                                     spec.path,spec.path.type   true\n" +
+		"test-app-reg3       TestCustomCRD3        CRD_NAME3                                     spec.path,spec.path.type   true\n"
+	cmdArgs = []string{"get", "appreg"}
+	testCommon(t, cmdArgs, nil, expected, false)
+
+}

--- a/pkg/storkctl/get.go
+++ b/pkg/storkctl/get.go
@@ -33,6 +33,7 @@ func newGetCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *c
 		newGetApplicationRestoreCommand(cmdFactory, ioStreams),
 		newGetApplicationCloneCommand(cmdFactory, ioStreams),
 		newGetBackupLocationCommand(cmdFactory, ioStreams),
+		newGetapplicationRegistrationCommand(cmdFactory, ioStreams),
 	)
 
 	return getCommands

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -144,8 +144,7 @@ func newActivateMigrationsCommand(cmdFactory Factory, ioStreams genericclioption
 				updateIBPObjects("IBPCA", ns, true, ioStreams)
 				updateIBPObjects("IBPOrderer", ns, true, ioStreams)
 				updateIBPObjects("IBPConsole", ns, true, ioStreams)
-				updateCouchbaseObjects("couchbase.com/v1", "CouchbaseCluster", ns, true, ioStreams)
-				updateCouchbaseObjects("couchbase.com/v2", "CouchbaseCluster", ns, true, ioStreams)
+				updateCRDObjects(ns, true, ioStreams)
 			}
 
 		},
@@ -186,8 +185,7 @@ func newDeactivateMigrationsCommand(cmdFactory Factory, ioStreams genericcliopti
 				updateIBPObjects("IBPCA", ns, false, ioStreams)
 				updateIBPObjects("IBPOrderer", ns, false, ioStreams)
 				updateIBPObjects("IBPConsole", ns, false, ioStreams)
-				updateCouchbaseObjects("couchbase.com/v1", "CouchbaseCluster", ns, false, ioStreams)
-				updateCouchbaseObjects("couchbase.com/v2", "CouchbaseCluster", ns, false, ioStreams)
+				updateCRDObjects(ns, false, ioStreams)
 			}
 
 		},
@@ -257,50 +255,77 @@ func updateDeploymentConfigs(namespace string, activate bool, ioStreams genericc
 	}
 }
 
-func updateCouchbaseObjects(version string, kind string, namespace string, activate bool, ioStreams genericclioptions.IOStreams) {
-	objects, err := dynamic.Instance().ListObjects(
-		&metav1.ListOptions{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       kind,
-				APIVersion: version},
-		},
-		namespace)
+func updateCRDObjects(ns string, activate bool, ioStreams genericclioptions.IOStreams) {
+	crdList, err := storkops.Instance().ListApplicationRegistrations()
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			util.CheckErr(err)
-		}
+		util.CheckErr(err)
 		return
 	}
-	for _, o := range objects.Items {
-		err := unstructured.SetNestedField(o.Object, !activate, "spec", "paused")
-		if err != nil {
-			printMsg(fmt.Sprintf("Error updating \"spec.paused\" for %v %v/%v to %v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), !activate, err), ioStreams.ErrOut)
-			continue
-		}
-		_, err = dynamic.Instance().UpdateObject(&o)
-		if err != nil {
-			printMsg(fmt.Sprintf("Error updating \"spec.paused\" for %v %v/%v to %v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), !activate, err), ioStreams.ErrOut)
-			continue
-		}
-		printMsg(fmt.Sprintf("Updated \"spec.paused\" for %v %v/%v to %v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), !activate, err), ioStreams.ErrOut)
-		if !activate {
-			pods, found, err := unstructured.NestedStringSlice(o.Object, "status", "members", "ready")
+	for _, res := range crdList.Items {
+		for _, crd := range res.Resources {
+			objects, err := dynamic.Instance().ListObjects(
+				&metav1.ListOptions{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       crd.Kind,
+						APIVersion: crd.Group + "/" + crd.Version},
+				},
+				ns)
 			if err != nil {
-				printMsg(fmt.Sprintf("Error getting pods for %v %v/%v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), err), ioStreams.ErrOut)
-				continue
+				if errors.IsNotFound(err) {
+					continue
+				}
+				util.CheckErr(err)
+				return
 			}
-			if !found {
-				continue
+			for _, o := range objects.Items {
+				specPath := strings.Split(crd.SuspendOptions.Path, ".")
+				if len(specPath) > 1 {
+					var disableVersion interface{}
+					if crd.SuspendOptions.Type == "bool" {
+						disableVersion = !activate
+					} else if crd.SuspendOptions.Type == "int" {
+						replicas, _ := getUpdatedReplicaCount(o.GetAnnotations(), activate, ioStreams)
+						disableVersion = replicas
+					} else {
+						util.CheckErr(fmt.Errorf("invalid type %v to suspend cr", crd.SuspendOptions.Type))
+						return
+					}
+					err := unstructured.SetNestedField(o.Object, disableVersion, specPath[0], specPath[1])
+					if err != nil {
+						printMsg(fmt.Sprintf("Error updating \"%v\" for %v %v/%v to %v : %v", crd.SuspendOptions.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), !activate, err), ioStreams.ErrOut)
+						continue
+					}
+					_, err = dynamic.Instance().UpdateObject(&o)
+					if err != nil {
+						printMsg(fmt.Sprintf("Error updating \"%v\" for %v %v/%v to %v : %v", crd.SuspendOptions.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), !activate, err), ioStreams.ErrOut)
+						continue
+					}
+					printMsg(fmt.Sprintf("Updated \"%v\" for %v %v/%v to %v : %v", crd.SuspendOptions.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), !activate, err), ioStreams.ErrOut)
+					if !activate {
+						if crd.PodsPath == "" {
+							continue
+						}
+						podpath := strings.Split(crd.PodsPath, ".")
+						pods, found, err := unstructured.NestedStringSlice(o.Object, podpath...)
+						if err != nil {
+							printMsg(fmt.Sprintf("Error getting pods for %v %v/%v : %v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), ioStreams.ErrOut)
+							continue
+						}
+						if !found {
+							continue
+						}
+						for _, pod := range pods {
+							err = core.Instance().DeletePod(o.GetNamespace(), pod, true)
+							printMsg(fmt.Sprintf("Error deleting pod %v for %v %v/%v : %v", pod, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), ioStreams.ErrOut)
+							continue
+						}
+					}
+				}
+
 			}
-			for _, pod := range pods {
-				err = core.Instance().DeletePod(o.GetNamespace(), pod, true)
-				printMsg(fmt.Sprintf("Error deleting pod %v for %v %v/%v : %v", pod, strings.ToLower(kind), o.GetNamespace(), o.GetName(), err), ioStreams.ErrOut)
-				continue
-			}
+
 		}
-
 	}
-
 }
 func updateIBPObjects(kind string, namespace string, activate bool, ioStreams genericclioptions.IOStreams) {
 	objects, err := dynamic.Instance().ListObjects(

--- a/vendor/github.com/portworx/sched-ops/k8s/apps/statefulsets.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apps/statefulsets.go
@@ -243,6 +243,10 @@ func (c *Client) GetStatefulSetsUsingStorageClass(scName string) ([]appsv1.State
 
 // GetPVCsForStatefulSet returns all the PVCs for given stateful set
 func (c *Client) GetPVCsForStatefulSet(ss *appsv1.StatefulSet) (*corev1.PersistentVolumeClaimList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
 	listOptions, err := c.getListOptionsForStatefulSet(ss)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/applicationregistration.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/applicationregistration.go
@@ -1,0 +1,93 @@
+package stork
+
+import (
+	"fmt"
+	"time"
+
+	storkv1alpha1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s/errors"
+	"github.com/portworx/sched-ops/task"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ApplicationRegistrationOps is an interface to perform k8s ApplicationRegistration operations
+type ApplicationRegistrationOps interface {
+	// CreateApplicationRegistration creates the ApplicationRegistration
+	CreateApplicationRegistration(*storkv1alpha1.ApplicationRegistration) (*storkv1alpha1.ApplicationRegistration, error)
+	// GetApplicationRegistration gets the ApplicationRegistration
+	GetApplicationRegistration(string) (*storkv1alpha1.ApplicationRegistration, error)
+	// ListApplicationRegistrations lists all the ApplicationRegistrations
+	ListApplicationRegistrations() (*storkv1alpha1.ApplicationRegistrationList, error)
+	// UpdateApplicationRegistration updates the ApplicationRegistration
+	UpdateApplicationRegistration(*storkv1alpha1.ApplicationRegistration) (*storkv1alpha1.ApplicationRegistration, error)
+	// DeleteApplicationRegistration deletes the ApplicationRegistration
+	DeleteApplicationRegistration(string) error
+	// ValidateApplicationRegistration validates the ApplicationRegistration
+	ValidateApplicationRegistration(string, time.Duration, time.Duration) error
+}
+
+// CreateApplicationRegistration creates the ApplicationRegistration
+func (c *Client) CreateApplicationRegistration(ApplicationRegistration *storkv1alpha1.ApplicationRegistration) (*storkv1alpha1.ApplicationRegistration, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.stork.StorkV1alpha1().ApplicationRegistrations().Create(ApplicationRegistration)
+}
+
+// GetApplicationRegistration gets the ApplicationRegistration
+func (c *Client) GetApplicationRegistration(name string) (*storkv1alpha1.ApplicationRegistration, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.stork.StorkV1alpha1().ApplicationRegistrations().Get(name, metav1.GetOptions{})
+}
+
+// ListApplicationRegistrations lists all the ApplicationRegistrations
+func (c *Client) ListApplicationRegistrations() (*storkv1alpha1.ApplicationRegistrationList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.stork.StorkV1alpha1().ApplicationRegistrations().List(metav1.ListOptions{})
+
+}
+
+// UpdateApplicationRegistration updates the ApplicationRegistration
+func (c *Client) UpdateApplicationRegistration(ApplicationRegistration *storkv1alpha1.ApplicationRegistration) (*storkv1alpha1.ApplicationRegistration, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.stork.StorkV1alpha1().ApplicationRegistrations().Update(ApplicationRegistration)
+}
+
+// DeleteApplicationRegistration deletes the ApplicationRegistration
+func (c *Client) DeleteApplicationRegistration(name string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+	return c.stork.StorkV1alpha1().ApplicationRegistrations().Delete(name, &metav1.DeleteOptions{
+		PropagationPolicy: &deleteForegroundPolicy,
+	})
+}
+
+// ValidateApplicationRegistration validates the ApplicationRegistration
+func (c *Client) ValidateApplicationRegistration(name string, timeout, retryInterval time.Duration) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+	t := func() (interface{}, bool, error) {
+		resp, err := c.GetApplicationRegistration(name)
+		if err != nil {
+			return "", true, &errors.ErrFailedToValidateCustomSpec{
+				Name:  name,
+				Cause: fmt.Sprintf("ApplicationRegistration failed . Error: %v", err),
+				Type:  resp,
+			}
+		}
+		return "", false, nil
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, timeout, retryInterval); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/stork.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/stork.go
@@ -33,6 +33,7 @@ type Ops interface {
 	ApplicationBackupRestoreOps
 	ApplicationCloneOps
 	VolumeSnapshotRestoreOps
+	ApplicationRegistrationOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)


### PR DESCRIPTION
**What type of PR is this?**
>feature

**What this PR does / why we need it**:
Add support in stork to migration/backup/restore generic CRDs

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
support in stork to migration/backup/restore generic CRDs. Users has to register their CRD's via ApplicationRegistration CRs. 
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.4.2

Note: depends on PR #653 