### PR TITLE
Retain restorenamespace annotation for groupvolumesnapshots

### DIFF
--- a/pkg/groupsnapshot/controllers/groupsnapshot.go
+++ b/pkg/groupsnapshot/controllers/groupsnapshot.go
@@ -689,7 +689,13 @@ func (m *GroupSnapshotController) handleFinal(groupSnap *stork_api.GroupVolumeSn
 	childSnapshots := groupSnap.Status.VolumeSnapshots
 	if len(childSnapshots) > 0 {
 		currentRestoreNamespaces := ""
-		latestRestoreNamespacesInCSV := strings.Join(groupSnap.Spec.RestoreNamespaces, ",")
+		latestRestoreNamespacesInCSV := ""
+		if groupSnap.GetAnnotations() != nil {
+			if val, ok := groupSnap.GetAnnotations()[snapshotcontrollers.StorkSnapshotRestoreNamespacesAnnotation]; ok {
+				latestRestoreNamespacesInCSV = val
+			}
+		}
+		latestRestoreNamespacesInCSV += strings.Join(groupSnap.Spec.RestoreNamespaces, ",")
 
 		vsObject, err := k8sextops.Instance().GetSnapshot(childSnapshots[0].VolumeSnapshotName, groupSnap.GetNamespace())
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Groupvolumesnapshot restore for across namespace is failing because of overriding annotation with spec.RestoreNamespaces option

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Fixed issue where restore across namespace was failing for snapshot created by groupvolumesnapshot with error -Cannot be used in namespace
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6.3
