### PR TITLE
Passing empty endpoint to AWS objectstore operations

### DIFF
--- a/pkg/objectstore/s3/s3.go
+++ b/pkg/objectstore/s3/s3.go
@@ -14,8 +14,15 @@ import (
 )
 
 func getSession(backupLocation *stork_api.BackupLocation) (*session.Session, error) {
+	// AWS SDK fetches the correct endpoint based on region provided if endpoint is passed empty
+	var endpoint string
+	if backupLocation.Location.S3Config.Endpoint == "s3.amazonaws.com" {
+		endpoint = ""
+	} else {
+		endpoint = backupLocation.Location.S3Config.Endpoint
+	}
 	return session.NewSession(&aws.Config{
-		Endpoint: aws.String(backupLocation.Location.S3Config.Endpoint),
+		Endpoint: aws.String(endpoint),
 		Credentials: credentials.NewStaticCredentials(backupLocation.Location.S3Config.AccessKeyID,
 			backupLocation.Location.S3Config.SecretAccessKey, ""),
 		Region:           aws.String(backupLocation.Location.S3Config.Region),


### PR DESCRIPTION
AWS SDK fetches correct endpoint based on provided region


**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:
AWS SDK supports fetching of correct endpoints based on region provided if the user passes an empty endpoint.
This makes the user experience better wherein they need to remember different endpoints for different regions.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
