### PR TITLE
Don't collect service,configmaps which has ownerref set

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -215,7 +215,6 @@ func (r *ResourceCollector) GetResources(
 			}
 		}
 	}
-
 	allObjects, err = r.pruneOwnedResources(allObjects, resourceMap)
 	if err != nil {
 		return nil, err
@@ -348,10 +347,10 @@ func (r *ResourceCollector) pruneOwnedResources(
 							collect = false
 							break
 						}
-						if objectType.GetKind() != "Deployment" && objectType.GetKind() != "StatefulSet" {
+						if objectType.GetKind() != "Deployment" && objectType.GetKind() != "StatefulSet" &&
+							objectType.GetKind() != "Service" && objectType.GetKind() != "ConfigMap" {
 							continue
 						}
-
 						// Skip object if we are already collecting its owner
 						if _, exists := resourceMap[owner.UID]; exists {
 							collect = false


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
We collect service,configmap even though they have ownerref set.

**Does this PR change a user-facing CRD or CLI?**:
bo

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.4.3

