### PR TITLE
Re-enable deploying stork as part of test-deploy script

### DIFF
--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -54,13 +54,13 @@ case $i in
         shift
         ;;
     --src-config-path)
-        echo "Remote kubeconfig path to use for test: $2"
+        echo "Source kubeconfig path to use for test: $2"
         src_config_path=$2
         shift
         shift
         ;;
     --dest-config-path)
-        echo "Remote kubeconfig path to use for test: $2"
+        echo "Destination kubeconfig path to use for test: $2"
         dest_config_path=$2
         shift
         shift
@@ -165,7 +165,7 @@ kubectl delete cm stork-mock-time  -n kube-system || true
 kubectl create cm stork-mock-time  -n kube-system --from-literal=time=""
 
 echo "Creating stork deployment"
-#kubectl apply -f /specs/stork-deployment.yaml
+kubectl apply -f /specs/stork-deployment.yaml
 
 # Turn on test mode
 kubectl set env deploy/stork -n kube-system TEST_MODE="true"


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Deploying stork as part of test-deploy was commented by mistake.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

