### PR TITLE
stor-391: application clone fails if dest namespace

### DIFF
--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -133,9 +133,9 @@ func (a *ApplicationCloneController) verifyNamespaces(clone *stork_api.Applicati
 	log.ApplicationCloneLog(clone).Infof("Creating dest namespace %v", ns.Name)
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			log.ApplicationCloneLog(clone).Errorf("Updating dest namespace %v", ns.Name)
-			// regardless of replace policy we should always update namespace is
-			// its already exist to keel latest annotations/labels
+			log.ApplicationCloneLog(clone).Infof("Updating dest namespace %v", ns.Name)
+			// regardless of replace policy we should always update namespace
+			// to keep latest annotations/labels
 			_, err = core.Instance().UpdateNamespace(&v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        clone.Spec.DestinationNamespace,
@@ -143,6 +143,7 @@ func (a *ApplicationCloneController) verifyNamespaces(clone *stork_api.Applicati
 					Annotations: ns.GetAnnotations(),
 				},
 			})
+			return err
 		}
 		log.ApplicationCloneLog(clone).Errorf("error creating destination namespace  %v: %v", clone.Spec.DestinationNamespace, err)
 		return fmt.Errorf("error creating destination namespace %v: %v", clone.Spec.DestinationNamespace, err)


### PR DESCRIPTION
**What type of PR is this?**
> bug

**What this PR does / why we need it**:
Fix issue where application clone fails if destination namespace(clone namespace) already exists

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Application clone stuck if destination namespace already exists https://github.com/libopenstorage/stork/issues/826
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6

