### PR TITLE
Get ApplicationRegistrations only once when preparing resources

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -858,6 +858,11 @@ func (m *MigrationController) prepareResources(
 	migration *stork_api.Migration,
 	objects []runtime.Unstructured,
 ) error {
+	crdList, err := storkops.Instance().ListApplicationRegistrations()
+	if err != nil {
+		return err
+	}
+
 	for _, o := range objects {
 		metadata, err := meta.Accessor(o)
 		if err != nil {
@@ -883,10 +888,6 @@ func (m *MigrationController) prepareResources(
 		}
 
 		// prepare CR resources
-		crdList, err := storkops.Instance().ListApplicationRegistrations()
-		if err != nil {
-			return err
-		}
 		for _, crd := range crdList.Items {
 			for _, v := range crd.Resources {
 				if v.Kind == resource.Kind &&


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Fixed issue during migrations where ApplicationRegistrations were being fetched for each resource causing a delay while preparing resources
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
2.6
