### PR TITLE
Add prometheus metrics for application backup and restore CRs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -976,7 +976,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:790ca389064f3f49e6660bf442561c1386870dd9d9fa2ad862d5001ce525f077"
+  digest = "1:a87986494fb9d67a97da35d8a95e714194f6f9152d9a5767c2c6edcd39454e0a"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s/admissionregistration",
@@ -997,7 +997,7 @@
     "task",
   ]
   pruneopts = "UT"
-  revision = "b13b1fcf2c6ef369ed1b60b5b9f65fdf83559f60"
+  revision = "8c92f41450e8772b2a5e589e43683499ada7cf09"
 
 [[projects]]
   branch = "master"

--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -22,6 +22,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/dbg"
 	"github.com/libopenstorage/stork/pkg/extender"
 	"github.com/libopenstorage/stork/pkg/groupsnapshot"
+	"github.com/libopenstorage/stork/pkg/metrics"
 	"github.com/libopenstorage/stork/pkg/migration"
 	"github.com/libopenstorage/stork/pkg/monitor"
 	"github.com/libopenstorage/stork/pkg/pvcwatcher"
@@ -199,6 +200,9 @@ func run(c *cli.Context) {
 
 		if c.Bool("stork-metrics") {
 			http.Handle("/metrics", promhttp.Handler())
+			if err = metrics.StartMetrics(); err != nil {
+				log.Fatalf("Error starting prometheus metrics for stork: %v", err)
+			}
 		}
 
 		if c.Bool("extender") {

--- a/pkg/metrics/applicationbackup.go
+++ b/pkg/metrics/applicationbackup.go
@@ -1,0 +1,96 @@
+package metrics
+
+import (
+	"fmt"
+
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	app_backup "github.com/libopenstorage/stork/pkg/applicationmanager/controllers"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	// BackupStatusCounter for application backup CR status on server
+	backupStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_backup_status",
+		Help: "Status of application backups",
+	}, []string{MetricName, MetricNamespace, MetricSchedule}) // annotation to figure out schedule
+	// BackupStageCounter for application backup CR stages on server
+	backupStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_backup_stage",
+		Help: "Stage of application backups",
+	}, []string{MetricName, MetricNamespace, MetricSchedule})
+	// BackupDurationCounter for time taken by application backup to complete
+	backupDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_backup_duration",
+		Help: "Duration of application backups",
+	}, []string{MetricName, MetricNamespace, MetricSchedule})
+	// BackupSizeCounter for application backup size
+	backupSizeCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_backup_size",
+		Help: "Size of application backups",
+	}, []string{MetricName, MetricNamespace, MetricSchedule})
+)
+
+var (
+	// BackupStatus map of application backup status to enum
+	BackupStatus = map[stork_api.ApplicationBackupStatusType]float64{
+		stork_api.ApplicationBackupStatusInitial:        0,
+		stork_api.ApplicationBackupStatusPending:        1,
+		stork_api.ApplicationBackupStatusInProgress:     2,
+		stork_api.ApplicationBackupStatusFailed:         3,
+		stork_api.ApplicationBackupStatusPartialSuccess: 4,
+		stork_api.ApplicationBackupStatusSuccessful:     5,
+	}
+	// BackupStage map of application backup stage to enum
+	BackupStage = map[stork_api.ApplicationBackupStageType]float64{
+		stork_api.ApplicationBackupStageInitial:      0,
+		stork_api.ApplicationBackupStagePreExecRule:  1,
+		stork_api.ApplicationBackupStagePostExecRule: 2,
+		stork_api.ApplicationBackupStageVolumes:      3,
+		stork_api.ApplicationBackupStageApplications: 4,
+		stork_api.ApplicationBackupStageFinal:        5,
+	}
+)
+
+func watchBackupCR(object runtime.Object) error {
+	backup, ok := object.(*stork_api.ApplicationBackup)
+	if !ok {
+		err := fmt.Errorf("invalid object type on backup watch: %v", object)
+		return err
+	}
+	labels := make(prometheus.Labels)
+	labels[MetricName] = backup.Name
+	labels[MetricNamespace] = backup.Namespace
+	labels[MetricSchedule] = backup.Annotations[app_backup.ApplicationBackupScheduleNameAnnotation]
+	if backup.DeletionTimestamp != nil {
+		backupStatusCounter.Delete(labels)
+		backupStageCounter.Delete(labels)
+		backupDurationCounter.Delete(labels)
+		backupSizeCounter.Delete(labels)
+		return nil
+	}
+	// Set Backup Status counter
+	backupStatusCounter.With(labels).Set(BackupStatus[backup.Status.Status])
+	// Set Backup Stage Counter
+	backupStageCounter.With(labels).Set(BackupStage[backup.Status.Stage])
+	if backup.Status.Stage == stork_api.ApplicationBackupStageFinal && (backup.Status.Status == stork_api.ApplicationBackupStatusSuccessful ||
+		backup.Status.Status == stork_api.ApplicationBackupStatusPartialSuccess ||
+		backup.Status.Status == stork_api.ApplicationBackupStatusFailed) {
+		st := backup.Status.TriggerTimestamp.Unix()
+		et := backup.Status.FinishTimestamp.Unix()
+		// Set backup Duration
+		backupDurationCounter.With(labels).Set(float64(et - st))
+		// Set BackupSize
+		backupSizeCounter.With(labels).Set(float64(backup.Status.TotalSize))
+	}
+
+	return nil
+}
+
+func init() {
+	prometheus.MustRegister(backupStatusCounter)
+	prometheus.MustRegister(backupStageCounter)
+	prometheus.MustRegister(backupDurationCounter)
+	prometheus.MustRegister(backupSizeCounter)
+}

--- a/pkg/metrics/applicationbackup.go
+++ b/pkg/metrics/applicationbackup.go
@@ -14,27 +14,27 @@ var (
 	backupStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_backup_status",
 		Help: "Status of application backups",
-	}, []string{MetricName, MetricNamespace, MetricSchedule}) // annotation to figure out schedule
+	}, []string{metricName, metricNamespace, MetricSchedule}) // annotation to figure out schedule
 	// BackupStageCounter for application backup CR stages on server
 	backupStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_backup_stage",
 		Help: "Stage of application backups",
-	}, []string{MetricName, MetricNamespace, MetricSchedule})
+	}, []string{metricName, metricNamespace, MetricSchedule})
 	// BackupDurationCounter for time taken by application backup to complete
 	backupDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_backup_duration",
 		Help: "Duration of application backups",
-	}, []string{MetricName, MetricNamespace, MetricSchedule})
+	}, []string{metricName, metricNamespace, MetricSchedule})
 	// BackupSizeCounter for application backup size
 	backupSizeCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_backup_size",
 		Help: "Size of application backups",
-	}, []string{MetricName, MetricNamespace, MetricSchedule})
+	}, []string{metricName, metricNamespace, MetricSchedule})
 )
 
 var (
-	// BackupStatus map of application backup status to enum
-	BackupStatus = map[stork_api.ApplicationBackupStatusType]float64{
+	// backupStatus map of application backup status to enum
+	backupStatus = map[stork_api.ApplicationBackupStatusType]float64{
 		stork_api.ApplicationBackupStatusInitial:        0,
 		stork_api.ApplicationBackupStatusPending:        1,
 		stork_api.ApplicationBackupStatusInProgress:     2,
@@ -42,8 +42,8 @@ var (
 		stork_api.ApplicationBackupStatusPartialSuccess: 4,
 		stork_api.ApplicationBackupStatusSuccessful:     5,
 	}
-	// BackupStage map of application backup stage to enum
-	BackupStage = map[stork_api.ApplicationBackupStageType]float64{
+	// backupStage map of application backup stage to enum
+	backupStage = map[stork_api.ApplicationBackupStageType]float64{
 		stork_api.ApplicationBackupStageInitial:      0,
 		stork_api.ApplicationBackupStagePreExecRule:  1,
 		stork_api.ApplicationBackupStagePostExecRule: 2,
@@ -60,8 +60,8 @@ func watchBackupCR(object runtime.Object) error {
 		return err
 	}
 	labels := make(prometheus.Labels)
-	labels[MetricName] = backup.Name
-	labels[MetricNamespace] = backup.Namespace
+	labels[metricName] = backup.Name
+	labels[metricNamespace] = backup.Namespace
 	labels[MetricSchedule] = backup.Annotations[app_backup.ApplicationBackupScheduleNameAnnotation]
 	if backup.DeletionTimestamp != nil {
 		backupStatusCounter.Delete(labels)
@@ -71,9 +71,9 @@ func watchBackupCR(object runtime.Object) error {
 		return nil
 	}
 	// Set Backup Status counter
-	backupStatusCounter.With(labels).Set(BackupStatus[backup.Status.Status])
+	backupStatusCounter.With(labels).Set(backupStatus[backup.Status.Status])
 	// Set Backup Stage Counter
-	backupStageCounter.With(labels).Set(BackupStage[backup.Status.Stage])
+	backupStageCounter.With(labels).Set(backupStage[backup.Status.Stage])
 	if backup.Status.Stage == stork_api.ApplicationBackupStageFinal && (backup.Status.Status == stork_api.ApplicationBackupStatusSuccessful ||
 		backup.Status.Status == stork_api.ApplicationBackupStatusPartialSuccess ||
 		backup.Status.Status == stork_api.ApplicationBackupStatusFailed) {

--- a/pkg/metrics/applicationbackup_test.go
+++ b/pkg/metrics/applicationbackup_test.go
@@ -45,9 +45,9 @@ func TestBackupSuccessMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// InProgress
-	require.Equal(t, float64(BackupStatus[storkv1.ApplicationBackupStatusInProgress]), testutil.ToFloat64(backupStatusCounter), "application_backup_status does not matched")
+	require.Equal(t, float64(backupStatus[storkv1.ApplicationBackupStatusInProgress]), testutil.ToFloat64(backupStatusCounter), "application_backup_status does not matched")
 	// Volume
-	require.Equal(t, float64(BackupStage[storkv1.ApplicationBackupStageVolumes]), testutil.ToFloat64(backupStageCounter), "application_backup_stage does not matched")
+	require.Equal(t, float64(backupStage[storkv1.ApplicationBackupStageVolumes]), testutil.ToFloat64(backupStageCounter), "application_backup_stage does not matched")
 
 	resp.Status.Stage = storkv1.ApplicationBackupStageFinal
 	resp.Status.Status = storkv1.ApplicationBackupStatusSuccessful
@@ -56,9 +56,9 @@ func TestBackupSuccessMetrics(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(3 * time.Second)
 	// Successful
-	require.Equal(t, float64(BackupStatus[storkv1.ApplicationBackupStatusSuccessful]), testutil.ToFloat64(backupStatusCounter), "application_backup_status does not matched")
+	require.Equal(t, float64(backupStatus[storkv1.ApplicationBackupStatusSuccessful]), testutil.ToFloat64(backupStatusCounter), "application_backup_status does not matched")
 	// Final
-	require.Equal(t, float64(BackupStage[storkv1.ApplicationBackupStageFinal]), testutil.ToFloat64(backupStageCounter), "application_backup_stage does not matched")
+	require.Equal(t, float64(backupStage[storkv1.ApplicationBackupStageFinal]), testutil.ToFloat64(backupStageCounter), "application_backup_stage does not matched")
 	// Size
 	require.Equal(t, float64(1024), testutil.ToFloat64(backupSizeCounter), "application_backup_size does not matched")
 
@@ -73,12 +73,12 @@ func TestBackupFailureMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	labels := make(prometheus.Labels)
-	labels[MetricName] = "test"
-	labels[MetricNamespace] = "test-fail"
+	labels[metricName] = "test"
+	labels[metricNamespace] = "test-fail"
 	labels[MetricSchedule] = ""
 
 	// Failure
-	require.Equal(t, float64(BackupStatus[storkv1.ApplicationBackupStatusFailed]), testutil.ToFloat64(backupStatusCounter.With(labels)), "application_backup_status does not matched")
+	require.Equal(t, float64(backupStatus[storkv1.ApplicationBackupStatusFailed]), testutil.ToFloat64(backupStatusCounter.With(labels)), "application_backup_status does not matched")
 	// Initial
-	require.Equal(t, float64(BackupStage[storkv1.ApplicationBackupStageInitial]), testutil.ToFloat64(backupStageCounter.With(labels)), "application_backup_stage does not matched")
+	require.Equal(t, float64(backupStage[storkv1.ApplicationBackupStageInitial]), testutil.ToFloat64(backupStageCounter.With(labels)), "application_backup_stage does not matched")
 }

--- a/pkg/metrics/applicationbackup_test.go
+++ b/pkg/metrics/applicationbackup_test.go
@@ -1,0 +1,84 @@
+// +build unittest
+
+package metrics
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s/stork"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func createApplicationBackup(name, ns string, status storkv1.ApplicationBackupStatusType, stage storkv1.ApplicationBackupStageType, vol, app int) (*storkv1.ApplicationBackup, error) {
+	backup := &storkv1.ApplicationBackup{}
+	backup.Name = name
+	backup.Namespace = ns
+	resp, err := stork.Instance().CreateApplicationBackup(backup)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < vol; i++ {
+		vol := &storkv1.ApplicationBackupVolumeInfo{
+			Volume:                "vol" + strconv.Itoa(i+1),
+			PersistentVolumeClaim: "pvc" + strconv.Itoa(i+1),
+		}
+		resp.Status.Stage = stage
+		resp.Status.Status = status
+		resp.Status.Volumes = append(backup.Status.Volumes, vol)
+	}
+	updated, err := stork.Instance().UpdateApplicationBackup(resp)
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func TestBackupSuccessMetrics(t *testing.T) {
+	defer resetTest()
+	resp, err := createApplicationBackup("test", "test", storkv1.ApplicationBackupStatusInProgress, storkv1.ApplicationBackupStageVolumes, 2, 2)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	// InProgress
+	require.Equal(t, float64(BackupStatus[storkv1.ApplicationBackupStatusInProgress]), testutil.ToFloat64(backupStatusCounter), "application_backup_status does not matched")
+	// Volume
+	require.Equal(t, float64(BackupStage[storkv1.ApplicationBackupStageVolumes]), testutil.ToFloat64(backupStageCounter), "application_backup_stage does not matched")
+
+	resp.Status.Stage = storkv1.ApplicationBackupStageFinal
+	resp.Status.Status = storkv1.ApplicationBackupStatusSuccessful
+	resp.Status.TotalSize = 1024
+	_, err = stork.Instance().UpdateApplicationBackup(resp)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+	// Successful
+	require.Equal(t, float64(BackupStatus[storkv1.ApplicationBackupStatusSuccessful]), testutil.ToFloat64(backupStatusCounter), "application_backup_status does not matched")
+	// Final
+	require.Equal(t, float64(BackupStage[storkv1.ApplicationBackupStageFinal]), testutil.ToFloat64(backupStageCounter), "application_backup_stage does not matched")
+	// Size
+	require.Equal(t, float64(1024), testutil.ToFloat64(backupSizeCounter), "application_backup_size does not matched")
+
+	err = stork.Instance().DeleteApplicationBackup("test", "test")
+	require.NoError(t, err)
+}
+
+func TestBackupFailureMetrics(t *testing.T) {
+	defer resetTest()
+	_, err := createApplicationBackup("test", "test-fail", storkv1.ApplicationBackupStatusFailed, storkv1.ApplicationBackupStageInitial, 2, 2)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	labels := make(prometheus.Labels)
+	labels[MetricName] = "test"
+	labels[MetricNamespace] = "test-fail"
+	labels[MetricSchedule] = ""
+
+	// Failure
+	require.Equal(t, float64(BackupStatus[storkv1.ApplicationBackupStatusFailed]), testutil.ToFloat64(backupStatusCounter.With(labels)), "application_backup_status does not matched")
+	// Initial
+	require.Equal(t, float64(BackupStage[storkv1.ApplicationBackupStageInitial]), testutil.ToFloat64(backupStageCounter.With(labels)), "application_backup_stage does not matched")
+}

--- a/pkg/metrics/applicationclone.go
+++ b/pkg/metrics/applicationclone.go
@@ -1,0 +1,87 @@
+package metrics
+
+import (
+	"fmt"
+
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	// CloneStatusCounter for application clone CR status on server
+	cloneStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_clone_status",
+		Help: "Status of application clones",
+	}, []string{MetricName, MetricNamespace})
+	// CloneStageCounter for application clone CR stages on server
+	cloneStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_clone_stage",
+		Help: "Stage of application clones",
+	}, []string{MetricName, MetricNamespace})
+	// CloneDurationCounter for time taken by application clone to complete
+	cloneDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_clone_duration",
+		Help: "Duration of application clones",
+	}, []string{MetricName, MetricNamespace})
+)
+
+var (
+	// CloneStatus map of application clone status to enum
+	CloneStatus = map[stork_api.ApplicationCloneStatusType]float64{
+		stork_api.ApplicationCloneStatusInitial:        0,
+		stork_api.ApplicationCloneStatusPending:        1,
+		stork_api.ApplicationCloneStatusInProgress:     2,
+		stork_api.ApplicationCloneStatusFailed:         3,
+		stork_api.ApplicationCloneStatusSuccessful:     4,
+		stork_api.ApplicationCloneStatusRetained:       5,
+		stork_api.ApplicationCloneStatusPartialSuccess: 6,
+	}
+
+	// CloneStage map of application clone stage to enum
+	CloneStage = map[stork_api.ApplicationCloneStageType]float64{
+		stork_api.ApplicationCloneStageInitial:      0,
+		stork_api.ApplicationCloneStagePreExecRule:  1,
+		stork_api.ApplicationCloneStagePostExecRule: 2,
+		stork_api.ApplicationCloneStageVolumes:      3,
+		stork_api.ApplicationCloneStageApplications: 4,
+		stork_api.ApplicationCloneStageFinal:        5,
+	}
+)
+
+func watchCloneCR(object runtime.Object) error {
+	clone, ok := object.(*stork_api.ApplicationClone)
+	if !ok {
+		err := fmt.Errorf("invalid object type on clone watch: %v", object)
+		return err
+	}
+	labels := make(prometheus.Labels)
+	labels[MetricName] = clone.Name
+	labels[MetricNamespace] = clone.Namespace
+	if clone.DeletionTimestamp != nil {
+		cloneStatusCounter.Delete(labels)
+		cloneStageCounter.Delete(labels)
+		cloneDurationCounter.Delete(labels)
+		return nil
+	}
+	// Set Clone Status counter
+	cloneStatusCounter.With(labels).Set(CloneStatus[clone.Status.Status])
+	// Set Clone Stage Counter
+	cloneStageCounter.With(labels).Set(CloneStage[clone.Status.Stage])
+	if clone.Status.Stage == stork_api.ApplicationCloneStageFinal && (clone.Status.Status == stork_api.ApplicationCloneStatusSuccessful ||
+		clone.Status.Status == stork_api.ApplicationCloneStatusPartialSuccess ||
+		clone.Status.Status == stork_api.ApplicationCloneStatusFailed) {
+		st := clone.CreationTimestamp.Unix()
+		et := clone.Status.FinishTimestamp.Unix()
+		// Set Clone Duration
+		cloneDurationCounter.With(labels).Set(float64(et - st))
+	}
+
+	return nil
+}
+
+func init() {
+	prometheus.MustRegister(cloneStatusCounter)
+	prometheus.MustRegister(cloneStageCounter)
+	prometheus.MustRegister(cloneDurationCounter)
+}

--- a/pkg/metrics/applicationclone.go
+++ b/pkg/metrics/applicationclone.go
@@ -13,22 +13,22 @@ var (
 	cloneStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_clone_status",
 		Help: "Status of application clones",
-	}, []string{MetricName, MetricNamespace})
+	}, []string{metricName, metricNamespace})
 	// CloneStageCounter for application clone CR stages on server
 	cloneStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_clone_stage",
 		Help: "Stage of application clones",
-	}, []string{MetricName, MetricNamespace})
+	}, []string{metricName, metricNamespace})
 	// CloneDurationCounter for time taken by application clone to complete
 	cloneDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_clone_duration",
 		Help: "Duration of application clones",
-	}, []string{MetricName, MetricNamespace})
+	}, []string{metricName, metricNamespace})
 )
 
 var (
-	// CloneStatus map of application clone status to enum
-	CloneStatus = map[stork_api.ApplicationCloneStatusType]float64{
+	// cloneStatus map of application clone status to enum
+	cloneStatus = map[stork_api.ApplicationCloneStatusType]float64{
 		stork_api.ApplicationCloneStatusInitial:        0,
 		stork_api.ApplicationCloneStatusPending:        1,
 		stork_api.ApplicationCloneStatusInProgress:     2,
@@ -38,8 +38,8 @@ var (
 		stork_api.ApplicationCloneStatusPartialSuccess: 6,
 	}
 
-	// CloneStage map of application clone stage to enum
-	CloneStage = map[stork_api.ApplicationCloneStageType]float64{
+	// cloneStage map of application clone stage to enum
+	cloneStage = map[stork_api.ApplicationCloneStageType]float64{
 		stork_api.ApplicationCloneStageInitial:      0,
 		stork_api.ApplicationCloneStagePreExecRule:  1,
 		stork_api.ApplicationCloneStagePostExecRule: 2,
@@ -56,8 +56,8 @@ func watchCloneCR(object runtime.Object) error {
 		return err
 	}
 	labels := make(prometheus.Labels)
-	labels[MetricName] = clone.Name
-	labels[MetricNamespace] = clone.Namespace
+	labels[metricName] = clone.Name
+	labels[metricNamespace] = clone.Namespace
 	if clone.DeletionTimestamp != nil {
 		cloneStatusCounter.Delete(labels)
 		cloneStageCounter.Delete(labels)
@@ -65,9 +65,9 @@ func watchCloneCR(object runtime.Object) error {
 		return nil
 	}
 	// Set Clone Status counter
-	cloneStatusCounter.With(labels).Set(CloneStatus[clone.Status.Status])
+	cloneStatusCounter.With(labels).Set(cloneStatus[clone.Status.Status])
 	// Set Clone Stage Counter
-	cloneStageCounter.With(labels).Set(CloneStage[clone.Status.Stage])
+	cloneStageCounter.With(labels).Set(cloneStage[clone.Status.Stage])
 	if clone.Status.Stage == stork_api.ApplicationCloneStageFinal && (clone.Status.Status == stork_api.ApplicationCloneStatusSuccessful ||
 		clone.Status.Status == stork_api.ApplicationCloneStatusPartialSuccess ||
 		clone.Status.Status == stork_api.ApplicationCloneStatusFailed) {

--- a/pkg/metrics/applicationclone_test.go
+++ b/pkg/metrics/applicationclone_test.go
@@ -1,0 +1,80 @@
+// +build unittest
+
+package metrics
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s/stork"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func createApplicationClone(name, ns string, status storkv1.ApplicationCloneStatusType, stage storkv1.ApplicationCloneStageType, vol, app int) (*storkv1.ApplicationClone, error) {
+	clone := &storkv1.ApplicationClone{}
+	clone.Name = name
+	clone.Namespace = ns
+	resp, err := stork.Instance().CreateApplicationClone(clone)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < vol; i++ {
+		vol := &storkv1.ApplicationCloneVolumeInfo{
+			Volume:                "vol" + strconv.Itoa(i+1),
+			PersistentVolumeClaim: "pvc" + strconv.Itoa(i+1),
+		}
+		resp.Status.Stage = stage
+		resp.Status.Status = status
+		resp.Status.Volumes = append(clone.Status.Volumes, vol)
+	}
+	updated, err := stork.Instance().UpdateApplicationClone(resp)
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func TestCloneSuccessMetrics(t *testing.T) {
+	defer resetTest()
+	resp, err := createApplicationClone("test", "test", storkv1.ApplicationCloneStatusInProgress, storkv1.ApplicationCloneStageVolumes, 2, 2)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	// InProgress
+	require.Equal(t, float64(CloneStatus[storkv1.ApplicationCloneStatusInProgress]), testutil.ToFloat64(cloneStatusCounter), "application_clone_status does not matched")
+	// Volume
+	require.Equal(t, float64(CloneStage[storkv1.ApplicationCloneStageVolumes]), testutil.ToFloat64(cloneStageCounter), "application_clone_stage does not matched")
+
+	resp.Status.Stage = storkv1.ApplicationCloneStageFinal
+	resp.Status.Status = storkv1.ApplicationCloneStatusSuccessful
+	_, err = stork.Instance().UpdateApplicationClone(resp)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+	// Successful
+	require.Equal(t, float64(CloneStatus[storkv1.ApplicationCloneStatusSuccessful]), testutil.ToFloat64(cloneStatusCounter), "application_clone_status does not matched")
+	// Final
+	require.Equal(t, float64(CloneStage[storkv1.ApplicationCloneStageFinal]), testutil.ToFloat64(cloneStageCounter), "application_clone_stage does not matched")
+
+	err = stork.Instance().DeleteApplicationClone("test", "test")
+	require.NoError(t, err)
+}
+
+func TestCloneFailureMetrics(t *testing.T) {
+	defer resetTest()
+	_, err := createApplicationClone("test", "test-fail", storkv1.ApplicationCloneStatusFailed, storkv1.ApplicationCloneStageInitial, 2, 2)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	labels := make(prometheus.Labels)
+	labels[MetricName] = "test"
+	labels[MetricNamespace] = "test-fail"
+
+	// Failure
+	require.Equal(t, float64(CloneStatus[storkv1.ApplicationCloneStatusFailed]), testutil.ToFloat64(cloneStatusCounter.With(labels)), "application_clone_status does not matched")
+	// Initial
+	require.Equal(t, float64(CloneStage[storkv1.ApplicationCloneStageInitial]), testutil.ToFloat64(cloneStageCounter.With(labels)), "application_clone_stage does not matched")
+}

--- a/pkg/metrics/applicationclone_test.go
+++ b/pkg/metrics/applicationclone_test.go
@@ -45,9 +45,9 @@ func TestCloneSuccessMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// InProgress
-	require.Equal(t, float64(CloneStatus[storkv1.ApplicationCloneStatusInProgress]), testutil.ToFloat64(cloneStatusCounter), "application_clone_status does not matched")
+	require.Equal(t, float64(cloneStatus[storkv1.ApplicationCloneStatusInProgress]), testutil.ToFloat64(cloneStatusCounter), "application_clone_status does not matched")
 	// Volume
-	require.Equal(t, float64(CloneStage[storkv1.ApplicationCloneStageVolumes]), testutil.ToFloat64(cloneStageCounter), "application_clone_stage does not matched")
+	require.Equal(t, float64(cloneStage[storkv1.ApplicationCloneStageVolumes]), testutil.ToFloat64(cloneStageCounter), "application_clone_stage does not matched")
 
 	resp.Status.Stage = storkv1.ApplicationCloneStageFinal
 	resp.Status.Status = storkv1.ApplicationCloneStatusSuccessful
@@ -55,9 +55,9 @@ func TestCloneSuccessMetrics(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(3 * time.Second)
 	// Successful
-	require.Equal(t, float64(CloneStatus[storkv1.ApplicationCloneStatusSuccessful]), testutil.ToFloat64(cloneStatusCounter), "application_clone_status does not matched")
+	require.Equal(t, float64(cloneStatus[storkv1.ApplicationCloneStatusSuccessful]), testutil.ToFloat64(cloneStatusCounter), "application_clone_status does not matched")
 	// Final
-	require.Equal(t, float64(CloneStage[storkv1.ApplicationCloneStageFinal]), testutil.ToFloat64(cloneStageCounter), "application_clone_stage does not matched")
+	require.Equal(t, float64(cloneStage[storkv1.ApplicationCloneStageFinal]), testutil.ToFloat64(cloneStageCounter), "application_clone_stage does not matched")
 
 	err = stork.Instance().DeleteApplicationClone("test", "test")
 	require.NoError(t, err)
@@ -70,11 +70,11 @@ func TestCloneFailureMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	labels := make(prometheus.Labels)
-	labels[MetricName] = "test"
-	labels[MetricNamespace] = "test-fail"
+	labels[metricName] = "test"
+	labels[metricNamespace] = "test-fail"
 
 	// Failure
-	require.Equal(t, float64(CloneStatus[storkv1.ApplicationCloneStatusFailed]), testutil.ToFloat64(cloneStatusCounter.With(labels)), "application_clone_status does not matched")
+	require.Equal(t, float64(cloneStatus[storkv1.ApplicationCloneStatusFailed]), testutil.ToFloat64(cloneStatusCounter.With(labels)), "application_clone_status does not matched")
 	// Initial
-	require.Equal(t, float64(CloneStage[storkv1.ApplicationCloneStageInitial]), testutil.ToFloat64(cloneStageCounter.With(labels)), "application_clone_stage does not matched")
+	require.Equal(t, float64(cloneStage[storkv1.ApplicationCloneStageInitial]), testutil.ToFloat64(cloneStageCounter.With(labels)), "application_clone_stage does not matched")
 }

--- a/pkg/metrics/applicationrestore.go
+++ b/pkg/metrics/applicationrestore.go
@@ -1,0 +1,94 @@
+package metrics
+
+import (
+	"fmt"
+
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	// RestoreStatusCounter for application restore CR status on server
+	restoreStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_restore_status",
+		Help: "Status of application restores",
+	}, []string{MetricName, MetricNamespace})
+	// RestoreStageCounter for application restore CR stages on server
+	restoreStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_restore_stage",
+		Help: "Stage of application restore",
+	}, []string{MetricName, MetricNamespace})
+	// RestoreDurationCounter for time taken by application restore to complete
+	restoreDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_restore_duration",
+		Help: "Duration of application restores",
+	}, []string{MetricName, MetricNamespace})
+	// RestoreSizeCounter for application restore size
+	restoreSizeCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "application_restore_size",
+		Help: "Size of application restores",
+	}, []string{MetricName, MetricNamespace})
+)
+
+var (
+	// RestoreStatus map of application restore status to enum
+	RestoreStatus = map[stork_api.ApplicationRestoreStatusType]float64{
+		stork_api.ApplicationRestoreStatusInitial:        0,
+		stork_api.ApplicationRestoreStatusPending:        1,
+		stork_api.ApplicationRestoreStatusInProgress:     2,
+		stork_api.ApplicationRestoreStatusFailed:         3,
+		stork_api.ApplicationRestoreStatusPartialSuccess: 4,
+		stork_api.ApplicationRestoreStatusRetained:       5,
+		stork_api.ApplicationRestoreStatusSuccessful:     6,
+	}
+
+	// RestoreStage map of application restore stage to enum
+	RestoreStage = map[stork_api.ApplicationRestoreStageType]float64{
+		stork_api.ApplicationRestoreStageInitial:      0,
+		stork_api.ApplicationRestoreStageVolumes:      1,
+		stork_api.ApplicationRestoreStageApplications: 2,
+		stork_api.ApplicationRestoreStageFinal:        3,
+	}
+)
+
+func watchRestoreCR(object runtime.Object) error {
+	restore, ok := object.(*stork_api.ApplicationRestore)
+	if !ok {
+		err := fmt.Errorf("invalid object type on restore watch: %v", object)
+		return err
+	}
+	labels := make(prometheus.Labels)
+	labels[MetricName] = restore.Name
+	labels[MetricNamespace] = restore.Namespace
+	if restore.DeletionTimestamp != nil {
+		restoreStatusCounter.Delete(labels)
+		restoreStageCounter.Delete(labels)
+		restoreDurationCounter.Delete(labels)
+		restoreSizeCounter.Delete(labels)
+		return nil
+	}
+	// Set Restore Status counter
+	restoreStatusCounter.With(labels).Set(RestoreStatus[restore.Status.Status])
+	// Set Restore Stage Counter
+	restoreStageCounter.With(labels).Set(RestoreStage[restore.Status.Stage])
+	if restore.Status.Stage == stork_api.ApplicationRestoreStageFinal && (restore.Status.Status == stork_api.ApplicationRestoreStatusSuccessful ||
+		restore.Status.Status == stork_api.ApplicationRestoreStatusPartialSuccess ||
+		restore.Status.Status == stork_api.ApplicationRestoreStatusFailed) {
+		st := restore.CreationTimestamp.Unix()
+		et := restore.Status.FinishTimestamp.Unix()
+		// Set Restore Duration
+		restoreDurationCounter.With(labels).Set(float64(et - st))
+		// Set Restore Size
+		restoreSizeCounter.With(labels).Set(float64(restore.Status.TotalSize))
+	}
+
+	return nil
+}
+
+func init() {
+	prometheus.MustRegister(restoreStatusCounter)
+	prometheus.MustRegister(restoreStageCounter)
+	prometheus.MustRegister(restoreDurationCounter)
+	prometheus.MustRegister(restoreSizeCounter)
+}

--- a/pkg/metrics/applicationrestore.go
+++ b/pkg/metrics/applicationrestore.go
@@ -13,27 +13,27 @@ var (
 	restoreStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_restore_status",
 		Help: "Status of application restores",
-	}, []string{MetricName, MetricNamespace})
+	}, []string{metricName, metricNamespace})
 	// RestoreStageCounter for application restore CR stages on server
 	restoreStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_restore_stage",
 		Help: "Stage of application restore",
-	}, []string{MetricName, MetricNamespace})
+	}, []string{metricName, metricNamespace})
 	// RestoreDurationCounter for time taken by application restore to complete
 	restoreDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_restore_duration",
 		Help: "Duration of application restores",
-	}, []string{MetricName, MetricNamespace})
+	}, []string{metricName, metricNamespace})
 	// RestoreSizeCounter for application restore size
 	restoreSizeCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_restore_size",
 		Help: "Size of application restores",
-	}, []string{MetricName, MetricNamespace})
+	}, []string{metricName, metricNamespace})
 )
 
 var (
-	// RestoreStatus map of application restore status to enum
-	RestoreStatus = map[stork_api.ApplicationRestoreStatusType]float64{
+	// restoreStatus map of application restore status to enum
+	restoreStatus = map[stork_api.ApplicationRestoreStatusType]float64{
 		stork_api.ApplicationRestoreStatusInitial:        0,
 		stork_api.ApplicationRestoreStatusPending:        1,
 		stork_api.ApplicationRestoreStatusInProgress:     2,
@@ -43,8 +43,8 @@ var (
 		stork_api.ApplicationRestoreStatusSuccessful:     6,
 	}
 
-	// RestoreStage map of application restore stage to enum
-	RestoreStage = map[stork_api.ApplicationRestoreStageType]float64{
+	// restoreStage map of application restore stage to enum
+	restoreStage = map[stork_api.ApplicationRestoreStageType]float64{
 		stork_api.ApplicationRestoreStageInitial:      0,
 		stork_api.ApplicationRestoreStageVolumes:      1,
 		stork_api.ApplicationRestoreStageApplications: 2,
@@ -59,8 +59,8 @@ func watchRestoreCR(object runtime.Object) error {
 		return err
 	}
 	labels := make(prometheus.Labels)
-	labels[MetricName] = restore.Name
-	labels[MetricNamespace] = restore.Namespace
+	labels[metricName] = restore.Name
+	labels[metricNamespace] = restore.Namespace
 	if restore.DeletionTimestamp != nil {
 		restoreStatusCounter.Delete(labels)
 		restoreStageCounter.Delete(labels)
@@ -69,9 +69,9 @@ func watchRestoreCR(object runtime.Object) error {
 		return nil
 	}
 	// Set Restore Status counter
-	restoreStatusCounter.With(labels).Set(RestoreStatus[restore.Status.Status])
+	restoreStatusCounter.With(labels).Set(restoreStatus[restore.Status.Status])
 	// Set Restore Stage Counter
-	restoreStageCounter.With(labels).Set(RestoreStage[restore.Status.Stage])
+	restoreStageCounter.With(labels).Set(restoreStage[restore.Status.Stage])
 	if restore.Status.Stage == stork_api.ApplicationRestoreStageFinal && (restore.Status.Status == stork_api.ApplicationRestoreStatusSuccessful ||
 		restore.Status.Status == stork_api.ApplicationRestoreStatusPartialSuccess ||
 		restore.Status.Status == stork_api.ApplicationRestoreStatusFailed) {

--- a/pkg/metrics/applicationrestore_test.go
+++ b/pkg/metrics/applicationrestore_test.go
@@ -1,0 +1,83 @@
+// +build unittest
+
+package metrics
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s/stork"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func createApplicationRestore(name, ns string, status storkv1.ApplicationRestoreStatusType, stage storkv1.ApplicationRestoreStageType, vol, app int) (*storkv1.ApplicationRestore, error) {
+	restore := &storkv1.ApplicationRestore{}
+	restore.Name = name
+	restore.Namespace = ns
+	resp, err := stork.Instance().CreateApplicationRestore(restore)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < vol; i++ {
+		vol := &storkv1.ApplicationRestoreVolumeInfo{
+			RestoreVolume:         "vol" + strconv.Itoa(i+1),
+			PersistentVolumeClaim: "pvc" + strconv.Itoa(i+1),
+		}
+		resp.Status.Stage = stage
+		resp.Status.Status = status
+		resp.Status.Volumes = append(restore.Status.Volumes, vol)
+	}
+	updated, err := stork.Instance().UpdateApplicationRestore(resp)
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func TestRestoreSuccessMetrics(t *testing.T) {
+	defer resetTest()
+	resp, err := createApplicationRestore("test", "test", storkv1.ApplicationRestoreStatusInProgress, storkv1.ApplicationRestoreStageVolumes, 2, 2)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	// InProgress
+	require.Equal(t, float64(RestoreStatus[storkv1.ApplicationRestoreStatusInProgress]), testutil.ToFloat64(restoreStatusCounter), "application_restore_status does not matched")
+	// Volume
+	require.Equal(t, float64(RestoreStage[storkv1.ApplicationRestoreStageVolumes]), testutil.ToFloat64(restoreStageCounter), "application_restore_stage does not matched")
+
+	resp.Status.Stage = storkv1.ApplicationRestoreStageFinal
+	resp.Status.Status = storkv1.ApplicationRestoreStatusSuccessful
+	resp.Status.TotalSize = 1024
+	_, err = stork.Instance().UpdateApplicationRestore(resp)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+	// Successful
+	require.Equal(t, float64(RestoreStatus[storkv1.ApplicationRestoreStatusSuccessful]), testutil.ToFloat64(restoreStatusCounter), "application_restore_status does not matched")
+	// Final
+	require.Equal(t, float64(RestoreStage[storkv1.ApplicationRestoreStageFinal]), testutil.ToFloat64(restoreStageCounter), "application_restore_stage does not matched")
+	// Size
+	require.Equal(t, float64(1024), testutil.ToFloat64(restoreSizeCounter), "application_restore_size does not matched")
+
+	err = stork.Instance().DeleteApplicationRestore("test", "test")
+	require.NoError(t, err)
+}
+
+func TestRestoreFailureMetrics(t *testing.T) {
+	defer resetTest()
+	_, err := createApplicationRestore("test", "test-fail", storkv1.ApplicationRestoreStatusFailed, storkv1.ApplicationRestoreStageInitial, 2, 2)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	labels := make(prometheus.Labels)
+	labels[MetricName] = "test"
+	labels[MetricNamespace] = "test-fail"
+
+	// Failure
+	require.Equal(t, float64(RestoreStatus[storkv1.ApplicationRestoreStatusFailed]), testutil.ToFloat64(restoreStatusCounter.With(labels)), "application_restore_status does not matched")
+	// Initial
+	require.Equal(t, float64(RestoreStage[storkv1.ApplicationRestoreStageInitial]), testutil.ToFloat64(restoreStageCounter.With(labels)), "application_restore_stage does not matched")
+}

--- a/pkg/metrics/applicationrestore_test.go
+++ b/pkg/metrics/applicationrestore_test.go
@@ -45,9 +45,9 @@ func TestRestoreSuccessMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// InProgress
-	require.Equal(t, float64(RestoreStatus[storkv1.ApplicationRestoreStatusInProgress]), testutil.ToFloat64(restoreStatusCounter), "application_restore_status does not matched")
+	require.Equal(t, float64(restoreStatus[storkv1.ApplicationRestoreStatusInProgress]), testutil.ToFloat64(restoreStatusCounter), "application_restore_status does not matched")
 	// Volume
-	require.Equal(t, float64(RestoreStage[storkv1.ApplicationRestoreStageVolumes]), testutil.ToFloat64(restoreStageCounter), "application_restore_stage does not matched")
+	require.Equal(t, float64(restoreStage[storkv1.ApplicationRestoreStageVolumes]), testutil.ToFloat64(restoreStageCounter), "application_restore_stage does not matched")
 
 	resp.Status.Stage = storkv1.ApplicationRestoreStageFinal
 	resp.Status.Status = storkv1.ApplicationRestoreStatusSuccessful
@@ -56,9 +56,9 @@ func TestRestoreSuccessMetrics(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(3 * time.Second)
 	// Successful
-	require.Equal(t, float64(RestoreStatus[storkv1.ApplicationRestoreStatusSuccessful]), testutil.ToFloat64(restoreStatusCounter), "application_restore_status does not matched")
+	require.Equal(t, float64(restoreStatus[storkv1.ApplicationRestoreStatusSuccessful]), testutil.ToFloat64(restoreStatusCounter), "application_restore_status does not matched")
 	// Final
-	require.Equal(t, float64(RestoreStage[storkv1.ApplicationRestoreStageFinal]), testutil.ToFloat64(restoreStageCounter), "application_restore_stage does not matched")
+	require.Equal(t, float64(restoreStage[storkv1.ApplicationRestoreStageFinal]), testutil.ToFloat64(restoreStageCounter), "application_restore_stage does not matched")
 	// Size
 	require.Equal(t, float64(1024), testutil.ToFloat64(restoreSizeCounter), "application_restore_size does not matched")
 
@@ -73,11 +73,11 @@ func TestRestoreFailureMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	labels := make(prometheus.Labels)
-	labels[MetricName] = "test"
-	labels[MetricNamespace] = "test-fail"
+	labels[metricName] = "test"
+	labels[metricNamespace] = "test-fail"
 
 	// Failure
-	require.Equal(t, float64(RestoreStatus[storkv1.ApplicationRestoreStatusFailed]), testutil.ToFloat64(restoreStatusCounter.With(labels)), "application_restore_status does not matched")
+	require.Equal(t, float64(restoreStatus[storkv1.ApplicationRestoreStatusFailed]), testutil.ToFloat64(restoreStatusCounter.With(labels)), "application_restore_status does not matched")
 	// Initial
-	require.Equal(t, float64(RestoreStage[storkv1.ApplicationRestoreStageInitial]), testutil.ToFloat64(restoreStageCounter.With(labels)), "application_restore_stage does not matched")
+	require.Equal(t, float64(restoreStage[storkv1.ApplicationRestoreStageInitial]), testutil.ToFloat64(restoreStageCounter.With(labels)), "application_restore_stage does not matched")
 }

--- a/pkg/metrics/clusterpair.go
+++ b/pkg/metrics/clusterpair.go
@@ -12,17 +12,17 @@ var (
 	// clusterpairStatusCounter for clusterpair status
 	clusterpairSchedStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "clusterpair_scheduler_status",
-		Help: "Status of clusterpair",
-	}, []string{MetricName, MetricNamespace})
+		Help: "Status of scheduler clusterpair",
+	}, []string{metricName, metricNamespace})
 	clusterpairStorageStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "clusterpair_storage_status",
-		Help: "Status of clusterpair",
-	}, []string{MetricName, MetricNamespace})
+		Help: "Status of storage clusterpair",
+	}, []string{metricName, metricNamespace})
 )
 
 var (
-	// ClusterpairStatus map of clusterpair status
-	ClusterpairStatus = map[stork_api.ClusterPairStatusType]float64{
+	// clusterpairStatus map of clusterpair status
+	clusterpairStatus = map[stork_api.ClusterPairStatusType]float64{
 		stork_api.ClusterPairStatusInitial:     0,
 		stork_api.ClusterPairStatusPending:     1,
 		stork_api.ClusterPairStatusReady:       2,
@@ -40,16 +40,16 @@ func watchclusterpairCR(object runtime.Object) error {
 		return err
 	}
 	labels := make(prometheus.Labels)
-	labels[MetricName] = clusterpair.Name
-	labels[MetricNamespace] = clusterpair.Namespace
+	labels[metricName] = clusterpair.Name
+	labels[metricNamespace] = clusterpair.Namespace
 	if clusterpair.DeletionTimestamp != nil {
 		clusterpairSchedStatusCounter.Delete(labels)
 		clusterpairStorageStatusCounter.Delete(labels)
 		return nil
 	}
 	// Set clusterpair Status counter
-	clusterpairSchedStatusCounter.With(labels).Set(ClusterpairStatus[clusterpair.Status.SchedulerStatus])
-	clusterpairStorageStatusCounter.With(labels).Set(ClusterpairStatus[clusterpair.Status.StorageStatus])
+	clusterpairSchedStatusCounter.With(labels).Set(clusterpairStatus[clusterpair.Status.SchedulerStatus])
+	clusterpairStorageStatusCounter.With(labels).Set(clusterpairStatus[clusterpair.Status.StorageStatus])
 	return nil
 }
 

--- a/pkg/metrics/clusterpair.go
+++ b/pkg/metrics/clusterpair.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"fmt"
+
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	// clusterpairStatusCounter for clusterpair status
+	clusterpairSchedStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "clusterpair_scheduler_status",
+		Help: "Status of clusterpair",
+	}, []string{MetricName, MetricNamespace})
+	clusterpairStorageStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "clusterpair_storage_status",
+		Help: "Status of clusterpair",
+	}, []string{MetricName, MetricNamespace})
+)
+
+var (
+	// ClusterpairStatus map of clusterpair status
+	ClusterpairStatus = map[stork_api.ClusterPairStatusType]float64{
+		stork_api.ClusterPairStatusInitial:     0,
+		stork_api.ClusterPairStatusPending:     1,
+		stork_api.ClusterPairStatusReady:       2,
+		stork_api.ClusterPairStatusError:       3,
+		stork_api.ClusterPairStatusDegraded:    4,
+		stork_api.ClusterPairStatusDeleting:    5,
+		stork_api.ClusterPairStatusNotProvided: 6,
+	}
+)
+
+func watchclusterpairCR(object runtime.Object) error {
+	clusterpair, ok := object.(*stork_api.ClusterPair)
+	if !ok {
+		err := fmt.Errorf("invalid object type on clusterpair watch: %v", object)
+		return err
+	}
+	labels := make(prometheus.Labels)
+	labels[MetricName] = clusterpair.Name
+	labels[MetricNamespace] = clusterpair.Namespace
+	if clusterpair.DeletionTimestamp != nil {
+		clusterpairSchedStatusCounter.Delete(labels)
+		clusterpairStorageStatusCounter.Delete(labels)
+		return nil
+	}
+	// Set clusterpair Status counter
+	clusterpairSchedStatusCounter.With(labels).Set(ClusterpairStatus[clusterpair.Status.SchedulerStatus])
+	clusterpairStorageStatusCounter.With(labels).Set(ClusterpairStatus[clusterpair.Status.StorageStatus])
+	return nil
+}
+
+func init() {
+	prometheus.MustRegister(clusterpairSchedStatusCounter)
+	prometheus.MustRegister(clusterpairStorageStatusCounter)
+}

--- a/pkg/metrics/clusterpair_test.go
+++ b/pkg/metrics/clusterpair_test.go
@@ -1,0 +1,60 @@
+// +build unittest
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s/stork"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func createClusterPair(name, ns string, storage, sched storkv1.ClusterPairStatusType) (*storkv1.ClusterPair, error) {
+	pair := &storkv1.ClusterPair{}
+	pair.Name = name
+	pair.Namespace = ns
+	resp, err := stork.Instance().CreateClusterPair(pair)
+	if err != nil {
+		return nil, err
+	}
+	resp.Status.StorageStatus = storage
+	resp.Status.SchedulerStatus = sched
+	updated, err := stork.Instance().UpdateClusterPair(resp)
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func TestClusterPairSuccessMetrics(t *testing.T) {
+	defer resetTest()
+	_, err := createClusterPair("test", "test", storkv1.ClusterPairStatusReady, storkv1.ClusterPairStatusReady)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	require.Equal(t, float64(ClusterpairStatus[storkv1.ClusterPairStatusReady]), testutil.ToFloat64(clusterpairSchedStatusCounter), "clusterpair_sched_status does not matched")
+	require.Equal(t, float64(ClusterpairStatus[storkv1.ClusterPairStatusReady]), testutil.ToFloat64(clusterpairStorageStatusCounter), "clusterpair_storage_status does not matched")
+
+	err = stork.Instance().DeleteClusterPair("test", "test")
+	require.NoError(t, err)
+}
+
+func TestClusterPairFailureMetrics(t *testing.T) {
+	defer resetTest()
+	_, err := createClusterPair("test", "test-fail", storkv1.ClusterPairStatusDegraded, storkv1.ClusterPairStatusError)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	labels := make(prometheus.Labels)
+	labels[MetricName] = "test"
+	labels[MetricNamespace] = "test-fail"
+	require.Equal(t, float64(ClusterpairStatus[storkv1.ClusterPairStatusError]), testutil.ToFloat64(clusterpairSchedStatusCounter.With(labels)), "clusterpair_sched_status does not matched")
+	require.Equal(t, float64(ClusterpairStatus[storkv1.ClusterPairStatusDegraded]), testutil.ToFloat64(clusterpairStorageStatusCounter.With(labels)), "clusterpair_storage_status does not matched")
+
+	err = stork.Instance().DeleteClusterPair("test", "test-fail")
+	require.NoError(t, err)
+}

--- a/pkg/metrics/clusterpair_test.go
+++ b/pkg/metrics/clusterpair_test.go
@@ -36,8 +36,8 @@ func TestClusterPairSuccessMetrics(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(3 * time.Second)
 
-	require.Equal(t, float64(ClusterpairStatus[storkv1.ClusterPairStatusReady]), testutil.ToFloat64(clusterpairSchedStatusCounter), "clusterpair_sched_status does not matched")
-	require.Equal(t, float64(ClusterpairStatus[storkv1.ClusterPairStatusReady]), testutil.ToFloat64(clusterpairStorageStatusCounter), "clusterpair_storage_status does not matched")
+	require.Equal(t, float64(clusterpairStatus[storkv1.ClusterPairStatusReady]), testutil.ToFloat64(clusterpairSchedStatusCounter), "clusterpair_sched_status does not matched")
+	require.Equal(t, float64(clusterpairStatus[storkv1.ClusterPairStatusReady]), testutil.ToFloat64(clusterpairStorageStatusCounter), "clusterpair_storage_status does not matched")
 
 	err = stork.Instance().DeleteClusterPair("test", "test")
 	require.NoError(t, err)
@@ -50,10 +50,10 @@ func TestClusterPairFailureMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	labels := make(prometheus.Labels)
-	labels[MetricName] = "test"
-	labels[MetricNamespace] = "test-fail"
-	require.Equal(t, float64(ClusterpairStatus[storkv1.ClusterPairStatusError]), testutil.ToFloat64(clusterpairSchedStatusCounter.With(labels)), "clusterpair_sched_status does not matched")
-	require.Equal(t, float64(ClusterpairStatus[storkv1.ClusterPairStatusDegraded]), testutil.ToFloat64(clusterpairStorageStatusCounter.With(labels)), "clusterpair_storage_status does not matched")
+	labels[metricName] = "test"
+	labels[metricNamespace] = "test-fail"
+	require.Equal(t, float64(clusterpairStatus[storkv1.ClusterPairStatusError]), testutil.ToFloat64(clusterpairSchedStatusCounter.With(labels)), "clusterpair_sched_status does not matched")
+	require.Equal(t, float64(clusterpairStatus[storkv1.ClusterPairStatusDegraded]), testutil.ToFloat64(clusterpairStorageStatusCounter.With(labels)), "clusterpair_storage_status does not matched")
 
 	err = stork.Instance().DeleteClusterPair("test", "test-fail")
 	require.NoError(t, err)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// MetricName for stork prometheus metrics
+	MetricName = "name"
+	// MetricNamespace for stork prometheus metrics
+	MetricNamespace = "namespace"
+	// MetricSchedule for stork prometheus metrics
+	MetricSchedule = "schedule"
+)
+
+func StartMetrics() error {
+	if err := storkops.Instance().WatchApplicationBackup("", watchBackupCR, metav1.ListOptions{}); err != nil {
+		logrus.Errorf("failed to watch applicationbackups due to: %v", err)
+		return err
+	}
+	if err := storkops.Instance().WatchApplicationRestore("", watchRestoreCR, metav1.ListOptions{}); err != nil {
+		logrus.Errorf("failed to watch applicationrestores due to: %v", err)
+		return err
+	}
+	if err := storkops.Instance().WatchApplicationClone("", watchCloneCR, metav1.ListOptions{}); err != nil {
+		logrus.Errorf("failed to watch applicationclones due to: %v", err)
+		return err
+	}
+	if err := storkops.Instance().WatchClusterPair("", watchclusterpairCR, metav1.ListOptions{}); err != nil {
+		logrus.Errorf("failed to watch clusterpair due to: %v", err)
+		return err
+	}
+	if err := storkops.Instance().WatchMigration("", watchmigrationCR, metav1.ListOptions{}); err != nil {
+		logrus.Errorf("failed to watch migration due to: %v", err)
+		return err
+	}
+	return nil
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -7,14 +7,15 @@ import (
 )
 
 const (
-	// MetricName for stork prometheus metrics
-	MetricName = "name"
-	// MetricNamespace for stork prometheus metrics
-	MetricNamespace = "namespace"
+	// metricName for stork prometheus metrics
+	metricName = "name"
+	// metricNamespace for stork prometheus metrics
+	metricNamespace = "namespace"
 	// MetricSchedule for stork prometheus metrics
 	MetricSchedule = "schedule"
 )
 
+// StartMetrics watch over stork controllers to collect metrics
 func StartMetrics() error {
 	if err := storkops.Instance().WatchApplicationBackup("", watchBackupCR, metav1.ListOptions{}); err != nil {
 		logrus.Errorf("failed to watch applicationbackups due to: %v", err)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,53 @@
+// +build unittest
+
+package metrics
+
+import (
+	"fmt"
+	"os"
+
+	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
+	v1alpha1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	fakeclient "github.com/libopenstorage/stork/pkg/client/clientset/versioned/fake"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/cli-runtime/pkg/resource"
+	kubernetes "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest/fake"
+	v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+)
+
+var codec runtime.Codec
+var fakeRestClient *fake.RESTClient
+var unstructuredSerializer = resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer
+
+func init() {
+	resetTest()
+}
+
+func resetTest() {
+	scheme := runtime.NewScheme()
+	if err := snapv1.AddToScheme(scheme); err != nil {
+		fmt.Printf("Error updating scheme: %v", err)
+		os.Exit(1)
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		fmt.Printf("Error updating scheme: %v", err)
+		os.Exit(1)
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		fmt.Printf("Error updating scheme: %v", err)
+		os.Exit(1)
+	}
+	codec = serializer.NewCodecFactory(scheme).LegacyCodec(scheme.PrioritizedVersionsAllGroups()...)
+	fakeStorkClient := fakeclient.NewSimpleClientset()
+	fakeRestClient = &fake.RESTClient{
+		NegotiatedSerializer: unstructuredSerializer,
+	}
+
+	fakeKubeClient := kubernetes.NewSimpleClientset()
+
+	storkops.SetInstance(storkops.New(fakeKubeClient, fakeStorkClient, fakeRestClient))
+	StartMetrics()
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -49,5 +49,8 @@ func resetTest() {
 	fakeKubeClient := kubernetes.NewSimpleClientset()
 
 	storkops.SetInstance(storkops.New(fakeKubeClient, fakeStorkClient, fakeRestClient))
-	StartMetrics()
+	if err := StartMetrics(); err != nil {
+		fmt.Printf("Error starting metrics: %v", err)
+		os.Exit(1)
+	}
 }

--- a/pkg/metrics/migration.go
+++ b/pkg/metrics/migration.go
@@ -13,22 +13,22 @@ var (
 	migrationStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "migration_status",
 		Help: "Status of migration",
-	}, []string{MetricName, MetricNamespace, MetricSchedule})
+	}, []string{metricName, metricNamespace, MetricSchedule})
 	// migrationStageCounter for migration CR stages on server
 	migrationStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "migration_stage",
 		Help: "Stage of migration",
-	}, []string{MetricName, MetricNamespace, MetricSchedule})
+	}, []string{metricName, metricNamespace, MetricSchedule})
 	// migrationDurationCounter for time taken by migration to complete
 	migrationDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "migration_duration",
 		Help: "Duration of migrations",
-	}, []string{MetricName, MetricNamespace, MetricSchedule})
+	}, []string{metricName, metricNamespace, MetricSchedule})
 )
 
 var (
-	// MigrationStatus map of application migration status to enum
-	MigrationStatus = map[stork_api.MigrationStatusType]float64{
+	// migrationStatus map of application migration status to enum
+	migrationStatus = map[stork_api.MigrationStatusType]float64{
 		stork_api.MigrationStatusInitial:        0,
 		stork_api.MigrationStatusPending:        1,
 		stork_api.MigrationStatusInProgress:     2,
@@ -38,8 +38,8 @@ var (
 		stork_api.MigrationStatusPurged:         6,
 	}
 
-	// MigrationStage map of application migration stage to enum
-	MigrationStage = map[stork_api.MigrationStageType]float64{
+	// migrationStage map of application migration stage to enum
+	migrationStage = map[stork_api.MigrationStageType]float64{
 		stork_api.MigrationStageInitial:      0,
 		stork_api.MigrationStagePreExecRule:  1,
 		stork_api.MigrationStagePostExecRule: 2,
@@ -56,8 +56,8 @@ func watchmigrationCR(object runtime.Object) error {
 		return err
 	}
 	labels := make(prometheus.Labels)
-	labels[MetricName] = migration.Name
-	labels[MetricNamespace] = migration.Namespace
+	labels[metricName] = migration.Name
+	labels[metricNamespace] = migration.Namespace
 	sched := ""
 	for _, v := range migration.OwnerReferences {
 		sched = v.Name
@@ -71,9 +71,9 @@ func watchmigrationCR(object runtime.Object) error {
 		return nil
 	}
 	// Set migration Status counter
-	migrationStatusCounter.With(labels).Set(MigrationStatus[migration.Status.Status])
+	migrationStatusCounter.With(labels).Set(migrationStatus[migration.Status.Status])
 	// Set migration Stage Counter
-	migrationStageCounter.With(labels).Set(MigrationStage[migration.Status.Stage])
+	migrationStageCounter.With(labels).Set(migrationStage[migration.Status.Stage])
 	if migration.Status.Stage == stork_api.MigrationStageFinal && (migration.Status.Status == stork_api.MigrationStatusSuccessful ||
 		migration.Status.Status == stork_api.MigrationStatusPartialSuccess ||
 		migration.Status.Status == stork_api.MigrationStatusFailed) {

--- a/pkg/metrics/migration.go
+++ b/pkg/metrics/migration.go
@@ -1,0 +1,93 @@
+package metrics
+
+import (
+	"fmt"
+
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	// migrationStatusCounter for migration status
+	migrationStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "migration_status",
+		Help: "Status of migration",
+	}, []string{MetricName, MetricNamespace, MetricSchedule})
+	// migrationStageCounter for migration CR stages on server
+	migrationStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "migration_stage",
+		Help: "Stage of migration",
+	}, []string{MetricName, MetricNamespace, MetricSchedule})
+	// migrationDurationCounter for time taken by migration to complete
+	migrationDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "migration_duration",
+		Help: "Duration of migrations",
+	}, []string{MetricName, MetricNamespace, MetricSchedule})
+)
+
+var (
+	// MigrationStatus map of application migration status to enum
+	MigrationStatus = map[stork_api.MigrationStatusType]float64{
+		stork_api.MigrationStatusInitial:        0,
+		stork_api.MigrationStatusPending:        1,
+		stork_api.MigrationStatusInProgress:     2,
+		stork_api.MigrationStatusFailed:         3,
+		stork_api.MigrationStatusPartialSuccess: 4,
+		stork_api.MigrationStatusSuccessful:     5,
+		stork_api.MigrationStatusPurged:         6,
+	}
+
+	// MigrationStage map of application migration stage to enum
+	MigrationStage = map[stork_api.MigrationStageType]float64{
+		stork_api.MigrationStageInitial:      0,
+		stork_api.MigrationStagePreExecRule:  1,
+		stork_api.MigrationStagePostExecRule: 2,
+		stork_api.MigrationStageVolumes:      3,
+		stork_api.MigrationStageApplications: 4,
+		stork_api.MigrationStageFinal:        5,
+	}
+)
+
+func watchmigrationCR(object runtime.Object) error {
+	migration, ok := object.(*stork_api.Migration)
+	if !ok {
+		err := fmt.Errorf("invalid object type on migration watch: %v", object)
+		return err
+	}
+	labels := make(prometheus.Labels)
+	labels[MetricName] = migration.Name
+	labels[MetricNamespace] = migration.Namespace
+	sched := ""
+	for _, v := range migration.OwnerReferences {
+		sched = v.Name
+	}
+	labels[MetricSchedule] = sched
+
+	if migration.DeletionTimestamp != nil {
+		migrationStatusCounter.Delete(labels)
+		migrationStageCounter.Delete(labels)
+		migrationDurationCounter.Delete(labels)
+		return nil
+	}
+	// Set migration Status counter
+	migrationStatusCounter.With(labels).Set(MigrationStatus[migration.Status.Status])
+	// Set migration Stage Counter
+	migrationStageCounter.With(labels).Set(MigrationStage[migration.Status.Stage])
+	if migration.Status.Stage == stork_api.MigrationStageFinal && (migration.Status.Status == stork_api.MigrationStatusSuccessful ||
+		migration.Status.Status == stork_api.MigrationStatusPartialSuccess ||
+		migration.Status.Status == stork_api.MigrationStatusFailed) {
+		st := migration.CreationTimestamp.Unix()
+		et := migration.Status.FinishTimestamp.Unix()
+		// Set migration Duration
+		migrationDurationCounter.With(labels).Set(float64(et - st))
+	}
+
+	return nil
+}
+
+func init() {
+	prometheus.MustRegister(migrationStatusCounter)
+	prometheus.MustRegister(migrationStageCounter)
+	prometheus.MustRegister(migrationDurationCounter)
+}

--- a/pkg/metrics/migration_test.go
+++ b/pkg/metrics/migration_test.go
@@ -1,0 +1,81 @@
+// +build unittest
+
+package metrics
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s/stork"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func createMigration(name, ns string, status storkv1.MigrationStatusType, stage storkv1.MigrationStageType, vol, app int) (*storkv1.Migration, error) {
+	migration := &storkv1.Migration{}
+	migration.Name = name
+	migration.Namespace = ns
+	resp, err := stork.Instance().CreateMigration(migration)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < vol; i++ {
+		vol := &storkv1.MigrationVolumeInfo{
+			Volume:                "vol" + strconv.Itoa(i+1),
+			PersistentVolumeClaim: "pvc" + strconv.Itoa(i+1),
+		}
+		resp.Status.Stage = stage
+		resp.Status.Status = status
+		resp.Status.Volumes = append(migration.Status.Volumes, vol)
+	}
+	updated, err := stork.Instance().UpdateMigration(resp)
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func TestMigrationSuccessMetrics(t *testing.T) {
+	defer resetTest()
+	resp, err := createMigration("test", "test", storkv1.MigrationStatusInProgress, storkv1.MigrationStageVolumes, 2, 2)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	// InProgress
+	require.Equal(t, float64(MigrationStatus[storkv1.MigrationStatusInProgress]), testutil.ToFloat64(migrationStatusCounter), "migration_status does not matched")
+	// Volume
+	require.Equal(t, float64(MigrationStage[storkv1.MigrationStageVolumes]), testutil.ToFloat64(migrationStageCounter), "migration_stage does not matched")
+
+	resp.Status.Stage = storkv1.MigrationStageFinal
+	resp.Status.Status = storkv1.MigrationStatusSuccessful
+	_, err = stork.Instance().UpdateMigration(resp)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+	// Successful
+	require.Equal(t, float64(MigrationStatus[storkv1.MigrationStatusSuccessful]), testutil.ToFloat64(migrationStatusCounter), "migration_status does not matched")
+	// Final
+	require.Equal(t, float64(MigrationStage[storkv1.MigrationStageFinal]), testutil.ToFloat64(migrationStageCounter), "migration_stage does not matched")
+
+	err = stork.Instance().DeleteMigration("test", "test")
+	require.NoError(t, err)
+}
+
+func TestMigrationFailureMetrics(t *testing.T) {
+	defer resetTest()
+	_, err := createMigration("test", "test-fail", storkv1.MigrationStatusFailed, storkv1.MigrationStageInitial, 2, 2)
+	require.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	labels := make(prometheus.Labels)
+	labels[MetricName] = "test"
+	labels[MetricNamespace] = "test-fail"
+	labels[MetricSchedule] = ""
+
+	// Failure
+	require.Equal(t, float64(MigrationStatus[storkv1.MigrationStatusFailed]), testutil.ToFloat64(migrationStatusCounter.With(labels)), "migration_status does not matched")
+	// Initial
+	require.Equal(t, float64(MigrationStage[storkv1.MigrationStageInitial]), testutil.ToFloat64(migrationStageCounter.With(labels)), "migration_stage does not matched")
+}

--- a/pkg/metrics/migration_test.go
+++ b/pkg/metrics/migration_test.go
@@ -45,9 +45,9 @@ func TestMigrationSuccessMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// InProgress
-	require.Equal(t, float64(MigrationStatus[storkv1.MigrationStatusInProgress]), testutil.ToFloat64(migrationStatusCounter), "migration_status does not matched")
+	require.Equal(t, float64(migrationStatus[storkv1.MigrationStatusInProgress]), testutil.ToFloat64(migrationStatusCounter), "migration_status does not matched")
 	// Volume
-	require.Equal(t, float64(MigrationStage[storkv1.MigrationStageVolumes]), testutil.ToFloat64(migrationStageCounter), "migration_stage does not matched")
+	require.Equal(t, float64(migrationStage[storkv1.MigrationStageVolumes]), testutil.ToFloat64(migrationStageCounter), "migration_stage does not matched")
 
 	resp.Status.Stage = storkv1.MigrationStageFinal
 	resp.Status.Status = storkv1.MigrationStatusSuccessful
@@ -55,9 +55,9 @@ func TestMigrationSuccessMetrics(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(3 * time.Second)
 	// Successful
-	require.Equal(t, float64(MigrationStatus[storkv1.MigrationStatusSuccessful]), testutil.ToFloat64(migrationStatusCounter), "migration_status does not matched")
+	require.Equal(t, float64(migrationStatus[storkv1.MigrationStatusSuccessful]), testutil.ToFloat64(migrationStatusCounter), "migration_status does not matched")
 	// Final
-	require.Equal(t, float64(MigrationStage[storkv1.MigrationStageFinal]), testutil.ToFloat64(migrationStageCounter), "migration_stage does not matched")
+	require.Equal(t, float64(migrationStage[storkv1.MigrationStageFinal]), testutil.ToFloat64(migrationStageCounter), "migration_stage does not matched")
 
 	err = stork.Instance().DeleteMigration("test", "test")
 	require.NoError(t, err)
@@ -70,12 +70,12 @@ func TestMigrationFailureMetrics(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	labels := make(prometheus.Labels)
-	labels[MetricName] = "test"
-	labels[MetricNamespace] = "test-fail"
+	labels[metricName] = "test"
+	labels[metricNamespace] = "test-fail"
 	labels[MetricSchedule] = ""
 
 	// Failure
-	require.Equal(t, float64(MigrationStatus[storkv1.MigrationStatusFailed]), testutil.ToFloat64(migrationStatusCounter.With(labels)), "migration_status does not matched")
+	require.Equal(t, float64(migrationStatus[storkv1.MigrationStatusFailed]), testutil.ToFloat64(migrationStatusCounter.With(labels)), "migration_status does not matched")
 	// Initial
-	require.Equal(t, float64(MigrationStage[storkv1.MigrationStageInitial]), testutil.ToFloat64(migrationStageCounter.With(labels)), "migration_stage does not matched")
+	require.Equal(t, float64(migrationStage[storkv1.MigrationStageInitial]), testutil.ToFloat64(migrationStageCounter.With(labels)), "migration_stage does not matched")
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/batch/batch.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/batch/batch.go
@@ -152,5 +152,6 @@ func (c *Client) loadClient() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/applicationbackuprestore.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/applicationbackuprestore.go
@@ -7,6 +7,7 @@ import (
 	storkv1alpha1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/errors"
 	"github.com/portworx/sched-ops/task"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -25,6 +26,8 @@ type ApplicationBackupRestoreOps interface {
 	DeleteApplicationBackup(string, string) error
 	// ValidateApplicationBackup validates the ApplicationBackup
 	ValidateApplicationBackup(string, string, time.Duration, time.Duration) error
+	// WatchApplicationBackup watch the ApplicationBackup
+	WatchApplicationBackup(namespace string, fn WatchFunc, listOptions metav1.ListOptions) error
 	// CreateApplicationRestore creates the ApplicationRestore
 	CreateApplicationRestore(*storkv1alpha1.ApplicationRestore) (*storkv1alpha1.ApplicationRestore, error)
 	// GetApplicationRestore gets the ApplicationRestore
@@ -37,6 +40,8 @@ type ApplicationBackupRestoreOps interface {
 	DeleteApplicationRestore(string, string) error
 	// ValidateApplicationRestore validates the ApplicationRestore
 	ValidateApplicationRestore(string, string, time.Duration, time.Duration) error
+	// WatchApplicationRestore watch the ApplicationRestore
+	WatchApplicationRestore(namespace string, fn WatchFunc, listOptions metav1.ListOptions) error
 	// GetApplicationBackupSchedule gets the ApplicationBackupSchedule
 	GetApplicationBackupSchedule(string, string) (*storkv1alpha1.ApplicationBackupSchedule, error)
 	// CreateApplicationBackupSchedule creates an ApplicationBackupSchedule
@@ -331,4 +336,40 @@ func (c *Client) ValidateApplicationBackupSchedule(name string, namespace string
 	}
 
 	return backups, nil
+}
+
+// WatchApplicationBackup sets up a watcher that listens for changes on application backups
+func (c *Client) WatchApplicationBackup(namespace string, fn WatchFunc, listOptions metav1.ListOptions) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	listOptions.Watch = true
+	watchInterface, err := c.stork.StorkV1alpha1().ApplicationBackups(namespace).Watch(listOptions)
+	if err != nil {
+		logrus.WithError(err).Error("error invoking the watch api for application backups")
+		return err
+	}
+
+	// fire off watch function
+	go c.handleWatch(watchInterface, &storkv1alpha1.ApplicationBackup{}, "", fn, listOptions)
+	return nil
+}
+
+// WatchApplicationRestore sets up a watcher that listens for changes on application restores
+func (c *Client) WatchApplicationRestore(namespace string, fn WatchFunc, listOptions metav1.ListOptions) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	listOptions.Watch = true
+	watchInterface, err := c.stork.StorkV1alpha1().ApplicationRestores(namespace).Watch(listOptions)
+	if err != nil {
+		logrus.WithError(err).Error("error invoking the watch api for application restores")
+		return err
+	}
+
+	// fire off watch function
+	go c.handleWatch(watchInterface, &storkv1alpha1.ApplicationRestore{}, "", fn, listOptions)
+	return nil
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/clusterdomains.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/clusterdomains.go
@@ -175,14 +175,14 @@ func (c *Client) ValidateClusterDomainUpdate(name string, timeout, retryInterval
 		} else if resp.Status.Status == storkv1alpha1.ClusterDomainUpdateStatusFailed {
 			return "", false, &errors.ErrFailedToValidateCustomSpec{
 				Name:  name,
-				Cause: fmt.Sprintf("ClusterDomainUpdate Status %v", resp.Status.Status),
+				Cause: fmt.Sprintf("ClusterDomainUpdate Status %v, Reason: %v", resp.Status.Status, resp.Status.Reason),
 				Type:  resp,
 			}
 		}
 
 		return "", true, &errors.ErrFailedToValidateCustomSpec{
 			Name:  name,
-			Cause: fmt.Sprintf("ClusterDomainUpdate Status %v", resp.Status.Status),
+			Cause: fmt.Sprintf("ClusterDomainUpdate Status %v, Reason: %v", resp.Status.Status, resp.Status.Reason),
 			Type:  resp,
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
Add prometheus metrics for stork controllers
 - application backup, restore and clone
 - cluster pair and migration

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Added prometheus metrics support for stork controllers which includes -
 - application backup, restore and clone
 - cluster pair and migration
```

**Does this change need to be cherry-picked to a release branch?**:
2.6.1

