### PR TITLE
Don't check for namespace mapping again when finding objects to delete

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -314,23 +314,6 @@ func (a *ApplicationRestoreController) getDriversForRestore(restore *storkapi.Ap
 func (a *ApplicationRestoreController) getNamespacedObjectsToDelete(restore *storkapi.ApplicationRestore, objects []runtime.Unstructured) ([]runtime.Unstructured, error) {
 	tempObjects := make([]runtime.Unstructured, 0)
 	for _, o := range objects {
-		metadata, err := meta.Accessor(o)
-		if err != nil {
-			return nil, err
-		}
-
-		if metadata.GetNamespace() != "" {
-			var val string
-			var present bool
-			// Skip the object if it isn't in the namespace mapping
-			if val, present = restore.Spec.NamespaceMapping[metadata.GetNamespace()]; !present {
-				continue
-			}
-
-			// Update the namespace of the object, will be no-op for clustered resources
-			metadata.SetNamespace(val)
-		}
-
 		objectType, err := meta.TypeAccessor(o)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Namespace is already being mapped to the destination


**What type of PR is this?**
Bug
**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.6
