### PR TITLE
[WIP] [CSI] Replace policies, resourcecollector ignore VS obj, and namespace mapping

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationrestore.go
+++ b/pkg/apis/stork/v1alpha1/applicationrestore.go
@@ -72,6 +72,7 @@ type ApplicationRestoreVolumeInfo struct {
 	SourceNamespace       string                       `json:"sourceNamespace"`
 	SourceVolume          string                       `json:"sourceVolume"`
 	RestoreVolume         string                       `json:"restoreVolume"`
+	SnapshotID            string                       `json:"restoreSnapshotID"`
 	DriverName            string                       `json:"driverName"`
 	Zones                 []string                     `json:"zones"`
 	Status                ApplicationRestoreStatusType `json:"status"`
@@ -95,6 +96,8 @@ const (
 	ApplicationRestoreStatusPartialSuccess ApplicationRestoreStatusType = "PartialSuccess"
 	// ApplicationRestoreStatusRetained for when restore was skipped to retain an already existing resource
 	ApplicationRestoreStatusRetained ApplicationRestoreStatusType = "Retained"
+	// ApplicationRestoreStatusDeletingPrevious for when a volume is being deleted prior to restore
+	ApplicationRestoreStatusDeletingPrevious ApplicationRestoreStatusType = "DeletingPrevious"
 	// ApplicationRestoreStatusSuccessful for when restore has completed successfully
 	ApplicationRestoreStatusSuccessful ApplicationRestoreStatusType = "Successful"
 )

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -511,6 +511,11 @@ func (r *ResourceCollector) includeObject(
 		return false, err
 	}
 
+	// Skip VolumeSnapshot objects
+	if objectType.GetKind() == "VolumeSnapshot" {
+		return false, nil
+	}
+
 	// Even if PV isn't specified need to check if the corresponding PVC is, so
 	// skip the check here
 	if objectType.GetKind() != "PersistentVolume" {


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>


**What type of PR is this?**
bug

**What this PR does / why we need it**:
* Adds support for Replace policy in CSI Driver
* Resource collector now ignores VS Objs
* CSI Driver restore now understands namespace mappings

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No