### PR TITLE
Prune migrations even for PartialSuccess

### DIFF
--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -352,7 +352,8 @@ func (m *MigrationScheduleController) pruneMigrations(migrationSchedule *stork_a
 		if numMigrations > 1 {
 			// Start from the end and find the last successful migration
 			for i := range policyMigration {
-				if policyMigration[(numMigrations-i-1)].Status == stork_api.MigrationStatusSuccessful {
+				if policyMigration[(numMigrations-i-1)].Status == stork_api.MigrationStatusSuccessful ||
+					policyMigration[(numMigrations-i-1)].Status == stork_api.MigrationStatusPartialSuccess {
 					deleteBefore = numMigrations - i - 1
 					break
 				}


### PR DESCRIPTION
Some resources might always fail to be migrated, this causes the status for all
PartialSuccess migrations to be saved. Only need to keep the last one in this
case


**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
