### PR TITLE
Integration test for stork webhook dryRun only option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/pborman/uuid v1.2.0
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/portworx/kvdb v0.0.0-20200311180812-b2c72382d652 // indirect
-	github.com/portworx/sched-ops v0.0.0-20200723032629-257aba0944dc
+	github.com/portworx/sched-ops v0.20.4-openstorage-rc3.0.20210325150944-0b2c202335f7
 	github.com/portworx/torpedo v0.0.0-20210302010102-e291f3361bd7
 	github.com/prometheus/client_golang v1.7.1
 	github.com/sirupsen/logrus v1.7.0
@@ -82,8 +82,8 @@ replace (
 	github.com/kubernetes-csi/external-snapshotter/client/v4 => github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 	github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc3
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3
-	github.com/portworx/torpedo => github.com/portworx/torpedo v0.20.4-rc1
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3.0.20210325160501-71c13c330a2e
+	github.com/portworx/torpedo => github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.5.2
 

--- a/go.sum
+++ b/go.sum
@@ -872,9 +872,15 @@ github.com/portworx/kvdb v0.0.0-20200311180812-b2c72382d652/go.mod h1:Q8YyrNDvPp
 github.com/portworx/px-backup-api v1.0.1-0.20200915150042-274508e876ef/go.mod h1:puy7YVXeb6glot1vVCIePIiRLSwB//+rFtN2ZjvXeEw=
 github.com/portworx/sched-ops v0.20.4-openstorage-rc3 h1:tXnHsjZT2wZ2BCXf8avDoya7zGyCgLNUC8Upt+WEQrY=
 github.com/portworx/sched-ops v0.20.4-openstorage-rc3/go.mod h1:DpRDDqXWQrReFJ5SHWWrURuZdzVKjrh2OxbAfwnrAyk=
+github.com/portworx/sched-ops v0.20.4-openstorage-rc3.0.20210325150944-0b2c202335f7 h1:E/ZYLCbNezKg4bT1CmZXWgi2vY6PuPHwdVBZOdQDmfM=
+github.com/portworx/sched-ops v0.20.4-openstorage-rc3.0.20210325150944-0b2c202335f7/go.mod h1:DpRDDqXWQrReFJ5SHWWrURuZdzVKjrh2OxbAfwnrAyk=
+github.com/portworx/sched-ops v0.20.4-openstorage-rc3.0.20210325160501-71c13c330a2e h1:sPC3suNQQtGG2tNE7lOvVchMt7GKp+gg0T/10NQu5po=
+github.com/portworx/sched-ops v0.20.4-openstorage-rc3.0.20210325160501-71c13c330a2e/go.mod h1:DpRDDqXWQrReFJ5SHWWrURuZdzVKjrh2OxbAfwnrAyk=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/torpedo v0.20.4-rc1 h1:iI6J8IgMfZdqYpFQ2jNDNet7RbMOcuBmvh8T+B3NJF0=
 github.com/portworx/torpedo v0.20.4-rc1/go.mod h1:4m4ORL/hpBOP2DUaIK6CzRkYiEn3AT8WP65wZHmO8MI=
+github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145 h1:J5D0JPZWueVAK8/Dr5s84I7/tCfin6NjIGbKKCSyyJ0=
+github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145/go.mod h1:CkLAs/ojTzSu3SPyeDxc3qhsbRU78H5Xz1qJlj1Ap1U=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 h1:J9b7z+QKAmPf4YLrFg6oQUotqHQeUNWwkvo7jZp1GLU=

--- a/pkg/storkctl/migration_test.go
+++ b/pkg/storkctl/migration_test.go
@@ -273,7 +273,7 @@ func createMigratedDeployment(t *testing.T) {
 			Replicas: &replicas,
 		},
 	}
-	_, err = apps.Instance().CreateDeployment(deployment)
+	_, err = apps.Instance().CreateDeployment(deployment, metav1.CreateOptions{})
 	require.NoError(t, err, "Error creating deployment")
 }
 
@@ -294,7 +294,7 @@ func createMigratedStatefulSet(t *testing.T) {
 			Replicas: &replicas,
 		},
 	}
-	_, err = apps.Instance().CreateStatefulSet(statefulSet)
+	_, err = apps.Instance().CreateStatefulSet(statefulSet, metav1.CreateOptions{})
 	require.NoError(t, err, "Error creating statefulset")
 
 }

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -113,6 +113,7 @@ func TestSnapshotMigration(t *testing.T) {
 	t.Run("testSnapshot", testSnapshot)
 	t.Run("testSnapshotRestore", testSnapshotRestore)
 	t.Run("testMigration", testMigration)
+	t.Run("testWebhook", testWebhook)
 }
 
 // TODO: Take driver name from input

--- a/test/integration_test/webhook_test.go
+++ b/test/integration_test/webhook_test.go
@@ -1,0 +1,27 @@
+// +build integrationtest
+
+package integrationtest
+
+import (
+	"testing"
+
+	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testWebhook(t *testing.T) {
+	err := setSourceKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+
+	t.Run("simpleDryRunTest", simpleDryRunTest)
+	err = setRemoteConfig("")
+	require.NoError(t, err, "setting kubeconfig to default failed")
+}
+
+func simpleDryRunTest(t *testing.T) {
+	ctx, err := schedulerDriver.Schedule(generateInstanceID(t, ""),
+		scheduler.ScheduleOptions{AppKeys: []string{"mysql-2-pvc"}, DryRun: []string{metav1.DryRunAll}})
+	require.NoError(t, err, "Error scheduling task")
+	require.Equal(t, 1, len(ctx), "Only one task should have started")
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/apps/daemonsets.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apps/daemonsets.go
@@ -16,7 +16,7 @@ import (
 // DaemonSetOps is an interface to perform k8s daemon set operations
 type DaemonSetOps interface {
 	// CreateDaemonSet creates the given daemonset
-	CreateDaemonSet(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error)
+	CreateDaemonSet(ds *appsv1.DaemonSet, opts metav1.CreateOptions) (*appsv1.DaemonSet, error)
 	// ListDaemonSets lists all daemonsets in given namespace
 	ListDaemonSets(namespace string, listOpts metav1.ListOptions) ([]appsv1.DaemonSet, error)
 	// GetDaemonSet gets the the daemon set with given name
@@ -32,12 +32,12 @@ type DaemonSetOps interface {
 }
 
 // CreateDaemonSet creates the given daemonset
-func (c *Client) CreateDaemonSet(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
+func (c *Client) CreateDaemonSet(ds *appsv1.DaemonSet, opts metav1.CreateOptions) (*appsv1.DaemonSet, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
 
-	return c.apps.DaemonSets(ds.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
+	return c.apps.DaemonSets(ds.Namespace).Create(context.TODO(), ds, opts)
 }
 
 // ListDaemonSets lists all daemonsets in given namespace

--- a/vendor/github.com/portworx/sched-ops/k8s/apps/deployments.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apps/deployments.go
@@ -21,7 +21,7 @@ type DeploymentOps interface {
 	// GetDeployment returns a deployment for the give name and namespace
 	GetDeployment(name, namespace string) (*appsv1.Deployment, error)
 	// CreateDeployment creates the given deployment
-	CreateDeployment(*appsv1.Deployment) (*appsv1.Deployment, error)
+	CreateDeployment(*appsv1.Deployment, metav1.CreateOptions) (*appsv1.Deployment, error)
 	// UpdateDeployment updates the given deployment
 	UpdateDeployment(*appsv1.Deployment) (*appsv1.Deployment, error)
 	// DeleteDeployment deletes the given deployment
@@ -57,7 +57,7 @@ func (c *Client) GetDeployment(name, namespace string) (*appsv1.Deployment, erro
 }
 
 // CreateDeployment creates the given deployment
-func (c *Client) CreateDeployment(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
+func (c *Client) CreateDeployment(deployment *appsv1.Deployment, opts metav1.CreateOptions) (*appsv1.Deployment, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (c *Client) CreateDeployment(deployment *appsv1.Deployment) (*appsv1.Deploy
 		ns = corev1.NamespaceDefault
 	}
 
-	return c.apps.Deployments(ns).Create(context.TODO(), deployment, metav1.CreateOptions{})
+	return c.apps.Deployments(ns).Create(context.TODO(), deployment, opts)
 }
 
 // DeleteDeployment deletes the given deployment

--- a/vendor/github.com/portworx/sched-ops/k8s/apps/replicasets.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apps/replicasets.go
@@ -18,7 +18,7 @@ import (
 // ReplicaSetOps is an interface to perform k8s daemon set operations
 type ReplicaSetOps interface {
 	// CreateReplicaSet creates the given ReplicaSet
-	CreateReplicaSet(rs *appsv1.ReplicaSet) (*appsv1.ReplicaSet, error)
+	CreateReplicaSet(rs *appsv1.ReplicaSet, opts metav1.CreateOptions) (*appsv1.ReplicaSet, error)
 	// ListReplicaSets lists all ReplicaSets in given namespace
 	ListReplicaSets(namespace string, listOpts metav1.ListOptions) ([]appsv1.ReplicaSet, error)
 	// GetReplicaSet gets the the daemon set with given name
@@ -36,12 +36,12 @@ type ReplicaSetOps interface {
 }
 
 // CreateReplicaSet creates the given ReplicaSet
-func (c *Client) CreateReplicaSet(rs *appsv1.ReplicaSet) (*appsv1.ReplicaSet, error) {
+func (c *Client) CreateReplicaSet(rs *appsv1.ReplicaSet, opts metav1.CreateOptions) (*appsv1.ReplicaSet, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
 
-	return c.apps.ReplicaSets(rs.Namespace).Create(context.TODO(), rs, metav1.CreateOptions{})
+	return c.apps.ReplicaSets(rs.Namespace).Create(context.TODO(), rs, opts)
 }
 
 // ListReplicaSets lists all ReplicaSets in given namespace

--- a/vendor/github.com/portworx/sched-ops/k8s/apps/statefulsets.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apps/statefulsets.go
@@ -22,7 +22,7 @@ type StatefulSetOps interface {
 	// GetStatefulSet returns a statefulset for given name and namespace
 	GetStatefulSet(name, namespace string) (*appsv1.StatefulSet, error)
 	// CreateStatefulSet creates the given statefulset
-	CreateStatefulSet(ss *appsv1.StatefulSet) (*appsv1.StatefulSet, error)
+	CreateStatefulSet(ss *appsv1.StatefulSet, opts metav1.CreateOptions) (*appsv1.StatefulSet, error)
 	// UpdateStatefulSet creates the given statefulset
 	UpdateStatefulSet(ss *appsv1.StatefulSet) (*appsv1.StatefulSet, error)
 	// DeleteStatefulSet deletes the given statefulset
@@ -62,7 +62,7 @@ func (c *Client) GetStatefulSet(name, namespace string) (*appsv1.StatefulSet, er
 }
 
 // CreateStatefulSet creates the given statefulset
-func (c *Client) CreateStatefulSet(statefulset *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
+func (c *Client) CreateStatefulSet(statefulset *appsv1.StatefulSet, opts metav1.CreateOptions) (*appsv1.StatefulSet, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (c *Client) CreateStatefulSet(statefulset *appsv1.StatefulSet) (*appsv1.Sta
 		ns = corev1.NamespaceDefault
 	}
 
-	return c.apps.StatefulSets(ns).Create(context.TODO(), statefulset, metav1.CreateOptions{})
+	return c.apps.StatefulSets(ns).Create(context.TODO(), statefulset, opts)
 }
 
 // DeleteStatefulSet deletes the given statefulset

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/stork.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/stork.go
@@ -257,10 +257,10 @@ func (c *Client) handleWatch(
 						err = c.WatchApplicationBackup(namespace, fn, listOptions)
 					} else if _, ok := object.(*storkv1.ApplicationRestore); ok {
 						err = c.WatchApplicationRestore(namespace, fn, listOptions)
-					} else if _, ok := object.(*storkv1.ApplicationClone); ok {
-						err = c.WatchApplicationClone(namespace, fn, listOptions)
 					} else if _, ok := object.(*storkv1.ApplicationBackupSchedule); ok {
 						err = c.WatchApplicationBackupSchedule(namespace, fn, listOptions)
+					} else if _, ok := object.(*storkv1.ApplicationClone); ok {
+						err = c.WatchApplicationClone(namespace, fn, listOptions)
 					} else if _, ok := object.(*storkv1.ClusterPair); ok {
 						err = c.WatchClusterPair(namespace, fn, listOptions)
 					} else if _, ok := object.(*storkv1.Migration); ok {

--- a/vendor/github.com/portworx/torpedo/drivers/node/ssh/ssh.go
+++ b/vendor/github.com/portworx/torpedo/drivers/node/ssh/ssh.go
@@ -20,6 +20,7 @@ import (
 	ssh_pkg "golang.org/x/crypto/ssh"
 	appsv1_api "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -132,7 +133,7 @@ func (s *SSH) initExecPod() error {
 		if err != nil {
 			return fmt.Errorf("Error while getting debug daemonset spec. Err: %s", err)
 		}
-		ds, err = k8sApps.CreateDaemonSet(dsSpec.SpecList[0].(*appsv1_api.DaemonSet))
+		ds, err = k8sApps.CreateDaemonSet(dsSpec.SpecList[0].(*appsv1_api.DaemonSet), metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("Error while creating debug daemonset. Err: %s", err)
 		}

--- a/vendor/github.com/portworx/torpedo/drivers/scheduler/scheduler.go
+++ b/vendor/github.com/portworx/torpedo/drivers/scheduler/scheduler.go
@@ -104,6 +104,8 @@ type ScheduleOptions struct {
 	Scheduler string
 	// Labels is a map of {key,value} pairs for labeling spec objects
 	Labels map[string]string
+	// DryRun options for app scheduling
+	DryRun []string
 }
 
 // Driver must be implemented to provide test support to various schedulers.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -430,7 +430,7 @@ github.com/pmezard/go-difflib/difflib
 github.com/portworx/kvdb
 github.com/portworx/kvdb/common
 github.com/portworx/kvdb/mem
-# github.com/portworx/sched-ops v0.0.0-20200723032629-257aba0944dc => github.com/portworx/sched-ops v0.20.4-openstorage-rc3
+# github.com/portworx/sched-ops v0.20.4-openstorage-rc3.0.20210325150944-0b2c202335f7 => github.com/portworx/sched-ops v0.20.4-openstorage-rc3.0.20210325160501-71c13c330a2e
 ## explicit
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -448,7 +448,7 @@ github.com/portworx/sched-ops/k8s/rbac
 github.com/portworx/sched-ops/k8s/storage
 github.com/portworx/sched-ops/k8s/stork
 github.com/portworx/sched-ops/task
-# github.com/portworx/torpedo v0.0.0-20210302010102-e291f3361bd7 => github.com/portworx/torpedo v0.20.4-rc1
+# github.com/portworx/torpedo v0.0.0-20210302010102-e291f3361bd7 => github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 ## explicit
 github.com/portworx/torpedo/drivers/api
 github.com/portworx/torpedo/drivers/node
@@ -1299,8 +1299,8 @@ sigs.k8s.io/yaml
 # github.com/kubernetes-csi/external-snapshotter/client/v4 => github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 # github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc3
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3
-# github.com/portworx/torpedo => github.com/portworx/torpedo v0.20.4-rc1
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3.0.20210325160501-71c13c330a2e
+# github.com/portworx/torpedo => github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.5.2
 # k8s.io/api => k8s.io/api v0.20.4


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Add Integration test which validates mysql spec with dryRun options for recent fix #802 

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6.3

**Note** : Please review vendor/github.com/portworx/torpedo changes as well since we are not adding changes torpedo master (open PR for k8s v1.20 lib updates https://github.com/portworx/torpedo/pull/562)

Integration-test Run: 
```
=== RUN   TestSnapshotMigration
=== RUN   TestSnapshotMigration/testWebhook
=== RUN   TestSnapshotMigration/testWebhook/simpleDryRunTest
time="2021-03-25T16:39:40Z" level=info msg="[mysql-2-pvc] Created PVC: mysql-data"
time="2021-03-25T16:39:40Z" level=info msg="[mysql-2-pvc] Created PVC: mysql-temp"
time="2021-03-25T16:39:40Z" level=info msg="Setting provisioner of mysql-sc to kubernetes.io/portworx-volume"
time="2021-03-25T16:39:40Z" level=info msg="[mysql-2-pvc] Found existing storage class: mysql-sc"
time="2021-03-25T16:39:40Z" level=info msg="[mysql-2-pvc] Created deployment: mysql"
--- PASS: TestSnapshotMigration (0.11s)
    --- PASS: TestSnapshotMigration/testWebhook (0.11s)
        --- PASS: TestSnapshotMigration/testWebhook/simpleDryRunTest (0.09s)
PASS

DONE 3 tests in 16.057s
```
