### PR TITLE
allow string type for appreg suspend option

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationregistration.go
+++ b/pkg/apis/stork/v1alpha1/applicationregistration.go
@@ -32,13 +32,14 @@ type ApplicationResource struct {
 	// SuspendOptions to disable CRD upon migration/restore/clone
 	SuspendOptions SuspendOptions `json:"suspendOptions"`
 	// PodsPath to help activate/deactivate crd upon migration
-	PodsPath string `json:"podsPath`
+	PodsPath string `json:"podsPath"`
 }
 
 // SuspendOptions to disable CRD upon migration/restore/clone
 type SuspendOptions struct {
-	Path string `json:"path"`
-	Type string `json:"type"`
+	Path  string `json:"path"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/applicationmanager/controllers/applicationregistration.go
+++ b/pkg/applicationmanager/controllers/applicationregistration.go
@@ -17,6 +17,8 @@ const (
 	RedisClusterApp = "redis"
 	// CassandraApp registration name
 	CassandraApp = "cassandra"
+	// WeblogicDomainApp registration name
+	WeblogicDomainApp = "weblogic"
 )
 
 func getSupportedCRD() map[string][]stork_api.ApplicationResource {
@@ -196,7 +198,22 @@ func getSupportedCRD() map[string][]stork_api.ApplicationResource {
 				KeepStatus: false,
 			},
 		}
-
+		// weblogic domain crds
+	defCRD[WeblogicDomainApp] = []stork_api.ApplicationResource{
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "Domain",
+				Group:   "weblogic.oracle",
+				Version: "v8",
+			},
+			KeepStatus: false,
+			SuspendOptions: stork_api.SuspendOptions{
+				Path:  "spec.serverStartPolicy",
+				Type:  "string",
+				Value: "NEVER",
+			},
+		},
+	}
 	return defCRD
 }
 

--- a/pkg/storkctl/applicationregistration.go
+++ b/pkg/storkctl/applicationregistration.go
@@ -73,6 +73,9 @@ func applicationRegistrationPrinter(
 			suspendOptions := ""
 			if res.SuspendOptions.Path != "" {
 				suspendOptions = res.SuspendOptions.Path + "," + res.SuspendOptions.Type
+				if res.SuspendOptions.Value != "" {
+					suspendOptions = suspendOptions + "," + res.SuspendOptions.Value
+				}
 			}
 			row := getRow(&app,
 				[]interface{}{app.Name,


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
Allow string type option to be set for crd migration. 

**Does this PR change a user-facing CRD or CLI?**:
yes, in case of string type we will display value in `storkctl get appreg` 
```
# /tmp/storkctl get appreg
NAME        KIND                       CRD-NAME                 VERSION    SUSPEND-OPTIONS                       KEEP-STATUS
weblogic    Domain                     weblogic.oracle          v8         spec.serverStartPolicy,string,NEVER   false
```

**Is a release note needed?**:
yes

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.4.4
