### PR TITLE
Don't skip VolumeName update on CSI driver check failure

### DIFF
--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -110,7 +110,7 @@ func (r *ResourceCollector) preparePVResourceForApply(
 		return false, fmt.Errorf("error converting to persistent volume: %v", err)
 	}
 
-	isCSIPV, err := isCSIPersistentVolume(&pv)
+	isCSIPV, err := isGenericCSIPersistentVolume(&pv)
 	if err != nil {
 		return false, fmt.Errorf("failed to check if PV was provisioned by a CSI driver: %v", err)
 	}

--- a/pkg/resourcecollector/persistentvolumeclaim.go
+++ b/pkg/resourcecollector/persistentvolumeclaim.go
@@ -64,18 +64,29 @@ func (r *ResourceCollector) preparePVCResourceForApply(
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &pvc); err != nil {
 		return false, fmt.Errorf("error converting PVC object: %v: %v", object, err)
 	}
-	pv, err := getCSIPV(&pvc, allObjects)
+
+	// Find the matching PV for this PVC.
+	pv, err := getPVForPVC(&pvc, allObjects)
 	if err != nil {
-		// if not a CSI PVC, this may fail. Do not return error to allow for non-CSI PVCs
-		return false, nil
+		// if not a generic CSI PVC, this call may fail. Do not return error to allow for non-CSI PVCs.
+		logrus.Debugf("did not find PV for PVC %s in backup resources for generic CSI restore: %v", pvc.Name, err)
 	}
-	isCSIPVC, err := isCSIPersistentVolume(pv)
-	if err != nil {
-		return false, fmt.Errorf("failed to check if PVC is for a CSI driver: %v", err)
-	}
-	if isCSIPVC {
-		logrus.Debugf("skipping CSI PVC in pre-restore: %s", metadata.GetName())
-		return true, nil
+
+	// We have found a PV for this PVC. Check if it is a generic CSI PV
+	// that we do not already have native volume driver support for.
+	if pv != nil {
+		isGenericCSIPVC, err := isGenericCSIPersistentVolume(pv)
+		if err != nil {
+			logrus.Debugf("failed to check if PVC %s is for a CSI driver: %v", pvc.Name, err)
+		}
+
+		// If we have a generic CSI PVC, we should return true to indicate
+		// that the resourcecollector should not restore the PVC.
+		// Instead, PVC creation is handled by the CSI volume driver.
+		if isGenericCSIPVC {
+			logrus.Debugf("skipping CSI PVC in pre-restore: %s", metadata.GetName())
+			return true, nil
+		}
 	}
 
 	if updatedName, present = pvNameMappings[pvc.Spec.VolumeName]; !present {

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -456,12 +456,11 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 	return nil
 }
 
-func isCSIPersistentVolume(pv *v1.PersistentVolume) (bool, error) {
+func isGenericCSIPersistentVolume(pv *v1.PersistentVolume) (bool, error) {
 	driverName, err := volume.GetPVDriver(pv)
 	if err != nil {
 		return false, err
 	}
-	logrus.Infof("isCSIPersistentVolume driver name - %s", driverName)
 	if driverName == "csi" {
 		return true, nil
 	}
@@ -469,7 +468,7 @@ func isCSIPersistentVolume(pv *v1.PersistentVolume) (bool, error) {
 	return false, nil
 }
 
-func getCSIPV(pvc *v1.PersistentVolumeClaim, allObjects []runtime.Unstructured) (*v1.PersistentVolume, error) {
+func getPVForPVC(pvc *v1.PersistentVolumeClaim, allObjects []runtime.Unstructured) (*v1.PersistentVolume, error) {
 	for _, o := range allObjects {
 		objectType, err := meta.TypeAccessor(o)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What type of PR is this?**
bug

**What this PR does / why we need it**:
Fixes a check in PVC pre-apply that was causing the PVC VolumeName to not be set.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
none - unreleased
```

**Does this change need to be cherry-picked to a release branch?**:
2.6.0
