### PR TITLE
Improve storkctl migration interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1748,7 +1748,7 @@
   version = "kubernetes-1.16.6"
 
 [[projects]]
-  digest = "1:ede0bcaf06a0254305041f6519eed27e8a24bd05414524af214d09dca0e722ae"
+  digest = "1:ab5e202034d8548ce2e6fc280a098bbf0866591dc22e03668dc19421d1872b35"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1961,6 +1961,7 @@
     "tools/record/util",
     "tools/reference",
     "tools/remotecommand",
+    "tools/watch",
     "transport",
     "transport/spdy",
     "util/cert",
@@ -2336,6 +2337,7 @@
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/uuid",
     "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/util/yaml",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/apiserver/pkg/authentication/serviceaccount",
     "k8s.io/cli-runtime/pkg/genericclioptions",
@@ -2358,6 +2360,7 @@
     "k8s.io/client-go/tools/leaderelection",
     "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/record",
+    "k8s.io/client-go/tools/watch",
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",
@@ -2370,6 +2373,7 @@
     "k8s.io/kube-openapi/cmd/openapi-gen",
     "k8s.io/kubectl/pkg/cmd/testing",
     "k8s.io/kubectl/pkg/cmd/util",
+    "k8s.io/kubectl/pkg/util/interrupt",
     "k8s.io/kubernetes/pkg/api/legacyscheme",
     "k8s.io/kubernetes/pkg/apis/core",
     "k8s.io/kubernetes/pkg/apis/core/v1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -963,7 +963,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3fd95e2b0332a1965cfa4d759f2448e76a75470a74657f28b2699c873ee716e9"
+  digest = "1:c2ea25056c39407d8baa4869006c0e3e94c1d89a3095614502f844a8a78cc44e"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s/admissionregistration",
@@ -984,7 +984,7 @@
     "task",
   ]
   pruneopts = "UT"
-  revision = "7ba5af1a13e0bfffd9c8b3404d9a8c5bce152716"
+  revision = "6f7e9d6fd9881a425d42af1d00345a7738dcbaee"
 
 [[projects]]
   branch = "master"

--- a/pkg/storkctl/applicationbackup.go
+++ b/pkg/storkctl/applicationbackup.go
@@ -81,7 +81,7 @@ func newCreateApplicationBackupCommand(cmdFactory Factory, ioStreams genericclio
 		},
 	}
 	createApplicationBackupCommand.Flags().StringSliceVarP(&namespaceList, "namespaces", "", nil, "Comma separated list of namespaces to backup")
-	createApplicationBackupCommand.Flags().BoolVarP(&waitForCompletion, "wait", "w", false, "Wait for applicationbackup to complete")
+	createApplicationBackupCommand.Flags().BoolVarP(&waitForCompletion, "wait", "", false, "Wait for applicationbackup to complete")
 	createApplicationBackupCommand.Flags().StringVarP(&preExecRule, "preExecRule", "", "", "Rule to run before executing applicationbackup")
 	createApplicationBackupCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Rule to run after executing applicationbackup")
 	createApplicationBackupCommand.Flags().StringVarP(&backupLocation, "backupLocation", "b", "", "BackupLocation to use for the backup")
@@ -130,6 +130,13 @@ func newGetApplicationBackupCommand(cmdFactory Factory, ioStreams genericcliopti
 
 			if len(applicationBackups.Items) == 0 {
 				handleEmptyList(ioStreams.Out)
+				return
+			}
+			if cmdFactory.IsWatchSet() {
+				if err := printObjectsWithWatch(c, applicationBackups, cmdFactory, applicationBackupColumns, applicationBackupPrinter, ioStreams.Out); err != nil {
+					util.CheckErr(err)
+					return
+				}
 				return
 			}
 

--- a/pkg/storkctl/applicationbackup_test.go
+++ b/pkg/storkctl/applicationbackup_test.go
@@ -189,7 +189,7 @@ func TestCreateApplicationBackupWaitSuccess(t *testing.T) {
 
 	namespace := "dummy-namespace"
 	name := "dummy-name"
-	cmdArgs := []string{"create", "backups", "-n", namespace, "--namespaces", namespace, name, "--backupLocation", "backuplocation", "-w"}
+	cmdArgs := []string{"create", "backups", "-n", namespace, "--namespaces", namespace, name, "--backupLocation", "backuplocation", "--wait"}
 
 	expected := "ApplicationBackup dummy-name started successfully\n" +
 		"STAGE\t\tSTATUS              \n" +
@@ -206,7 +206,7 @@ func TestCreateApplicationBackupWaitFailed(t *testing.T) {
 
 	namespace := "dummy-namespace"
 	name := "dummy-name"
-	cmdArgs := []string{"create", "applicationbackup", "-n", namespace, "--namespaces", namespace, name, "--backupLocation", "backuplocation", "-w"}
+	cmdArgs := []string{"create", "applicationbackup", "-n", namespace, "--namespaces", namespace, name, "--backupLocation", "backuplocation", "--wait"}
 
 	expected := "ApplicationBackup dummy-name started successfully\n" +
 		"STAGE\t\tSTATUS              \n" +

--- a/pkg/storkctl/applicationbackupschedule.go
+++ b/pkg/storkctl/applicationbackupschedule.go
@@ -146,7 +146,13 @@ func newGetApplicationBackupScheduleCommand(cmdFactory Factory, ioStreams generi
 				handleEmptyList(ioStreams.Out)
 				return
 			}
-
+			if cmdFactory.IsWatchSet() {
+				if err := printObjectsWithWatch(c, applicationBackupSchedules, cmdFactory, applicationBackupScheduleColumns, applicationBackupSchedulePrinter, ioStreams.Out); err != nil {
+					util.CheckErr(err)
+					return
+				}
+				return
+			}
 			if err := printObjects(c, applicationBackupSchedules, cmdFactory, applicationBackupScheduleColumns, applicationBackupSchedulePrinter, ioStreams.Out); err != nil {
 				util.CheckErr(err)
 				return

--- a/pkg/storkctl/applicationclone.go
+++ b/pkg/storkctl/applicationclone.go
@@ -74,7 +74,7 @@ func newCreateApplicationCloneCommand(cmdFactory Factory, ioStreams genericcliop
 			}
 		},
 	}
-	createApplicationCloneCommand.Flags().BoolVarP(&waitForCompletion, "wait", "w", false, "Wait for applicationclone to complete")
+	createApplicationCloneCommand.Flags().BoolVarP(&waitForCompletion, "wait", "", false, "Wait for applicationclone to complete")
 	createApplicationCloneCommand.Flags().StringVarP(&preExecRule, "preExecRule", "", "", "Rule to run before executing applicationclone")
 	createApplicationCloneCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Rule to run after executing applicationclone")
 	createApplicationCloneCommand.Flags().StringVarP(&sourceNamespace, "sourceNamespace", "", "", "The namespace from where applications should be cloned")
@@ -127,7 +127,13 @@ func newGetApplicationCloneCommand(cmdFactory Factory, ioStreams genericclioptio
 				handleEmptyList(ioStreams.Out)
 				return
 			}
-
+			if cmdFactory.IsWatchSet() {
+				if err := printObjectsWithWatch(c, applicationClones, cmdFactory, applicationCloneColumns, applicationClonePrinter, ioStreams.Out); err != nil {
+					util.CheckErr(err)
+					return
+				}
+				return
+			}
 			if err := printObjects(c, applicationClones, cmdFactory, applicationCloneColumns, applicationClonePrinter, ioStreams.Out); err != nil {
 				util.CheckErr(err)
 				return

--- a/pkg/storkctl/applicationclone_test.go
+++ b/pkg/storkctl/applicationclone_test.go
@@ -182,7 +182,7 @@ func TestCreateApplicationCloneWaitSuccess(t *testing.T) {
 	dstNamespace := "dummy-dst-namespace"
 	name := "dummy-name"
 	cmdArgs := []string{"create", "clones", "-n", srcNamespace, "--sourceNamespace", srcNamespace,
-		"--destinationNamespace", dstNamespace, name, "-w"}
+		"--destinationNamespace", dstNamespace, name, "--wait"}
 
 	expected := "ApplicationClone dummy-name started successfully\n" +
 		"STAGE\t\tSTATUS              \n" +
@@ -201,7 +201,7 @@ func TestCreateApplicationCloneWaitFailed(t *testing.T) {
 	dstNamespace := "dummy-dst-namespace"
 	name := "dummy-name"
 	cmdArgs := []string{"create", "clones", "-n", srcNamespace, "--sourceNamespace", srcNamespace,
-		"--destinationNamespace", dstNamespace, name, "-w"}
+		"--destinationNamespace", dstNamespace, name, "--wait"}
 
 	expected := "ApplicationClone dummy-name started successfully\n" +
 		"STAGE\t\tSTATUS              \n" +

--- a/pkg/storkctl/applicationrestore.go
+++ b/pkg/storkctl/applicationrestore.go
@@ -79,7 +79,7 @@ func newCreateApplicationRestoreCommand(cmdFactory Factory, ioStreams genericcli
 			}
 		},
 	}
-	createApplicationRestoreCommand.Flags().BoolVarP(&waitForCompletion, "wait", "w", false, "Wait for applicationrestore to complete")
+	createApplicationRestoreCommand.Flags().BoolVarP(&waitForCompletion, "wait", "", false, "Wait for applicationrestore to complete")
 	createApplicationRestoreCommand.Flags().StringVarP(&backupLocation, "backupLocation", "l", "", "BackupLocation to use for the restore")
 	createApplicationRestoreCommand.Flags().StringVarP(&backupName, "backupName", "b", "", "Backup to restore from")
 	createApplicationRestoreCommand.Flags().StringVarP(&replacePolicy, "replacePolicy", "r", "Retain", "Policy to use if resources being restored already exist (Retain or Delete).")
@@ -130,7 +130,13 @@ func newGetApplicationRestoreCommand(cmdFactory Factory, ioStreams genericcliopt
 				handleEmptyList(ioStreams.Out)
 				return
 			}
-
+			if cmdFactory.IsWatchSet() {
+				if err := printObjectsWithWatch(c, applicationRestores, cmdFactory, applicationRestoreColumns, applicationRestorePrinter, ioStreams.Out); err != nil {
+					util.CheckErr(err)
+					return
+				}
+				return
+			}
 			if err := printObjects(c, applicationRestores, cmdFactory, applicationRestoreColumns, applicationRestorePrinter, ioStreams.Out); err != nil {
 				util.CheckErr(err)
 				return

--- a/pkg/storkctl/applicationrestore_test.go
+++ b/pkg/storkctl/applicationrestore_test.go
@@ -182,7 +182,7 @@ func TestCreateApplicationRestoreWaitSuccess(t *testing.T) {
 
 	namespace := "dummy-namespace"
 	name := "dummy-name"
-	cmdArgs := []string{"create", "apprestores", "-n", namespace, name, "--backupLocation", "backuplocation", "--backupName", "backupname", "-w"}
+	cmdArgs := []string{"create", "apprestores", "-n", namespace, name, "--backupLocation", "backuplocation", "--backupName", "backupname", "--wait"}
 
 	expected := "ApplicationRestore dummy-name started successfully\n" +
 		"STAGE\t\tSTATUS              \n" +
@@ -199,7 +199,7 @@ func TestCreateApplicationRestoreWaitFailed(t *testing.T) {
 
 	namespace := "dummy-namespace"
 	name := "dummy-name"
-	cmdArgs := []string{"create", "applicationrestore", "-n", namespace, name, "--backupLocation", "backuplocation", "--backupName", "backupname", "-w"}
+	cmdArgs := []string{"create", "applicationrestore", "-n", namespace, name, "--backupLocation", "backuplocation", "--backupName", "backupname", "--wait"}
 
 	expected := "ApplicationRestore dummy-name started successfully\n" +
 		"STAGE\t\tSTATUS              \n" +

--- a/pkg/storkctl/clusterdomainsstatus.go
+++ b/pkg/storkctl/clusterdomainsstatus.go
@@ -43,6 +43,13 @@ func newGetClusterDomainsStatusCommand(cmdFactory Factory, ioStreams genericclio
 				handleEmptyList(ioStreams.Out)
 				return
 			}
+			if cmdFactory.IsWatchSet() {
+				if err := printObjectsWithWatch(c, cdStatuses, cmdFactory, clusterDomainsStatusColumns, clusterDomainsStatusPrinter, ioStreams.Out); err != nil {
+					util.CheckErr(err)
+					return
+				}
+				return
+			}
 			if err := printObjects(c, cdStatuses, cmdFactory, clusterDomainsStatusColumns, clusterDomainsStatusPrinter, ioStreams.Out); err != nil {
 				util.CheckErr(err)
 				return

--- a/pkg/storkctl/clusterdomainupdate.go
+++ b/pkg/storkctl/clusterdomainupdate.go
@@ -107,7 +107,7 @@ func newActivateClusterDomainCommand(cmdFactory Factory, ioStreams genericcliopt
 		},
 	}
 	activateClusterDomainCommand.Flags().BoolVarP(&allClusterDomains, "all", "a", false, "Activate all inactive cluster domains")
-	activateClusterDomainCommand.Flags().BoolVarP(&waitForCompletion, "wait", "w", false, "Wait for clusterdomain update to complete")
+	activateClusterDomainCommand.Flags().BoolVarP(&waitForCompletion, "wait", "", false, "Wait for clusterdomain update to complete")
 	activateClusterDomainCommand.Flags().StringVar(&nameClusterDomainUpdate, "name", "", "Name for the activate cluster domain action")
 
 	return activateClusterDomainCommand
@@ -162,7 +162,7 @@ func newDeactivateClusterDomainCommand(cmdFactory Factory, ioStreams genericclio
 		},
 	}
 	deactivateClusterDomainCommand.Flags().StringVar(&nameClusterDomainUpdate, "name", "", "Name for the deactivate cluster domain action")
-	deactivateClusterDomainCommand.Flags().BoolVarP(&waitForCompletion, "wait", "w", false, "Wait for clusterdomain update to complete")
+	deactivateClusterDomainCommand.Flags().BoolVarP(&waitForCompletion, "wait", "", false, "Wait for clusterdomain update to complete")
 
 	return deactivateClusterDomainCommand
 }

--- a/pkg/storkctl/clusterdomainupdate_test.go
+++ b/pkg/storkctl/clusterdomainupdate_test.go
@@ -227,7 +227,7 @@ func TestActivateClusterDomainWaitSuccess(t *testing.T) {
 
 	name := "testzone"
 	domainName := "zone2"
-	cmdArgs := []string{"activate", "clusterdomain", domainName, "--name", name, "-w"}
+	cmdArgs := []string{"activate", "clusterdomain", domainName, "--name", name, "--wait"}
 
 	expected := "Cluster Domain activate operation started successfully for zone2\nActivating..\n" +
 		"Cluster Domain zone2 updated successfully\n"
@@ -244,7 +244,7 @@ func TestActivateClusterDomainWaitFailed(t *testing.T) {
 
 	name := "testzone"
 	domainName := "zone2"
-	cmdArgs := []string{"activate", "clusterdomain", domainName, "--name", name, "-w"}
+	cmdArgs := []string{"activate", "clusterdomain", domainName, "--name", name, "--wait"}
 
 	expected := "Cluster Domain activate operation started successfully for zone2\n" +
 		"Activating..\nFailed to update ClusterDomain, Reason : Unavailable\n"
@@ -261,7 +261,7 @@ func TestDeactivateClusterDomainWaitSuccess(t *testing.T) {
 
 	name := "testzone"
 	domainName := "zone2"
-	cmdArgs := []string{"deactivate", "clusterdomain", domainName, "--name", name, "-w"}
+	cmdArgs := []string{"deactivate", "clusterdomain", domainName, "--name", name, "--wait"}
 
 	expected := "Cluster Domain deactivate operation started successfully for zone2\n" +
 		"Deactivating..\nCluster Domain zone2 updated successfully\n"
@@ -278,7 +278,7 @@ func TestDectivateClusterDomainWaitFailed(t *testing.T) {
 
 	name := "testzone"
 	domainName := "zone2"
-	cmdArgs := []string{"deactivate", "clusterdomain", domainName, "--name", name, "-w"}
+	cmdArgs := []string{"deactivate", "clusterdomain", domainName, "--name", name, "--wait"}
 
 	expected := "Cluster Domain deactivate operation started successfully for zone2\n" +
 		"Deactivating..\nFailed to update ClusterDomain, Reason : Unavailable\n"

--- a/pkg/storkctl/factory.go
+++ b/pkg/storkctl/factory.go
@@ -27,6 +27,7 @@ type factory struct {
 	kubeconfig    string
 	context       string
 	outputFormat  string
+	watch         bool
 }
 
 // Factory to be used for command line
@@ -54,6 +55,8 @@ type Factory interface {
 	setOutputFormat(string)
 	// setNamespace Set the namespace
 	setNamespace(string)
+	// IsWatchSet return true if -w/watch is passed
+	IsWatchSet() bool
 }
 
 // NewFactory Return a new factory interface that can be used by commands
@@ -66,6 +69,7 @@ func (f *factory) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&f.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests")
 	flags.StringVar(&f.context, "context", "", "The name of the kubeconfig context to use")
 	flags.StringVarP(&f.outputFormat, "output", "o", outputFormatTable, "Output format. One of: table|json|yaml")
+	flags.BoolVarP(&f.watch, "watch", "w", false, "watch stork resourrces")
 }
 
 func (f *factory) BindGetFlags(flags *pflag.FlagSet) {
@@ -109,6 +113,10 @@ func (f *factory) getKubeconfig() clientcmd.ClientConfig {
 
 func (f *factory) GetConfig() (*rest.Config, error) {
 	return f.getKubeconfig().ClientConfig()
+}
+
+func (f *factory) IsWatchSet() bool {
+	return f.watch
 }
 
 func (f *factory) UpdateConfig() error {

--- a/pkg/storkctl/migration_test.go
+++ b/pkg/storkctl/migration_test.go
@@ -369,7 +369,7 @@ func TestCreateMigrationWaitSuccess(t *testing.T) {
 	namespace := "dummy-namespace"
 	name := "dummy-name"
 	clusterpair := "dummy-clusterpair"
-	cmdArgs := []string{"create", "migrations", "-n", namespace, "-c", clusterpair, "--namespaces", namespace, name, "-w"}
+	cmdArgs := []string{"create", "migrations", "-n", namespace, "-c", clusterpair, "--namespaces", namespace, name, "--wait"}
 
 	expected := "STAGE\t\tSTATUS              \n\t\t                    \nVolumes\t\tSuccessful          \nMigration dummy-name completed successfully\n"
 	go setMigrationStatus(name, namespace, false, t)
@@ -382,7 +382,7 @@ func TestCreateMigrationWaitFailed(t *testing.T) {
 	namespace := "dummy-namespace"
 	name := "dummy-name"
 	clusterpair := "dummy-clusterpair"
-	cmdArgs := []string{"create", "migrations", "-n", namespace, "-c", clusterpair, "--namespaces", namespace, name, "-w"}
+	cmdArgs := []string{"create", "migrations", "-n", namespace, "-c", clusterpair, "--namespaces", namespace, name, "--wait"}
 
 	expected := "STAGE\t\tSTATUS              \n\t\t                    \nVolumes\t\tFailed              \nMigration dummy-name failed\n"
 	go setMigrationStatus(name, namespace, true, t)

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -155,7 +155,13 @@ func newGetMigrationScheduleCommand(cmdFactory Factory, ioStreams genericcliopti
 				handleEmptyList(ioStreams.Out)
 				return
 			}
-
+			if cmdFactory.IsWatchSet() {
+				if err := printObjectsWithWatch(c, migrationSchedules, cmdFactory, migrationScheduleColumns, migrationSchedulePrinter, ioStreams.Out); err != nil {
+					util.CheckErr(err)
+					return
+				}
+				return
+			}
 			if err := printObjects(c, migrationSchedules, cmdFactory, migrationScheduleColumns, migrationSchedulePrinter, ioStreams.Out); err != nil {
 				util.CheckErr(err)
 				return

--- a/pkg/storkctl/snapshot.go
+++ b/pkg/storkctl/snapshot.go
@@ -314,7 +314,13 @@ func newGetVolumeSnapshotRestoreCommand(cmdFactory Factory, ioStreams genericcli
 				handleEmptyList(ioStreams.Out)
 				return
 			}
-
+			if cmdFactory.IsWatchSet() {
+				if err := printObjectsWithWatch(c, snapRestoreList, cmdFactory, snapRestoreColumns, snapshotRestorePrinter, ioStreams.Out); err != nil {
+					util.CheckErr(err)
+					return
+				}
+				return
+			}
 			if err := printObjects(c, snapRestoreList, cmdFactory, snapRestoreColumns, snapshotRestorePrinter, ioStreams.Out); err != nil {
 				util.CheckErr(err)
 				return

--- a/pkg/storkctl/watch.go
+++ b/pkg/storkctl/watch.go
@@ -1,0 +1,35 @@
+package storkctl
+
+import (
+	"context"
+	"io"
+
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/kubectl/pkg/util/interrupt"
+)
+
+// printObjectsWithWatch prints  by listening to even updates
+func printObjectsWithWatch(cmd *cobra.Command, object runtime.Object, cmdFactory Factory, columns []string, printerFunc interface{}, out io.Writer) error {
+	var watchObject watch.Interface
+	var err error
+	watchObject, err = storkops.Instance().WatchStorkResources(cmdFactory.GetNamespace(), object)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	intr := interrupt.New(nil, cancel)
+	return intr.Run(func() error {
+		_, err := watchtools.UntilWithoutRetry(ctx, watchObject, func(e watch.Event) (bool, error) {
+			if err := printObjects(cmd, object, cmdFactory, columns, printerFunc, out); err != nil {
+				return false, err
+			}
+			return false, nil
+		})
+		return err
+	})
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/stork.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/stork.go
@@ -6,8 +6,13 @@ import (
 	"sync"
 
 	snapclient "github.com/kubernetes-incubator/external-storage/snapshot/pkg/client"
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	storkclientset "github.com/libopenstorage/stork/pkg/client/clientset/versioned"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -37,6 +42,9 @@ type Ops interface {
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)
+
+	// WatchStorkResources sets up and return resource watch
+	WatchStorkResources(runtime.Object) (watch.Interface, error)
 }
 
 // Instance returns a singleton instance of the client.
@@ -181,4 +189,50 @@ func (c *Client) loadClient() error {
 	}
 
 	return nil
+}
+
+// WatchStorkResources sets up and return resource watch
+func (c *Client) WatchStorkResources(object runtime.Object) (watch.Interface, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		fmt.Printf("Watch dynamic get meta %v\n", err)
+		return nil, err
+	}
+
+	listOptions := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", metadata.GetName()).String(),
+		Watch:         true,
+	}
+	var watchInterface watch.Interface
+	if obj, ok := object.(*storkv1.ApplicationBackup); ok {
+		watchInterface, err = c.stork.StorkV1alpha1().ApplicationBackups(obj.Namespace).Watch(listOptions)
+	} else if obj, ok := object.(*storkv1.ApplicationBackupSchedule); ok {
+		watchInterface, err = c.stork.StorkV1alpha1().ApplicationBackupSchedules(obj.Namespace).Watch(listOptions)
+	} else if obj, ok := object.(*storkv1.ApplicationRestore); ok {
+		watchInterface, err = c.stork.StorkV1alpha1().ApplicationRestores(obj.Namespace).Watch(listOptions)
+	} else if obj, ok := object.(*storkv1.ApplicationClone); ok {
+		watchInterface, err = c.stork.StorkV1alpha1().ApplicationClones(obj.Namespace).Watch(listOptions)
+	} else if obj, ok := object.(*storkv1.ClusterPair); ok {
+		watchInterface, err = c.stork.StorkV1alpha1().ClusterPairs(obj.Namespace).Watch(listOptions)
+	} else if _, ok := object.(*storkv1.ClusterDomainsStatus); ok {
+		watchInterface, err = c.stork.StorkV1alpha1().ClusterDomainsStatuses().Watch(listOptions)
+	} else if obj, ok := object.(*storkv1.ApplicationBackup); ok {
+		watchInterface, err = c.stork.StorkV1alpha1().ApplicationBackups(obj.Namespace).Watch(listOptions)
+	} else if obj, ok := object.(*storkv1.Migration); ok {
+		watchInterface, err = c.stork.StorkV1alpha1().Migrations(obj.Namespace).Watch(listOptions)
+	} else if obj, ok := object.(*storkv1.MigrationSchedule); ok {
+		watchInterface, err = c.stork.StorkV1alpha1().MigrationSchedules(obj.Namespace).Watch(listOptions)
+	} else if obj, ok := object.(*storkv1.VolumeSnapshotRestore); ok {
+		watchInterface, err = c.stork.StorkV1alpha1().VolumeSnapshotRestores(obj.Namespace).Watch(listOptions)
+	} else {
+		return nil, fmt.Errorf("unsupported object, %v", object)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return watchInterface, nil
 }

--- a/vendor/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/vendor/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+func newEventProcessor(out chan<- watch.Event) *eventProcessor {
+	return &eventProcessor{
+		out:  out,
+		cond: sync.NewCond(&sync.Mutex{}),
+		done: make(chan struct{}),
+	}
+}
+
+// eventProcessor buffers events and writes them to an out chan when a reader
+// is waiting. Because of the requirement to buffer events, it synchronizes
+// input with a condition, and synchronizes output with a channels. It needs to
+// be able to yield while both waiting on an input condition and while blocked
+// on writing to the output channel.
+type eventProcessor struct {
+	out chan<- watch.Event
+
+	cond *sync.Cond
+	buff []watch.Event
+
+	done chan struct{}
+}
+
+func (e *eventProcessor) run() {
+	for {
+		batch := e.takeBatch()
+		e.writeBatch(batch)
+		if e.stopped() {
+			return
+		}
+	}
+}
+
+func (e *eventProcessor) takeBatch() []watch.Event {
+	e.cond.L.Lock()
+	defer e.cond.L.Unlock()
+
+	for len(e.buff) == 0 && !e.stopped() {
+		e.cond.Wait()
+	}
+
+	batch := e.buff
+	e.buff = nil
+	return batch
+}
+
+func (e *eventProcessor) writeBatch(events []watch.Event) {
+	for _, event := range events {
+		select {
+		case e.out <- event:
+		case <-e.done:
+			return
+		}
+	}
+}
+
+func (e *eventProcessor) push(event watch.Event) {
+	e.cond.L.Lock()
+	defer e.cond.L.Unlock()
+	defer e.cond.Signal()
+	e.buff = append(e.buff, event)
+}
+
+func (e *eventProcessor) stopped() bool {
+	select {
+	case <-e.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *eventProcessor) stop() {
+	close(e.done)
+	e.cond.Signal()
+}
+
+// NewIndexerInformerWatcher will create an IndexerInformer and wrap it into watch.Interface
+// so you can use it anywhere where you'd have used a regular Watcher returned from Watch method.
+// it also returns a channel you can use to wait for the informers to fully shutdown.
+func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (cache.Indexer, cache.Controller, watch.Interface, <-chan struct{}) {
+	ch := make(chan watch.Event)
+	w := watch.NewProxyWatcher(ch)
+	e := newEventProcessor(ch)
+
+	indexer, informer := cache.NewIndexerInformer(lw, objType, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			e.push(watch.Event{
+				Type:   watch.Added,
+				Object: obj.(runtime.Object),
+			})
+		},
+		UpdateFunc: func(old, new interface{}) {
+			e.push(watch.Event{
+				Type:   watch.Modified,
+				Object: new.(runtime.Object),
+			})
+		},
+		DeleteFunc: func(obj interface{}) {
+			staleObj, stale := obj.(cache.DeletedFinalStateUnknown)
+			if stale {
+				// We have no means of passing the additional information down using
+				// watch API based on watch.Event but the caller can filter such
+				// objects by checking if metadata.deletionTimestamp is set
+				obj = staleObj
+			}
+
+			e.push(watch.Event{
+				Type:   watch.Deleted,
+				Object: obj.(runtime.Object),
+			})
+		},
+	}, cache.Indexers{})
+
+	go e.run()
+
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		defer e.stop()
+		informer.Run(w.StopChan())
+	}()
+
+	return indexer, informer, w, doneCh
+}

--- a/vendor/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/vendor/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// resourceVersionGetter is an interface used to get resource version from events.
+// We can't reuse an interface from meta otherwise it would be a cyclic dependency and we need just this one method
+type resourceVersionGetter interface {
+	GetResourceVersion() string
+}
+
+// RetryWatcher will make sure that in case the underlying watcher is closed (e.g. due to API timeout or etcd timeout)
+// it will get restarted from the last point without the consumer even knowing about it.
+// RetryWatcher does that by inspecting events and keeping track of resourceVersion.
+// Especially useful when using watch.UntilWithoutRetry where premature termination is causing issues and flakes.
+// Please note that this is not resilient to etcd cache not having the resource version anymore - you would need to
+// use Informers for that.
+type RetryWatcher struct {
+	lastResourceVersion string
+	watcherClient       cache.Watcher
+	resultChan          chan watch.Event
+	stopChan            chan struct{}
+	doneChan            chan struct{}
+	minRestartDelay     time.Duration
+}
+
+// NewRetryWatcher creates a new RetryWatcher.
+// It will make sure that watches gets restarted in case of recoverable errors.
+// The initialResourceVersion will be given to watch method when first called.
+func NewRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher) (*RetryWatcher, error) {
+	return newRetryWatcher(initialResourceVersion, watcherClient, 1*time.Second)
+}
+
+func newRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher, minRestartDelay time.Duration) (*RetryWatcher, error) {
+	switch initialResourceVersion {
+	case "", "0":
+		// TODO: revisit this if we ever get WATCH v2 where it means start "now"
+		//       without doing the synthetic list of objects at the beginning (see #74022)
+		return nil, fmt.Errorf("initial RV %q is not supported due to issues with underlying WATCH", initialResourceVersion)
+	default:
+		break
+	}
+
+	rw := &RetryWatcher{
+		lastResourceVersion: initialResourceVersion,
+		watcherClient:       watcherClient,
+		stopChan:            make(chan struct{}),
+		doneChan:            make(chan struct{}),
+		resultChan:          make(chan watch.Event, 0),
+		minRestartDelay:     minRestartDelay,
+	}
+
+	go rw.receive()
+	return rw, nil
+}
+
+func (rw *RetryWatcher) send(event watch.Event) bool {
+	// Writing to an unbuffered channel is blocking operation
+	// and we need to check if stop wasn't requested while doing so.
+	select {
+	case rw.resultChan <- event:
+		return true
+	case <-rw.stopChan:
+		return false
+	}
+}
+
+// doReceive returns true when it is done, false otherwise.
+// If it is not done the second return value holds the time to wait before calling it again.
+func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
+	watcher, err := rw.watcherClient.Watch(metav1.ListOptions{
+		ResourceVersion: rw.lastResourceVersion,
+	})
+	// We are very unlikely to hit EOF here since we are just establishing the call,
+	// but it may happen that the apiserver is just shutting down (e.g. being restarted)
+	// This is consistent with how it is handled for informers
+	switch err {
+	case nil:
+		break
+
+	case io.EOF:
+		// watch closed normally
+		return false, 0
+
+	case io.ErrUnexpectedEOF:
+		klog.V(1).Infof("Watch closed with unexpected EOF: %v", err)
+		return false, 0
+
+	default:
+		msg := "Watch failed: %v"
+		if net.IsProbableEOF(err) {
+			klog.V(5).Infof(msg, err)
+			// Retry
+			return false, 0
+		}
+
+		klog.Errorf(msg, err)
+		// Retry
+		return false, 0
+	}
+
+	if watcher == nil {
+		klog.Error("Watch returned nil watcher")
+		// Retry
+		return false, 0
+	}
+
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+
+	for {
+		select {
+		case <-rw.stopChan:
+			klog.V(4).Info("Stopping RetryWatcher.")
+			return true, 0
+		case event, ok := <-ch:
+			if !ok {
+				klog.V(4).Infof("Failed to get event! Re-creating the watcher. Last RV: %s", rw.lastResourceVersion)
+				return false, 0
+			}
+
+			// We need to inspect the event and get ResourceVersion out of it
+			switch event.Type {
+			case watch.Added, watch.Modified, watch.Deleted, watch.Bookmark:
+				metaObject, ok := event.Object.(resourceVersionGetter)
+				if !ok {
+					_ = rw.send(watch.Event{
+						Type:   watch.Error,
+						Object: &apierrors.NewInternalError(errors.New("retryWatcher: doesn't support resourceVersion")).ErrStatus,
+					})
+					// We have to abort here because this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+					return true, 0
+				}
+
+				resourceVersion := metaObject.GetResourceVersion()
+				if resourceVersion == "" {
+					_ = rw.send(watch.Event{
+						Type:   watch.Error,
+						Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher: object %#v doesn't support resourceVersion", event.Object)).ErrStatus,
+					})
+					// We have to abort here because this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+					return true, 0
+				}
+
+				// All is fine; send the event and update lastResourceVersion
+				ok = rw.send(event)
+				if !ok {
+					return true, 0
+				}
+				rw.lastResourceVersion = resourceVersion
+
+				continue
+
+			case watch.Error:
+				// This round trip allows us to handle unstructured status
+				errObject := apierrors.FromObject(event.Object)
+				statusErr, ok := errObject.(*apierrors.StatusError)
+				if !ok {
+					klog.Error(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
+					// Retry unknown errors
+					return false, 0
+				}
+
+				status := statusErr.ErrStatus
+
+				statusDelay := time.Duration(0)
+				if status.Details != nil {
+					statusDelay = time.Duration(status.Details.RetryAfterSeconds) * time.Second
+				}
+
+				switch status.Code {
+				case http.StatusGone:
+					// Never retry RV too old errors
+					_ = rw.send(event)
+					return true, 0
+
+				case http.StatusGatewayTimeout, http.StatusInternalServerError:
+					// Retry
+					return false, statusDelay
+
+				default:
+					// We retry by default. RetryWatcher is meant to proceed unless it is certain
+					// that it can't. If we are not certain, we proceed with retry and leave it
+					// up to the user to timeout if needed.
+
+					// Log here so we have a record of hitting the unexpected error
+					// and we can whitelist some error codes if we missed any that are expected.
+					klog.V(5).Info(spew.Sprintf("Retrying after unexpected error: %#+v", event.Object))
+
+					// Retry
+					return false, statusDelay
+				}
+
+			default:
+				klog.Errorf("Failed to recognize Event type %q", event.Type)
+				_ = rw.send(watch.Event{
+					Type:   watch.Error,
+					Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher failed to recognize Event type %q", event.Type)).ErrStatus,
+				})
+				// We are unable to restart the watch and have to stop the loop or this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+				return true, 0
+			}
+		}
+	}
+}
+
+// receive reads the result from a watcher, restarting it if necessary.
+func (rw *RetryWatcher) receive() {
+	defer close(rw.doneChan)
+	defer close(rw.resultChan)
+
+	klog.V(4).Info("Starting RetryWatcher.")
+	defer klog.V(4).Info("Stopping RetryWatcher.")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-rw.stopChan:
+			cancel()
+			return
+		case <-ctx.Done():
+			return
+		}
+	}()
+
+	// We use non sliding until so we don't introduce delays on happy path when WATCH call
+	// timeouts or gets closed and we need to reestablish it while also avoiding hot loops.
+	wait.NonSlidingUntilWithContext(ctx, func(ctx context.Context) {
+		done, retryAfter := rw.doReceive()
+		if done {
+			cancel()
+			return
+		}
+
+		time.Sleep(retryAfter)
+
+		klog.V(4).Infof("Restarting RetryWatcher at RV=%q", rw.lastResourceVersion)
+	}, rw.minRestartDelay)
+}
+
+// ResultChan implements Interface.
+func (rw *RetryWatcher) ResultChan() <-chan watch.Event {
+	return rw.resultChan
+}
+
+// Stop implements Interface.
+func (rw *RetryWatcher) Stop() {
+	close(rw.stopChan)
+}
+
+// Done allows the caller to be notified when Retry watcher stops.
+func (rw *RetryWatcher) Done() <-chan struct{} {
+	return rw.doneChan
+}

--- a/vendor/k8s.io/client-go/tools/watch/until.go
+++ b/vendor/k8s.io/client-go/tools/watch/until.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// PreconditionFunc returns true if the condition has been reached, false if it has not been reached yet,
+// or an error if the condition failed or detected an error state.
+type PreconditionFunc func(store cache.Store) (bool, error)
+
+// ConditionFunc returns true if the condition has been reached, false if it has not been reached yet,
+// or an error if the condition cannot be checked and should terminate. In general, it is better to define
+// level driven conditions over edge driven conditions (pod has ready=true, vs pod modified and ready changed
+// from false to true).
+type ConditionFunc func(event watch.Event) (bool, error)
+
+// ErrWatchClosed is returned when the watch channel is closed before timeout in UntilWithoutRetry.
+var ErrWatchClosed = errors.New("watch closed before UntilWithoutRetry timeout")
+
+// UntilWithoutRetry reads items from the watch until each provided condition succeeds, and then returns the last watch
+// encountered. The first condition that returns an error terminates the watch (and the event is also returned).
+// If no event has been received, the returned event will be nil.
+// Conditions are satisfied sequentially so as to provide a useful primitive for higher level composition.
+// Waits until context deadline or until context is canceled.
+//
+// Warning: Unless you have a very specific use case (probably a special Watcher) don't use this function!!!
+// Warning: This will fail e.g. on API timeouts and/or 'too old resource version' error.
+// Warning: You are most probably looking for a function *Until* or *UntilWithSync* below,
+// Warning: solving such issues.
+// TODO: Consider making this function private to prevent misuse when the other occurrences in our codebase are gone.
+func UntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions ...ConditionFunc) (*watch.Event, error) {
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+	var lastEvent *watch.Event
+	for _, condition := range conditions {
+		// check the next condition against the previous event and short circuit waiting for the next watch
+		if lastEvent != nil {
+			done, err := condition(*lastEvent)
+			if err != nil {
+				return lastEvent, err
+			}
+			if done {
+				continue
+			}
+		}
+	ConditionSucceeded:
+		for {
+			select {
+			case event, ok := <-ch:
+				if !ok {
+					return lastEvent, ErrWatchClosed
+				}
+				lastEvent = &event
+
+				done, err := condition(event)
+				if err != nil {
+					return lastEvent, err
+				}
+				if done {
+					break ConditionSucceeded
+				}
+
+			case <-ctx.Done():
+				return lastEvent, wait.ErrWaitTimeout
+			}
+		}
+	}
+	return lastEvent, nil
+}
+
+// Until wraps the watcherClient's watch function with RetryWatcher making sure that watcher gets restarted in case of errors.
+// The initialResourceVersion will be given to watch method when first called. It shall not be "" or "0"
+// given the underlying WATCH call issues (#74022). If you want the initial list ("", "0") done for you use ListWatchUntil instead.
+// Remaining behaviour is identical to function UntilWithoutRetry. (See above.)
+// Until can deal with API timeouts and lost connections.
+// It guarantees you to see all events and in the order they happened.
+// Due to this guarantee there is no way it can deal with 'Resource version too old error'. It will fail in this case.
+// (See `UntilWithSync` if you'd prefer to recover from all the errors including RV too old by re-listing
+//  those items. In normal code you should care about being level driven so you'd not care about not seeing all the edges.)
+// The most frequent usage for Until would be a test where you want to verify exact order of events ("edges").
+func Until(ctx context.Context, initialResourceVersion string, watcherClient cache.Watcher, conditions ...ConditionFunc) (*watch.Event, error) {
+	w, err := NewRetryWatcher(initialResourceVersion, watcherClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return UntilWithoutRetry(ctx, w, conditions...)
+}
+
+// UntilWithSync creates an informer from lw, optionally checks precondition when the store is synced,
+// and watches the output until each provided condition succeeds, in a way that is identical
+// to function UntilWithoutRetry. (See above.)
+// UntilWithSync can deal with all errors like API timeout, lost connections and 'Resource version too old'.
+// It is the only function that can recover from 'Resource version too old', Until and UntilWithoutRetry will
+// just fail in that case. On the other hand it can't provide you with guarantees as strong as using simple
+// Watch method with Until. It can skip some intermediate events in case of watch function failing but it will
+// re-list to recover and you always get an event, if there has been a change, after recovery.
+// Also with the current implementation based on DeltaFIFO, order of the events you receive is guaranteed only for
+// particular object, not between more of them even it's the same resource.
+// The most frequent usage would be a command that needs to watch the "state of the world" and should't fail, like:
+// waiting for object reaching a state, "small" controllers, ...
+func UntilWithSync(ctx context.Context, lw cache.ListerWatcher, objType runtime.Object, precondition PreconditionFunc, conditions ...ConditionFunc) (*watch.Event, error) {
+	indexer, informer, watcher, done := NewIndexerInformerWatcher(lw, objType)
+	// We need to wait for the internal informers to fully stop so it's easier to reason about
+	// and it works with non-thread safe clients.
+	defer func() { <-done }()
+	// Proxy watcher can be stopped multiple times so it's fine to use defer here to cover alternative branches and
+	// let UntilWithoutRetry to stop it
+	defer watcher.Stop()
+
+	if precondition != nil {
+		if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+			return nil, fmt.Errorf("UntilWithSync: unable to sync caches: %v", ctx.Err())
+		}
+
+		done, err := precondition(indexer)
+		if err != nil {
+			return nil, err
+		}
+
+		if done {
+			return nil, nil
+		}
+	}
+
+	return UntilWithoutRetry(ctx, watcher, conditions...)
+}
+
+// ContextWithOptionalTimeout wraps context.WithTimeout and handles infinite timeouts expressed as 0 duration.
+func ContextWithOptionalTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout < 0 {
+		// This should be handled in validation
+		klog.Errorf("Timeout for context shall not be negative!")
+		timeout = 0
+	}
+
+	if timeout == 0 {
+		return context.WithCancel(parent)
+	}
+
+	return context.WithTimeout(parent, timeout)
+}
+
+// ListWatchUntil first lists objects, converts them into synthetic ADDED events
+// and checks conditions for those synthetic events. If the conditions have not been reached so far
+// it continues by calling Until which establishes a watch from resourceVersion of the list call
+// to evaluate those conditions based on new events.
+// ListWatchUntil provides the same guarantees as Until and replaces the old WATCH from RV "" (or "0")
+// which was mixing list and watch calls internally and having severe design issues. (see #74022)
+// There is no resourceVersion order guarantee for the initial list and those synthetic events.
+func ListWatchUntil(ctx context.Context, lw cache.ListerWatcher, conditions ...ConditionFunc) (*watch.Event, error) {
+	if len(conditions) == 0 {
+		return nil, nil
+	}
+
+	list, err := lw.List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	initialItems, err := meta.ExtractList(list)
+	if err != nil {
+		return nil, err
+	}
+
+	// use the initial items as simulated "adds"
+	var lastEvent *watch.Event
+	currIndex := 0
+	passedConditions := 0
+	for _, condition := range conditions {
+		// check the next condition against the previous event and short circuit waiting for the next watch
+		if lastEvent != nil {
+			done, err := condition(*lastEvent)
+			if err != nil {
+				return lastEvent, err
+			}
+			if done {
+				passedConditions = passedConditions + 1
+				continue
+			}
+		}
+
+	ConditionSucceeded:
+		for currIndex < len(initialItems) {
+			lastEvent = &watch.Event{Type: watch.Added, Object: initialItems[currIndex]}
+			currIndex++
+
+			done, err := condition(*lastEvent)
+			if err != nil {
+				return lastEvent, err
+			}
+			if done {
+				passedConditions = passedConditions + 1
+				break ConditionSucceeded
+			}
+		}
+	}
+	if passedConditions == len(conditions) {
+		return lastEvent, nil
+	}
+	remainingConditions := conditions[passedConditions:]
+
+	metaObj, err := meta.ListAccessor(list)
+	if err != nil {
+		return nil, err
+	}
+	currResourceVersion := metaObj.GetResourceVersion()
+
+	return Until(ctx, currResourceVersion, lw, remainingConditions...)
+}


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
Adds Enhancement to storkctl migration options
 - add option to allow validating migration spec
- add watch option to storkctl stork resources
- accept storage option for clusterpair

**Does this PR change a user-facing CRD or CLI?**:
yes
Validate : 
```
# storkctl validate migrations -m ./migration.yaml
Checking Migration Namespaces....Ok
Checking ClusterPair Status....Ok
Checking PreExec Rule....Missing
Checking PostExec Rule....Missing
All Ready!!
```

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.4