### PR TITLE
Use client from resource collector when checking for PVC ownership

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -111,7 +111,7 @@ func (a *aws) Stop() error {
 	return nil
 }
 
-func (a *aws) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
+func (a *aws) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 
 	provisioner := ""
 	// Check for the provisioner in the PVC annotation. If not populated
@@ -132,7 +132,7 @@ func (a *aws) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
 
 	if provisioner == "" {
 		// Try to get info from the PV since storage class could be deleted
-		pv, err := core.Instance().GetPersistentVolume(pvc.Spec.VolumeName)
+		pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)
 		if err != nil {
 			logrus.Warnf("Error getting pv %v for pvc %v: %v", pvc.Spec.VolumeName, pvc.Name, err)
 			return false

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -143,7 +143,7 @@ func (a *azure) Stop() error {
 	return nil
 }
 
-func (a *azure) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
+func (a *azure) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 
 	provisioner := ""
 	// Check for the provisioner in the PVC annotation. If not populated
@@ -164,7 +164,7 @@ func (a *azure) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
 
 	if provisioner == "" {
 		// Try to get info from the PV since storage class could be deleted
-		pv, err := core.Instance().GetPersistentVolume(pvc.Spec.VolumeName)
+		pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)
 		if err != nil {
 			logrus.Warnf("Error getting pv %v for pvc %v: %v", pvc.Spec.VolumeName, pvc.Name, err)
 			return false

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -146,9 +146,9 @@ func (c *csi) Stop() error {
 	return nil
 }
 
-func (c *csi) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
+func (c *csi) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 	// Try to get info from the PV since storage class could be deleted
-	pv, err := core.Instance().GetPersistentVolume(pvc.Spec.VolumeName)
+	pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)
 	if err != nil {
 		log.PVCLog(pvc).Warnf("error getting pv %v for pvc %v: %v", pvc.Spec.VolumeName, pvc.Name, err)
 		return false

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -89,7 +89,7 @@ func (g *gcp) Stop() error {
 	return nil
 }
 
-func (g *gcp) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
+func (g *gcp) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 
 	provisioner := ""
 	// Check for the provisioner in the PVC annotation. If not populated
@@ -110,7 +110,7 @@ func (g *gcp) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
 
 	if provisioner == "" {
 		// Try to get info from the PV since storage class could be deleted
-		pv, err := core.Instance().GetPersistentVolume(pvc.Spec.VolumeName)
+		pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)
 		if err != nil {
 			logrus.Warnf("Error getting pv %v for pvc %v: %v", pvc.Spec.VolumeName, pvc.Name, err)
 			return false

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -262,7 +262,7 @@ func (l *linstor) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*stork
 				return nil, err
 			}
 
-			if !l.OwnsPVC(pvc) {
+			if !l.OwnsPVC(core.Instance(), pvc) {
 				continue
 			}
 
@@ -291,14 +291,14 @@ func (l *linstor) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*stork
 func (l *linstor) GetVolumeClaimTemplates(templates []v1.PersistentVolumeClaim) ([]v1.PersistentVolumeClaim, error) {
 	var linstorTemplates []v1.PersistentVolumeClaim
 	for _, t := range templates {
-		if l.OwnsPVC(&t) {
+		if l.OwnsPVC(core.Instance(), &t) {
 			linstorTemplates = append(linstorTemplates, t)
 		}
 	}
 	return linstorTemplates, nil
 }
 
-func (l *linstor) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
+func (l *linstor) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 	provisioner := ""
 	// Check for the provisioner in the PVC annotation. If not populated
 	// try getting the provisioner from the Storage class.
@@ -318,7 +318,7 @@ func (l *linstor) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
 
 	if provisioner == "" {
 		// Try to get info from the PV since storage class could be deleted
-		pv, err := core.Instance().GetPersistentVolume(pvc.Spec.VolumeName)
+		pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)
 		if err != nil {
 			logrus.Warnf("Error getting pv %v for pvc %v: %v", pvc.Spec.VolumeName, pvc.Name, err)
 			return false

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -10,6 +10,7 @@ import (
 	storkvolume "github.com/libopenstorage/stork/drivers/volume"
 	"github.com/libopenstorage/stork/pkg/errors"
 	"github.com/pborman/uuid"
+	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	k8shelper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
@@ -253,7 +254,7 @@ func (m Driver) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*storkvo
 }
 
 // OwnsPVC returns true because it owns all PVCs created by tests
-func (m *Driver) OwnsPVC(pvc *v1.PersistentVolumeClaim) bool {
+func (m *Driver) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 	return true
 }
 

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -9,6 +9,7 @@ import (
 	snapshotVolume "github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/errors"
+	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,7 +48,7 @@ type Driver interface {
 	GetVolumeClaimTemplates([]v1.PersistentVolumeClaim) ([]v1.PersistentVolumeClaim, error)
 
 	// OwnsPVC returns true if the PVC is owned by the driver
-	OwnsPVC(pvc *v1.PersistentVolumeClaim) bool
+	OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool
 
 	// OwnsPV returns true if the PV is owned by the driver
 	OwnsPV(pvc *v1.PersistentVolume) bool
@@ -258,9 +259,9 @@ func Get(name string) (Driver, error) {
 
 // GetPVCDriver gets the driver associated with a PVC. Returns ErrNotFound if the PVC is
 // not owned by any available driver
-func GetPVCDriver(pvc *v1.PersistentVolumeClaim) (string, error) {
+func GetPVCDriver(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) (string, error) {
 	for driverName, d := range volDrivers {
-		if d.OwnsPVC(pvc) {
+		if d.OwnsPVC(coreOps, pvc) {
 			return driverName, nil
 		}
 	}

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -493,7 +493,7 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 			if pvc.Status.Phase != v1.ClaimBound || pvc.DeletionTimestamp != nil {
 				continue
 			}
-			driverName, err := volume.GetPVCDriver(&pvc)
+			driverName, err := volume.GetPVCDriver(core.Instance(), &pvc)
 			if err != nil {
 				// Skip unsupported PVCs
 				if _, ok := err.(*errors.ErrNotSupported); ok {

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -317,7 +317,7 @@ func (a *ApplicationCloneController) generateCloneVolumeNames(clone *stork_api.A
 
 	volumeInfos := make([]*stork_api.ApplicationCloneVolumeInfo, 0)
 	for _, pvc := range pvcList.Items {
-		if !a.volDriver.OwnsPVC(&pvc) {
+		if !a.volDriver.OwnsPVC(core.Instance(), &pvc) {
 			continue
 		}
 		volume, err := core.Instance().GetVolumeForPersistentVolumeClaim(&pvc)

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -291,7 +291,7 @@ func (m *Monitor) doesDriverOwnVolumeAttachment(va *storagev1.VolumeAttachment) 
 		return false, err
 	}
 
-	return m.Driver.OwnsPVC(pvc), nil
+	return m.Driver.OwnsPVC(core.Instance(), pvc), nil
 }
 
 func (m *Monitor) cleanupVolumeAttachmentsByPod(pod *v1.Pod) error {

--- a/pkg/pvcwatcher/pvcwatcher.go
+++ b/pkg/pvcwatcher/pvcwatcher.go
@@ -111,7 +111,7 @@ func (p *PVCWatcher) handleSnapshotScheduleUpdates(pvc *corev1.PersistentVolumeC
 	}
 
 	// Do nothing if the driver doesn't own the PVC or if it isn't bound yet
-	if !p.volDriver.OwnsPVC(pvc) || pvc.Status.Phase != corev1.ClaimBound {
+	if !p.volDriver.OwnsPVC(core.Instance(), pvc) || pvc.Status.Phase != corev1.ClaimBound {
 		return nil
 	}
 

--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -63,11 +63,11 @@ func (r *ResourceCollector) pvToBeCollected(
 
 		// Don't collect PVCs not owned by the driver if collecting for a specific
 		// driver
-		if !allDrivers && !r.Driver.OwnsPVC(pvc) {
+		if !allDrivers && !r.Driver.OwnsPVC(r.coreOps, pvc) {
 			return false, nil
 		}
 		// Else collect PVCs for all supported drivers
-		_, err = volume.GetPVCDriver(pvc)
+		_, err = volume.GetPVCDriver(r.coreOps, pvc)
 		if err != nil {
 			return false, nil
 		}

--- a/pkg/resourcecollector/persistentvolumeclaim.go
+++ b/pkg/resourcecollector/persistentvolumeclaim.go
@@ -33,11 +33,11 @@ func (r *ResourceCollector) pvcToBeCollected(
 
 	// Don't collect PVCs not owned by the driver if collecting for a specific
 	// driver
-	if !allDrivers && !r.Driver.OwnsPVC(pvc) {
+	if !allDrivers && !r.Driver.OwnsPVC(r.coreOps, pvc) {
 		return false, nil
 	}
 	// Else collect PVCs for all supported drivers
-	_, err = volume.GetPVCDriver(pvc)
+	_, err = volume.GetPVCDriver(r.coreOps, pvc)
 	if err != nil {
 		return false, nil
 	}

--- a/pkg/webhookadmission/webhook.go
+++ b/pkg/webhookadmission/webhook.go
@@ -195,7 +195,7 @@ func (c *Controller) checkVolumeOwner(volumes []v1.Volume, namespace string) (bo
 		if err != nil {
 			return false, err
 		}
-		if c.Driver.OwnsPVC(pvc) {
+		if c.Driver.OwnsPVC(core.Instance(), pvc) {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Without this, if the resource collector is called for a remote cluster it tries
to fetch objects from the local cluster


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
No
