### PR TITLE
Create application registration CR for all crds found on system

### DIFF
--- a/vendor/github.com/portworx/sched-ops/k8s/apiextensions/crds.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apiextensions/crds.go
@@ -25,6 +25,8 @@ type CRDOps interface {
 	ValidateCRD(resource CustomResource, timeout, retryInterval time.Duration) error
 	// DeleteCRD deletes the CRD for the given complete name (plural.group)
 	DeleteCRD(fullName string) error
+	// ListCRD list all crds on system
+	ListCRD() (*apiextensionsv1beta1.CustomResourceDefinitionList, error)
 }
 
 // CustomResource is for creating a Kubernetes TPR/CRD
@@ -147,4 +149,15 @@ func (c *Client) DeleteCRD(fullName string) error {
 	return c.extension.ApiextensionsV1beta1().
 		CustomResourceDefinitions().
 		Delete(fullName, &metav1.DeleteOptions{PropagationPolicy: &deleteForegroundPolicy})
+}
+
+// ListCRD deletes the CRD for the given complete name (plural.group)
+func (c *Client) ListCRD() (*apiextensionsv1beta1.CustomResourceDefinitionList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.extension.ApiextensionsV1beta1().
+		CustomResourceDefinitions().
+		List(metav1.ListOptions{})
 }


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
- Detect all registered crd on k8s server and create application registration resource fo all of them
- Add debug logs in Webhooks controller

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
yes, 
```ApplicationRegistration resources are now created for all CRD's found on k8s server.  So backup and restore of CR does not require any additional step of registering CR with stork. 
Note: For migration, user has to add `suspendOption` to disable/enable CRs on migrations
```
**Does this change need to be cherry-picked to a release branch?**:
2.5.0

Example Output: 
```
# storkctl get appreg
NAME                       KIND                       CRD-NAME                 VERSION    SUSPEND-OPTIONS                       KEEP-STATUS
cassandra                  CassandraDatacenter        cassandra.datastax.com   v1beta1    spec.stopped,bool                     false
couchbase                  CouchbaseBucket            couchbase.com            v2                                               false
couchbase                  CouchbaseCluster           couchbase.com            v2         spec.paused,bool                      false
couchbase                  CouchbaseEphemeralBucket   couchbase.com            v2                                               false
couchbase                  CouchbaseMemcachedBucket   couchbase.com            v2                                               false
couchbase                  CouchbaseReplication       couchbase.com            v2                                               false
couchbase                  CouchbaseUser              couchbase.com            v2                                               false
couchbase                  CouchbaseGroup             couchbase.com            v2                                               false
couchbase                  CouchbaseRoleBinding       couchbase.com            v2                                               false
couchbase                  CouchbaseBackup            couchbase.com            v2                                               false
couchbase                  CouchbaseBackupRestore     couchbase.com            v2                                               false
couchbasebackup            CouchbaseBackup            couchbase.com            v1                                               false
couchbasebackup            CouchbaseBackup            couchbase.com            v2                                               false
couchbasebackuprestore     CouchbaseBackupRestore     couchbase.com            v1                                               false
couchbasebackuprestore     CouchbaseBackupRestore     couchbase.com            v2                                               false
couchbasebucket            CouchbaseBucket            couchbase.com            v1                                               false
couchbasebucket            CouchbaseBucket            couchbase.com            v2                                               false
couchbasecluster           CouchbaseCluster           couchbase.com            v2                                               false
couchbasecluster           CouchbaseCluster           couchbase.com            v1                                               false
couchbaseephemeralbucket   CouchbaseEphemeralBucket   couchbase.com            v1                                               false
couchbaseephemeralbucket   CouchbaseEphemeralBucket   couchbase.com            v2                                               false
couchbasegroup             CouchbaseGroup             couchbase.com            v1                                               false
couchbasegroup             CouchbaseGroup             couchbase.com            v2                                               false
couchbasememcachedbucket   CouchbaseMemcachedBucket   couchbase.com            v1                                               false
couchbasememcachedbucket   CouchbaseMemcachedBucket   couchbase.com            v2                                               false
couchbasereplication       CouchbaseReplication       couchbase.com            v1                                               false
couchbasereplication       CouchbaseReplication       couchbase.com            v2                                               false
couchbaserolebinding       CouchbaseRoleBinding       couchbase.com            v1                                               false
couchbaserolebinding       CouchbaseRoleBinding       couchbase.com            v2                                               false
couchbaseuser              CouchbaseUser              couchbase.com            v1                                               false
couchbaseuser              CouchbaseUser              couchbase.com            v2                                               false
domain                     Domain                     weblogic.oracle          v8                                               false
domain                     Domain                     weblogic.oracle          v7                                               false
ibm                        IBPCA                      ibp.com                  v1alpha1   spec.replicas,int                     false
ibm                        IBPConsole                 ibp.com                  v1alpha1   spec.replicas,int                     false
ibm                        IBPOrderer                 ibp.com                  v1alpha1   spec.replicas,int                     false
ibm                        IBPPeer                    ibp.com                  v1alpha1   spec.replicas,int                     false
podmonitor                 PodMonitor                 monitoring.coreos.com    v1                                               false
redis                      RedisEnterpriseCluster     app.redislabs.com        v1                                               false
redis                      RedisEnterpriseDatabase    app.redislabs.com        v1                                               false
redisenterprisecluster     RedisEnterpriseCluster     app.redislabs.com        v1                                               false
redisenterprisecluster     RedisEnterpriseCluster     app.redislabs.com        v1alpha1                                         false
servicemonitor             ServiceMonitor             monitoring.coreos.com    v1                                               false
volumeplacementstrategy    VolumePlacementStrategy    portworx.io              v1beta1                                          false
weblogic                   Domain                     weblogic.oracle          v8         spec.serverStartPolicy,string,NEVER   false
```
time="2020-08-21T12:10:41Z" level=debug msg="Received admission review request for deployment mysql,default"
time="2020-08-21T12:10:41Z" level=debug msg="Updating scheduler to stork for Resource:Deployment, Name: mysql, Namespace:default"
time="2020-08-21T12:10:41Z" level=debug msg="Received admission review request for pod ,default"
time="2020-08-21T12:10:41Z" level=debug msg="Updating scheduler to stork for Resource:Pod, Name: , Namespace:default"
```
