### PR TITLE
[CSI] Restore cleanup without backup obj and various fixes

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -327,7 +327,15 @@ func (a *ApplicationRestoreController) getNamespacedObjectsToDelete(restore *sto
 			metadata.SetNamespace(val)
 		}
 
-		tempObjects = append(tempObjects, o)
+		objectType, err := meta.TypeAccessor(o)
+		if err != nil {
+			return nil, err
+		}
+
+		// Skip PVs, we will let the PVC handle PV deletion where needed
+		if objectType.GetKind() != "PersistentVolume" {
+			tempObjects = append(tempObjects, o)
+		}
 	}
 
 	return tempObjects, nil

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -93,7 +93,7 @@ func (r *ResourceCollector) Init(config *restclient.Config) error {
 
 func resourceToBeCollected(resource metav1.APIResource, grp schema.GroupVersion, crdKinds []metav1.GroupVersionKind, optionalResourceTypes []string) bool {
 	// Ignore CSI Snapshot object
-	if resource.Kind == "VolumeSnapshot" && resource.Group == "snapshot.storage.k8s.io" {
+	if resource.Kind == "VolumeSnapshot" {
 		return false
 	}
 


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>


**What type of PR is this?**
bug

**What this PR does / why we need it**:
* When a restore is issued through PX-Backup, it creates a backup in the namespace and cleans it up when finished. There was some race where the cleanup was failing to find the backup object to cleanup the VS objects.
* This PR makes the cleanup independent of the backup object, by only cleaning up objects associated with the given restore UID.
* Uses PVC size for backup/restore info sizes
* Fix VolumeSnapshot skip check to not look at group


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No