### PR TITLE
Add security annotations migration create method

### DIFF
--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -38,7 +38,10 @@ func testSnapshot(t *testing.T) {
 	t.Run("groupSnapshotTest", groupSnapshotTest)
 	t.Run("groupSnapshotScaleTest", groupSnapshotScaleTest)
 	t.Run("scheduleTests", snapshotScheduleTests)
-	t.Run("storageclassTests", storageclassTests)
+	// TODO: waiting for https://portworx.atlassian.net/browse/STOR-281 to be resolved
+	if authTokenConfigMap == "" {
+		t.Run("storageclassTests", storageclassTests)
+	}
 }
 
 func simpleSnapshotTest(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
* When creating migration object using the private method, add security annotations if needed
* Skip certain migration tests until a bug is resolved.


**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
master
