### PR TITLE
Fix to populate backup and restore size for azure volumes

### DIFF
--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -340,10 +340,10 @@ func (a *azure) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi
 		case "Succeeded":
 			vInfo.Status = storkapi.ApplicationBackupStatusSuccessful
 			vInfo.Reason = "Backup successful for volume"
+			vInfo.Size = uint64(*snapshot.DiskSizeBytes)
 		default:
 			vInfo.Status = storkapi.ApplicationBackupStatusInProgress
 			vInfo.Reason = fmt.Sprintf("Volume backup in progress: %v", snapshot.ProvisioningState)
-			vInfo.Size = uint64(*snapshot.DiskSizeBytes)
 		}
 		volumeInfos = append(volumeInfos, vInfo)
 	}
@@ -539,10 +539,10 @@ func (a *azure) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*stork
 		case "Succeeded":
 			vInfo.Status = storkapi.ApplicationRestoreStatusSuccessful
 			vInfo.Reason = "Restore successful for volume"
+			vInfo.Size = uint64(*disk.DiskSizeBytes)
 		default:
 			vInfo.Status = storkapi.ApplicationRestoreStatusInProgress
 			vInfo.Reason = fmt.Sprintf("Volume restore in progress: %v", disk.ProvisioningState)
-			vInfo.Size = uint64(*disk.DiskSizeBytes)
 		}
 		volumeInfos = append(volumeInfos, vInfo)
 	}


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What this PR does / why we need it**:
Backup/Restore size for azure volumes are not shown as currently, it was populating for in-progress backups. Moved the same to fetch once the backup is completed.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

