### PR TITLE
Applying label selector for clusterRole, clusterRoleBinding and ServiceAccount resources.

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -180,12 +180,8 @@ func (r *ResourceCollector) GetResources(
 
 				var selectors string
 				// PVs don't get the labels from their PVCs, so don't use the label selector
-				// Also skip for some other resources that aren't necessarily tied to an application
 				switch resource.Kind {
-				case "PersistentVolume",
-					"ClusterRoleBinding",
-					"ClusterRole",
-					"ServiceAccount":
+				case "PersistentVolume":
 				default:
 					selectors = labels.Set(labelSelectors).String()
 				}


### PR DESCRIPTION


**What type of PR is this?**
bug

**What this PR does / why we need it**:
Currently the label selector are not getting applied for clusterRole, clusterRoleBinding and ServiceAccount resources in resourceCollector.GetResources(). Because of that these resources are getting included in backup, even if they do not have the labels.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
N.A.

**Does this change need to be cherry-picked to a release branch?**:
2.5 branch

