### PR TITLE
[Portworx]: Setting backup size to zero on failure when fetching size

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2922,7 +2922,9 @@ func (p *portworx) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*stork
 					log.ApplicationBackupLog(backup).Warnf("Unsupported porx version to fetch backup size for backup ID %v: %v", csStatus.cloudSnapID, err)
 				} else {
 					log.ApplicationBackupLog(backup).Errorf("Failed to fetch backup size for backup ID %v: %v", csStatus.cloudSnapID, err)
-					return nil, err
+					// TODO: Temporarily not returning error due to porx timing out to fetch size having more backups
+					// Will be fixed once porx fixes the same
+					// return nil, err
 				}
 			} else {
 				vInfo.TotalSize = resp.GetSize()


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
Temporarily fix to set backup size to zero when fetching of backupsize fails in Portworx. Once porx fixes the issue, the same would be reverted back.  Today few of the backups (incremental) timeouts fetching size which leads to backup failure.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes to 2.6 branch

