### PR TITLE
Reporting volume size in bytes for EKS

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -15,6 +15,7 @@ import (
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 	snapshotVolume "github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	"github.com/libopenstorage/openstorage/pkg/units"
 	storkvolume "github.com/libopenstorage/stork/drivers/volume"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/errors"
@@ -369,8 +370,9 @@ func (a *aws) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 		case "completed":
 			vInfo.Status = storkapi.ApplicationBackupStatusSuccessful
 			vInfo.Reason = "Backup successful for volume"
-			vInfo.TotalSize = uint64(*snapshot.VolumeSize)
-			vInfo.ActualSize = uint64(*snapshot.VolumeSize)
+			// converting to bytes
+			vInfo.TotalSize = uint64(*snapshot.VolumeSize) * units.GiB
+			vInfo.ActualSize = uint64(*snapshot.VolumeSize) * units.GiB
 		}
 		volumeInfos = append(volumeInfos, vInfo)
 	}


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
Reports EKS volume size in bytes instead of GiB

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
For 2.5
