### PR TITLE
Fix crd migration issue for api extensionV1 crds

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -976,7 +976,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a87986494fb9d67a97da35d8a95e714194f6f9152d9a5767c2c6edcd39454e0a"
+  digest = "1:99cf0a5a9e92bf48b811bdab9bdfd075fdf311d9ac1342e22e7679c584bc8014"
   name = "github.com/portworx/sched-ops"
   packages = [
     "k8s/admissionregistration",
@@ -997,7 +997,7 @@
     "task",
   ]
   pruneopts = "UT"
-  revision = "8c92f41450e8772b2a5e589e43683499ada7cf09"
+  revision = "3c4158808ca2c7dfa692b45b195cc298cddd63da"
 
 [[projects]]
   branch = "master"
@@ -2343,6 +2343,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/api/storage/v1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apimachinery/pkg/api/errors",

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -12,6 +12,7 @@ import (
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/controllers"
 	"github.com/libopenstorage/stork/pkg/crypto"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/objectstore"
 	"github.com/libopenstorage/stork/pkg/resourcecollector"
@@ -20,7 +21,9 @@ import (
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -634,6 +637,7 @@ func (a *ApplicationRestoreController) downloadCRD(
 	namespace string,
 ) error {
 	var crds []*apiextensionsv1beta1.CustomResourceDefinition
+	var crdsV1 []*apiextensionsv1.CustomResourceDefinition
 	crdData, err := a.downloadObject(backup, backupLocation, namespace, crdObjectName, true)
 	if err != nil {
 		return err
@@ -645,17 +649,66 @@ func (a *ApplicationRestoreController) downloadCRD(
 	if err = json.Unmarshal(crdData, &crds); err != nil {
 		return err
 	}
+	if err = json.Unmarshal(crdData, &crdsV1); err != nil {
+		return err
+	}
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("error getting cluster config: %v", err)
+	}
+
+	client, err := apiextensionsclient.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	regCrd := make(map[string]bool)
 	for _, crd := range crds {
 		crd.ResourceVersion = ""
-		if err := apiextensions.Instance().RegisterCRD(crd); err != nil && !errors.IsAlreadyExists(err) {
-			return err
+		regCrd[crd.GetName()] = false
+		if _, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd); err != nil && !errors.IsAlreadyExists(err) {
+			regCrd[crd.GetName()] = true
+			logrus.Warnf("error registering crds %v,%v", crd.GetName(), err)
+			continue
 		}
-		if err := apiextensions.Instance().ValidateCRD(apiextensions.CustomResource{
-			Plural: crd.Spec.Names.Plural,
-			Group:  crd.Spec.Group}, validateCRDTimeout, validateCRDInterval); err != nil {
-			return err
+		// wait for crd to be ready
+		if err := k8sutils.ValidateCRD(client, crd.GetName()); err != nil {
+			logrus.Warnf("Unable to validate crds %v,%v", crd.GetName(), err)
 		}
 	}
+
+	for _, crd := range crdsV1 {
+		if val, ok := regCrd[crd.GetName()]; ok && val {
+			crd.ResourceVersion = ""
+			var updatedVersions []apiextensionsv1.CustomResourceDefinitionVersion
+			if crd.Spec.PreserveUnknownFields {
+				crd.Spec.PreserveUnknownFields = false
+				for _, version := range crd.Spec.Versions {
+					isTrue := true
+					if version.Schema == nil {
+						openAPISchema := &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{XPreserveUnknownFields: &isTrue},
+						}
+						version.Schema = openAPISchema
+					} else {
+						version.Schema.OpenAPIV3Schema.XPreserveUnknownFields = &isTrue
+					}
+					updatedVersions = append(updatedVersions, version)
+				}
+				crd.Spec.Versions = updatedVersions
+			}
+			if _, err := client.ApiextensionsV1().CustomResourceDefinitions().Create(crd); err != nil && !errors.IsAlreadyExists(err) {
+				logrus.Warnf("error registering crds %v,%v", crd.GetName(), err)
+				continue
+			}
+			// wait for crd to be ready
+			if err := k8sutils.ValidateCRDV1(client, crd.GetName()); err != nil {
+				logrus.Warnf("Unable to validate crds %v,%v", crd.GetName(), err)
+			}
+
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libopenstorage/stork/drivers/volume"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/controllers"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	"github.com/libopenstorage/stork/pkg/rule"
@@ -20,7 +21,9 @@ import (
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -1079,7 +1083,12 @@ func (m *MigrationController) prepareCRDClusterResource(
 		if suspend.Type == "bool" {
 			disableVersion = true
 		} else if suspend.Type == "int" {
-			disableVersion = 0
+			curr, found, err := unstructured.NestedInt64(content, fields...)
+			if err != nil || !found {
+				return fmt.Errorf("unable to find suspend path, err: %v", err)
+			}
+			disableVersion = int64(0)
+			currVal = fmt.Sprintf("%v", curr)
 		} else if suspend.Type == "string" {
 			curr, found, err := unstructured.NestedString(content, fields...)
 			if err != nil || !found {
@@ -1090,6 +1099,7 @@ func (m *MigrationController) prepareCRDClusterResource(
 		} else {
 			return fmt.Errorf("invalid type %v to suspend cr", suspend.Type)
 		}
+
 		if err := unstructured.SetNestedField(content, disableVersion, fields...); err != nil {
 			return err
 		}
@@ -1152,29 +1162,73 @@ func (m *MigrationController) applyResources(
 			if _, ok := resKinds[v.Kind]; !ok {
 				continue
 			}
-			crdName := inflect.Pluralize(strings.ToLower(v.Kind)) + "." + v.Group
-			res, err := apiextensions.Instance().GetCRD(crdName, metav1.GetOptions{})
+			config, err := rest.InClusterConfig()
 			if err != nil {
-				if errors.IsNotFound(err) {
+				return fmt.Errorf("error getting cluster config: %v", err)
+			}
+
+			srcClnt, err := apiextensionsclient.NewForConfig(config)
+			if err != nil {
+				return err
+			}
+			destClnt, err := apiextensionsclient.NewForConfig(remoteAdminConfig)
+			if err != nil {
+				return err
+			}
+			crdName := inflect.Pluralize(strings.ToLower(v.Kind)) + "." + v.Group
+			crdvbeta1, err := srcClnt.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.GetName(), metav1.GetOptions{})
+			if err == nil {
+				crdvbeta1.ResourceVersion = ""
+				if _, regErr := destClnt.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crdvbeta1); regErr != nil && !errors.IsAlreadyExists(regErr) {
+					log.MigrationLog(migration).Warnf("error registering CRD %s, %v", crdvbeta1.GetName(), err)
+				} else if regErr == nil {
+					if err := k8sutils.ValidateCRD(destClnt, crd.GetName()); err != nil {
+						logrus.Warnf("Unable to validate crds %v,%v", crdvbeta1.GetName(), err)
+					}
 					continue
 				}
-				log.MigrationLog(migration).Errorf("unable to get customresourcedefination for %s, err: %v", v.Kind, err)
-				return err
 			}
-			clnt, err := apiextensions.NewForConfig(remoteAdminConfig)
+			res, err := srcClnt.ApiextensionsV1().CustomResourceDefinitions().Get(crd.GetName(), metav1.GetOptions{})
 			if err != nil {
+				if errors.IsNotFound(err) {
+					log.MigrationLog(migration).Warnf("CRDV1 not found %v for kind %v", crdName, v.Kind)
+					continue
+				}
+				log.MigrationLog(migration).Errorf("unable to get customresourcedefination for %s, err: %v", crdName, err)
 				return err
 			}
+
 			res.ResourceVersion = ""
-			if err := clnt.RegisterCRD(res); err != nil && !errors.IsAlreadyExists(err) {
-				log.MigrationLog(migration).Errorf("error registering CRD %s, %v", res.GetName(), err)
-				return err
+			// if crds is applied as v1beta on k8s version 1.16+ it will have
+			// preservedUnkownField set and api version converted to v1 ,
+			// which cause issue while applying it on dest cluster,
+			// since we will be applying v1 crds with non-valid schema
+
+			// this converts `preserveUnknownFiels`(deprecated) to spec.Versions[*].xPreservedUnknown
+			// equivalent
+			var updatedVersions []apiextensionsv1.CustomResourceDefinitionVersion
+			if res.Spec.PreserveUnknownFields {
+				res.Spec.PreserveUnknownFields = false
+				for _, version := range res.Spec.Versions {
+					isTrue := true
+					if version.Schema == nil {
+						openAPISchema := &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{XPreserveUnknownFields: &isTrue},
+						}
+						version.Schema = openAPISchema
+					} else {
+						version.Schema.OpenAPIV3Schema.XPreserveUnknownFields = &isTrue
+					}
+					updatedVersions = append(updatedVersions, version)
+				}
+				res.Spec.Versions = updatedVersions
 			}
-			if err := clnt.ValidateCRD(apiextensions.CustomResource{
-				Plural: res.Spec.Names.Plural,
-				Group:  res.Spec.Group}, validateCRDTimeout, validateCRDInterval); err != nil {
-				log.MigrationLog(migration).Errorf("error validating CRD %s, %v", res.GetName(), err)
-				return err
+			if _, err := destClnt.ApiextensionsV1().CustomResourceDefinitions().Create(res); err != nil && !errors.IsAlreadyExists(err) {
+				log.MigrationLog(migration).Errorf("error registering CRD %s, %v", res.GetName(), err)
+			}
+			// wait for crd to be ready
+			if err := k8sutils.ValidateCRDV1(destClnt, res.GetName()); err != nil {
+				logrus.Warnf("Unable to validate crds %v,%v", res.GetName(), err)
 			}
 		}
 	}

--- a/vendor/github.com/portworx/sched-ops/k8s/core/pods.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/pods.go
@@ -205,9 +205,11 @@ func (c *Client) getPodsUsingPVWithListOptions(pvName string, opts metav1.ListOp
 		return nil, err
 	}
 
-	if pv.Spec.ClaimRef != nil && pv.Spec.ClaimRef.Kind == "PersistentVolumeClaim" {
-		return c.getPodsUsingPVCWithListOptions(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace, opts)
-	}
+	if pv.Status.Phase == corev1.VolumeBound {
+		if pv.Spec.ClaimRef != nil && pv.Spec.ClaimRef.Kind == "PersistentVolumeClaim" {
+			return c.getPodsUsingPVCWithListOptions(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace, opts)
+		}
+	} // else the volume is not bound so cannot rely on stale claim ref objects
 
 	return nil, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Allow CRDs using apiextenstion v1 api to migrate/backup/restore. Fix replica count issue for crds with `int` as suspendValue

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
np

**Does this change need to be cherry-picked to a release branch?**:
2.6.1

