### PR TITLE
Set resource version to empty before applying restored objects

### DIFF
--- a/pkg/applicationmanager/controllers/applicationregistration.go
+++ b/pkg/applicationmanager/controllers/applicationregistration.go
@@ -10,13 +10,13 @@ import (
 
 const (
 	// IBMApp registration name
-	IBMApp = "ibm-app-reg"
+	IBMApp = "ibm"
 	// CouchBaseApp registration name
-	CouchBaseApp = "couchbase-app-reg"
+	CouchBaseApp = "couchbase"
 	// RedisClusterApp registration name
-	RedisClusterApp = "redis-app-reg"
+	RedisClusterApp = "redis"
 	// CassandraApp registration name
-	CassandraApp = "cassandra-app-reg"
+	CassandraApp = "cassandra"
 )
 
 func getSupportedCRD() map[string][]stork_api.ApplicationResource {
@@ -91,7 +91,7 @@ func getSupportedCRD() map[string][]stork_api.ApplicationResource {
 			},
 			KeepStatus: false,
 			SuspendOptions: stork_api.SuspendOptions{
-				Path: "spec.suspend",
+				Path: "spec.paused",
 				Type: "bool",
 			},
 			PodsPath: "status.members.ready",
@@ -155,7 +155,7 @@ func getSupportedCRD() map[string][]stork_api.ApplicationResource {
 		{
 			GroupVersionKind: metav1.GroupVersionKind{
 				Kind:    "CouchbaseBackupRestore",
-				Group:   "ouchbase.com",
+				Group:   "couchbase.com",
 				Version: "v2",
 			},
 			KeepStatus: false,

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1205,7 +1205,6 @@ func (m *MigrationController) applyResources(
 		migrAnnot[StorkMigrationName] = migration.GetName()
 		migrAnnot[StorkMigrationTime] = time.Now().Format(nameTimeSuffixFormat)
 		unstructured.SetAnnotations(migrAnnot)
-		unstructured.SetResourceVersion("")
 		retries := 0
 		for {
 			_, err = dynamicClient.Create(unstructured, metav1.CreateOptions{})

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -418,19 +418,20 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 					if !kind.KeepStatus {
 						delete(content, "status")
 					}
-					// remove metadata annotations
-					metadataMap := content["metadata"].(map[string]interface{})
-					// Remove all metadata except some well-known ones
-					for key := range metadataMap {
-						switch key {
-						case "name", "namespace", "labels", "annotations":
-						default:
-							delete(metadataMap, key)
-						}
-					}
 				}
 			}
 		}
+		// remove metadata annotations
+		metadataMap := content["metadata"].(map[string]interface{})
+		// Remove all metadata except some well-known ones
+		for key := range metadataMap {
+			switch key {
+			case "name", "namespace", "labels", "annotations":
+			default:
+				delete(metadataMap, key)
+			}
+		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Fix for restore fails with - resourceVersion should not be set on objects to be created

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no


**Does this change need to be cherry-picked to a release branch?**:
yes, 2.4
