### PR TITLE
rename stork prometheus metrics with standard prefix

### DIFF
--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -48,19 +48,19 @@ var (
 	// HyperConvergedPodsCounter for pods hyper-converged by stork scheduler i.e scheduled on
 	// node where replicas for all pod volumes exists
 	HyperConvergedPodsCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "hyperconverged_pods_total",
+		Name: "stork_hyperconverged_pods_total",
 		Help: "The total number of pods hyper-converged by stork scheduler",
 	}, []string{"pod", "namespace"})
 	// NonHyperConvergePodsCounter for pods which are placed on driver node but not on node
 	// where pod volume replicas exists
 	NonHyperConvergePodsCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "non_hyperconverged_pods_total",
+		Name: "stork_non_hyperconverged_pods_total",
 		Help: "The total number of pods that are not hyper-converged by stork scheduler",
 	}, []string{"pod", "namespace"})
 	// SemiHyperConvergePodsCounter for pods which scheduled on node where replicas for all
 	// volumes does not exists
 	SemiHyperConvergePodsCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "semi_hyperconverged_pods_total",
+		Name: "stork_semi_hyperconverged_pods_total",
 		Help: "The total number of pods that are partially hyper-converged by stork scheduler",
 	}, []string{"pod", "namespace"})
 )

--- a/pkg/metrics/applicationbackup.go
+++ b/pkg/metrics/applicationbackup.go
@@ -12,27 +12,27 @@ import (
 var (
 	// backupStatusCounter for application backup CR status on server
 	backupStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_backup_status",
+		Name: "stork_application_backup_status",
 		Help: "Status of application backups",
 	}, []string{metricName, metricNamespace, metricSchedule})
 	// backupStageCounter for application backup CR stages on server
 	backupStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_backup_stage",
+		Name: "stork_application_backup_stage",
 		Help: "Stage of application backups",
 	}, []string{metricName, metricNamespace, metricSchedule})
 	// backupDurationCounter for time taken by application backup to complete
 	backupDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_backup_duration",
+		Name: "stork_application_backup_duration",
 		Help: "Duration of application backups",
 	}, []string{metricName, metricNamespace, metricSchedule})
 	// backupSizeCounter for application backup size
 	backupSizeCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_backup_size",
+		Name: "stork_application_backup_size",
 		Help: "Size of application backups",
 	}, []string{metricName, metricNamespace, metricSchedule})
 	// backupScheduleStatusCounter for application backup schedule CR status on server
 	backupScheduleStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_backup__schedule_status",
+		Name: "stork_application_backup_schedule_status",
 		Help: "Status of application backup Schedules",
 	}, []string{metricName, metricNamespace})
 )

--- a/pkg/metrics/applicationclone.go
+++ b/pkg/metrics/applicationclone.go
@@ -11,17 +11,17 @@ import (
 var (
 	// CloneStatusCounter for application clone CR status on server
 	cloneStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_clone_status",
+		Name: "stork_application_clone_status",
 		Help: "Status of application clones",
 	}, []string{metricName, metricNamespace})
 	// CloneStageCounter for application clone CR stages on server
 	cloneStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_clone_stage",
+		Name: "stork_application_clone_stage",
 		Help: "Stage of application clones",
 	}, []string{metricName, metricNamespace})
 	// CloneDurationCounter for time taken by application clone to complete
 	cloneDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_clone_duration",
+		Name: "stork_application_clone_duration",
 		Help: "Duration of application clones",
 	}, []string{metricName, metricNamespace})
 )

--- a/pkg/metrics/applicationrestore.go
+++ b/pkg/metrics/applicationrestore.go
@@ -11,22 +11,22 @@ import (
 var (
 	// RestoreStatusCounter for application restore CR status on server
 	restoreStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_restore_status",
+		Name: "stork_application_restore_status",
 		Help: "Status of application restores",
 	}, []string{metricName, metricNamespace})
 	// RestoreStageCounter for application restore CR stages on server
 	restoreStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_restore_stage",
+		Name: "stork_application_restore_stage",
 		Help: "Stage of application restore",
 	}, []string{metricName, metricNamespace})
 	// RestoreDurationCounter for time taken by application restore to complete
 	restoreDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_restore_duration",
+		Name: "stork_application_restore_duration",
 		Help: "Duration of application restores",
 	}, []string{metricName, metricNamespace})
 	// RestoreSizeCounter for application restore size
 	restoreSizeCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "application_restore_size",
+		Name: "stork_application_restore_size",
 		Help: "Size of application restores",
 	}, []string{metricName, metricNamespace})
 )

--- a/pkg/metrics/clusterpair.go
+++ b/pkg/metrics/clusterpair.go
@@ -11,11 +11,11 @@ import (
 var (
 	// clusterpairStatusCounter for clusterpair status
 	clusterpairSchedStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "clusterpair_scheduler_status",
+		Name: "stork_clusterpair_scheduler_status",
 		Help: "Status of scheduler clusterpair",
 	}, []string{metricName, metricNamespace})
 	clusterpairStorageStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "clusterpair_storage_status",
+		Name: "stork_clusterpair_storage_status",
 		Help: "Status of storage clusterpair",
 	}, []string{metricName, metricNamespace})
 )

--- a/pkg/metrics/migration.go
+++ b/pkg/metrics/migration.go
@@ -11,22 +11,22 @@ import (
 var (
 	// migrationStatusCounter for migration status
 	migrationStatusCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "migration_status",
+		Name: "stork_migration_status",
 		Help: "Status of migration",
 	}, []string{metricName, metricNamespace, metricSchedule})
 	// migrationStageCounter for migration CR stages on server
 	migrationStageCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "migration_stage",
+		Name: "stork_migration_stage",
 		Help: "Stage of migration",
 	}, []string{metricName, metricNamespace, metricSchedule})
 	// migrationDurationCounter for time taken by migration to complete
 	migrationDurationCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "migration_duration",
+		Name: "stork_migration_duration",
 		Help: "Duration of migrations",
 	}, []string{metricName, metricNamespace, metricSchedule})
 	// migrationScheduleCounter for migration schedule status
 	migrationScheduleCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "migration_schedule_status",
+		Name: "stork_migration_schedule_status",
 		Help: "Status of migration schedules",
 	}, []string{metricName, metricNamespace})
 )

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -34,7 +34,7 @@ const (
 var (
 	// HealthCounter for pods which are rescheduled by stork monitor
 	HealthCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pods_reschduled_total",
+		Name: "stork_pods_rescheduled_total",
 		Help: "The total number of pods reschduler by stork pod monitor",
 	})
 )


### PR DESCRIPTION
**What type of PR is this?**
>cleanup

**What this PR does / why we need it**:
Standardize stork prometheus metrics with set prefix `stork`

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
-->
```release-note
All stork prometheus metrics will now have `stork_` as prefix, eg
stork_application_backup_status, stork_migration_status, stork_hyperconverged_pods_total etc
All existing metrics will now move over to `stork_` prefix convention 
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6.3

