### PR TITLE
Add security annotations to CRDs for auth-runs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -961,7 +961,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c5fd37a68f5bcac81d6d1222842dabcdc2418bcf18b9101376f1b723f4991680"
+  digest = "1:99ed02bcf392e933610c2144161b3ba02fe3faae40fa24ca2c81cf35b80dbb9b"
   name = "github.com/portworx/torpedo"
   packages = [
     "drivers/api",
@@ -982,7 +982,7 @@
     "pkg/units",
   ]
   pruneopts = "UT"
-  revision = "7ddea58d8e04aa4e4f94521f106bf6667e9d3da7"
+  revision = "c551e4254b66a2ea4a61a327b67b411c0021a80a"
 
 [[projects]]
   branch = "master"

--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2 
+FROM golang:1.13.3
 
 # Install dependancies
 RUN apt-get update && \ 

--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -30,6 +30,10 @@ const (
 	s3SecretName         = "s3secret"
 	azureSecretName      = "azuresecret"
 	googleSecretName     = "googlesecret"
+	secretNameKey        = "secret_name"
+	secretNamespaceKey   = "secret_namespace"
+	secretName           = "openstorage.io/auth-secret-name"
+	secretNamespace      = "openstorage.io/auth-secret-namespace"
 
 	applicationBackupScheduleRetryInterval = 10 * time.Second
 	applicationBackupScheduleRetryTimeout  = 5 * time.Minute
@@ -291,6 +295,14 @@ func createBackupLocation(
 			SecretConfig: secretObj.Name,
 		},
 	}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(backupLocation)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return storkops.Instance().CreateBackupLocation(backupLocation)
 }
 
@@ -314,6 +326,14 @@ func createApplicationRestore(
 			NamespaceMapping: namespaceMapping,
 		},
 	}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(appRestore)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return storkops.Instance().CreateApplicationRestore(appRestore)
 }
 
@@ -335,6 +355,14 @@ func createApplicationBackupWithAnnotation(
 			BackupLocation: backupLocation.Name,
 		},
 	}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(appBackup)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return storkops.Instance().CreateApplicationBackup(appBackup)
 }
 
@@ -517,7 +545,7 @@ func intervalApplicationBackupScheduleTest(t *testing.T) {
 	policyName := "intervalpolicy-appbackup"
 	retain := 2
 	interval := 2
-	_, err = storkops.Instance().CreateSchedulePolicy(&storkv1.SchedulePolicy{
+	schedPolicy := &storkv1.SchedulePolicy{
 		ObjectMeta: meta.ObjectMeta{
 			Name: policyName,
 		},
@@ -526,13 +554,20 @@ func intervalApplicationBackupScheduleTest(t *testing.T) {
 				Retain:          storkv1.Retain(retain),
 				IntervalMinutes: interval,
 			},
-		}})
+		}}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(schedPolicy)
+		require.NoError(t, err, "Error creating interval schedule policy")
+	}
+
+	_, err = storkops.Instance().CreateSchedulePolicy(schedPolicy)
 	require.NoError(t, err, "Error creating interval schedule policy")
 	logrus.Infof("Created schedulepolicy %v with %v minute interval and retain at %v", policyName, interval, retain)
 
 	scheduleName := "intervalscheduletest"
 	namespace := ctx.GetID()
-	_, err = storkops.Instance().CreateApplicationBackupSchedule(&storkv1.ApplicationBackupSchedule{
+	appBackupSched := &storkv1.ApplicationBackupSchedule{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      scheduleName,
 			Namespace: namespace,
@@ -547,7 +582,14 @@ func intervalApplicationBackupScheduleTest(t *testing.T) {
 			},
 			SchedulePolicyName: policyName,
 		},
-	})
+	}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(appBackupSched)
+		require.NoError(t, err, "Error creating interval applicationBackup schedule")
+	}
+
+	_, err = storkops.Instance().CreateApplicationBackupSchedule(appBackupSched)
 	require.NoError(t, err, "Error creating interval applicationBackup schedule")
 	sleepTime := time.Duration((retain+1)*interval) * time.Minute
 	logrus.Infof("Created applicationBackupschedule %v in namespace %v, sleeping for %v for schedule to trigger",
@@ -581,7 +623,7 @@ func dailyApplicationBackupScheduleTest(t *testing.T) {
 	// Set first trigger 2 minutes from now
 	scheduledTime := time.Now().Add(2 * time.Minute)
 	nextScheduledTime := scheduledTime.AddDate(0, 0, 1)
-	_, err = storkops.Instance().CreateSchedulePolicy(&storkv1.SchedulePolicy{
+	schedPolicy := &storkv1.SchedulePolicy{
 		ObjectMeta: meta.ObjectMeta{
 			Name: policyName,
 		},
@@ -590,14 +632,21 @@ func dailyApplicationBackupScheduleTest(t *testing.T) {
 				Retain: storkv1.Retain(retain),
 				Time:   scheduledTime.Format(time.Kitchen),
 			},
-		}})
+		}}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(schedPolicy)
+		require.NoError(t, err, "Error creating daily schedule policy")
+	}
+
+	_, err = storkops.Instance().CreateSchedulePolicy(schedPolicy)
 	require.NoError(t, err, "Error creating daily schedule policy")
 	logrus.Infof("Created schedulepolicy %v at time %v and retain at %v",
 		policyName, scheduledTime.Format(time.Kitchen), retain)
 
 	scheduleName := "dailyscheduletest"
 	namespace := ctx.GetID()
-	_, err = storkops.Instance().CreateApplicationBackupSchedule(&storkv1.ApplicationBackupSchedule{
+	appBackupSched := &storkv1.ApplicationBackupSchedule{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      scheduleName,
 			Namespace: namespace,
@@ -612,7 +661,14 @@ func dailyApplicationBackupScheduleTest(t *testing.T) {
 			},
 			SchedulePolicyName: policyName,
 		},
-	})
+	}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(appBackupSched)
+		require.NoError(t, err, "Error creating daily applicationBackup schedule")
+	}
+
+	_, err = storkops.Instance().CreateApplicationBackupSchedule(appBackupSched)
 	require.NoError(t, err, "Error creating daily applicationBackup schedule")
 	logrus.Infof("Created applicationBackupschedule %v in namespace %v",
 		scheduleName, namespace)
@@ -633,7 +689,7 @@ func weeklyApplicationBackupScheduleTest(t *testing.T) {
 	// Set first trigger 2 minutes from now
 	scheduledTime := time.Now().Add(2 * time.Minute)
 	nextScheduledTime := scheduledTime.AddDate(0, 0, 7)
-	_, err = storkops.Instance().CreateSchedulePolicy(&storkv1.SchedulePolicy{
+	schedPolicy := &storkv1.SchedulePolicy{
 		ObjectMeta: meta.ObjectMeta{
 			Name: policyName,
 		},
@@ -643,14 +699,21 @@ func weeklyApplicationBackupScheduleTest(t *testing.T) {
 				Day:    scheduledTime.Weekday().String(),
 				Time:   scheduledTime.Format(time.Kitchen),
 			},
-		}})
+		}}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(schedPolicy)
+		require.NoError(t, err, "Error creating weekly schedule policy")
+	}
+
+	_, err = storkops.Instance().CreateSchedulePolicy(schedPolicy)
 	require.NoError(t, err, "Error creating weekly schedule policy")
 	logrus.Infof("Created schedulepolicy %v at time %v on day %v and retain at %v",
 		policyName, scheduledTime.Format(time.Kitchen), scheduledTime.Weekday().String(), retain)
 
 	scheduleName := "weeklyscheduletest"
 	namespace := ctx.GetID()
-	_, err = storkops.Instance().CreateApplicationBackupSchedule(&storkv1.ApplicationBackupSchedule{
+	appBackupSched := &storkv1.ApplicationBackupSchedule{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      scheduleName,
 			Namespace: namespace,
@@ -665,7 +728,14 @@ func weeklyApplicationBackupScheduleTest(t *testing.T) {
 			},
 			SchedulePolicyName: policyName,
 		},
-	})
+	}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(appBackupSched)
+		require.NoError(t, err, "Error creating weekly applicationBackup schedule")
+	}
+
+	_, err = storkops.Instance().CreateApplicationBackupSchedule(appBackupSched)
 	require.NoError(t, err, "Error creating weekly applicationBackup schedule")
 	logrus.Infof("Created applicationBackupschedule %v in namespace %v",
 		scheduleName, namespace)
@@ -690,7 +760,7 @@ func monthlyApplicationBackupScheduleTest(t *testing.T) {
 	if nextScheduledTime.Day() != scheduledTime.Day() {
 		nextScheduledTime = time.Time{}
 	}
-	_, err = storkops.Instance().CreateSchedulePolicy(&storkv1.SchedulePolicy{
+	schedPolicy := &storkv1.SchedulePolicy{
 		ObjectMeta: meta.ObjectMeta{
 			Name: policyName,
 		},
@@ -700,14 +770,21 @@ func monthlyApplicationBackupScheduleTest(t *testing.T) {
 				Date:   scheduledTime.Day(),
 				Time:   scheduledTime.Format(time.Kitchen),
 			},
-		}})
+		}}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(schedPolicy)
+		require.NoError(t, err, "Error creating monthly schedule policy")
+	}
+
+	_, err = storkops.Instance().CreateSchedulePolicy(schedPolicy)
 	require.NoError(t, err, "Error creating monthly schedule policy")
 	logrus.Infof("Created schedulepolicy %v at time %v on date %v and retain at %v",
 		policyName, scheduledTime.Format(time.Kitchen), scheduledTime.Day(), retain)
 
 	scheduleName := "monthlyscheduletest"
 	namespace := ctx.GetID()
-	_, err = storkops.Instance().CreateApplicationBackupSchedule(&storkv1.ApplicationBackupSchedule{
+	appBackupSched := &storkv1.ApplicationBackupSchedule{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      scheduleName,
 			Namespace: namespace,
@@ -722,7 +799,14 @@ func monthlyApplicationBackupScheduleTest(t *testing.T) {
 			},
 			SchedulePolicyName: policyName,
 		},
-	})
+	}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(appBackupSched)
+		require.NoError(t, err, "Error creating monthly applicationBackup schedule")
+	}
+
+	_, err = storkops.Instance().CreateApplicationBackupSchedule(appBackupSched)
 	require.NoError(t, err, "Error creating monthly applicationBackup schedule")
 	logrus.Infof("Created applicationBackupschedule %v in namespace %v",
 		scheduleName, namespace)

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -13,11 +13,13 @@ import (
 	"testing"
 	"time"
 
+	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 	storkdriver "github.com/libopenstorage/stork/drivers/volume"
 	_ "github.com/libopenstorage/stork/drivers/volume/aws"
 	_ "github.com/libopenstorage/stork/drivers/volume/azure"
 	_ "github.com/libopenstorage/stork/drivers/volume/gcp"
 	_ "github.com/libopenstorage/stork/drivers/volume/portworx"
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/schedule"
 	"github.com/libopenstorage/stork/pkg/storkctl"
 	"github.com/portworx/sched-ops/k8s/apps"
@@ -40,7 +42,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/skyrings/skyring-common/tools/uuid"
 	"github.com/stretchr/testify/require"
+	appsapi "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	storageapi "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -548,6 +552,107 @@ func addTimestampSuffix(path string) string {
 	t := time.Now()
 	timeStampSuffix := t.Format("20060102150405")
 	return fmt.Sprintf("%s-%s-%s", bucketPrefix, path, timeStampSuffix)
+}
+
+func addSecurityAnnotation(spec interface{}) error {
+	// Adds annotations required for auth enabled runs
+	configMap, err := core.Instance().GetConfigMap(authTokenConfigMap, "default")
+	if err != nil {
+		logrus.Errorf("Error reading config map: %v", err)
+		return err
+	}
+	logrus.Debugf("Config Map details: %v", configMap.Data)
+	if _, ok := configMap.Data[secretNameKey]; !ok {
+		return fmt.Errorf("failed to get secret name from config map")
+	}
+	if _, ok := configMap.Data[secretNamespaceKey]; !ok {
+		return fmt.Errorf("failed to get secret namespace from config map")
+	}
+	if obj, ok := spec.(*storageapi.StorageClass); ok {
+		if obj.Parameters == nil {
+			obj.Parameters = make(map[string]string)
+		}
+		obj.Parameters[secretName] = configMap.Data[secretNameKey]
+		obj.Parameters[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*v1.PersistentVolumeClaim); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*snapv1.VolumeSnapshot); ok {
+		if obj.Metadata.Annotations == nil {
+			obj.Metadata.Annotations = make(map[string]string)
+		}
+		obj.Metadata.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Metadata.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*appsapi.StatefulSet); ok {
+		var pvcList []v1.PersistentVolumeClaim
+		for _, pvc := range obj.Spec.VolumeClaimTemplates {
+			if pvc.Annotations == nil {
+				pvc.Annotations = make(map[string]string)
+			}
+			pvc.Annotations[secretName] = configMap.Data[secretNameKey]
+			pvc.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+			pvcList = append(pvcList, pvc)
+		}
+		obj.Spec.VolumeClaimTemplates = pvcList
+	} else if obj, ok := spec.(*storkv1.ApplicationBackup); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*storkv1.ApplicationClone); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*storkv1.ApplicationRestore); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*storkv1.Migration); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*storkv1.VolumeSnapshotRestore); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*storkv1.GroupVolumeSnapshot); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*storkv1.ApplicationBackupSchedule); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*storkv1.SchedulePolicy); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*storkv1.VolumeSnapshotSchedule); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	}
+	return nil
 }
 
 func TestMain(m *testing.M) {

--- a/vendor/github.com/portworx/torpedo/LICENSE
+++ b/vendor/github.com/portworx/torpedo/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2015-2016 Portworx, Inc.
+   Copyright 2015-2020 Portworx, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/portworx/torpedo/drivers/scheduler/k8s/k8s.go
+++ b/vendor/github.com/portworx/torpedo/drivers/scheduler/k8s/k8s.go
@@ -41,6 +41,7 @@ import (
 	"github.com/sirupsen/logrus"
 	appsapi "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -199,7 +200,7 @@ func (k *K8s) Init(schedOpts scheduler.InitOptions) error {
 	return nil
 }
 
-func (k *K8s) addNewNode(newNode v1.Node) error {
+func (k *K8s) addNewNode(newNode corev1.Node) error {
 	n := k.parseK8SNode(newNode)
 	if err := k.IsNodeReady(n); err != nil {
 		return err
@@ -384,9 +385,9 @@ func validateSpec(in interface{}) (interface{}, error) {
 		return specObj, nil
 	} else if specObj, ok := in.(*appsapi.DaemonSet); ok {
 		return specObj, nil
-	} else if specObj, ok := in.(*v1.Service); ok {
+	} else if specObj, ok := in.(*corev1.Service); ok {
 		return specObj, nil
-	} else if specObj, ok := in.(*v1.PersistentVolumeClaim); ok {
+	} else if specObj, ok := in.(*corev1.PersistentVolumeClaim); ok {
 		return specObj, nil
 	} else if specObj, ok := in.(*storageapi.StorageClass); ok {
 		return specObj, nil
@@ -394,13 +395,13 @@ func validateSpec(in interface{}) (interface{}, error) {
 		return specObj, nil
 	} else if specObj, ok := in.(*storkapi.GroupVolumeSnapshot); ok {
 		return specObj, nil
-	} else if specObj, ok := in.(*v1.Secret); ok {
+	} else if specObj, ok := in.(*corev1.Secret); ok {
 		return specObj, nil
-	} else if specObj, ok := in.(*v1.ConfigMap); ok {
+	} else if specObj, ok := in.(*corev1.ConfigMap); ok {
 		return specObj, nil
 	} else if specObj, ok := in.(*storkapi.Rule); ok {
 		return specObj, nil
-	} else if specObj, ok := in.(*v1.Pod); ok {
+	} else if specObj, ok := in.(*corev1.Pod); ok {
 		return specObj, nil
 	} else if specObj, ok := in.(*storkapi.ClusterPair); ok {
 		return specObj, nil
@@ -422,7 +423,7 @@ func validateSpec(in interface{}) (interface{}, error) {
 		return specObj, nil
 	} else if specObj, ok := in.(*apapi.AutopilotRule); ok {
 		return specObj, nil
-	} else if specObj, ok := in.(*v1.ServiceAccount); ok {
+	} else if specObj, ok := in.(*corev1.ServiceAccount); ok {
 		return specObj, nil
 	} else if specObj, ok := in.(*rbacv1.ClusterRole); ok {
 		return specObj, nil
@@ -434,7 +435,7 @@ func validateSpec(in interface{}) (interface{}, error) {
 		return specObj, nil
 	} else if specObj, ok := in.(*batchv1beta1.CronJob); ok {
 		return specObj, nil
-	} else if specObj, ok := in.(*v1.LimitRange); ok {
+	} else if specObj, ok := in.(*corev1.LimitRange); ok {
 		return specObj, nil
 	} else if specObj, ok := in.(*networkingv1beta1.Ingress); ok {
 		return specObj, nil
@@ -445,10 +446,10 @@ func validateSpec(in interface{}) (interface{}, error) {
 
 // getAddressesForNode  Get IP address for the nodes in the cluster
 //
-func (k *K8s) getAddressesForNode(n v1.Node) []string {
+func (k *K8s) getAddressesForNode(n corev1.Node) []string {
 	var addrs []string
 	for _, addr := range n.Status.Addresses {
-		if addr.Type == v1.NodeExternalIP || addr.Type == v1.NodeInternalIP {
+		if addr.Type == corev1.NodeExternalIP || addr.Type == corev1.NodeInternalIP {
 			addrs = append(addrs, addr.Address)
 		}
 	}
@@ -457,7 +458,7 @@ func (k *K8s) getAddressesForNode(n v1.Node) []string {
 
 // parseK8SNode Parse the kubernetes clsuter nodes
 //
-func (k *K8s) parseK8SNode(n v1.Node) node.Node {
+func (k *K8s) parseK8SNode(n corev1.Node) node.Node {
 	var nodeType node.Type
 	var zone, region string
 	if k8sCore.IsNodeMaster(n) {
@@ -731,7 +732,7 @@ func (k *K8s) UpdateTasksID(ctx *scheduler.Context, id string) error {
 	return nil
 }
 
-func (k *K8s) createNamespace(app *spec.AppSpec, namespace string, options scheduler.ScheduleOptions) (*v1.Namespace, error) {
+func (k *K8s) createNamespace(app *spec.AppSpec, namespace string, options scheduler.ScheduleOptions) (*corev1.Namespace, error) {
 	k8sOps := k8sCore
 
 	t := func() (interface{}, bool, error) {
@@ -743,7 +744,7 @@ func (k *K8s) createNamespace(app *spec.AppSpec, namespace string, options sched
 			}
 		}
 
-		nsSpec := &v1.Namespace{
+		nsSpec := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   namespace,
 				Labels: metadata,
@@ -772,10 +773,10 @@ func (k *K8s) createNamespace(app *spec.AppSpec, namespace string, options sched
 		return nil, err
 	}
 
-	return nsObj.(*v1.Namespace), nil
+	return nsObj.(*corev1.Namespace), nil
 }
 
-func (k *K8s) createStorageObject(spec interface{}, ns *v1.Namespace, app *spec.AppSpec,
+func (k *K8s) createStorageObject(spec interface{}, ns *corev1.Namespace, app *spec.AppSpec,
 	options scheduler.ScheduleOptions) (interface{}, error) {
 
 	// Add security annotations if running with auth-enabled
@@ -821,7 +822,7 @@ func (k *K8s) createStorageObject(spec interface{}, ns *v1.Namespace, app *spec.
 		logrus.Infof("[%v] Created storage class: %v", app.Key, sc.Name)
 		return sc, nil
 
-	} else if obj, ok := spec.(*v1.PersistentVolumeClaim); ok {
+	} else if obj, ok := spec.(*corev1.PersistentVolumeClaim); ok {
 		obj.Namespace = ns.Name
 		k.substituteNamespaceInPVC(obj, ns.Name)
 		if len(options.Labels) > 0 {
@@ -906,7 +907,7 @@ func (k *K8s) createStorageObject(spec interface{}, ns *v1.Namespace, app *spec.
 	return nil, nil
 }
 
-func (k *K8s) substituteNamespaceInPVC(pvc *v1.PersistentVolumeClaim, ns string) {
+func (k *K8s) substituteNamespaceInPVC(pvc *corev1.PersistentVolumeClaim, ns string) {
 	pvc.Name = namespaceRegex.ReplaceAllString(pvc.Name, ns)
 	for k, v := range pvc.Annotations {
 		pvc.Annotations[k] = namespaceRegex.ReplaceAllString(v, ns)
@@ -914,7 +915,7 @@ func (k *K8s) substituteNamespaceInPVC(pvc *v1.PersistentVolumeClaim, ns string)
 }
 
 func (k *K8s) createVolumeSnapshotRestore(specObj interface{},
-	ns *v1.Namespace,
+	ns *corev1.Namespace,
 	app *spec.AppSpec,
 ) (interface{}, error) {
 	// Add security annotations if running with auth-enabled
@@ -951,7 +952,7 @@ func (k *K8s) createVolumeSnapshotRestore(specObj interface{},
 	return nil, nil
 }
 
-func (k *K8s) addSecurityAnnotation(spec interface{}, configMap *v1.ConfigMap) error {
+func (k *K8s) addSecurityAnnotation(spec interface{}, configMap *corev1.ConfigMap) error {
 	logrus.Debugf("Config Map details: %v", configMap.Data)
 	if _, ok := configMap.Data[secretNameKey]; !ok {
 		return fmt.Errorf("failed to get secret name from config map")
@@ -959,7 +960,13 @@ func (k *K8s) addSecurityAnnotation(spec interface{}, configMap *v1.ConfigMap) e
 	if _, ok := configMap.Data[secretNamespaceKey]; !ok {
 		return fmt.Errorf("failed to get secret namespace from config map")
 	}
-	if obj, ok := spec.(*v1.PersistentVolumeClaim); ok {
+	if obj, ok := spec.(*storageapi.StorageClass); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Parameters[secretName] = configMap.Data[secretNameKey]
+		obj.Parameters[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*corev1.PersistentVolumeClaim); ok {
 		if obj.Annotations == nil {
 			obj.Annotations = make(map[string]string)
 		}
@@ -972,7 +979,7 @@ func (k *K8s) addSecurityAnnotation(spec interface{}, configMap *v1.ConfigMap) e
 		obj.Metadata.Annotations[secretName] = configMap.Data[secretNameKey]
 		obj.Metadata.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
 	} else if obj, ok := spec.(*appsapi.StatefulSet); ok {
-		var pvcList []v1.PersistentVolumeClaim
+		var pvcList []corev1.PersistentVolumeClaim
 		for _, pvc := range obj.Spec.VolumeClaimTemplates {
 			if pvc.Annotations == nil {
 				pvc.Annotations = make(map[string]string)
@@ -1006,6 +1013,12 @@ func (k *K8s) addSecurityAnnotation(spec interface{}, configMap *v1.ConfigMap) e
 		}
 		obj.Annotations[secretName] = configMap.Data[secretNameKey]
 		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
+	} else if obj, ok := spec.(*storkapi.MigrationSchedule); ok {
+		if obj.Annotations == nil {
+			obj.Annotations = make(map[string]string)
+		}
+		obj.Annotations[secretName] = configMap.Data[secretNameKey]
+		obj.Annotations[secretNamespace] = configMap.Data[secretNamespaceKey]
 	} else if obj, ok := spec.(*storkapi.VolumeSnapshotRestore); ok {
 		if obj.Annotations == nil {
 			obj.Annotations = make(map[string]string)
@@ -1022,7 +1035,7 @@ func (k *K8s) addSecurityAnnotation(spec interface{}, configMap *v1.ConfigMap) e
 	return nil
 }
 
-func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.AppSpec,
+func (k *K8s) createCoreObject(spec interface{}, ns *corev1.Namespace, app *spec.AppSpec,
 	options scheduler.ScheduleOptions) (interface{}, error) {
 	if obj, ok := spec.(*appsapi.Deployment); ok {
 		obj.Namespace = ns.Name
@@ -1073,7 +1086,7 @@ func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.App
 			obj.Spec.Template.Spec.SchedulerName = options.Scheduler
 		}
 
-		var pvcList []v1.PersistentVolumeClaim
+		var pvcList []corev1.PersistentVolumeClaim
 		for _, pvc := range obj.Spec.VolumeClaimTemplates {
 			if pvc.Annotations == nil {
 				pvc.Annotations = make(map[string]string)
@@ -1100,7 +1113,7 @@ func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.App
 		logrus.Infof("[%v] Created StatefulSet: %v", app.Key, ss.Name)
 		return ss, nil
 
-	} else if obj, ok := spec.(*v1.Service); ok {
+	} else if obj, ok := spec.(*corev1.Service); ok {
 		obj.Namespace = ns.Name
 		svc, err := k8sCore.CreateService(obj)
 		if errors.IsAlreadyExists(err) {
@@ -1119,7 +1132,7 @@ func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.App
 		logrus.Infof("[%v] Created Service: %v", app.Key, svc.Name)
 		return svc, nil
 
-	} else if obj, ok := spec.(*v1.Secret); ok {
+	} else if obj, ok := spec.(*corev1.Secret); ok {
 		obj.Namespace = ns.Name
 		if k.SecretType == scheduler.SecretVault {
 			if err := k.createVaultSecret(obj); err != nil {
@@ -1162,7 +1175,7 @@ func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.App
 		}
 		logrus.Infof("[%v] Created Rule: %v", app.Key, rule.GetName())
 		return rule, nil
-	} else if obj, ok := spec.(*v1.Pod); ok {
+	} else if obj, ok := spec.(*corev1.Pod); ok {
 		obj.Namespace = ns.Name
 		if options.Scheduler != "" {
 			obj.Spec.SchedulerName = options.Scheduler
@@ -1183,7 +1196,7 @@ func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.App
 
 		logrus.Infof("[%v] Created Pod: %v", app.Key, pod.Name)
 		return pod, nil
-	} else if obj, ok := spec.(*v1.ConfigMap); ok {
+	} else if obj, ok := spec.(*corev1.ConfigMap); ok {
 		obj.Namespace = ns.Name
 		configMap, err := k8sCore.CreateConfigMap(obj)
 		if errors.IsAlreadyExists(err) {
@@ -1206,7 +1219,7 @@ func (k *K8s) createCoreObject(spec interface{}, ns *v1.Namespace, app *spec.App
 	return nil, nil
 }
 
-func (k *K8s) createVaultSecret(obj *v1.Secret) error {
+func (k *K8s) createVaultSecret(obj *corev1.Secret) error {
 	client, err := vaultapi.NewClient(nil)
 	if err != nil {
 		return err
@@ -1230,7 +1243,7 @@ func (k *K8s) createVaultSecret(obj *v1.Secret) error {
 
 func (k *K8s) destroyCoreObject(spec interface{}, opts map[string]bool, app *spec.AppSpec) (interface{}, error) {
 	var pods interface{}
-	var podList []*v1.Pod
+	var podList []*corev1.Pod
 	var err error
 	if obj, ok := spec.(*appsapi.Deployment); ok {
 		if value, ok := opts[scheduler.OptionsWaitForResourceLeakCleanup]; ok && value {
@@ -1258,7 +1271,7 @@ func (k *K8s) destroyCoreObject(spec interface{}, opts map[string]bool, app *spe
 				Cause: fmt.Sprintf("Failed to destroy stateful set: %v. Err: %v", obj.Name, err),
 			}
 		}
-	} else if obj, ok := spec.(*v1.Service); ok {
+	} else if obj, ok := spec.(*corev1.Service); ok {
 		err := k8sCore.DeleteService(obj.Name, obj.Namespace)
 		if err != nil {
 			return pods, &scheduler.ErrFailedToDestroyApp{
@@ -1278,7 +1291,7 @@ func (k *K8s) destroyCoreObject(spec interface{}, opts map[string]bool, app *spe
 		}
 
 		logrus.Infof("[%v] Destroyed Rule: %v", app.Key, obj.Name)
-	} else if obj, ok := spec.(*v1.Pod); ok {
+	} else if obj, ok := spec.(*corev1.Pod); ok {
 		if value, ok := opts[scheduler.OptionsWaitForResourceLeakCleanup]; ok && value {
 			pod, err := k8sCore.GetPodByName(obj.Name, obj.Namespace)
 			if err != nil {
@@ -1296,7 +1309,7 @@ func (k *K8s) destroyCoreObject(spec interface{}, opts map[string]bool, app *spe
 		}
 
 		logrus.Infof("[%v] Destroyed Pod: %v", app.Key, obj.Name)
-	} else if obj, ok := spec.(*v1.ConfigMap); ok {
+	} else if obj, ok := spec.(*corev1.ConfigMap); ok {
 		if value, ok := opts[scheduler.OptionsWaitForResourceLeakCleanup]; ok && value {
 			_, err := k8sCore.GetConfigMap(obj.Name, obj.Namespace)
 			if err != nil {
@@ -1328,8 +1341,8 @@ func (k *K8s) destroyCoreObject(spec interface{}, opts map[string]bool, app *spe
 
 }
 
-func (k *K8s) substituteNamespaceInContainers(containers []v1.Container, ns string) []v1.Container {
-	var updatedContainers []v1.Container
+func (k *K8s) substituteNamespaceInContainers(containers []corev1.Container, ns string) []corev1.Container {
+	var updatedContainers []corev1.Container
 	for _, container := range containers {
 		var temp []string
 		for _, arg := range container.Args {
@@ -1341,8 +1354,8 @@ func (k *K8s) substituteNamespaceInContainers(containers []v1.Container, ns stri
 	return updatedContainers
 }
 
-func (k *K8s) substituteNamespaceInVolumes(volumes []v1.Volume, ns string) []v1.Volume {
-	var updatedVolumes []v1.Volume
+func (k *K8s) substituteNamespaceInVolumes(volumes []corev1.Volume, ns string) []corev1.Volume {
+	var updatedVolumes []corev1.Volume
 	for _, vol := range volumes {
 		if vol.VolumeSource.PersistentVolumeClaim != nil {
 			claimName := namespaceRegex.ReplaceAllString(vol.VolumeSource.PersistentVolumeClaim.ClaimName, ns)
@@ -1375,7 +1388,7 @@ func (k *K8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 			}
 
 			logrus.Infof("[%v] Validated statefulset: %v", ctx.App.Key, obj.Name)
-		} else if obj, ok := specObj.(*v1.Service); ok {
+		} else if obj, ok := specObj.(*corev1.Service); ok {
 			svc, err := k8sCore.GetService(obj.Name, obj.Namespace)
 			if err != nil {
 				return &scheduler.ErrFailedToValidateApp{
@@ -1395,7 +1408,7 @@ func (k *K8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 			}
 
 			logrus.Infof("[%v] Validated Rule: %v", ctx.App.Key, svc.Name)
-		} else if obj, ok := specObj.(*v1.Pod); ok {
+		} else if obj, ok := specObj.(*corev1.Pod); ok {
 			if err := k8sCore.ValidatePod(obj, timeout, retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidatePod{
 					App: ctx.App,
@@ -1522,7 +1535,7 @@ func (k *K8s) WaitForRunning(ctx *scheduler.Context, timeout, retryInterval time
 
 // Destroy destroy
 func (k *K8s) Destroy(ctx *scheduler.Context, opts map[string]bool) error {
-	var podList []v1.Pod
+	var podList []corev1.Pod
 	k8sOps := k8sAutopilot
 	apRule := ctx.ScheduleOptions.AutopilotRule
 	if apRule.Name != "" {
@@ -1547,7 +1560,7 @@ func (k *K8s) Destroy(ctx *scheduler.Context, opts map[string]bool) error {
 				return err
 			}
 			if pods != nil {
-				podList = append(podList, pods.([]v1.Pod)...)
+				podList = append(podList, pods.([]corev1.Pod)...)
 			}
 			// we're ignoring this error since we want to verify cleanup down below, so simply logging it
 			logrus.Warnf("Failed to destroy core objects. Cause: %v", err)
@@ -1609,7 +1622,7 @@ func (k *K8s) Destroy(ctx *scheduler.Context, opts map[string]bool) error {
 	return nil
 }
 
-func (k *K8s) waitForCleanup(ctx *scheduler.Context, podList []v1.Pod) error {
+func (k *K8s) waitForCleanup(ctx *scheduler.Context, podList []corev1.Pod) error {
 	for _, pod := range podList {
 		t := func() (interface{}, bool, error) {
 			return nil, true, k.validateVolumeDirCleanup(pod.UID, ctx.App)
@@ -1674,7 +1687,7 @@ func (k *K8s) WaitForDestroy(ctx *scheduler.Context, timeout time.Duration) erro
 			}
 
 			logrus.Infof("[%v] Validated destroy of StatefulSet: %v", ctx.App.Key, obj.Name)
-		} else if obj, ok := specObj.(*v1.Service); ok {
+		} else if obj, ok := specObj.(*corev1.Service); ok {
 			if err := k8sCore.ValidateDeletedService(obj.Name, obj.Namespace); err != nil {
 				return &scheduler.ErrFailedToValidateAppDestroy{
 					App:   ctx.App,
@@ -1683,7 +1696,7 @@ func (k *K8s) WaitForDestroy(ctx *scheduler.Context, timeout time.Duration) erro
 			}
 
 			logrus.Infof("[%v] Validated destroy of Service: %v", ctx.App.Key, obj.Name)
-		} else if obj, ok := specObj.(*v1.Pod); ok {
+		} else if obj, ok := specObj.(*corev1.Pod); ok {
 			if err := k8sCore.WaitForPodDeletion(obj.UID, obj.Namespace, deleteTasksWaitTimeout); err != nil {
 				return &scheduler.ErrFailedToValidatePodDestroy{
 					App:   ctx.App,
@@ -1721,7 +1734,7 @@ func (k *K8s) DeleteTasks(ctx *scheduler.Context, opts *scheduler.DeleteTasksOpt
 				}
 				if err := k8sOps.WaitForPodDeletion(pod.UID, pod.Namespace, deleteTasksWaitTimeout); err != nil {
 					logrus.Errorf("k8s %s failed to wait for pod: [%s] %s to terminate. err: %v", fn, pod.Namespace, pod.Name, err)
-					return err
+					return fmt.Errorf("k8s %s failed to wait for pod: [%s] %s to terminate. err: %v", fn, pod.Namespace, pod.Name, err)
 				}
 
 				if err := k.WaitForRunning(ctx, DefaultTimeout, DefaultRetryInterval); err != nil {
@@ -1745,7 +1758,7 @@ func (k *K8s) DeleteTasks(ctx *scheduler.Context, opts *scheduler.DeleteTasksOpt
 				err = k8sOps.WaitForPodDeletion(pod.UID, pod.Namespace, deleteTasksWaitTimeout)
 				if err != nil {
 					logrus.Errorf("k8s %s failed to wait for pod: [%s] %s to terminate. err: %v", fn, pod.Namespace, pod.Name, err)
-					return err
+					return fmt.Errorf("k8s %s failed to wait for pod: [%s] %s to terminate. err: %v", fn, pod.Namespace, pod.Name, err)
 				}
 			}
 		}
@@ -1774,7 +1787,7 @@ func (k *K8s) GetVolumeParameters(ctx *scheduler.Context) (map[string]map[string
 	result := make(map[string]map[string]string)
 
 	for _, specObj := range ctx.App.SpecList {
-		if obj, ok := specObj.(*v1.PersistentVolumeClaim); ok {
+		if obj, ok := specObj.(*corev1.PersistentVolumeClaim); ok {
 			params, err := k8sCore.GetPersistentVolumeClaimParams(obj)
 			if err != nil {
 				return nil, &scheduler.ErrFailedToGetVolumeParameters{
@@ -1894,7 +1907,6 @@ func (k *K8s) ValidateVolumes(ctx *scheduler.Context, timeout, retryInterval tim
 					}
 				}
 			}
-			logrus.Infof("[%v] Validated storage class: %v", ctx.App.Key, obj.Name)
 		} else if obj, ok := specObj.(*v1.PersistentVolumeClaim); ok {
 			if err := k8sCore.ValidatePersistentVolumeClaim(obj, timeout, retryInterval); err != nil {
 				return &scheduler.ErrFailedToValidateStorage{
@@ -2002,7 +2014,7 @@ func getSpecAppEnvVar(ctx *scheduler.Context, key string) string {
 	return ""
 }
 
-func (k *K8s) validatePVCSize(ctx *scheduler.Context, obj *v1.PersistentVolumeClaim, rule apapi.AutopilotRule, timeout time.Duration, retryInterval time.Duration) error {
+func (k *K8s) validatePVCSize(ctx *scheduler.Context, obj *corev1.PersistentVolumeClaim, rule apapi.AutopilotRule, timeout time.Duration, retryInterval time.Duration) error {
 	wSize, err := k.GetWorkloadSizeFromAppSpec(ctx)
 	if err != nil {
 		return err
@@ -2022,10 +2034,9 @@ func (k *K8s) validatePVCSize(ctx *scheduler.Context, obj *v1.PersistentVolumeCl
 	return nil
 }
 
-func (k *K8s) isPVCShared(pvc *v1.PersistentVolumeClaim) bool {
+func (k *K8s) isPVCShared(pvc *corev1.PersistentVolumeClaim) bool {
 	for _, mode := range pvc.Spec.AccessModes {
-		if mode == v1.PersistentVolumeAccessMode(v1.ReadOnlyMany) ||
-			mode == v1.PersistentVolumeAccessMode(v1.ReadWriteMany) {
+		if mode == corev1.ReadOnlyMany || mode == corev1.ReadWriteMany {
 			return true
 		}
 	}
@@ -2049,7 +2060,7 @@ func (k *K8s) DeleteVolumes(ctx *scheduler.Context, options *scheduler.VolumeOpt
 
 				logrus.Infof("[%v] Destroyed storage class: %v", ctx.App.Key, obj.Name)
 			}
-		} else if obj, ok := specObj.(*v1.PersistentVolumeClaim); ok {
+		} else if obj, ok := specObj.(*corev1.PersistentVolumeClaim); ok {
 			pvcObj, err := k8sCore.GetPersistentVolumeClaim(obj.Name, obj.Namespace)
 			if err != nil {
 				return nil, err
@@ -2137,13 +2148,13 @@ func (k *K8s) GetVolumes(ctx *scheduler.Context) ([]*volume.Volume, error) {
 	k8sOps := k8sApps
 	var vols []*volume.Volume
 	for _, specObj := range ctx.App.SpecList {
-		if obj, ok := specObj.(*v1.PersistentVolumeClaim); ok {
+		if obj, ok := specObj.(*corev1.PersistentVolumeClaim); ok {
 			pvcObj, err := k8sCore.GetPersistentVolumeClaim(obj.Name, obj.Namespace)
 			if err != nil {
 				return nil, err
 			}
 
-			pvcSizeObj := pvcObj.Spec.Resources.Requests[v1.ResourceStorage]
+			pvcSizeObj := pvcObj.Spec.Resources.Requests[corev1.ResourceStorage]
 			pvcSize, _ := pvcSizeObj.AsInt64()
 			vol := &volume.Volume{
 				ID:          string(pvcObj.Spec.VolumeName),
@@ -2177,7 +2188,7 @@ func (k *K8s) GetVolumes(ctx *scheduler.Context) ([]*volume.Volume, error) {
 
 			for _, pvc := range pvcList.Items {
 				vols = append(vols, &volume.Volume{
-					ID:        string(pvc.Spec.VolumeName),
+					ID:        pvc.Spec.VolumeName,
 					Name:      pvc.Name,
 					Namespace: pvc.Namespace,
 					Shared:    k.isPVCShared(&pvc),
@@ -2209,7 +2220,7 @@ func (k *K8s) ResizeVolume(ctx *scheduler.Context, configMapName string) ([]*vol
 			}
 
 		}
-		if obj, ok := specObj.(*v1.PersistentVolumeClaim); ok {
+		if obj, ok := specObj.(*corev1.PersistentVolumeClaim); ok {
 			updatedPVC, _ := k8sCore.GetPersistentVolumeClaim(obj.Name, obj.Namespace)
 			vol, err := k.resizePVCBy1GB(ctx, updatedPVC)
 			if err != nil {
@@ -2246,9 +2257,9 @@ func (k *K8s) ResizeVolume(ctx *scheduler.Context, configMapName string) ([]*vol
 	return vols, nil
 }
 
-func (k *K8s) resizePVCBy1GB(ctx *scheduler.Context, pvc *v1.PersistentVolumeClaim) (*volume.Volume, error) {
+func (k *K8s) resizePVCBy1GB(ctx *scheduler.Context, pvc *corev1.PersistentVolumeClaim) (*volume.Volume, error) {
 	k8sOps := k8sCore
-	storageSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
+	storageSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 
 	// TODO this test is required since stork snapshot doesn't support resizing, remove when feature is added
 	resizeSupported := true
@@ -2258,7 +2269,7 @@ func (k *K8s) resizePVCBy1GB(ctx *scheduler.Context, pvc *v1.PersistentVolumeCla
 	if resizeSupported {
 		extraAmount, _ := resource.ParseQuantity("1Gi")
 		storageSize.Add(extraAmount)
-		pvc.Spec.Resources.Requests[v1.ResourceStorage] = storageSize
+		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = storageSize
 		if _, err := k8sOps.UpdatePersistentVolumeClaim(pvc); err != nil {
 			return nil, &scheduler.ErrFailedToResizeStorage{
 				App:   ctx.App,
@@ -2366,9 +2377,9 @@ func (k *K8s) GetNodesForApp(ctx *scheduler.Context) ([]node.Node, error) {
 	return nodes.([]node.Node), nil
 }
 
-func (k *K8s) getPodsForApp(ctx *scheduler.Context) ([]v1.Pod, error) {
+func (k *K8s) getPodsForApp(ctx *scheduler.Context) ([]corev1.Pod, error) {
 	k8sOps := k8sApps
-	var pods []v1.Pod
+	var pods []corev1.Pod
 
 	for _, specObj := range ctx.App.SpecList {
 		if obj, ok := specObj.(*appsapi.Deployment); ok {
@@ -2428,9 +2439,9 @@ func (k *K8s) Describe(ctx *scheduler.Context) (string, error) {
 				buf.WriteString(dumpPodStatusRecursively(pod))
 			}
 			buf.WriteString(insertLineBreak("END StatefulSet"))
-		} else if obj, ok := specObj.(*v1.Service); ok {
+		} else if obj, ok := specObj.(*corev1.Service); ok {
 			buf.WriteString(insertLineBreak(fmt.Sprintf("Service: [%s] %s", obj.Namespace, obj.Name)))
-			var svcStatus *v1.ServiceStatus
+			var svcStatus *corev1.ServiceStatus
 			if svcStatus, err = k8sCore.DescribeService(obj.Name, obj.Namespace); err != nil {
 				buf.WriteString(fmt.Sprintf("%v", &scheduler.ErrFailedToGetAppStatus{
 					App:   ctx.App,
@@ -2441,9 +2452,9 @@ func (k *K8s) Describe(ctx *scheduler.Context) (string, error) {
 			buf.WriteString(fmt.Sprintf("%+v\n", *svcStatus))
 			buf.WriteString(fmt.Sprintf("%v", dumpEvents(obj.Namespace, "Service", obj.Name)))
 			buf.WriteString(insertLineBreak("END Service"))
-		} else if obj, ok := specObj.(*v1.PersistentVolumeClaim); ok {
+		} else if obj, ok := specObj.(*corev1.PersistentVolumeClaim); ok {
 			buf.WriteString(insertLineBreak(fmt.Sprintf("PersistentVolumeClaim: [%s] %s", obj.Namespace, obj.Name)))
-			var pvcStatus *v1.PersistentVolumeClaimStatus
+			var pvcStatus *corev1.PersistentVolumeClaimStatus
 			if pvcStatus, err = k8sCore.GetPersistentVolumeClaimStatus(obj); err != nil {
 				buf.WriteString(fmt.Sprintf("%v", &scheduler.ErrFailedToGetStorageStatus{
 					App:   ctx.App,
@@ -2467,9 +2478,9 @@ func (k *K8s) Describe(ctx *scheduler.Context) (string, error) {
 			buf.WriteString(fmt.Sprintf("%+v\n", scParams))
 			buf.WriteString(fmt.Sprintf("%v", dumpEvents(obj.Namespace, "StorageClass", obj.Name)))
 			buf.WriteString(insertLineBreak("END StorageClass"))
-		} else if obj, ok := specObj.(*v1.Pod); ok {
+		} else if obj, ok := specObj.(*corev1.Pod); ok {
 			buf.WriteString(insertLineBreak(fmt.Sprintf("Pod: [%s] %s", obj.Namespace, obj.Name)))
-			var podStatus *v1.PodList
+			var podStatus *corev1.PodList
 			if podStatus, err = k8sCore.GetPods(obj.Name, nil); err != nil {
 				buf.WriteString(fmt.Sprintf("%v", &scheduler.ErrFailedToGetPodStatus{
 					App:   ctx.App,
@@ -2609,9 +2620,9 @@ func (k *K8s) Describe(ctx *scheduler.Context) (string, error) {
 			buf.WriteString(fmt.Sprintf("%v\n", autopilotRule))
 			buf.WriteString(fmt.Sprintf("%v", dumpEvents(obj.Namespace, "AutopilotRule", obj.Name)))
 			buf.WriteString(insertLineBreak("END AutopilotRule"))
-		} else if obj, ok := specObj.(*v1.Secret); ok {
+		} else if obj, ok := specObj.(*corev1.Secret); ok {
 			buf.WriteString(insertLineBreak(fmt.Sprintf("Secret: [%s] %s", obj.Namespace, obj.Name)))
-			var secret *v1.Secret
+			var secret *corev1.Secret
 			if secret, err = k8sCore.GetSecret(obj.Name, obj.Namespace); err != nil {
 				buf.WriteString(fmt.Sprintf("%v", &scheduler.ErrFailedToGetSecret{
 					App:   ctx.App,
@@ -2760,7 +2771,7 @@ func (k *K8s) IsScalable(spec interface{}) bool {
 				return false
 			}
 			for _, ac := range pvc.Spec.AccessModes {
-				if ac == v1.ReadWriteOnce {
+				if ac == corev1.ReadWriteOnce {
 					return false
 				}
 			}
@@ -2775,7 +2786,7 @@ func (k *K8s) IsScalable(spec interface{}) bool {
 func (k *K8s) GetTokenFromConfigMap(configMapName string) (string, error) {
 	var token string
 	var err error
-	var configMap *v1.ConfigMap
+	var configMap *corev1.ConfigMap
 	k8sOps := k8sCore
 	if configMap, err = k8sOps.GetConfigMap(configMapName, "default"); err == nil {
 		if secret, err := k8sOps.GetSecret(configMap.Data[secretNameKey], configMap.Data[secretNamespaceKey]); err == nil {
@@ -2790,10 +2801,27 @@ func (k *K8s) GetTokenFromConfigMap(configMapName string) (string, error) {
 
 func (k *K8s) createMigrationObjects(
 	specObj interface{},
-	ns *v1.Namespace,
+	ns *corev1.Namespace,
 	app *spec.AppSpec,
 ) (interface{}, error) {
 	k8sOps := k8sStork
+	// Add security annotations if running with auth-enabled
+	configMapName := k.secretConfigMapName
+	if configMapName != "" {
+		configMap, err := k8sCore.GetConfigMap(configMapName, "default")
+		if err != nil {
+			return nil, &scheduler.ErrFailedToGetConfigMap{
+				Name:  configMapName,
+				Cause: fmt.Sprintf("Failed to get config map: Err: %v", err),
+			}
+		}
+		err = k.addSecurityAnnotation(specObj, configMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add annotations to migration object: %v", err)
+		}
+
+	}
+
 	if obj, ok := specObj.(*storkapi.ClusterPair); ok {
 		obj.Namespace = ns.Name
 		clusterPair, err := k8sOps.CreateClusterPair(obj)
@@ -2849,9 +2877,9 @@ func (k *K8s) createMigrationObjects(
 	return nil, nil
 }
 
-func (k *K8s) getPodsUsingStorage(pods []v1.Pod, provisioner string) []v1.Pod {
+func (k *K8s) getPodsUsingStorage(pods []corev1.Pod, provisioner string) []corev1.Pod {
 	k8sOps := k8sCore
-	podsUsingStorage := make([]v1.Pod, 0)
+	podsUsingStorage := make([]corev1.Pod, 0)
 	for _, pod := range pods {
 		for _, vol := range pod.Spec.Volumes {
 			if vol.PersistentVolumeClaim == nil {
@@ -3013,7 +3041,7 @@ func (k *K8s) ValidateVolumeSnapshotRestore(ctx *scheduler.Context, timeStart ti
 
 func (k *K8s) createBackupObjects(
 	specObj interface{},
-	ns *v1.Namespace,
+	ns *corev1.Namespace,
 	app *spec.AppSpec,
 ) (interface{}, error) {
 	k8sOps := k8sStork
@@ -3087,6 +3115,7 @@ func (k *K8s) destroyBackupObjects(
 			}
 		}
 		logrus.Infof("[%v] Destroyed ApplicationBackup: %v", app.Key, obj.Name)
+
 	} else if obj, ok := specObj.(*storkapi.ApplicationRestore); ok {
 		err := k8sOps.DeleteApplicationRestore(obj.Name, obj.Namespace)
 		if err != nil {
@@ -3111,7 +3140,7 @@ func (k *K8s) destroyBackupObjects(
 
 func (k *K8s) createRbacObjects(
 	spec interface{},
-	ns *v1.Namespace,
+	ns *corev1.Namespace,
 	app *spec.AppSpec,
 ) (interface{}, error) {
 	if obj, ok := spec.(*rbacv1.Role); ok {
@@ -3186,7 +3215,7 @@ func (k *K8s) createRbacObjects(
 
 		logrus.Infof("[%v] Created Cluster Role: %v", app.Key, clusterrolebinding.Name)
 		return clusterrolebinding, nil
-	} else if obj, ok := spec.(*v1.ServiceAccount); ok {
+	} else if obj, ok := spec.(*corev1.ServiceAccount); ok {
 		obj.Namespace = ns.Name
 		serviceaccount, err := k8sCore.CreateServiceAccount(obj)
 		if errors.IsAlreadyExists(err) {
@@ -3211,7 +3240,7 @@ func (k *K8s) createRbacObjects(
 
 func (k *K8s) createNetworkingObjects(
 	spec interface{},
-	ns *v1.Namespace,
+	ns *corev1.Namespace,
 	app *spec.AppSpec,
 ) (interface{}, error) {
 	if obj, ok := spec.(*networkingv1beta1.Ingress); ok {
@@ -3238,7 +3267,7 @@ func (k *K8s) createNetworkingObjects(
 
 func (k *K8s) createBatchObjects(
 	spec interface{},
-	ns *v1.Namespace,
+	ns *corev1.Namespace,
 	app *spec.AppSpec,
 ) (interface{}, error) {
 	if obj, ok := spec.(*batchv1beta1.CronJob); ok {
@@ -3264,8 +3293,8 @@ func (k *K8s) createBatchObjects(
 }
 
 // EstimatePVCExpansion calculates expected size of PVC based on autopilot rule and workload
-func (k *K8s) EstimatePVCExpansion(pvc *v1.PersistentVolumeClaim, apRule apapi.AutopilotRule, wSize uint64) (uint64, int, error) {
-	pvcObjSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
+func (k *K8s) EstimatePVCExpansion(pvc *corev1.PersistentVolumeClaim, apRule apapi.AutopilotRule, wSize uint64) (uint64, int, error) {
+	pvcObjSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 	pvcSize, _ := pvcObjSize.AsInt64()
 	initialPVCSize := uint64(pvcSize)
 
@@ -3288,7 +3317,7 @@ func (k *K8s) ValidateAutopilotEvents(ctx *scheduler.Context) error {
 	}
 
 	for _, specObj := range ctx.App.SpecList {
-		if obj, ok := specObj.(*v1.PersistentVolumeClaim); ok {
+		if obj, ok := specObj.(*corev1.PersistentVolumeClaim); ok {
 
 			autopilotEnabled := false
 			var err error
@@ -3377,7 +3406,7 @@ func validateEvents(objName string, events map[string]int32, count int32) error 
 	return nil
 }
 
-func isAutopilotMatchPvcLabels(apRule apapi.AutopilotRule, pvc *v1.PersistentVolumeClaim) bool {
+func isAutopilotMatchPvcLabels(apRule apapi.AutopilotRule, pvc *corev1.PersistentVolumeClaim) bool {
 	apRuleLabels := apRule.Spec.Selector.LabelSelector.MatchLabels
 	for k, v := range apRuleLabels {
 		if pvcLabelValue, ok := pvc.Labels[k]; ok {
@@ -3406,7 +3435,7 @@ func (k *K8s) collectEvents() error {
 		return err
 	}
 	for i := range iface.ResultChan() {
-		event, ok := i.Object.(*v1.Event)
+		event, ok := i.Object.(*corev1.Event)
 		if event == nil {
 			continue
 		}
@@ -3509,7 +3538,7 @@ func (k *K8s) SaveSchedulerLogsToFile(n node.Node, location string) error {
 	return err
 }
 
-func (k *K8s) addLabelsToPVC(pvc *v1.PersistentVolumeClaim, labels map[string]string) {
+func (k *K8s) addLabelsToPVC(pvc *corev1.PersistentVolumeClaim, labels map[string]string) {
 	if len(pvc.Labels) == 0 {
 		pvc.Labels = map[string]string{}
 	}
@@ -3577,7 +3606,7 @@ func insertLineBreak(note string) string {
 	return fmt.Sprintf("------------------------------\n%s\n------------------------------\n", note)
 }
 
-func dumpPodStatusRecursively(pod v1.Pod) string {
+func dumpPodStatusRecursively(pod corev1.Pod) string {
 	var buf bytes.Buffer
 	buf.WriteString(insertLineBreak(fmt.Sprintf("Pod: [%s] %s", pod.Namespace, pod.Name)))
 	buf.WriteString(fmt.Sprintf("%v\n", pod.Status))

--- a/vendor/github.com/portworx/torpedo/drivers/scheduler/scheduler.go
+++ b/vendor/github.com/portworx/torpedo/drivers/scheduler/scheduler.go
@@ -35,6 +35,8 @@ type Context struct {
 	SkipVolumeValidation bool
 	// SkipClusterScopedObject for cases of multi-cluster backup when Storage class does not restored
 	SkipClusterScopedObject bool
+	// RefreshStorageEndpoint force refresh the storage driver endpoint
+	RefreshStorageEndpoint bool
 	// ReadinessTimeout time within which context is expected to be up
 	ReadinessTimeout time.Duration
 }

--- a/vendor/github.com/portworx/torpedo/drivers/volume/common.go
+++ b/vendor/github.com/portworx/torpedo/drivers/volume/common.go
@@ -176,7 +176,7 @@ func (d *DefaultDriver) GetReplicationFactor(vol *Volume) (int64, error) {
 }
 
 // SetReplicationFactor sets the volume's replication factor to the passed param rf.
-func (d *DefaultDriver) SetReplicationFactor(vol *Volume, replFactor int64) error {
+func (d *DefaultDriver) SetReplicationFactor(vol *Volume, replFactor int64, opts ...Options) error {
 	return &errors.ErrNotSupported{
 		Type:      "Function",
 		Operation: "SetReplicationFactor()",

--- a/vendor/github.com/portworx/torpedo/drivers/volume/portworx/schedops/k8s-schedops.go
+++ b/vendor/github.com/portworx/torpedo/drivers/volume/portworx/schedops/k8s-schedops.go
@@ -423,7 +423,6 @@ func (k *k8sSchedOps) validateStorkSnapshot(parent *api.Volume, params map[strin
 
 func (k *k8sSchedOps) GetVolumeName(vol *volume.Volume) string {
 	if vol != nil && vol.ID != "" {
-		logrus.Infof("Returning vol name as : %s", vol.ID)
 		return vol.ID
 	}
 	return ""
@@ -854,11 +853,11 @@ func printStatus(pods ...corev1.Pod) {
 			status += fmt.Sprintf("Phase: %v Reason: %s", pod.Status.Phase, pod.Status.Reason)
 		}
 		if ready {
-			logrus.Infof("Pod [%s] %s ready on node %s - %s", pod.Namespace, pod.Name, pod.Status.NominatedNodeName,
+			logrus.Infof("Pod [%s] %s ready on node %s - %s", pod.Namespace, pod.Name, pod.Spec.NodeName,
 				status)
 		} else {
 			logrus.Infof("Pod [%s] %s not ready on node %s - %s", pod.Namespace, pod.Name,
-				pod.Status.NominatedNodeName, status)
+				pod.Spec.NodeName, status)
 		}
 	}
 }

--- a/vendor/github.com/portworx/torpedo/drivers/volume/volume.go
+++ b/vendor/github.com/portworx/torpedo/drivers/volume/volume.go
@@ -37,6 +37,11 @@ type Image struct {
 	Version string
 }
 
+// Options to pass to APIs
+type Options struct {
+	ValidateReplicationUpdateTimeout time.Duration
+}
+
 // Driver defines an external volume driver interface that must be implemented
 // by any external storage provider that wants to qualify their product with
 // Torpedo.  The functions defined here are meant to be destructive and illustrative
@@ -114,7 +119,7 @@ type Driver interface {
 	GetReplicationFactor(vol *Volume) (int64, error)
 
 	// SetReplicationFactor sets the volume's replication factor to the passed param rf.
-	SetReplicationFactor(vol *Volume, rf int64) error
+	SetReplicationFactor(vol *Volume, rf int64, opts ...Options) error
 
 	// GetMaxReplicationFactor returns the max supported repl factor of a volume
 	GetMaxReplicationFactor() int64


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
For auth-enabled runs when not using custom method to create CRDs,  we need to add security annotations.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
