### PR TITLE
Added logic to exclude the controlled resources from GetResources API.

### DIFF
--- a/pkg/resourcecollector/configmap.go
+++ b/pkg/resourcecollector/configmap.go
@@ -1,0 +1,30 @@
+package resourcecollector
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) configmapToBeCollected(
+	object runtime.Unstructured,
+) (bool, error) {
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return false, err
+	}
+	// excludeConfigMap is a array of configmap that should not be
+	// included in GetResources API as they are controlled by some controller,
+	// "kube-root-ca.crt" is a configmap that is created in every namespace by
+	// kube-controller-manager from k8s 1.20.0 onwards.
+	excludeConfigMap := []string{"kube-root-ca.crt"}
+
+	for _, name := range excludeConfigMap {
+		ret := strings.Compare(metadata.GetName(), name)
+		if ret == 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -330,6 +330,8 @@ func (r *ResourceCollector) objectToBeCollected(
 		return r.roleBindingToBeCollected(object)
 	case "Ingress":
 		return r.ingressToBeCollected(object)
+	case "ConfigMap":
+		return r.configmapToBeCollected(object)
 	}
 
 	return true, nil


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
- Added logic to exclude the controlled resources from GetResources API.
- Define a list for excluding controlled resources being returned as part of 
   response of resourceCollector GetResources API.
- For now added configmap kube-root-ca.crt, which was getting created
   by kube-controller-manager in every namespace.


**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, to 2.6 branch.

**Testing:**
Tested with k8s 1.20.0 that GetResources API does not return the kube-root-ca.crt configMap.

```
Actual configMap in the namespace test:
[root@central-steel-drifter-0 tmp]#
[root@central-steel-drifter-0 tmp]# kubectl get configmap -n test
NAME               DATA   AGE
kube-root-ca.crt   1      25h
test1              0      3m41s
testcm             0      40h
With fix, we are excluding kube-root-ca.crt  in GetResources API:
[root@central-steel-drifter-0 tmp]# /tmp/get
allobjects: ---> [0xc00064bce8 0xc00064bcf0]
name: test1
name: testcm

With out fix, we were including kube-root-ca.crt :
[root@central-steel-drifter-0 tmp]# /tmp/get
allobjects: ---> [0xc0003cae40 0xc0003cae48 0xc0003cae50]
name: kube-root-ca.crt
name: test1
name: testcm
[root@central-steel-drifter-0 tmp]#
```