### PR TITLE
Fix for non-CSI PVC restore not erroring out

### DIFF
--- a/pkg/resourcecollector/persistentvolumeclaim.go
+++ b/pkg/resourcecollector/persistentvolumeclaim.go
@@ -66,7 +66,8 @@ func (r *ResourceCollector) preparePVCResourceForApply(
 	}
 	pv, err := getCSIPV(&pvc, allObjects)
 	if err != nil {
-		return false, fmt.Errorf("failed to get CSI PV for a given PVC %s: %v", pvc.Name, err)
+		// if not a CSI PVC, this may fail. Do not return error to allow for non-CSI PVCs
+		return false, nil
 	}
 	isCSIPVC, err := isCSIPersistentVolume(pv)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>


**What type of PR is this?**
bug

**What this PR does / why we need it**:
For non-CSI drivers, restore PVC is failing because we error out if we cannot find the PV for a given PVC.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

