### PR TITLE
add support for replicaset backup/migration

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -125,6 +125,7 @@ func resourceToBeCollected(resource metav1.APIResource, grp schema.GroupVersion,
 		"Template",
 		"CronJob",
 		"ResourceQuota",
+		"ReplicaSet",
 		"LimitRange":
 		return true
 	case "Job":
@@ -370,7 +371,7 @@ func (r *ResourceCollector) pruneOwnedResources(
 							collect = false
 							break
 						}
-						if objectType.GetKind() != "Deployment" && objectType.GetKind() != "StatefulSet" {
+						if objectType.GetKind() != "Deployment" && objectType.GetKind() != "StatefulSet" && objectType.GetKind() != "ReplicaSet" {
 							continue
 						}
 


### PR DESCRIPTION
**What type of PR is this?**
> enhancement

**What this PR does / why we need it**:
Support to collect non-owner ReplicaSet objects  for backup/migration

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Support to collect non-owner ref Replicaset object backup/migrations
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6.X

