### PR TITLE
[CSI] Remove cleanup checks for GetBackupStatus

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -65,8 +65,6 @@ const (
 
 	// snapshotTimeout represents the duration to wait before timing out on snapshot completion
 	snapshotTimeout = time.Minute * 5
-	// snapshotTimeout represents the duration to wait before timing out on snapshot completion
-	snapshotCleanupTimeout = time.Minute * 5
 	// restoreTimeout is the duration to wait before timing out the restore
 	restoreTimeout = time.Minute * 5
 )
@@ -551,82 +549,11 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 		if vInfo.DriverName != storkCSIDriverName {
 			continue
 		}
-		// Once a snapshot has been backed up and cleaned up, skip it
-		if vInfo.Status == storkapi.ApplicationBackupStatusSuccessful {
-			volumeInfos = append(volumeInfos, vInfo)
-			continue
-		}
 
 		// Get PVC we're checking the backup for
 		pvc, err := core.Instance().GetPersistentVolumeClaim(vInfo.PersistentVolumeClaim, vInfo.Namespace)
 		if err != nil {
 			return nil, err
-		}
-
-		// If this volume is in ApplicationBackupStatusInCleanup,
-		// check if cleanup has finished and mark successful if so
-		if vInfo.Status == storkapi.ApplicationBackupStatusInCleanup {
-			vInfo.Reason = "Cleaning up snapshot objects"
-			var snapshotDeleted, snapshotContentDeleted bool
-			vs, err := c.snapshotClient.SnapshotV1beta1().VolumeSnapshots(vInfo.Namespace).Get(c.getBackupSnapshotName(pvc, backup), metav1.GetOptions{})
-			if err != nil {
-				if k8s_errors.IsNotFound(err) {
-					snapshotDeleted = true
-				} else {
-					return nil, err
-				}
-			}
-
-			vscName, ok := vInfo.Options[optVolumeSnapshotContentName]
-			if !ok {
-				log.ApplicationBackupLog(backup).Debugf("failed to find volume snapshot content name for cleanup check: %v", vInfo.Options)
-			}
-			vsc, err := c.snapshotClient.SnapshotV1beta1().VolumeSnapshotContents().Get(vscName, metav1.GetOptions{})
-			if err != nil {
-				if k8s_errors.IsNotFound(err) {
-					snapshotContentDeleted = true
-				} else {
-					return nil, err
-				}
-			}
-
-			// Get when these objects were first deleted
-			var deletionTimestamp *metav1.Time
-			if vs != nil && vs.DeletionTimestamp != nil {
-				deletionTimestamp = vs.DeletionTimestamp
-			} else if vsc != nil && vsc.DeletionTimestamp != nil {
-				deletionTimestamp = vsc.DeletionTimestamp
-			}
-
-			// If we didn't find a deletion timestamp, retry cleanup
-			if deletionTimestamp == nil {
-				vsMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshot)
-				vscMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)
-				if vs != nil {
-					vsMap[vInfo.BackupID] = vs
-				}
-				if vsc != nil {
-					vscMap[vInfo.BackupID] = vsc
-				}
-				err := c.cleanupSnapshots(vsMap, vscMap, true)
-				if err != nil {
-					log.ApplicationBackupLog(backup).Errorf("cleanup retry failed for %s. Will try until timeout: %v", vInfo.BackupID, err)
-				}
-			}
-
-			// Mark successful if both VS and VSC cleaned up
-			if snapshotDeleted && snapshotContentDeleted {
-				vInfo.Status = storkapi.ApplicationBackupStatusSuccessful
-				vInfo.Reason = "Backup successful for volume"
-			} else if deletionTimestamp != nil && time.Now().After(deletionTimestamp.Add(snapshotCleanupTimeout)) {
-				// Timeout after 5 minutes of cleanup
-				vInfo.Status = storkapi.ApplicationBackupStatusFailed
-				vInfo.Reason = fmt.Sprintf("Snapshot cleanup timeout out after %s", snapshotCleanupTimeout.String())
-				anyFailed = true
-			}
-
-			volumeInfos = append(volumeInfos, vInfo)
-			continue
 		}
 
 		// Not in cleanup state. From here on, we're checking if the PVC snapshot has finished.
@@ -691,7 +618,8 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 		}
 		switch {
 		case volumeSnapshotReady && volumeSnapshotContentReady:
-			vInfo.Reason = "Snapshot finished, pending completion of other snapshots"
+			vInfo.Status = storkapi.ApplicationBackupStatusSuccessful
+			vInfo.Reason = "Backup successful for volume"
 			vInfo.ActualSize = uint64(size)
 			vInfo.TotalSize = uint64(size)
 
@@ -731,18 +659,12 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 		}
 		log.ApplicationBackupLog(backup).Debugf("finished and uploaded %v snapshots and %v snapshotcontents", len(vsMap), len(vsContentMap))
 
-		// enter cleanup phase after a successful object upload
-		backup.Status.Status = storkapi.ApplicationBackupStatusInCleanup
+		// cleanup after a successful object upload
 		err = c.cleanupSnapshots(vsMap, vsContentMap, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to cleanup snapshots: %v", err)
 		}
 		log.ApplicationBackupLog(backup).Debugf("started clean up of %v snapshots and %v snapshotcontents", len(vsMap), len(vsContentMap))
-
-		// Ensure all volumes are in cleanup state
-		for _, vInfo := range backup.Status.Volumes {
-			vInfo.Status = storkapi.ApplicationBackupStatusInCleanup
-		}
 	}
 
 	return volumeInfos, nil
@@ -806,7 +728,7 @@ func (c *csi) recreateSnapshotForDeletion(
 }
 
 func (c *csi) CancelBackup(backup *storkapi.ApplicationBackup) error {
-	if backup.Status.Status == storkapi.ApplicationBackupStatusInProgress || backup.Status.Status == storkapi.ApplicationBackupStatusInCleanup {
+	if backup.Status.Status == storkapi.ApplicationBackupStatusInProgress {
 		// set of all snapshot classes deleted
 		for _, vInfo := range backup.Status.Volumes {
 			snapshotName := vInfo.BackupID

--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -98,8 +98,6 @@ const (
 	ApplicationBackupStatusPending ApplicationBackupStatusType = "Pending"
 	// ApplicationBackupStatusInProgress for when backup is in progress
 	ApplicationBackupStatusInProgress ApplicationBackupStatusType = "InProgress"
-	// ApplicationBackupStatusInCleanup for when backup is cleaning up resources
-	ApplicationBackupStatusInCleanup ApplicationBackupStatusType = "InCleanup"
 	// ApplicationBackupStatusFailed for when backup has failed
 	ApplicationBackupStatusFailed ApplicationBackupStatusType = "Failed"
 	// ApplicationBackupStatusPartialSuccess for when backup was partially successful

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -619,7 +619,7 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 		// TODO: On failure of one volume cancel other backups?
 		for _, vInfo := range volumeInfos {
 			if vInfo.Status == stork_api.ApplicationBackupStatusInProgress || vInfo.Status == stork_api.ApplicationBackupStatusInitial ||
-				vInfo.Status == stork_api.ApplicationBackupStatusPending || vInfo.Status == stork_api.ApplicationBackupStatusInCleanup {
+				vInfo.Status == stork_api.ApplicationBackupStatusPending {
 				log.ApplicationBackupLog(backup).Infof("Volume backup still in progress: %v", vInfo.Volume)
 				inProgress = true
 			} else if vInfo.Status == stork_api.ApplicationBackupStatusFailed {


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>


**What type of PR is this?**
bug

**What this PR does / why we need it**:
Removes the cleanup checks to improve the reliability of backup status.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
2.6

