### PR TITLE
Add pluralizer rules for prometheus crd

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1291,7 +1291,11 @@ func (m *MigrationController) applyResources(
 			return err
 		}
 	}
-
+	// TODO: we should use k8s code generator logic to pluralize
+	// crd resources instead of depending on inflect lib
+	ruleset := inflect.NewDefaultRuleset()
+	ruleset.AddPlural("quota", "quotas")
+	ruleset.AddPlural("prometheus", "prometheuses")
 	for _, o := range objects {
 		metadata, err := meta.Accessor(o)
 		if err != nil {
@@ -1302,7 +1306,7 @@ func (m *MigrationController) applyResources(
 			return err
 		}
 		resource := &metav1.APIResource{
-			Name:       inflect.Pluralize(strings.ToLower(objectType.GetKind())),
+			Name:       ruleset.Pluralize(strings.ToLower(objectType.GetKind())),
 			Namespaced: len(metadata.GetNamespace()) > 0,
 		}
 		var dynamicClient dynamic.ResourceInterface

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -845,7 +845,7 @@ func (r *ResourceCollector) getDynamicClient(
 	// The default ruleset doesn't pluralize quotas correctly, so add that
 	ruleset := inflect.NewDefaultRuleset()
 	ruleset.AddPlural("quota", "quotas")
-
+	ruleset.AddPlural("prometheus", "prometheuses")
 	resource := &metav1.APIResource{
 		Name:       ruleset.Pluralize(strings.ToLower(objectType.GetKind())),
 		Namespaced: len(metadata.GetNamespace()) > 0,


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Adds pluraliser rule for prometheus CR detections during backup/restore and migration. 

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.6.3
