### PR TITLE
Add support to specify resources during application backup

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -31,7 +31,8 @@ type ApplicationBackupSpec struct {
 	PostExecRule   string                             `json:"postExecRule"`
 	ReclaimPolicy  ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
 	// Options to be passed in to the driver
-	Options map[string]string `json:"options"`
+	Options          map[string]string `json:"options"`
+	IncludeResources []ObjectInfo      `json:"includeResources"`
 }
 
 // ApplicationBackupReclaimPolicyType is the reclaim policy for the application backup
@@ -131,4 +132,16 @@ type ApplicationBackupList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	Items []ApplicationBackup `json:"items"`
+}
+
+// CreateObjectsMap create a map of objects that are to be included in an
+// operation. Allows quick lookup of objects
+func CreateObjectsMap(
+	includeObjects []ObjectInfo,
+) map[ObjectInfo]bool {
+	objectsMap := make(map[ObjectInfo]bool)
+	for i := 0; i < len(includeObjects); i++ {
+		objectsMap[includeObjects[i]] = true
+	}
+	return objectsMap
 }

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -246,6 +246,11 @@ func (in *ApplicationBackupSpec) DeepCopyInto(out *ApplicationBackupSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.IncludeResources != nil {
+		in, out := &in.IncludeResources, &out.IncludeResources
+		*out = make([]ObjectInfo, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -717,6 +717,7 @@ func (a *ApplicationCloneController) cloneResources(
 	allObjects, err := a.resourceCollector.GetResources(
 		[]string{clone.Spec.SourceNamespace},
 		clone.Spec.Selectors,
+		nil,
 		clone.Spec.IncludeOptionalResourceTypes,
 		false)
 	if err != nil {

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -311,7 +311,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 			return fmt.Errorf("error getting backup spec for restore: %v", err)
 		}
 		backupVolumeInfoMappings := make(map[string][]*storkapi.ApplicationBackupVolumeInfo)
-		objectMap := a.createObjectsMap(restore.Spec.IncludeResources)
+		objectMap := storkapi.CreateObjectsMap(restore.Spec.IncludeResources)
 		info := storkapi.ObjectInfo{
 			GroupVersionKind: metav1.GroupVersionKind{
 				Group:   "core",
@@ -652,16 +652,6 @@ func (a *ApplicationRestoreController) getPVNameMappings(
 	return pvNameMappings, nil
 }
 
-func (a *ApplicationRestoreController) createObjectsMap(
-	includeObjects []storkapi.ObjectInfo,
-) map[storkapi.ObjectInfo]bool {
-	objectsMap := make(map[storkapi.ObjectInfo]bool)
-	for i := 0; i < len(includeObjects); i++ {
-		objectsMap[includeObjects[i]] = true
-	}
-	return objectsMap
-}
-
 func (a *ApplicationRestoreController) applyResources(
 	restore *storkapi.ApplicationRestore,
 	objects []runtime.Unstructured,
@@ -671,7 +661,7 @@ func (a *ApplicationRestoreController) applyResources(
 		return err
 	}
 
-	objectMap := a.createObjectsMap(restore.Spec.IncludeResources)
+	objectMap := storkapi.CreateObjectsMap(restore.Spec.IncludeResources)
 	tempObjects := make([]runtime.Unstructured, 0)
 	for _, o := range objects {
 		skip, err := a.resourceCollector.PrepareResourceForApply(

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -371,6 +371,7 @@ func (m *MigrationController) purgeMigratedResources(migration *stork_api.Migrat
 	destObjects, err := rc.GetResources(
 		migration.Spec.Namespaces,
 		migration.Spec.Selectors,
+		nil,
 		migration.Spec.IncludeOptionalResourceTypes,
 		false)
 	if err != nil {
@@ -384,6 +385,7 @@ func (m *MigrationController) purgeMigratedResources(migration *stork_api.Migrat
 	srcObjects, err := m.resourceCollector.GetResources(
 		migration.Spec.Namespaces,
 		migration.Spec.Selectors,
+		nil,
 		migration.Spec.IncludeOptionalResourceTypes,
 		false)
 	if err != nil {
@@ -739,6 +741,7 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration) e
 	allObjects, err := m.resourceCollector.GetResources(
 		migration.Spec.Namespaces,
 		migration.Spec.Selectors,
+		nil,
 		migration.Spec.IncludeOptionalResourceTypes,
 		false)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
Yes, adds `IncludeResources` in ApplicationBackup and ApplicationBackupSchedule

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Added support to specify which resource to backup using ApplicationBackup. By default all resources in the namespace will be backed up
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.5
