### PR TITLE
stor:335 Adding batch processing logic in passing namespace list to the GetResources API of resourceCollector pkg

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -53,10 +53,11 @@ const (
 	backupCancelBackoffFactor       = 1
 	backupCancelBackoffSteps        = math.MaxInt32
 
-	allNamespacesSpecifier = "*"
-	backupVolumeBatchCount = 10
-	maxRetry               = 10
-	retrySleep             = 10 * time.Second
+	allNamespacesSpecifier    = "*"
+	backupVolumeBatchCount    = 10
+	backupResourcesBatchCount = 15
+	maxRetry                  = 10
+	retrySleep                = 10 * time.Second
 )
 
 var (
@@ -968,21 +969,62 @@ func (a *ApplicationBackupController) backupResources(
 	// Always backup optional resources. When restorting they need to be
 	// explicitly added to the spec
 	objectMap := stork_api.CreateObjectsMap(backup.Spec.IncludeResources)
-	allObjects, err := a.resourceCollector.GetResources(
-		backup.Spec.Namespaces,
-		backup.Spec.Selectors,
-		objectMap,
-		optionalBackupResources,
-		true)
-	if err != nil {
-		log.ApplicationBackupLog(backup).Errorf("Error getting resources: %v", err)
-		return err
+	namespacelist := backup.Spec.Namespaces
+	// GetResources takes more time, if we have more number of namespaces
+	// So, submitting it in batches and in between each batch,
+	// updating the LastUpdateTimestamp to show that backup is progressing
+	allObjects := make([]runtime.Unstructured, 0)
+	for i := 0; i < len(namespacelist); i += backupResourcesBatchCount {
+		batch := namespacelist[i:min(i+backupResourcesBatchCount, len(namespacelist))]
+		objects, err := a.resourceCollector.GetResources(
+			batch,
+			backup.Spec.Selectors,
+			objectMap,
+			optionalBackupResources,
+			true)
+		if err != nil {
+			log.ApplicationBackupLog(backup).Errorf("Error getting resources: %v", err)
+			return err
+		}
+		allObjects = append(allObjects, objects...)
+		// Do a dummy update to the backup CR to update only the last update timestamp
+		namespacedName := types.NamespacedName{}
+		namespacedName.Namespace = backup.Namespace
+		namespacedName.Name = backup.Name
+		for i := 0; i < maxRetry; i++ {
+			err = a.client.Get(context.TODO(), namespacedName, backup)
+			if err != nil {
+				time.Sleep(retrySleep)
+				continue
+			}
+			backup.Status.LastUpdateTimestamp = metav1.Now()
+			err = a.client.Update(context.TODO(), backup)
+			if err != nil {
+				time.Sleep(retrySleep)
+				continue
+			} else {
+				break
+			}
+		}
+	}
+	updatedAllObjects := make([]runtime.Unstructured, 0)
+	for _, obj := range allObjects {
+		resourceMap := make(map[types.UID]bool)
+		metadata, err := meta.Accessor(obj)
+		if err != nil {
+			return err
+		}
+		if _, ok := resourceMap[metadata.GetUID()]; ok {
+			continue
+		}
+		resourceMap[metadata.GetUID()] = true
+		updatedAllObjects = append(updatedAllObjects, obj)
 	}
 
 	if backup.Status.Resources == nil {
 		// Save the collected resources infos in the status
 		resourceInfos := make([]*stork_api.ApplicationBackupResourceInfo, 0)
-		for _, obj := range allObjects {
+		for _, obj := range updatedAllObjects {
 			metadata, err := meta.Accessor(obj)
 			if err != nil {
 				return err
@@ -1015,7 +1057,7 @@ func (a *ApplicationBackupController) backupResources(
 	}
 
 	// Do any additional preparation for the resources if required
-	if err = a.prepareResources(backup, allObjects); err != nil {
+	if err = a.prepareResources(backup, updatedAllObjects); err != nil {
 		message := fmt.Sprintf("Error preparing resources for backup: %v", err)
 		backup.Status.Status = stork_api.ApplicationBackupStatusFailed
 		backup.Status.Stage = stork_api.ApplicationBackupStageFinal
@@ -1034,7 +1076,7 @@ func (a *ApplicationBackupController) backupResources(
 	}
 
 	// Upload the resources to the backup location
-	if err = a.uploadResources(backup, allObjects); err != nil {
+	if err = a.uploadResources(backup, updatedAllObjects); err != nil {
 		message := fmt.Sprintf("Error uploading resources: %v", err)
 		backup.Status.Status = stork_api.ApplicationBackupStatusFailed
 		backup.Status.Stage = stork_api.ApplicationBackupStageFinal


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
GetResources takes more time, if we have more number of namespaces in namespace list. This make backup looks to be hang as the CR is not updated. This makes the px-backup to mark the backup as failed with timeout error.

So, submitting it in batches and in between each batch, we will updating the LastUpdateTimestamp in backup CR to show that backup is progressing and avoid timeout failure.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, to 2.6 branch.

**Testing:
Testcase1: ( To make sure that new logic does not add any extra time.)**
Increased the timeout value to 2 hours in px-backup.
Added 750 namespaces.
Added debug statement to calculate the time taken by GetResources with the new logic and old logic.
**New logic:**
siva-test-1-523b642 time taken for GetResources batching **52m49.060242546s**"
**Old logic:**
time="2021-01-15T13:15:36Z" level=info msg="Time taken by GetResources api **52m49.045374967s**"

**Testcase2:**
Tried with default timeout value of 30 sec with old code and new code.
With old code, it failed with timeout error.
With new code, it is success.
