### PR TITLE
Keep namespace metadata for application backups, restore and clones

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -963,7 +963,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3e11dbea9e1e2cdeb11252efbda51144b208667b55b23b1a8be9fcfc7be47d86"
+  digest = "1:f97067f57183ad4ce7b1116bbcc45c6ad296749083cef8c60c0f8029b8dd3fb5"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s/admissionregistration",
@@ -984,7 +984,7 @@
     "task",
   ]
   pruneopts = "UT"
-  revision = "7b23c232a58f815546b86e2498091335fb6847b7"
+  revision = "e806a0f3b975f56ec92ce371101c48d833926c96"
 
 [[projects]]
   branch = "master"

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -959,6 +959,14 @@ func (a *ApplicationBackupController) deleteBackup(backup *stork_api.Application
 		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, metadataObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
 			return fmt.Errorf("error deleting metadata for backup %v/%v: %v", backup.Namespace, backup.Name, err)
 		}
+
+		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, crdObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+			return fmt.Errorf("error deleting resources for backup %v/%v: %v", backup.Namespace, backup.Name, err)
+		}
+
+		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, nsObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+			return fmt.Errorf("error deleting resources for backup %v/%v: %v", backup.Namespace, backup.Name, err)
+		}
 	}
 
 	return nil

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -747,6 +747,7 @@ func (a *ApplicationBackupController) uploadNamespaces(backup *stork_api.Applica
 	}
 	return nil
 }
+
 func (a *ApplicationBackupController) uploadCRDResources(backup *stork_api.ApplicationBackup, resKinds map[string]string) error {
 	crdList, err := storkops.Instance().ListApplicationRegistrations()
 	if err != nil {
@@ -961,11 +962,11 @@ func (a *ApplicationBackupController) deleteBackup(backup *stork_api.Application
 		}
 
 		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, crdObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
-			return fmt.Errorf("error deleting resources for backup %v/%v: %v", backup.Namespace, backup.Name, err)
+			return fmt.Errorf("error deleting crds for backup %v/%v: %v", backup.Namespace, backup.Name, err)
 		}
 
 		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, nsObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
-			return fmt.Errorf("error deleting resources for backup %v/%v: %v", backup.Namespace, backup.Name, err)
+			return fmt.Errorf("error deleting namespaces for backup %v/%v: %v", backup.Namespace, backup.Name, err)
 		}
 	}
 

--- a/pkg/storkctl/applicationbackup_test.go
+++ b/pkg/storkctl/applicationbackup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -66,7 +67,7 @@ func TestGetApplicationBackupsOneApplicationBackup(t *testing.T) {
 
 func TestGetApplicationBackupsMultiple(t *testing.T) {
 	defer resetTest()
-	_, err := core.Instance().CreateNamespace("default", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}})
 	require.NoError(t, err, "Error creating default namespace")
 
 	createApplicationBackupAndVerify(t, "getbackuptest1", "default", []string{"namespace1"}, "backuplocation", "", "")
@@ -89,7 +90,7 @@ func TestGetApplicationBackupsMultiple(t *testing.T) {
 	cmdArgs = []string{"get", "backups", "getbackuptest1"}
 	testCommon(t, cmdArgs, nil, expected, false)
 
-	_, err = core.Instance().CreateNamespace("ns1", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}})
 	require.NoError(t, err, "Error creating ns1 namespace")
 	createApplicationBackupAndVerify(t, "getbackuptest21", "ns1", []string{"namespace1"}, "backuplocation", "", "")
 	cmdArgs = []string{"get", "backups", "--all-namespaces"}

--- a/pkg/storkctl/applicationbackupschedule_test.go
+++ b/pkg/storkctl/applicationbackupschedule_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -109,9 +110,9 @@ func TestGetApplicationBackupSchedulesMultiple(t *testing.T) {
 
 func TestGetApplicationBackupSchedulesMultipleNamespaces(t *testing.T) {
 	defer resetTest()
-	_, err := core.Instance().CreateNamespace("test1", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test1"}})
 	require.NoError(t, err, "Error creating test1 namespace")
-	_, err = core.Instance().CreateNamespace("test2", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test2"}})
 	require.NoError(t, err, "Error creating test2 namespace")
 
 	createApplicationBackupScheduleAndVerify(t, "getapplicationbackupscheduletest1", "testpolicy", "test1", "backuplocation1", []string{"namespace1"}, "", "", true)

--- a/pkg/storkctl/applicationclone_test.go
+++ b/pkg/storkctl/applicationclone_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -65,7 +66,7 @@ func TestGetApplicationClonesOneApplicationClone(t *testing.T) {
 
 func TestGetApplicationClonesMultiple(t *testing.T) {
 	defer resetTest()
-	_, err := core.Instance().CreateNamespace("default", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}})
 	require.NoError(t, err, "Error creating default namespace")
 
 	createApplicationCloneAndVerify(t, "getclonetest1", "default", "src", "dest", "", "")
@@ -88,7 +89,7 @@ func TestGetApplicationClonesMultiple(t *testing.T) {
 	cmdArgs = []string{"get", "clones", "getclonetest1"}
 	testCommon(t, cmdArgs, nil, expected, false)
 
-	_, err = core.Instance().CreateNamespace("ns1", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}})
 	require.NoError(t, err, "Error creating ns1 namespace")
 	createApplicationCloneAndVerify(t, "getclonetest21", "ns1", "src", "dest", "", "")
 	cmdArgs = []string{"get", "clones", "--all-namespaces"}

--- a/pkg/storkctl/applicationrestore_test.go
+++ b/pkg/storkctl/applicationrestore_test.go
@@ -10,6 +10,7 @@ import (
 	core "github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -56,7 +57,7 @@ func TestGetApplicationRestoresOneApplicationRestore(t *testing.T) {
 
 func TestGetApplicationRestoresMultiple(t *testing.T) {
 	defer resetTest()
-	_, err := core.Instance().CreateNamespace("default", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}})
 	require.NoError(t, err, "Error creating default namespace")
 
 	createApplicationRestoreAndVerify(t, "getrestoretest1", "default", []string{"namespace1"}, "backuplocation", "backupname")
@@ -79,7 +80,7 @@ func TestGetApplicationRestoresMultiple(t *testing.T) {
 	cmdArgs = []string{"get", "apprestores", "getrestoretest1"}
 	testCommon(t, cmdArgs, nil, expected, false)
 
-	_, err = core.Instance().CreateNamespace("ns1", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}})
 	require.NoError(t, err, "Error creating ns1 namespace")
 	createApplicationRestoreAndVerify(t, "getrestoretest21", "ns1", []string{"namespace1"}, "backuplocation", "backupname")
 	cmdArgs = []string{"get", "apprestores", "--all-namespaces"}

--- a/pkg/storkctl/backuplocation_test.go
+++ b/pkg/storkctl/backuplocation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -167,7 +168,7 @@ func TestGoogleBackupLocation(t *testing.T) {
 }
 
 func TestAllBackupLocation(t *testing.T) {
-	_, err := core.Instance().CreateNamespace("s3", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: meta.ObjectMeta{Name: "s3"}})
 	require.NoError(t, err, "Error creating s3 namespace")
 
 	backupLocation := &storkv1.BackupLocation{
@@ -190,7 +191,7 @@ func TestAllBackupLocation(t *testing.T) {
 	_, err = storkops.Instance().CreateBackupLocation(backupLocation)
 	require.NoError(t, err, "Error creating backuplocation")
 
-	_, err = core.Instance().CreateNamespace("azure", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: meta.ObjectMeta{Name: "azure"}})
 	require.NoError(t, err, "Error creating azure namespace")
 
 	backupLocation = &storkv1.BackupLocation{
@@ -210,7 +211,7 @@ func TestAllBackupLocation(t *testing.T) {
 	_, err = storkops.Instance().CreateBackupLocation(backupLocation)
 	require.NoError(t, err, "Error creating backuplocation")
 
-	_, err = core.Instance().CreateNamespace("google", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: meta.ObjectMeta{Name: "google"}})
 	require.NoError(t, err, "Error creating google namespace")
 
 	backupLocation = &storkv1.BackupLocation{

--- a/pkg/storkctl/clusterpair_test.go
+++ b/pkg/storkctl/clusterpair_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -57,9 +58,9 @@ func TestGetClusterPairNotFound(t *testing.T) {
 func TestGetClusterPair(t *testing.T) {
 	defer resetTest()
 
-	_, err := core.Instance().CreateNamespace("test", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
 	require.NoError(t, err, "Error creating test namespace")
-	_, err = core.Instance().CreateNamespace("test1", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test1"}})
 	require.NoError(t, err, "Error creating test1 namespace")
 
 	createClusterPairAndVerify(t, "getclusterpairtest", "test")

--- a/pkg/storkctl/groupsnapshot_test.go
+++ b/pkg/storkctl/groupsnapshot_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestOneGroupSnapshot(t *testing.T) {
@@ -107,7 +109,7 @@ func TestMultipleGroupSnapshots(t *testing.T) {
 	namespace := "default"
 	selectors := map[string]string{"app": "mysql"}
 
-	_, err := core.Instance().CreateNamespace(namespace, nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 	require.NoError(t, err, "Error creating namespace")
 
 	createGroupSnapshotAndVerify(t, name1, namespace, selectors, "", "", nil, nil, 0)
@@ -125,7 +127,7 @@ func TestMultipleGroupSnapshots(t *testing.T) {
 
 	name3 := "test-group-snap-3"
 	customNamespace := "ns1"
-	_, err = core.Instance().CreateNamespace(customNamespace, nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: customNamespace}})
 	require.NoError(t, err, "Error creating namespace")
 
 	createGroupSnapshotAndVerify(t, name3, customNamespace, selectors, "", "", nil, nil, 0)

--- a/pkg/storkctl/migration_test.go
+++ b/pkg/storkctl/migration_test.go
@@ -16,6 +16,7 @@ import (
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
 	appv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -70,7 +71,7 @@ func TestGetMigrationsOneMigration(t *testing.T) {
 
 func TestGetMigrationsMultiple(t *testing.T) {
 	defer resetTest()
-	_, err := core.Instance().CreateNamespace("default", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}})
 	require.NoError(t, err, "Error creating default namespace")
 
 	createMigrationAndVerify(t, "getmigrationtest1", "default", "clusterpair1", []string{"namespace1"}, "", "")
@@ -92,7 +93,7 @@ func TestGetMigrationsMultiple(t *testing.T) {
 	cmdArgs = []string{"get", "migrations", "getmigrationtest1"}
 	testCommon(t, cmdArgs, nil, expected, false)
 
-	_, err = core.Instance().CreateNamespace("ns1", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}})
 	require.NoError(t, err, "Error creating ns1 namespace")
 	createMigrationAndVerify(t, "getmigrationtest21", "ns1", "clusterpair2", []string{"namespace1"}, "", "")
 	cmdArgs = []string{"get", "migrations", "--all-namespaces"}
@@ -257,7 +258,7 @@ func TestExclueResourcesForMigrations(t *testing.T) {
 
 func createMigratedDeployment(t *testing.T) {
 	replicas := int32(0)
-	_, err := core.Instance().CreateNamespace("dep", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "dep"}})
 	require.NoError(t, err, "Error creating dep namespace")
 
 	deployment := &appv1.Deployment{
@@ -278,7 +279,7 @@ func createMigratedDeployment(t *testing.T) {
 
 func createMigratedStatefulSet(t *testing.T) {
 	replicas := int32(0)
-	_, err := core.Instance().CreateNamespace("sts", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "sts"}})
 	require.NoError(t, err, "Error creating sts namespace")
 
 	statefulSet := &appv1.StatefulSet{
@@ -300,7 +301,7 @@ func createMigratedStatefulSet(t *testing.T) {
 
 func createMigratedDeploymentConfig(t *testing.T) {
 	replicas := int32(0)
-	_, err := core.Instance().CreateNamespace("depconf", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "depconf"}})
 	require.NoError(t, err, "Error creating dep namespace")
 
 	deploymentConfig := &ocpv1.DeploymentConfig{

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -103,9 +104,9 @@ func TestGetMigrationSchedulesMultiple(t *testing.T) {
 
 func TestGetMigrationSchedulesMultipleNamespaces(t *testing.T) {
 	defer resetTest()
-	_, err := core.Instance().CreateNamespace("test1", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test1"}})
 	require.NoError(t, err, "Error creating test1 namespace")
-	_, err = core.Instance().CreateNamespace("test2", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test2"}})
 	require.NoError(t, err, "Error creating test2 namespace")
 
 	createMigrationScheduleAndVerify(t, "getmigrationscheduletest1", "testpolicy", "test1", "clusterpair1", []string{"namespace1"}, "", "", true)

--- a/pkg/storkctl/snapshot_test.go
+++ b/pkg/storkctl/snapshot_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -52,9 +53,9 @@ snap1   persistentVolumeClaimName   Pending                         Local
 
 func TestGetVolumeSnapshotsMultipleSnapshots(t *testing.T) {
 	var snapshots snapv1.VolumeSnapshotList
-	_, err := core.Instance().CreateNamespace("test1", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test1"}})
 	require.NoError(t, err, "Error creating test1 namespace")
-	_, err = core.Instance().CreateNamespace("test2", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test2"}})
 	require.NoError(t, err, "Error creating test2 namespace")
 
 	cmdArgs := []string{"get", "volumesnapshots", "--all-namespaces"}
@@ -153,9 +154,9 @@ func TestGetVolumeSnapshotRestoreNoRestores(t *testing.T) {
 
 func TestGetVolumeSnapshotRestoreAllRestores(t *testing.T) {
 
-	_, err := core.Instance().CreateNamespace("ns", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}})
 	require.NoError(t, err, "Error creating ns namespace")
-	_, err = core.Instance().CreateNamespace("default", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}})
 	require.NoError(t, err, "Error creating ns1 namespace")
 
 	cmdArgs := []string{"get", "volumesnapshotrestore", "--all-namespaces"}

--- a/pkg/storkctl/snapshotschedule_test.go
+++ b/pkg/storkctl/snapshotschedule_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -87,9 +88,9 @@ func TestGetSnapshotSchedulesMultiple(t *testing.T) {
 
 func TestGetSnapshotSchedulesMultipleNamespaces(t *testing.T) {
 	defer resetTest()
-	_, err := core.Instance().CreateNamespace("test1", nil)
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test1"}})
 	require.NoError(t, err, "Error creating test1 namespace")
-	_, err = core.Instance().CreateNamespace("test2", nil)
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test2"}})
 	require.NoError(t, err, "Error creating test2 namespace")
 
 	createSnapshotScheduleAndVerify(t, "getsnapshotscheduletest1", "pvcname", "testpolicy", "test1", "preExec", "postExec", true)

--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/portworx/torpedo/drivers/scheduler/spec"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -895,11 +896,15 @@ func applicationBackupSyncControllerTest(t *testing.T) {
 	require.NoError(t, err, "Error setting remote config")
 
 	// Create namespace for the backuplocation on second cluster
-	ns, err := core.Instance().CreateNamespace(appCtx.GetID(),
-		map[string]string{
-			"creator": "stork-test",
-			"app":     appCtx.App.Key,
-		})
+	ns, err := core.Instance().CreateNamespace(&v1.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name: appCtx.GetID(),
+			Labels: map[string]string{
+				"creator": "stork-test",
+				"app":     appCtx.App.Key,
+			},
+		},
+	})
 	require.NoError(t, err, "Failed to create namespace %s", appCtx.GetID())
 
 	backupLocation2, err := createBackupLocation(t, backupLocationName, ns.Name, defaultBackupLocation, defaultSecretName)

--- a/vendor/github.com/portworx/sched-ops/k8s/apps/apps.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apps/apps.go
@@ -25,6 +25,7 @@ type Ops interface {
 	DaemonSetOps
 	DeploymentOps
 	StatefulSetOps
+	ReplicaSetOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)

--- a/vendor/github.com/portworx/sched-ops/k8s/apps/deployments.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apps/deployments.go
@@ -248,20 +248,11 @@ func (c *Client) GetDeploymentPods(deployment *appsv1.Deployment) ([]corev1.Pod,
 		return nil, err
 	}
 
-	rSets, err := c.apps.ReplicaSets(deployment.Namespace).List(metav1.ListOptions{})
+	rSet, err := c.GetReplicaSetByDeployment(deployment)
 	if err != nil {
 		return nil, err
 	}
-
-	for _, rSet := range rSets.Items {
-		for _, owner := range rSet.OwnerReferences {
-			if owner.Name == deployment.Name {
-				return common.GetPodsByOwner(c.core, rSet.UID, rSet.Namespace)
-			}
-		}
-	}
-
-	return nil, nil
+	return c.GetReplicaSetPods(rSet)
 }
 
 // GetDeploymentsUsingStorageClass returns all deployments using the given storage class

--- a/vendor/github.com/portworx/sched-ops/k8s/apps/replicasets.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apps/replicasets.go
@@ -1,0 +1,202 @@
+package apps
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/portworx/sched-ops/k8s/common"
+	schederrors "github.com/portworx/sched-ops/k8s/errors"
+	"github.com/portworx/sched-ops/task"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ReplicaSetOps is an interface to perform k8s daemon set operations
+type ReplicaSetOps interface {
+	// CreateReplicaSet creates the given ReplicaSet
+	CreateReplicaSet(rs *appsv1.ReplicaSet) (*appsv1.ReplicaSet, error)
+	// ListReplicaSets lists all ReplicaSets in given namespace
+	ListReplicaSets(namespace string, listOpts metav1.ListOptions) ([]appsv1.ReplicaSet, error)
+	// GetReplicaSet gets the the daemon set with given name
+	GetReplicaSet(string, string) (*appsv1.ReplicaSet, error)
+	// ValidateReplicaSet checks if the given ReplicaSet is ready within given timeout
+	ValidateReplicaSet(name, namespace string, timeout time.Duration) error
+	// GetReplicaSetPods returns list of pods for the ReplicaSet
+	GetReplicaSetPods(*appsv1.ReplicaSet) ([]corev1.Pod, error)
+	// UpdateReplicaSet updates the given daemon set and returns the updated rs
+	UpdateReplicaSet(*appsv1.ReplicaSet) (*appsv1.ReplicaSet, error)
+	// DeleteReplicaSet deletes the given ReplicaSet
+	DeleteReplicaSet(name, namespace string) error
+	// GetReplicaSetByDeployment deletes the given ReplicaSet
+	GetReplicaSetByDeployment(deployment *appsv1.Deployment) (*appsv1.ReplicaSet, error)
+}
+
+// CreateReplicaSet creates the given ReplicaSet
+func (c *Client) CreateReplicaSet(rs *appsv1.ReplicaSet) (*appsv1.ReplicaSet, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.apps.ReplicaSets(rs.Namespace).Create(rs)
+}
+
+// ListReplicaSets lists all ReplicaSets in given namespace
+func (c *Client) ListReplicaSets(namespace string, listOpts metav1.ListOptions) ([]appsv1.ReplicaSet, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	rsList, err := c.apps.ReplicaSets(namespace).List(listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return rsList.Items, nil
+}
+
+// GetReplicaSet gets the the daemon set with given name
+func (c *Client) GetReplicaSet(name, namespace string) (*appsv1.ReplicaSet, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	if len(namespace) == 0 {
+		namespace = corev1.NamespaceDefault
+	}
+
+	rs, err := c.apps.ReplicaSets(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return rs, nil
+}
+
+// GetReplicaSetPods returns list of pods for the ReplicaSet
+func (c *Client) GetReplicaSetPods(rs *appsv1.ReplicaSet) ([]corev1.Pod, error) {
+	return common.GetPodsByOwner(c.core, rs.UID, rs.Namespace)
+}
+
+// ValidateReplicaSet checks if the given ReplicaSet is ready within given timeout
+func (c *Client) ValidateReplicaSet(name, namespace string, timeout time.Duration) error {
+	t := func() (interface{}, bool, error) {
+		rs, err := c.GetReplicaSet(name, namespace)
+		if err != nil {
+			return "", true, err
+		}
+
+		if rs.Status.ObservedGeneration == 0 {
+			return "", true, &schederrors.ErrAppNotReady{
+				ID:    name,
+				Cause: "Observed generation is still 0. Check back status after some time",
+			}
+		}
+
+		pods, err := c.GetReplicaSetPods(rs)
+		if err != nil || pods == nil {
+			return "", true, &schederrors.ErrAppNotReady{
+				ID:    rs.Name,
+				Cause: fmt.Sprintf("Failed to get pods for ReplicaSet. Err: %v", err),
+			}
+		}
+
+		if len(pods) == 0 {
+			return "", true, &schederrors.ErrAppNotReady{
+				ID:    rs.Name,
+				Cause: "ReplicaSet has 0 pods",
+			}
+		}
+
+		podsOverviewString := common.GeneratePodsOverviewString(pods)
+
+		if rs.Status.Replicas != rs.Status.AvailableReplicas {
+			return "", true, &schederrors.ErrAppNotReady{
+				ID: name,
+				Cause: fmt.Sprintf("Not all pods are updated. expected: %v updated: %v. Current pods overview:\n%s",
+					rs.Status.Replicas, rs.Status.AvailableReplicas, podsOverviewString),
+			}
+		}
+
+		unavailableReplicas := rs.Status.Replicas - rs.Status.ReadyReplicas
+		if unavailableReplicas > 0 {
+			return "", true, &schederrors.ErrAppNotReady{
+				ID: name,
+				Cause: fmt.Sprintf("%d pods are not available. available: %d ready: %d. Current pods overview:\n%s",
+					unavailableReplicas, rs.Status.AvailableReplicas,
+					rs.Status.ReadyReplicas, podsOverviewString),
+			}
+		}
+
+		if rs.Status.Replicas != rs.Status.ReadyReplicas {
+			return "", true, &schederrors.ErrAppNotReady{
+				ID: name,
+				Cause: fmt.Sprintf("Expected ready: %v Actual ready:%v Current pods overview:\n%s",
+					rs.Status.Replicas, rs.Status.ReadyReplicas, podsOverviewString),
+			}
+		}
+
+		var notReadyPods []string
+		var readyCount int32
+		for _, pod := range pods {
+			if !common.IsPodReady(pod) {
+				notReadyPods = append(notReadyPods, pod.Name)
+			} else {
+				readyCount++
+			}
+		}
+
+		if readyCount == rs.Status.Replicas {
+			return "", false, nil
+		}
+
+		return "", true, &schederrors.ErrAppNotReady{
+			ID:    rs.Name,
+			Cause: fmt.Sprintf("Pod(s): %#v not yet ready", notReadyPods),
+		}
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, timeout, 15*time.Second); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateReplicaSet updates the given daemon set and returns the updated rs
+func (c *Client) UpdateReplicaSet(rs *appsv1.ReplicaSet) (*appsv1.ReplicaSet, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.apps.ReplicaSets(rs.Namespace).Update(rs)
+}
+
+// DeleteReplicaSet deletes the given ReplicaSet
+func (c *Client) DeleteReplicaSet(name, namespace string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	return c.apps.ReplicaSets(namespace).Delete(
+		name,
+		&metav1.DeleteOptions{PropagationPolicy: &deleteForegroundPolicy})
+}
+
+// GetReplicaSetByDeployment get ReplicaSet for a Given Deployemnt
+func (c *Client) GetReplicaSetByDeployment(deployment *appsv1.Deployment) (*appsv1.ReplicaSet, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	rsets, err := c.apps.ReplicaSets(deployment.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rs := range rsets.Items {
+		for _, ownerReference := range rs.OwnerReferences {
+			if ownerReference.Name == deployment.Name {
+				return &rs, nil
+			}
+		}
+	}
+	return nil, nil
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/core/namespaces.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/namespaces.go
@@ -12,7 +12,9 @@ type NamespaceOps interface {
 	// GetNamespace returns a namespace object for given name
 	GetNamespace(name string) (*corev1.Namespace, error)
 	// CreateNamespace creates a namespace with given name and metadata
-	CreateNamespace(name string, metadata map[string]string) (*corev1.Namespace, error)
+	CreateNamespace(*corev1.Namespace) (*corev1.Namespace, error)
+	// UpdateNamespace update a namespace with given metadata
+	UpdateNamespace(*corev1.Namespace) (*corev1.Namespace, error)
 	// DeleteNamespace deletes a namespace with given name
 	DeleteNamespace(name string) error
 }
@@ -38,17 +40,12 @@ func (c *Client) GetNamespace(name string) (*corev1.Namespace, error) {
 }
 
 // CreateNamespace creates a namespace with given name and metadata
-func (c *Client) CreateNamespace(name string, metadata map[string]string) (*corev1.Namespace, error) {
+func (c *Client) CreateNamespace(namespace *corev1.Namespace) (*corev1.Namespace, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
 
-	return c.kubernetes.CoreV1().Namespaces().Create(&corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: metadata,
-		},
-	})
+	return c.kubernetes.CoreV1().Namespaces().Create(namespace)
 }
 
 // DeleteNamespace deletes a namespace with given name
@@ -58,4 +55,13 @@ func (c *Client) DeleteNamespace(name string) error {
 	}
 
 	return c.kubernetes.CoreV1().Namespaces().Delete(name, &metav1.DeleteOptions{})
+}
+
+// UpdateNamespace updates a namespace with given metadata
+func (c *Client) UpdateNamespace(namespace *corev1.Namespace) (*corev1.Namespace, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubernetes.CoreV1().Namespaces().Update(namespace)
 }

--- a/vendor/github.com/portworx/torpedo/drivers/scheduler/k8s/k8s.go
+++ b/vendor/github.com/portworx/torpedo/drivers/scheduler/k8s/k8s.go
@@ -741,7 +741,7 @@ func (k *K8s) createNamespace(app *spec.AppSpec, namespace string, options sched
 				metadata[k] = v
 			}
 		}
-		ns, err := k8sOps.CreateNamespace(namespace, metadata)
+		ns, err := k8sOps.CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace,Labels: metadata}})
 
 		if errors.IsAlreadyExists(err) {
 			if ns, err = k8sOps.GetNamespace(namespace); err == nil {


### PR DESCRIPTION
**What type of PR is this?**
> bug

**What this PR does / why we need it**:
- Keep namespace metadata for application backups, restore and clones
- handle pre/post exec rule for volumesnapshotschedules

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
No
**Does this change need to be cherry-picked to a release branch?**:
2.4


VolumesnapshotSchedule :
```
[root@test-essen-ink-crest-2 hook]# kubectl get volumesnapshot -nns-test
NAME                              AGE
test-interval-2020-07-07-190057   116s
[root@test-essen-ink-crest-2 hook]# kubectl describe volumesnapshot -nns-test
Name:         test-interval-2020-07-07-190057
Namespace:    ns-test
Labels:       SnapshotMetadata-PVName=pvc-f4b14e74-c081-11ea-b276-000c2990a7af
              SnapshotMetadata-Timestamp=1594148457109404428
Annotations:  stork.libopenstorage.org/post-snapshot-rule: mysql-post-backup-rule
              stork.libopenstorage.org/pre-snapshot-rule: mysql-pre-backup-rule
              stork.libopenstorage.org/snapshotScheduleName: test
              stork.libopenstorage.org/snapshotSchedulePolicyType: Interval
API Version:  volumesnapshot.external-storage.k8s.io/v1
Kind:         VolumeSnapshot
Metadata:
  Creation Timestamp:  2020-07-07T19:00:57Z
  Generation:          2
  Resource Version:    6875792
  Self Link:           /apis/volumesnapshot.external-storage.k8s.io/v1/namespaces/ns-test/volumesnapshots/test-interval-2020-07-07-190057
  UID:                 30899ca8-c084-11ea-b276-000c2990a7af
Spec:
  Persistent Volume Claim Name:  mysql-data
  Snapshot Data Name:            k8s-volume-snapshot-7f460a00-4180-410b-88b6-12e547047b27
Status:
  Conditions:
    Last Transition Time:  2020-07-07T19:01:25Z
    Message:               Snapshot created successfully and it is ready
    Reason:
    Status:                True
    Type:                  Ready
  Creation Timestamp:      <nil>
Events:                    <none>
```