### PR TITLE
Add support to pass in * to select all namespaces to backup and update rule to take container name

### DIFF
--- a/pkg/apis/stork/v1alpha1/rule.go
+++ b/pkg/apis/stork/v1alpha1/rule.go
@@ -27,6 +27,9 @@ type Rule struct {
 type RuleItem struct {
 	// PodSelector is a map of key value pairs that are used to select the pods using their labels
 	PodSelector map[string]string `json:"podSelector"`
+	// Container Name of the container in which to run the rule if there are
+	// multiple containers in the pod
+	Container string `json:"container"`
 	// Actions are actions to be performed on the pods selected using the selector
 	Actions []RuleAction `json:"actions"`
 }


### PR DESCRIPTION


**What this PR does / why we need it**:
Add support to pass in * to select all namespaces to backup

Update Rule spec to take in container name
This is required since a pod could have multiple containers and we
need to know which one we should run the commands in

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
Adds container field to Rule spec

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
* Added support to specify * as a wildcard to select all namespaces in ApplicationBackup spec
* Added container name in Rule spec. This is required if you have multiple containers in a pod and want to select a container to run the command in.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
No

