### PR TITLE
Added retry logic, while updating the ApplicationBackupStageApplications status to CR.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -681,8 +681,29 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 		// Update the current state and then move on to backing up resources
 		err := a.client.Update(context.TODO(), backup)
 		if err != nil {
-			return err
+			for i := 0; i < maxRetry; i++ {
+				err = a.client.Get(context.TODO(), namespacedName, backup)
+				if err != nil {
+					time.Sleep(retrySleep)
+					continue
+				}
+				backup.Status.Stage = stork_api.ApplicationBackupStageApplications
+				backup.Status.Status = stork_api.ApplicationBackupStatusInProgress
+				backup.Status.Reason = "Application resources backup is in progress"
+				backup.Status.LastUpdateTimestamp = metav1.Now()
+				err = a.client.Update(context.TODO(), backup)
+				if err != nil {
+					time.Sleep(retrySleep)
+					continue
+				} else {
+					break
+				}
+			}
+			if err != nil {
+				return err
+			}
 		}
+
 		err = a.backupResources(backup)
 		if err != nil {
 			message := fmt.Sprintf("Error backing up resources: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
 Added retry logic, while updating the ApplicationBackupStageApplications status to CR.
 If the CR update fails, we retry for 10 times with 10 sec delay.

**Does this PR change a user-facing CRD or CLI?**:
No.

**Is a release note needed?**:
No.

**Does this change need to be cherry-picked to a release branch?**:
Yes, 2.6 branch.

**Testing:**
Tested it on Bhavana's setup, where the error was reproduce. With retry fix, the backup completed succesfully. Most the retry was successful in second try.