### PR TITLE
Adding actual backup size in backup volume info

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -369,7 +369,8 @@ func (a *aws) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 		case "completed":
 			vInfo.Status = storkapi.ApplicationBackupStatusSuccessful
 			vInfo.Reason = "Backup successful for volume"
-			vInfo.Size = uint64(*snapshot.VolumeSize)
+			vInfo.TotalSize = uint64(*snapshot.VolumeSize)
+			vInfo.ActualSize = uint64(*snapshot.VolumeSize)
 		}
 		volumeInfos = append(volumeInfos, vInfo)
 	}
@@ -546,7 +547,7 @@ func (a *aws) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkap
 		case "available", "in-use":
 			vInfo.Status = storkapi.ApplicationRestoreStatusSuccessful
 			vInfo.Reason = "Restore successful for volume"
-			vInfo.Size = uint64(*ebsVolume.Size)
+			vInfo.TotalSize = uint64(*ebsVolume.Size)
 		}
 		volumeInfos = append(volumeInfos, vInfo)
 	}

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -340,7 +340,8 @@ func (a *azure) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi
 		case "Succeeded":
 			vInfo.Status = storkapi.ApplicationBackupStatusSuccessful
 			vInfo.Reason = "Backup successful for volume"
-			vInfo.Size = uint64(*snapshot.DiskSizeBytes)
+			vInfo.TotalSize = uint64(*snapshot.DiskSizeBytes)
+			vInfo.ActualSize = uint64(*snapshot.DiskSizeBytes)
 		default:
 			vInfo.Status = storkapi.ApplicationBackupStatusInProgress
 			vInfo.Reason = fmt.Sprintf("Volume backup in progress: %v", snapshot.ProvisioningState)
@@ -539,7 +540,7 @@ func (a *azure) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*stork
 		case "Succeeded":
 			vInfo.Status = storkapi.ApplicationRestoreStatusSuccessful
 			vInfo.Reason = "Restore successful for volume"
-			vInfo.Size = uint64(*disk.DiskSizeBytes)
+			vInfo.TotalSize = uint64(*disk.DiskSizeBytes)
 		default:
 			vInfo.Status = storkapi.ApplicationRestoreStatusInProgress
 			vInfo.Reason = fmt.Sprintf("Volume restore in progress: %v", disk.ProvisioningState)

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -329,7 +329,8 @@ func (g *gcp) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 		case "READY":
 			vInfo.Status = storkapi.ApplicationBackupStatusSuccessful
 			vInfo.Reason = "Backup successful for volume"
-			vInfo.Size = uint64(snapshot.StorageBytes)
+			vInfo.TotalSize = uint64(snapshot.StorageBytes)
+			vInfo.ActualSize = uint64(snapshot.StorageBytes)
 		}
 		volumeInfos = append(volumeInfos, vInfo)
 	}
@@ -512,7 +513,7 @@ func (g *gcp) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkap
 			// Returns size in GB to the nearest decimal, converting it into bytes
 			// to be consistent with other cloud providers
 			size := disk.SizeGb * 1024 * 1024
-			vInfo.Size = uint64(size)
+			vInfo.TotalSize = uint64(size)
 		} else {
 			disk, err := g.service.Disks.Get(g.projectID, vInfo.Zones[0], vInfo.RestoreVolume).Do()
 			if err != nil {
@@ -528,7 +529,7 @@ func (g *gcp) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkap
 			}
 			status = disk.Status
 			size := disk.SizeGb * 1024 * 1024
-			vInfo.Size = uint64(size)
+			vInfo.TotalSize = uint64(size)
 		}
 		switch status {
 		case "CREATING", "RESTORING":

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2843,6 +2843,7 @@ func (p *portworx) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*stork
 		} else {
 			vInfo.Status = storkapi.ApplicationBackupStatusSuccessful
 			vInfo.Reason = "Backup successful for volume"
+			vInfo.ActualSize = csStatus.bytesDone
 			req := &api.SdkCloudBackupSizeRequest{
 				BackupId:     csStatus.cloudSnapID,
 				CredentialId: csStatus.credentialID,
@@ -2851,7 +2852,7 @@ func (p *portworx) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*stork
 			st, _ := status.FromError(err)
 			if err != nil {
 				// On error explicitly make the value to zero
-				vInfo.Size = 0
+				vInfo.TotalSize = 0
 				if st.Code() == codes.Unimplemented {
 					// if using old porx version which doesn't support this API, log an
 					// warning and continue to next vol if available
@@ -2861,7 +2862,7 @@ func (p *portworx) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*stork
 					return nil, err
 				}
 			} else {
-				vInfo.Size = resp.GetSize()
+				vInfo.TotalSize = resp.GetSize()
 			}
 		}
 		volumeInfos = append(volumeInfos, vInfo)
@@ -3067,7 +3068,7 @@ func (p *portworx) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*st
 			vInfo.Status = storkapi.ApplicationRestoreStatusFailed
 			vInfo.Reason = fmt.Sprintf("Restore failed for volume: %v", csStatus.msg)
 		} else {
-			vInfo.Size = csStatus.bytesDone
+			vInfo.TotalSize = csStatus.bytesDone
 			vInfo.Status = storkapi.ApplicationRestoreStatusSuccessful
 			vInfo.Reason = "Restore successful for volume"
 		}

--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -57,7 +57,7 @@ type ApplicationBackupStatus struct {
 	TriggerTimestamp    metav1.Time                      `json:"triggerTimestamp"`
 	LastUpdateTimestamp metav1.Time                      `json:"lastUpdateTimestamp"`
 	FinishTimestamp     metav1.Time                      `json:"finishTimestamp"`
-	Size                uint64                           `json:"size"`
+	TotalSize           uint64                           `json:"totalSize"`
 }
 
 // ObjectInfo contains info about an object being backed up or restored
@@ -83,7 +83,8 @@ type ApplicationBackupVolumeInfo struct {
 	Status                ApplicationBackupStatusType `json:"status"`
 	Reason                string                      `json:"reason"`
 	Options               map[string]string           `jons:"options"`
-	Size                  uint64                      `json:"size"`
+	TotalSize             uint64                      `json:"totalSize"`
+	ActualSize            uint64                      `json:"actualSize"`
 }
 
 // ApplicationBackupStatusType is the status of the application backup

--- a/pkg/apis/stork/v1alpha1/applicationrestore.go
+++ b/pkg/apis/stork/v1alpha1/applicationrestore.go
@@ -56,7 +56,7 @@ type ApplicationRestoreStatus struct {
 	Volumes             []*ApplicationRestoreVolumeInfo   `json:"volumes"`
 	FinishTimestamp     metav1.Time                       `json:"finishTimestamp"`
 	LastUpdateTimestamp metav1.Time                       `json:"lastUpdateTimestamp"`
-	Size                uint64                            `json:"size"`
+	TotalSize           uint64                            `json:"totalSize"`
 }
 
 // ApplicationRestoreResourceInfo is the info for the restore of a resource
@@ -76,7 +76,7 @@ type ApplicationRestoreVolumeInfo struct {
 	Zones                 []string                     `json:"zones"`
 	Status                ApplicationRestoreStatusType `json:"status"`
 	Reason                string                       `json:"reason"`
-	Size                  uint64                       `json:"size"`
+	TotalSize             uint64                       `json:"totalSize"`
 }
 
 // ApplicationRestoreStatusType is the status of the application restore

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -936,7 +936,7 @@ func (a *ApplicationBackupController) backupResources(
 
 	// Only on success compute the total backup size
 	for _, vInfo := range backup.Status.Volumes {
-		backup.Status.Size += vInfo.Size
+		backup.Status.TotalSize += vInfo.TotalSize
 	}
 	// Upload the metadata for the backup to the backup location
 	if err = a.uploadMetadata(backup); err != nil {

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -479,7 +479,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 	restore.Status.LastUpdateTimestamp = metav1.Now()
 	// Only on success compute the total restore size
 	for _, vInfo := range restore.Status.Volumes {
-		restore.Status.Size += vInfo.Size
+		restore.Status.TotalSize += vInfo.TotalSize
 	}
 
 	err := a.client.Update(context.TODO(), restore)


### PR DESCRIPTION
**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:
Portworx supports incremental backups wherein the only incremental backup is taken which occupies less size. As part of this PR, actual size (only size of backup data written) is captured. For other cloud providers, this would be the same as the total size of the backup.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
