### PR TITLE
handle pre/post exec rule for volumesnapshotschedules

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -937,6 +937,10 @@ func (a *ApplicationBackupController) deleteBackup(backup *stork_api.Application
 		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, metadataObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
 			return fmt.Errorf("error deleting metadata for backup %v/%v: %v", backup.Namespace, backup.Name, err)
 		}
+
+		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, crdObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+			return fmt.Errorf("error deleting crds for backup %v/%v: %v", backup.Namespace, backup.Name, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
We don't pass pre/post exec rule to snapshot for volumesnapshotschedules. This PR handles pre/post exec rule for snapshotschedules
  - It also fix deletion of crd.json file on ApplicationBackup delete if retention policy is `Delete`

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
