### PR TITLE
Continuing with next namespace creation, if current ns already exists.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -152,6 +152,10 @@ func (a *ApplicationRestoreController) createNamespaces(backup *storkapi.Applica
 							Annotations: ns.GetAnnotations(),
 						},
 					})
+					if err != nil {
+						return err
+					}
+					continue
 				}
 				return err
 			}


### PR DESCRIPTION
**What type of PR is this?**
Bug
**What this PR does / why we need it**:
During restore, Continuing with next namespace creation, if current ns already exists.

**Does this PR change a user-facing CRD or CLI?**:
N.A

**Does this change need to be cherry-picked to a release branch?**:
2.5
**Tested the following use case:**
Backuped up default, mysql-ns1, mysql-ns2 namespaces.
Restored with following namespace map from px-backup. 
namespace-mapping default=default,mysql-ns1=mysql-ns1,mysql-ns2=mysql-ns22
Here default and mysql-ns1 namespace was already existed on the cluster.
With out fix, mysql-ns22 was not created and not restored. 
With fix, it was created and restored.

