### PR TITLE
Configure rsync time for application controllers

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -154,6 +154,11 @@ func main() {
 			Name:  "enable-metrics",
 			Usage: "Enable stork metrics collection for stork resources (default: true)",
 		},
+		cli.Int64Flag{
+			Name:  "application-backup-sync-interval",
+			Value: 10,
+			Usage: "The interval in seconds to sync reconcilers (default: 10 seconds)",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -377,6 +382,7 @@ func runStork(mgr manager.Manager, d volume.Driver, recorder record.EventRecorde
 			Driver:            d,
 			Recorder:          recorder,
 			ResourceCollector: resourceCollector,
+			RsyncTime:         c.Int64("application-backup-sync-interval"),
 		}
 		if err := appManager.Init(mgr, adminNamespace, signalChan); err != nil {
 			log.Fatalf("Error initializing application manager: %v", err)

--- a/pkg/applicationmanager/applicationmanager.go
+++ b/pkg/applicationmanager/applicationmanager.go
@@ -27,6 +27,7 @@ type ApplicationManager struct {
 	Driver            volume.Driver
 	Recorder          record.EventRecorder
 	ResourceCollector resourcecollector.ResourceCollector
+	RsyncTime         int64
 }
 
 // Init Initializes the ApplicationManager and any children controller
@@ -35,7 +36,7 @@ func (a *ApplicationManager) Init(mgr manager.Manager, adminNamespace string, st
 		return err
 	}
 	backupController := controllers.NewApplicationBackup(mgr, a.Recorder, a.ResourceCollector)
-	if err := backupController.Init(mgr, adminNamespace); err != nil {
+	if err := backupController.Init(mgr, adminNamespace, a.RsyncTime); err != nil {
 		return err
 	}
 

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -88,10 +88,11 @@ type ApplicationBackupController struct {
 	recorder             record.EventRecorder
 	resourceCollector    resourcecollector.ResourceCollector
 	backupAdminNamespace string
+	reconcileTime        time.Duration
 }
 
 // Init Initialize the application backup controller
-func (a *ApplicationBackupController) Init(mgr manager.Manager, backupAdminNamespace string) error {
+func (a *ApplicationBackupController) Init(mgr manager.Manager, backupAdminNamespace string, syncTime int64) error {
 	err := a.createCRD()
 	if err != nil {
 		return err
@@ -102,7 +103,7 @@ func (a *ApplicationBackupController) Init(mgr manager.Manager, backupAdminNames
 		logrus.Errorf("Failed to perform recovery for backup rules: %v", err)
 		return err
 	}
-
+	a.reconcileTime = time.Duration(syncTime) * time.Second
 	return controllers.RegisterTo(mgr, "application-backup-controller", a, &stork_api.ApplicationBackup{})
 }
 
@@ -133,7 +134,7 @@ func (a *ApplicationBackupController) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{RequeueAfter: controllers.DefaultRequeueError}, err
 	}
 
-	return reconcile.Result{RequeueAfter: controllers.DefaultRequeue}, nil
+	return reconcile.Result{RequeueAfter: a.reconcileTime}, nil
 }
 
 func setKind(snap *stork_api.ApplicationBackup) {
@@ -434,6 +435,9 @@ func (a *ApplicationBackupController) updateBackupCRWithRetry(
 			time.Sleep(retrySleep)
 			continue
 		}
+		if backup.Status.Stage == stork_api.ApplicationBackupStageFinal {
+			return backup, nil
+		}
 		backup.Status.Status = status
 		backup.Status.Stage = stage
 		backup.Status.Reason = reason
@@ -666,6 +670,9 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 					time.Sleep(retrySleep)
 					continue
 				}
+				if backup.Status.Stage == stork_api.ApplicationBackupStageFinal {
+					return nil
+				}
 				backup.Status.Volumes = volumeInfos
 				backup.Status.LastUpdateTimestamp = metav1.Now()
 				err = a.client.Update(context.TODO(), backup)
@@ -699,6 +706,9 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 				if err != nil {
 					time.Sleep(retrySleep)
 					continue
+				}
+				if backup.Status.Stage == stork_api.ApplicationBackupStageFinal {
+					return nil
 				}
 				backup.Status.Stage = stork_api.ApplicationBackupStageApplications
 				backup.Status.Status = stork_api.ApplicationBackupStatusInProgress
@@ -1035,6 +1045,9 @@ func (a *ApplicationBackupController) backupResources(
 			if err != nil {
 				time.Sleep(retrySleep)
 				continue
+			}
+			if backup.Status.Stage == stork_api.ApplicationBackupStageFinal {
+				return nil
 			}
 			backup.Status.LastUpdateTimestamp = metav1.Now()
 			err = a.client.Update(context.TODO(), backup)


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
- Avoid faulty read and update of controller sdk if backup resource is already at final stage
- allow to configure backup controller rsync interval

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```
Fixed issue where CSI volumes Application backup snapshots were deleted even though backups are completed successfully 
```

**Does this change need to be cherry-picked to a release branch?**:
2.6

