### PR TITLE
Allow option to prevent resource modification during backup/migration

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -24,12 +24,13 @@ type ApplicationBackup struct {
 
 // ApplicationBackupSpec is the spec used to backup applications
 type ApplicationBackupSpec struct {
-	Namespaces     []string                           `json:"namespaces"`
-	BackupLocation string                             `json:"backupLocation"`
-	Selectors      map[string]string                  `json:"selectors"`
-	PreExecRule    string                             `json:"preExecRule"`
-	PostExecRule   string                             `json:"postExecRule"`
-	ReclaimPolicy  ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
+	Namespaces        []string                           `json:"namespaces"`
+	BackupLocation    string                             `json:"backupLocation"`
+	Selectors         map[string]string                  `json:"selectors"`
+	PreExecRule       string                             `json:"preExecRule"`
+	PostExecRule      string                             `json:"postExecRule"`
+	ReclaimPolicy     ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
+	SkipServiceUpdate bool                               `json:"skipServiceUpdate"`
 	// Options to be passed in to the driver
 	Options          map[string]string `json:"options"`
 	IncludeResources []ObjectInfo      `json:"includeResources"`

--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -20,6 +20,7 @@ type MigrationSpec struct {
 	IncludeVolumes               *bool             `json:"includeVolumes"`
 	StartApplications            *bool             `json:"startApplications"`
 	PurgeDeletedResources        *bool             `json:"purgeDeletedResources"`
+	SkipServiceUpdate            *bool             `json:"skipServiceUpdate"`
 	Selectors                    map[string]string `json:"selectors"`
 	PreExecRule                  string            `json:"preExecRule"`
 	PostExecRule                 string            `json:"postExecRule"`

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -1710,6 +1710,11 @@ func (in *MigrationSpec) DeepCopyInto(out *MigrationSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SkipServiceUpdate != nil {
+		in, out := &in.SkipServiceUpdate, &out.SkipServiceUpdate
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Selectors != nil {
 		in, out := &in.Selectors, &out.Selectors
 		*out = make(map[string]string, len(*in))

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1000,6 +1000,14 @@ func (a *ApplicationBackupController) backupResources(
 		}
 	}
 
+	// Don't modify resources if mentioned explicitly in specs
+	if backup.Spec.SkipServiceUpdate {
+		if a.resourceCollector.Opts == nil {
+			a.resourceCollector.Opts = make(map[string]string)
+		}
+		a.resourceCollector.Opts[resourcecollector.ServiceKind] = "true"
+	}
+
 	// Always backup optional resources. When restorting they need to be
 	// explicitly added to the spec
 	objectMap := stork_api.CreateObjectsMap(backup.Spec.IncludeResources)

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -757,6 +757,14 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration, v
 	}
 	resKinds := make(map[string]string)
 	var updateObjects []runtime.Unstructured
+
+	// Don't modify resources if mentioned explicitly in specs
+	if *migration.Spec.SkipServiceUpdate {
+		if m.resourceCollector.Opts == nil {
+			m.resourceCollector.Opts = make(map[string]string)
+		}
+		m.resourceCollector.Opts[resourcecollector.ServiceKind] = "true"
+	}
 	allObjects, err := m.resourceCollector.GetResources(
 		migration.Spec.Namespaces,
 		migration.Spec.Selectors,

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1021,6 +1021,15 @@ func (m *MigrationController) checkAndUpdateDefaultSA(
 			destSA.ImagePullSecrets = append(destSA.ImagePullSecrets, s)
 		}
 	}
+	// merge annotation for SA
+	if destSA.Annotations != nil {
+		if sourceSA.Annotations == nil {
+			sourceSA.Annotations = make(map[string]string)
+		}
+		for k, v := range sourceSA.Annotations {
+			destSA.Annotations[k] = v
+		}
+	}
 	_, err = adminClient.CoreV1().ServiceAccounts(destSA.GetNamespace()).Update(context.TODO(), destSA, metav1.UpdateOptions{})
 	if err != nil {
 		return err

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -37,9 +37,10 @@ const (
 	skipResourceAnnotation           = "stork.libopenstorage.org/skip-resource"
 	skipOwnerRefCheckAnnotation      = "stork.libopenstorage.org/skip-owner-ref-check"
 	skipModifyResources              = "stork.libopenstorage.org/skip-modify-resource"
-	ServiceKind                      = "Service"
-	deletedMaxRetries                = 12
-	deletedRetryInterval             = 10 * time.Second
+	// ServiceKind for k8s service resources
+	ServiceKind          = "Service"
+	deletedMaxRetries    = 12
+	deletedRetryInterval = 10 * time.Second
 )
 
 // ResourceCollector is used to collect and process unstructured objects in namespaces and using label selectors

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -36,6 +36,8 @@ const (
 	skipResourceAnnotationDeprecated = "stork.libopenstorage.org/skipresource"
 	skipResourceAnnotation           = "stork.libopenstorage.org/skip-resource"
 	skipOwnerRefCheckAnnotation      = "stork.libopenstorage.org/skip-owner-ref-check"
+	skipModifyResources              = "stork.libopenstorage.org/skip-modify-resource"
+	ServiceKind                      = "Service"
 	deletedMaxRetries                = 12
 	deletedRetryInterval             = 10 * time.Second
 )
@@ -48,6 +50,7 @@ type ResourceCollector struct {
 	coreOps          core.Ops
 	rbacOps          rbac.Ops
 	storkOps         storkops.Ops
+	Opts             map[string]string
 }
 
 // Objects Collection of objects
@@ -556,9 +559,11 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 				return fmt.Errorf("error preparing PV resource %v: %v", metadata.GetName(), err)
 			}
 		case "Service":
-			err := r.prepareServiceResourceForCollection(o)
-			if err != nil {
-				return fmt.Errorf("error preparing Service resource %v/%v: %v", metadata.GetNamespace(), metadata.GetName(), err)
+			if _, ok := r.Opts[ServiceKind]; !ok {
+				err := r.prepareServiceResourceForCollection(o)
+				if err != nil {
+					return fmt.Errorf("error preparing Service resource %v/%v: %v", metadata.GetNamespace(), metadata.GetName(), err)
+				}
 			}
 		case "ClusterRoleBinding":
 			err := r.prepareClusterRoleBindingForCollection(o, namespaces)

--- a/pkg/resourcecollector/service.go
+++ b/pkg/resourcecollector/service.go
@@ -31,6 +31,14 @@ func (r *ResourceCollector) prepareServiceResourceForCollection(
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &service); err != nil {
 		return fmt.Errorf("error converting to service: %v", err)
 	}
+	if service.Annotations != nil {
+		if _, ok := service.Annotations[skipModifyResources]; ok {
+			// Skip Modify annotation set don't modify specs for resource
+			// Note: some metadata annotation resource will be deleted latet like
+			// resourceVersion, UID
+			return nil
+		}
+	}
 	// Reset the clusterIP if it is set
 	if service.Spec.ClusterIP != "None" {
 		err := unstructured.SetNestedField(object.UnstructuredContent(), "", "spec", "clusterIP")

--- a/pkg/resourcecollector/serviceaccount.go
+++ b/pkg/resourcecollector/serviceaccount.go
@@ -72,6 +72,15 @@ func (r *ResourceCollector) mergeAndUpdateServiceAccount(
 			currentSA.Secrets = append(currentSA.Secrets, secret)
 		}
 	}
+	// merge annotation for SA
+	if newSA.Annotations != nil {
+		if currentSA.Annotations == nil {
+			currentSA.Annotations = make(map[string]string)
+		}
+		for k, v := range newSA.Annotations {
+			currentSA.Annotations[k] = v
+		}
+	}
 	_, err = r.coreOps.UpdateServiceAccount(currentSA)
 	return err
 }


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
Add CRD option to `ApplicationBackup` and `Migration` for skipping resource field update during backup/migration operation. 

**Does this PR change a user-facing CRD or CLI?**:
yes, User can now specify `SkipServiceUpdate` in migration/backup CR specs so that stork will not modify cluster/loadbalancer ip field during resource collections
eg.: 
```
kind: ApplicationBackup
metadata:
  name: backup-mysql
  namespace: mysql
spec:
  backupLocation: mysql
  namespaces:
  - mysql
  reclaimPolicy: Delete
  skipServiceUpdate: true
 ```

**Is a release note needed?**:
yes
```release-note
Users can now specify `skipServiceUpdate` in backup/migration spec to avoid updating Loadbalancers IP/clusterIP field. Alternatively they can also use `stork.libopenstorage.org/skip-modify-resource` for single service resource
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6.4

