### PR TITLE
ResourceCollector: When checking for resources set group name for core

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -463,7 +463,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		return false, err
 	}
 
-	// Even if PV isn't specified need to check if the corresponding PV is, so
+	// Even if PV isn't specified need to check if the corresponding PVC is, so
 	// skip the check here
 	if len(includeObjects) != 0 && objectType.GetKind() != "PersistentVolume" {
 		info := stork_api.ObjectInfo{
@@ -474,6 +474,9 @@ func (r *ResourceCollector) PrepareResourceForApply(
 			},
 			Name:      metadata.GetName(),
 			Namespace: metadata.GetNamespace(),
+		}
+		if info.Group == "" {
+			info.Group = "core"
 		}
 		if val, present := includeObjects[info]; !present || !val {
 			return true, nil


### PR DESCRIPTION
The group in the resource is empty, need to set it to core before comparing


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
No

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
No

