### PR TITLE
Update go version to 1.13.1 for integration test container

### DIFF
--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2 
+FROM golang:1.13.1 
 
 # Install dependancies
 RUN apt-get update && \ 


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
Update go version for integration test container to 1.13.1

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes

