### PR TITLE
[CSI] Add check to make sure VolumeSnapshot and VSC are cleaned up

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -98,6 +98,8 @@ const (
 	ApplicationBackupStatusPending ApplicationBackupStatusType = "Pending"
 	// ApplicationBackupStatusInProgress for when backup is in progress
 	ApplicationBackupStatusInProgress ApplicationBackupStatusType = "InProgress"
+	// ApplicationBackupStatusInCleanup for when backup is cleaning up resources
+	ApplicationBackupStatusInCleanup ApplicationBackupStatusType = "InCleanup"
 	// ApplicationBackupStatusFailed for when backup has failed
 	ApplicationBackupStatusFailed ApplicationBackupStatusType = "Failed"
 	// ApplicationBackupStatusPartialSuccess for when backup was partially successful

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -619,7 +619,7 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 		// TODO: On failure of one volume cancel other backups?
 		for _, vInfo := range volumeInfos {
 			if vInfo.Status == stork_api.ApplicationBackupStatusInProgress || vInfo.Status == stork_api.ApplicationBackupStatusInitial ||
-				vInfo.Status == stork_api.ApplicationBackupStatusPending {
+				vInfo.Status == stork_api.ApplicationBackupStatusPending || vInfo.Status == stork_api.ApplicationBackupStatusInCleanup {
 				log.ApplicationBackupLog(backup).Infof("Volume backup still in progress: %v", vInfo.Volume)
 				inProgress = true
 			} else if vInfo.Status == stork_api.ApplicationBackupStatusFailed {


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>


**What type of PR is this?**
bug

**What this PR does / why we need it**:
Reworks csi.GetBackupStatus to make sure we ensure all VS objects are deleted before marking as success.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
