### PR TITLE
Fix namespaced schedule policy cache watch list

### DIFF
--- a/pkg/schedule/cache.go
+++ b/pkg/schedule/cache.go
@@ -50,13 +50,13 @@ func startSchedulePolicyCache() error {
 	)
 	go controller.Run(wait.NeverStop)
 
-	watchlist = cache.NewListWatchFromClient(restClient, stork_api.NamespacedSchedulePolicyResourcePlural, v1.NamespaceAll, fields.Everything())
+	nswatchlist := cache.NewListWatchFromClient(restClient, stork_api.NamespacedSchedulePolicyResourcePlural, v1.NamespaceAll, fields.Everything())
 	lw = &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return watchlist.List(options)
+			return nswatchlist.List(options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return watchlist.Watch(options)
+			return nswatchlist.Watch(options)
 		},
 	}
 	namespacedSchedulePolicyStore, controller = cache.NewInformer(lw, &stork_api.NamespacedSchedulePolicy{}, resyncPeriod,


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Fix stor-403: use separate cache watch list for namespaced schedule policy

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6.4
