### PR TITLE
Avoid including non-csi volume as part of csi's GetBackupStatus API.

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -548,8 +548,11 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 	vsContentMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)
 	vsClassMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshotClass)
 	for _, vInfo := range backup.Status.Volumes {
+		if vInfo.DriverName != storkCSIDriverName {
+			continue
+		}
 		// Once a snapshot has been backed up and cleaned up, skip it
-		if vInfo.DriverName != storkCSIDriverName || vInfo.Status == storkapi.ApplicationBackupStatusSuccessful {
+		if vInfo.Status == storkapi.ApplicationBackupStatusSuccessful {
 			volumeInfos = append(volumeInfos, vInfo)
 			continue
 		}


### PR DESCRIPTION
**What type of PR is this?**
>bug
**What this PR does / why we need it**:
Avoid including non-csi volume as part of csi's GetBackupStatus API.

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
no
**Does this change need to be cherry-picked to a release branch?**:
2.6

**Testing:**
Tested on the OCP cluster setup, where we saw the issue.
