### PR TITLE
Allow disabling/enabling cronjob object after migration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -976,7 +976,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7c430e70ba5ccc22b5005def7682dd42969809c3cc4a64f45a5fcf0f575f7e52"
+  digest = "1:790ca389064f3f49e6660bf442561c1386870dd9d9fa2ad862d5001ce525f077"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s/admissionregistration",
@@ -997,7 +997,7 @@
     "task",
   ]
   pruneopts = "UT"
-  revision = "3e8010dc70561546b4880ab67a51006afb5ce6b0"
+  revision = "b13b1fcf2c6ef369ed1b60b5b9f65fdf83559f60"
 
 [[projects]]
   branch = "master"
@@ -2275,6 +2275,7 @@
     "github.com/libopenstorage/openstorage/pkg/auth",
     "github.com/libopenstorage/openstorage/pkg/auth/secrets",
     "github.com/libopenstorage/openstorage/pkg/grpcserver",
+    "github.com/libopenstorage/openstorage/pkg/units",
     "github.com/libopenstorage/openstorage/volume",
     "github.com/libopenstorage/openstorage/volume/drivers/pwx",
     "github.com/libopenstorage/secrets",
@@ -2286,6 +2287,7 @@
     "github.com/portworx/sched-ops/k8s/admissionregistration",
     "github.com/portworx/sched-ops/k8s/apiextensions",
     "github.com/portworx/sched-ops/k8s/apps",
+    "github.com/portworx/sched-ops/k8s/batch",
     "github.com/portworx/sched-ops/k8s/core",
     "github.com/portworx/sched-ops/k8s/dynamic",
     "github.com/portworx/sched-ops/k8s/errors",

--- a/pkg/applicationmanager/controllers/applicationregistration.go
+++ b/pkg/applicationmanager/controllers/applicationregistration.go
@@ -229,7 +229,7 @@ func getRegisteredCRD() (map[string][]stork_api.ApplicationResource, error) {
 		"stork.libopenstorage.org":               "",
 	}
 	regCRD := make(map[string][]stork_api.ApplicationResource)
-	crds, err := apiextensions.Instance().ListCRD()
+	crds, err := apiextensions.Instance().ListCRDs()
 	if err != nil {
 		return regCRD, err
 	}

--- a/pkg/storkctl/common_test.go
+++ b/pkg/storkctl/common_test.go
@@ -14,6 +14,7 @@ import (
 	fakeocpclient "github.com/openshift/client-go/apps/clientset/versioned/fake"
 	fakeocpsecurityclient "github.com/openshift/client-go/security/clientset/versioned/fake"
 	"github.com/portworx/sched-ops/k8s/apps"
+	"github.com/portworx/sched-ops/k8s/batch"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/dynamic"
 	"github.com/portworx/sched-ops/k8s/externalstorage"
@@ -76,6 +77,7 @@ func resetTest() {
 	externalstorage.SetInstance(externalstorage.New(fakeRestClient))
 	openshift.SetInstance(openshift.New(fakeKubeClient, fakeOCPClient, fakeOCPSecurityClient))
 	apps.SetInstance(apps.New(fakeKubeClient.AppsV1(), fakeKubeClient.CoreV1()))
+	batch.SetInstance(batch.New(fakeKubeClient.BatchV1(), fakeKubeClient.BatchV1beta1()))
 	dynamic.SetInstance(dynamic.New(fakeDynamicClient))
 }
 

--- a/pkg/storkctl/factory.go
+++ b/pkg/storkctl/factory.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	appsops "github.com/portworx/sched-ops/k8s/apps"
+	"github.com/portworx/sched-ops/k8s/batch"
 	"github.com/portworx/sched-ops/k8s/core"
 	dynamicops "github.com/portworx/sched-ops/k8s/dynamic"
 	externalstorageops "github.com/portworx/sched-ops/k8s/externalstorage"
@@ -126,6 +127,7 @@ func (f *factory) UpdateConfig() error {
 	}
 	core.Instance().SetConfig(config)
 	storkops.Instance().SetConfig(config)
+	batch.Instance().SetConfig(config)
 	ocpops.Instance().SetConfig(config)
 	appsops.Instance().SetConfig(config)
 	dynamicops.Instance().SetConfig(config)

--- a/vendor/github.com/portworx/sched-ops/k8s/apiextensions/crds.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apiextensions/crds.go
@@ -25,8 +25,8 @@ type CRDOps interface {
 	ValidateCRD(resource CustomResource, timeout, retryInterval time.Duration) error
 	// DeleteCRD deletes the CRD for the given complete name (plural.group)
 	DeleteCRD(fullName string) error
-	// ListCRD list all the CRDs
-	ListCRD() (*apiextensionsv1beta1.CustomResourceDefinitionList, error)
+	// ListCRDs list all the CRDs
+	ListCRDs() (*apiextensionsv1beta1.CustomResourceDefinitionList, error)
 }
 
 // CustomResource is for creating a Kubernetes TPR/CRD
@@ -151,8 +151,8 @@ func (c *Client) DeleteCRD(fullName string) error {
 		Delete(fullName, &metav1.DeleteOptions{PropagationPolicy: &deleteForegroundPolicy})
 }
 
-// ListCRD list all CRD resources
-func (c *Client) ListCRD() (*apiextensionsv1beta1.CustomResourceDefinitionList, error) {
+// ListCRDs list all CRD resources
+func (c *Client) ListCRDs() (*apiextensionsv1beta1.CustomResourceDefinitionList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/portworx/sched-ops/k8s/batch/batch.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/batch/batch.go
@@ -44,9 +44,10 @@ func SetInstance(i Ops) {
 }
 
 // New builds a new batch client.
-func New(client batchv1client.BatchV1Interface) *Client {
+func New(client batchv1client.BatchV1Interface, batchv1beta1 batchv1beta1client.BatchV1beta1Interface) *Client {
 	return &Client{
-		batch: client,
+		batch:        client,
+		batchv1beta1: batchv1beta1,
 	}
 }
 
@@ -84,11 +85,12 @@ type Client struct {
 func (c *Client) SetConfig(cfg *rest.Config) {
 	c.config = cfg
 	c.batch = nil
+	c.batchv1beta1 = nil
 }
 
 // initClient the k8s client if uninitialized
 func (c *Client) initClient() error {
-	if c.batch != nil {
+	if c.batch != nil && c.batchv1beta1 != nil {
 		return nil
 	}
 
@@ -146,6 +148,9 @@ func (c *Client) loadClient() error {
 	if err != nil {
 		return err
 	}
-
+	c.batchv1beta1, err = batchv1beta1client.NewForConfig(c.config)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/batch/cron.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/batch/cron.go
@@ -21,6 +21,8 @@ type CronOps interface {
 	DeleteCronJob(name, namespace string) error
 	// ValidateCronJob validates the given cronJob
 	ValidateCronJob(cronJob *v1beta1.CronJob, timeout, retryInterval time.Duration) error
+	// ListCronJobs list cronjobs in given namespace
+	ListCronJobs(namespace string) (*v1beta1.CronJobList, error)
 }
 
 var NamespaceDefault = "default"
@@ -83,4 +85,13 @@ func (c *Client) ValidateCronJob(cronJob *v1beta1.CronJob, timeout, retryInterva
 		}
 	}
 	return nil
+}
+
+// ListCronJobs returns the cronJobs in given namespace
+func (c *Client) ListCronJobs(namespace string) (*v1beta1.CronJobList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.batchv1beta1.CronJobs(namespace).List(metav1.ListOptions{})
 }


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
This PR adds support for disable/enable cronjob object once migrated to remote cluster

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes

```release-note
Adds support for disabling cronjob object upon migration to remote cluster.  One can now activate/deactivate cronjob object as well using `storkctl activate/deactivate migration <migration_namespace>`
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6.0 (or any early release before 2.6.0)


Output: 
```
# kubectl get all -ncron
NAME                  SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
cronjob.batch/hello   */1 * * * *   True      0        <none>          75s

# storkctl activate  migration -ncron
Updated suspend option for cronjob cron/hello to false

# kubectl get all -ncron
NAME                  SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
cronjob.batch/hello   */1 * * * *   False     0        <none>          27m
```
