### PR TITLE
[CSI] Namespace mapping, skip VS obj in includeObject, and UID fix

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -94,6 +94,9 @@ func (r *ResourceCollector) Init(config *restclient.Config) error {
 
 func resourceToBeCollected(resource metav1.APIResource, grp schema.GroupVersion, crdKinds []metav1.GroupVersionKind, optionalResourceTypes []string) bool {
 	for _, res := range crdKinds {
+		if res.Kind == "VolumeSnapshot" {
+			return false
+		}
 		if res.Kind == resource.Kind &&
 			res.Group == grp.Group && res.Version == grp.Version && resource.Namespaced {
 			return true


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What type of PR is this?**
bug

**What this PR does / why we need it**:
* Some CSI providers require specific VSClass parameters. We should not delete the VSClass as the user may have added their driver-specific settings. We will only update the VSClass to have the retain policy, as that is required for backups. We will still create the VSClass if it does not exist.
* Skip vs object in includeObject (to hide from UI and ignore in backups)
* add namespace mapping support
* add CSI restore timeout

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
