### PR TITLE
Provide separate kubeconfig params for test, source and destination cluster

### DIFF
--- a/test/integration_test/applicationclone_test.go
+++ b/test/integration_test/applicationclone_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestApplicationClone(t *testing.T) {
+	err := setSourceKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+
 	t.Run("deploymentTest", deploymentApplicationCloneTest)
 	t.Run("statefulsetTest", statefulsetApplicationCloneTest)
 	t.Run("statefulsetRuleTest", statefulsetApplicationCloneRuleTest)
@@ -20,6 +23,8 @@ func TestApplicationClone(t *testing.T) {
 	t.Run("failingPostExecRuleTest", applicationCloneFailingPostExecRuleTest)
 	t.Run("labelSelectorTest", applicationCloneLabelSelectorTest)
 
+	err = setRemoteConfig("")
+	require.NoError(t, err, "setting kubeconfig to default failed")
 }
 
 func triggerApplicationCloneTest(

--- a/test/integration_test/clusterdomain_test.go
+++ b/test/integration_test/clusterdomain_test.go
@@ -108,6 +108,7 @@ func failoverAndFailbackClusterDomainTest(t *testing.T) {
 		true,
 		true,
 		false,
+		false,
 	)
 
 	// validate the following

--- a/test/integration_test/cmdexecutor_test.go
+++ b/test/integration_test/cmdexecutor_test.go
@@ -17,6 +17,10 @@ import (
 )
 
 func TestCommandExecutor(t *testing.T) {
+
+	err := setSourceKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+
 	id, err := uuid.New()
 	require.NoError(t, err, "failed to get uuid")
 
@@ -75,6 +79,9 @@ func TestCommandExecutor(t *testing.T) {
 	}
 
 	destroyAndWait(t, ctxs)
+
+	err = setRemoteConfig("")
+	require.NoError(t, err, "setting kubeconfig to default failed")
 }
 
 func startCommandInPods(t *testing.T, command string, pods []v1.Pod) []cmdexecutor.Executor {

--- a/test/integration_test/extender_test.go
+++ b/test/integration_test/extender_test.go
@@ -21,12 +21,18 @@ const (
 )
 
 func TestExtender(t *testing.T) {
+	err := setSourceKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+
 	t.Run("pvcOwnershipTest", pvcOwnershipTest)
 	t.Run("noPVCTest", noPVCTest)
 	t.Run("singlePVCTest", singlePVCTest)
 	t.Run("statefulsetTest", statefulsetTest)
 	t.Run("multiplePVCTest", multiplePVCTest)
 	t.Run("driverNodeErrorTest", driverNodeErrorTest)
+
+	err = setRemoteConfig("")
+	require.NoError(t, err, "setting kubeconfig to default failed")
 }
 
 func noPVCTest(t *testing.T) {
@@ -76,13 +82,13 @@ func statefulsetTest(t *testing.T) {
 	require.Equal(t, 3, len(scheduledNodes), "App should be scheduled on one node")
 
 	// TODO: torpedo doesn't return correct volumes here
-	//volumeNames := getVolumeNames(t, ctxs[0])
-	//require.Equal(t, 3, len(volumeNames), "Should have 3 volumes")
+	volumeNames := getVolumeNames(t, ctxs[0])
+	require.Equal(t, 3, len(volumeNames), "Should have 3 volumes")
 
 	// TODO: Add verification for node where it was scheduled
 	// torpedo doesn't return the pod->pvc mapping, so we can't validate that it
 	// got scheduled on a prioritized node
-	//verifyScheduledNode(t, scheduledNodes[0], volumeNames)
+	verifyScheduledNode(t, scheduledNodes[0], volumeNames)
 
 	destroyAndWait(t, ctxs)
 }

--- a/test/integration_test/health_monitor_test.go
+++ b/test/integration_test/health_monitor_test.go
@@ -16,9 +16,15 @@ import (
 )
 
 func TestHealthMonitor(t *testing.T) {
+	err := setSourceKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+
 	t.Run("stopDriverTest", stopDriverTest)
 	t.Run("stopKubeletTest", stopKubeletTest)
 	t.Run("healthCheckFixTest", healthCheckFixTest)
+
+	err = setRemoteConfig("")
+	require.NoError(t, err, "setting kubeconfig to default failed")
 }
 
 func stopDriverTest(t *testing.T) {

--- a/test/integration_test/snapshot_restore_test.go
+++ b/test/integration_test/snapshot_restore_test.go
@@ -11,12 +11,18 @@ import (
 )
 
 func testSnapshotRestore(t *testing.T) {
+	err := setSourceKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+
 	t.Run("simpleSnapshotRestoreTest", simpleSnapshotRestoreTest)
 	t.Run("groupSnapshotRestoreTest", groupSnapshotRestoreTest)
 	if !testing.Short() {
 		t.Run("cloudSnapshotRestoreTest", cloudSnapshotRestoreTest)
 		t.Run("groupCloudSnapshotRestoreTest", groupCloudSnapshotRestoreTest)
 	}
+
+	err = setRemoteConfig("")
+	require.NoError(t, err, "setting kubeconfig to default failed")
 }
 
 func createInPlaceRestore(t *testing.T, namespace string, appKeys []string) []*scheduler.Context {

--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -32,6 +32,9 @@ const (
 )
 
 func testSnapshot(t *testing.T) {
+	err := setSourceKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+
 	t.Run("simpleSnapshotTest", simpleSnapshotTest)
 	t.Run("cloudSnapshotTest", cloudSnapshotTest)
 	t.Run("snapshotScaleTest", snapshotScaleTest)
@@ -42,6 +45,9 @@ func testSnapshot(t *testing.T) {
 	if authTokenConfigMap == "" {
 		t.Run("storageclassTests", storageclassTests)
 	}
+
+	err = setRemoteConfig("")
+	require.NoError(t, err, "setting kubeconfig to default failed")
 }
 
 func simpleSnapshotTest(t *testing.T) {
@@ -285,6 +291,11 @@ func verifySnapshot(t *testing.T, ctxs []*scheduler.Context, pvcInUseByTest stri
 	snaps, err := schedulerDriver.GetSnapshots(ctxs[0])
 	require.NoError(t, err, "failed to get snapshots")
 	require.Len(t, snaps, 1, "should have received exactly one snapshot")
+
+	if externalTest {
+		// TODO: Figure out a way to communicate with PX nodes from other cluster
+		return
+	}
 
 	for _, snap := range snaps {
 		s, err := k8sextops.Instance().GetSnapshot(snap.Name, snap.Namespace)

--- a/test/integration_test/stork-test-pod.yaml
+++ b/test/integration_test/stork-test-pod.yaml
@@ -87,6 +87,8 @@ spec:
       value: aws_access_key_id
     - name: AWS_SECRET_ACCESS_KEY
       value: aws_secret_access_key
+    - name: EXTERNAL_TEST_CLUSTER 
+      value: external_test_cluster
   hostNetwork: false
   hostPID: false
   volumes:


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
This PR will provide the ability to run stork integration test via a third independent cluster.
At the same time will allow the test pod to interact with source and destination cluster.
With this architecture, tests can reboot either source or destination cluster or both without affecting the test pod

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

