### PR TITLE
Skipping backing up of gke-resource-quotas

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -468,6 +468,8 @@ func (r *ResourceCollector) objectToBeCollected(
 		return r.ingressToBeCollected(object)
 	case "ConfigMap":
 		return r.configmapToBeCollected(object)
+	case "ResourceQuota":
+		return r.resourceQuotaToBeCollected(object)
 	}
 
 	return true, nil

--- a/pkg/resourcecollector/resourcequota.go
+++ b/pkg/resourcecollector/resourcequota.go
@@ -1,0 +1,26 @@
+package resourcecollector
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) resourceQuotaToBeCollected(
+	object runtime.Unstructured,
+) (bool, error) {
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return false, err
+	}
+	// Excluding gke-resource-quotas as this is created per ns on GKE
+	excludeResourceQuota := []string{"gke-resource-quotas"}
+
+	for _, name := range excludeResourceQuota {
+		if strings.Compare(metadata.GetName(), name) == 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
- On GKE when a namespace is created by default this gets
  created so no need of backing it up

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 2.6.4
