### PR TITLE
Updating clusterIps field of service to nil in prepareServiceResourceForCollection.

### DIFF
--- a/pkg/resourcecollector/service.go
+++ b/pkg/resourcecollector/service.go
@@ -38,7 +38,11 @@ func (r *ResourceCollector) prepareServiceResourceForCollection(
 			return err
 		}
 	}
-
+	// Reset the clusterIps to nil
+	err := unstructured.SetNestedField(object.UnstructuredContent(), nil, "spec", "clusterIPs")
+	if err != nil {
+		return err
+	}
 	// Reset the loadBalancerIP
 	return unstructured.SetNestedField(object.UnstructuredContent(), "", "spec", "loadBalancerIP")
 }


### PR DESCRIPTION
**What type of PR is this?**
bug
**What this PR does / why we need it**:
In k8s 1.20.0, we have clusterIPs field along with clusterIP for service. Currently we are reseting clusterIP alone while preparing resource to take backup. Now make clusterIPs to be nil along with clusterIP.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no
**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6 branch

**Testing:**
Tested on the k8s 1.20.0 and 1.14.0 cluster with wordpress app. Verified that clusterIPs and clusterIP are getting rest to nil and empty.
![Screenshot 2021-03-11 at 4 44 11 PM](https://user-images.githubusercontent.com/52188641/110790563-2eb1aa00-8297-11eb-8e07-2f7b386e72f3.png)

