### PR TITLE
Add permissions for stork-scheduler for k8s 1.21

### DIFF
--- a/specs/stork-scheduler.yaml
+++ b/specs/stork-scheduler.yaml
@@ -53,7 +53,7 @@ rules:
     resources: ["persistentvolumeclaims", "persistentvolumes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes","csidrivers", "csistoragecapacities"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
bug


**What this PR does / why we need it**:
https://portworx.atlassian.net/browse/STOR-379

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no


**Does this change need to be cherry-picked to a release branch?**:
no

