### PR TITLE
Wait for resource deletion before re-creating during migration

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -54,8 +54,10 @@ const (
 	// the value to be set for deactivating crds
 	StorkMigrationCRDDeactivateAnnotation = "stork.libopenstorage.org/migrationCRDDeactivate"
 	// Max number of times to retry applying resources on the desination
-	maxApplyRetries   = 10
-	cattleAnnotations = "cattle.io"
+	maxApplyRetries      = 10
+	cattleAnnotations    = "cattle.io"
+	deletedMaxRetries    = 12
+	deletedRetryInterval = 10 * time.Second
 )
 
 // NewMigration creates a new instance of MigrationController.
@@ -1251,13 +1253,29 @@ func (m *MigrationController) applyResources(
 				default:
 					// Delete the resource if it already exists on the destination
 					// cluster and try creating again
+					deleteStart := metav1.Now()
 					err = dynamicClient.Delete(metadata.GetName(), &metav1.DeleteOptions{})
-					if err == nil {
-						_, err = dynamicClient.Create(unstructured, metav1.CreateOptions{})
-					} else {
+					if err != nil {
 						log.MigrationLog(migration).Errorf("Error deleting %v %v during migrate: %v", objectType.GetKind(), metadata.GetName(), err)
+					} else {
+						// wait for resources to get deleted
+						// 2 mins
+						for i := 0; i < deletedMaxRetries; i++ {
+							obj, err := dynamicClient.Get(metadata.GetName(), metav1.GetOptions{})
+							if err != nil && errors.IsNotFound(err) {
+								break
+							}
+							createTime := obj.GetCreationTimestamp()
+							if deleteStart.Before(&createTime) {
+								logrus.Warnf("Object[%v] got re-created after deletion. So, Ignore wait. deleteStart time:[%v], create time:[%v]",
+									obj.GetName(), deleteStart, createTime)
+								break
+							}
+							logrus.Warnf("Object %v still present, retrying in %v", metadata.GetName(), deletedRetryInterval)
+							time.Sleep(deletedRetryInterval)
+						}
+						_, err = dynamicClient.Create(unstructured, metav1.CreateOptions{})
 					}
-
 				}
 			}
 			// Retry a few times for Unauthorized errors

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -245,7 +245,8 @@ func getMigrationSchedules(clusterPair string, args []string, namespace string) 
 		}
 		for _, migrationSchedule := range migrationScheduleList.Items {
 			if migrationSchedule.Spec.Template.Spec.ClusterPair == clusterPair {
-				migrationSchedules = append(migrationSchedules, &migrationSchedule)
+				migrSched := migrationSchedule
+				migrationSchedules = append(migrationSchedules, &migrSched)
 			}
 		}
 	}

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -307,6 +307,7 @@ func TestDefaultMigrationSchedulePolicy(t *testing.T) {
 
 func TestSuspendResumeMigrationSchedule(t *testing.T) {
 	name := "testmigrationschedule"
+	name1 := "testmigrationschedule-2"
 	namespace := "default"
 	defer resetTest()
 	createMigrationScheduleAndVerify(t, name, "testpolicy", namespace, "clusterpair1", []string{"namespace1"}, "", "", false)
@@ -349,5 +350,15 @@ func TestSuspendResumeMigrationSchedule(t *testing.T) {
 
 	cmdArgs = []string{"resume", "migrationschedules", "invalidschedule"}
 	testCommon(t, cmdArgs, nil, expected, true)
+
+	// test multiple suspend/resume using same clusterpair
+	createMigrationScheduleAndVerify(t, name1, "testpolicy", namespace, "clusterpair1", []string{"namespace1"}, "", "", false)
+	cmdArgs = []string{"suspend", "migrationschedules", "-c", "clusterpair1"}
+	expected = "MigrationSchedule " + name + " suspended successfully\nMigrationSchedule " + name1 + " suspended successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	cmdArgs = []string{"resume", "migrationschedules", "-c", "clusterpair1"}
+	expected = "MigrationSchedule " + name + " resumed successfully\nMigrationSchedule " + name1 + " resumed successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
 
 }


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Adds wait for deletion of resources before re-creating them during migration, this will avoid migration failure because of `object is in deleting state already exist` error

- Fix storkctl migration schedule issue where one unable to suspend/resume multiple migration using same clusterpair  
```
# storkctl suspend migrationschedules -c testpair
MigrationSchedule test-1 suspended successfully
MigrationSchedule test-2 suspended successfully

# storkctl get migrationschedule -c testpair
NAME     POLICYNAME                 CLUSTERPAIR   SUSPEND   LAST-SUCCESS-TIME   LAST-SUCCESS-DURATION
test-1   default-migration-policy   testpair      true
test-2   default-migration-policy   testpair      true

# storkctl resume migrationschedules -c testpair
MigrationSchedule test-1 resumed successfully
MigrationSchedule test-2 resumed successfully

# storkctl get migrationschedule -c testpair
NAME     POLICYNAME                 CLUSTERPAIR   SUSPEND   LAST-SUCCESS-TIME   LAST-SUCCESS-DURATION
test-1   default-migration-policy   testpair      false
test-2   default-migration-policy   testpair      false

````
**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes

