### PR TITLE
Backing up NetworkPolicy and PodDisruptionBudget objects

### DIFF
--- a/pkg/resourcecollector/networkpolicy.go
+++ b/pkg/resourcecollector/networkpolicy.go
@@ -1,0 +1,41 @@
+package resourcecollector
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) networkPolicyToBeCollected(
+	object runtime.Unstructured,
+) (bool, error) {
+	var networkPolicy v1.NetworkPolicy
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &networkPolicy); err != nil {
+		return false, fmt.Errorf("error converting to networkpolicy: %v", err)
+	}
+	// Collect NetworkPolicy if ony CIDR is not set.
+	// If we backup NetworkPolicy with CIDR present when a user
+	// restores this, it's not guaranteed that same network topology is
+	// available on restore cluster.
+	ingressRule := networkPolicy.Spec.Ingress
+	for _, ingress := range ingressRule {
+		for _, fromPolicyPeer := range ingress.From {
+			ipBlock := fromPolicyPeer.IPBlock
+			if len(ipBlock.CIDR) != 0 {
+				return false, nil
+			}
+		}
+	}
+	egreeRule := networkPolicy.Spec.Egress
+	for _, egress := range egreeRule {
+		for _, networkPolicyPeer := range egress.To {
+			ipBlock := networkPolicyPeer.IPBlock
+			if len(ipBlock.CIDR) != 0 {
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -134,7 +134,9 @@ func resourceToBeCollected(resource metav1.APIResource, grp schema.GroupVersion,
 		"CronJob",
 		"ResourceQuota",
 		"ReplicaSet",
-		"LimitRange":
+		"LimitRange",
+		"NetworkPolicy",
+		"PodDisruptionBudget":
 		return true
 	case "Job":
 		return slice.ContainsString(optionalResourceTypes, "job", strings.ToLower) ||
@@ -470,6 +472,8 @@ func (r *ResourceCollector) objectToBeCollected(
 		return r.configmapToBeCollected(object)
 	case "ResourceQuota":
 		return r.resourceQuotaToBeCollected(object)
+	case "NetworkPolicy":
+		return r.networkPolicyToBeCollected(object)
 	}
 
 	return true, nil


### PR DESCRIPTION
**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:
Support for  backing up NetworkPolicy and PodDisruptionBudget objects

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes

Manul test
Applied below network policy, podDisrutpion budget and took a backup and checked resources.json file had the content

```

 [root@prashanth-muck-bug-0 np]# cat networkpolicy.yml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: allow-all-ingress-egress
  namespace: test
spec:
  podSelector: {}
  policyTypes:
  - Ingress
  - Egress
  ingress:
  - {}
  egress:
  - {}


podDisruptionBudget
[root@prashanth-muck-bug-0 np]# cat pdb.yml
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  name: pdb-1
  namespace: test
spec:
  minAvailable: 2
  selector:
    matchLabels:
      app: nginx

backup spec
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationBackup
metadata:
  name: test-backup-1
  namespace: test
spec:
  backupLocation: mysql
  namespaces:
  - test
  reclaimPolicy: Delete
  selectors:
  preExecRule:
  postExecRule:

```

NetworkPolicy which will be skipped
```
[root@prashanth-muck-bug-0 np]# k get networkpolicy test-network-policy -ntest -o json
{
    "apiVersion": "networking.k8s.io/v1",
    "kind": "NetworkPolicy",
    "metadata": {
        "annotations": {
            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"networking.k8s.io/v1\",\"kind\":\"NetworkPolicy\",\"metadata\":{\"annotations\":{},\"name\":\"test-network-policy\",\"namespace\":\"test\"},\"spec\":{\"egress\":[{\"ports\":[{\"port\":5978,\"protocol\":\"TCP\"}],\"to\":[{\"ipBlock\":{\"cidr\":\"10.0.0.0/24\"}}]}],\"ingress\":[{\"from\":[{\"ipBlock\":{\"cidr\":\"172.17.0.0/16\",\"except\":[\"172.17.1.0/24\"]}},{\"namespaceSelector\":{\"matchLabels\":{\"project\":\"myproject\"}}},{\"podSelector\":{\"matchLabels\":{\"role\":\"frontend\"}}}],\"ports\":[{\"port\":6379,\"protocol\":\"TCP\"}]}],\"podSelector\":{\"matchLabels\":{\"role\":\"db\"}},\"policyTypes\":[\"Ingress\",\"Egress\"]}}\n"
        },
        "creationTimestamp": "2021-06-14T14:41:50Z",
        "generation": 1,
        "managedFields": [
            {
                "apiVersion": "networking.k8s.io/v1",
                "fieldsType": "FieldsV1",
                "fieldsV1": {
                    "f:metadata": {
                        "f:annotations": {
                            ".": {},
                            "f:kubectl.kubernetes.io/last-applied-configuration": {}
                        }
                    },
                    "f:spec": {
                        "f:egress": {},
                        "f:ingress": {},
                        "f:podSelector": {},
                        "f:policyTypes": {}
                    }
                },
                "manager": "kubectl-client-side-apply",
                "operation": "Update",
                "time": "2021-06-14T14:41:50Z"
            }
        ],
        "name": "test-network-policy",
        "namespace": "test",
        "resourceVersion": "7028671",
        "uid": "53791b68-db0b-41dc-9119-7d072eda8226"
    },
"spec": {
        "egress": [
            {
                "ports": [
                    {
                        "port": 5978,
                        "protocol": "TCP"
                    }
                ],
                "to": [
                    {
                        "ipBlock": {
                            "cidr": "10.0.0.0/24"
                        }
                    }
                ]
            }
        ],
        "ingress": [
            {
                "from": [
                    {
                        "ipBlock": {
                            "cidr": "172.17.0.0/16",
                            "except": [
                                "172.17.1.0/24"
                            ]
                        }
                    },
                    {
                        "namespaceSelector": {
                            "matchLabels": {
                                "project": "myproject"
                            }
                        }
                    },
                    {
                        "podSelector": {
                            "matchLabels": {
                                "role": "frontend"
                            }
                        }
                    }
                ],
"ports": [
                    {
                        "port": 6379,
                        "protocol": "TCP"
                    }
                ]
            }
        ],
        "podSelector": {
            "matchLabels": {
                "role": "db"
            }
        },
        "policyTypes": [
            "Ingress",
            "Egress"
        ]
    }
}

```

Content of resources.json file from objecstore, showing only NetworkPolicy not having CIDR
```
{
  "apiVersion": "networking.k8s.io/v1",
  "kind": "NetworkPolicy",
  "metadata": {
   "annotations": {
    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"networking.k8s.io/v1\",\"kind\":\"NetworkPolicy\",\"metadata\":{\"annotations\":{},\"name\":\"allow-all-ingress-egress\",\"namespace\":\"test\"},\"spec\":{\"egress\":[{}],\"ingress\":[{}],\"podSelector\":{},\"policyTypes\":[\"Ingress\",\"Egress\"]}}\n"
   },
   "name": "allow-all-ingress-egress",
   "namespace": "test"
  },
  "spec": {
   "egress": [
    {}
   ],
   "ingress": [
    {}
   ],
   "podSelector": {},
   "policyTypes": [
    "Ingress",
    "Egress"
   ]
  }
 },
 {
  "apiVersion": "policy/v1beta1",
  "kind": "PodDisruptionBudget",
  "metadata": {
   "annotations": {
    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"policy/v1beta1\",\"kind\":\"PodDisruptionBudget\",\"metadata\":{\"annotations\":{},\"name\":\"pdb-1\",\"namespace\":\"test\"},\"spec\":{\"minAvailable\":2,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}}}}\n"
   },
   "name": "pdb-1",
   "namespace": "test"
  },
  "spec": {
   "minAvailable": 2,
   "selector": {
    "matchLabels": {
     "app": "nginx"
    }
   }
  },
  "status": {
   "currentHealthy": 2,
   "desiredHealthy": 2,
   "disruptionsAllowed": 0,
   "expectedPods": 2,
   "observedGeneration": 1
  }
 }
]
```
