### PR TITLE
Failback migration support and improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,8 @@ require (
 	github.com/pborman/uuid v1.2.0
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/portworx/kdmp v0.4.1-0.20220117074354-94dab8b8d98e
-	github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20211116074603-2b6905763b23
+	github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194 // indirect
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1218,6 +1218,10 @@ github.com/portworx/sched-ops v1.20.4-rc1.0.20211026113317-db80e47fe929 h1:yl7Lb
 github.com/portworx/sched-ops v1.20.4-rc1.0.20211026113317-db80e47fe929/go.mod h1:5xy8TTt9m/8UGG8Hw5NHxwc/mctjCsmj7mpcR7jIFjI=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20211116074603-2b6905763b23 h1:CvUosdpqAPPiGiDWuDuWUQXyEJcuDuTMqel378aiFUA=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20211116074603-2b6905763b23/go.mod h1:5xy8TTt9m/8UGG8Hw5NHxwc/mctjCsmj7mpcR7jIFjI=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220208024433-611d861089d4 h1:riohTP9IIoLnh/W0C/vJv4+ANEORHO3QXBl+OGf5gt8=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220208024433-611d861089d4/go.mod h1:5E/BwC3d4ysXce1fzNFjR2OU8rz7Kx6mt8T10HEiA0E=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8 h1:L85Dd2o3WmUDqHm4xnYG6rLO8FtBRo+GaGGFDIBJlbU=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8/go.mod h1:5E/BwC3d4ysXce1fzNFjR2OU8rz7Kx6mt8T10HEiA0E=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145 h1:J5D0JPZWueVAK8/Dr5s84I7/tCfin6NjIGbKKCSyyJ0=

--- a/pkg/apis/stork/v1alpha1/migrationschedule.go
+++ b/pkg/apis/stork/v1alpha1/migrationschedule.go
@@ -26,7 +26,8 @@ type MigrationTemplateSpec struct {
 
 // MigrationScheduleStatus is the status of a migration schedule
 type MigrationScheduleStatus struct {
-	Items map[SchedulePolicyType][]*ScheduledMigrationStatus `json:"items"`
+	Items                map[SchedulePolicyType][]*ScheduledMigrationStatus `json:"items"`
+	ApplicationActivated bool                                               `json:"applicationActivated"`
 }
 
 // ScheduledMigrationStatus keeps track of the migration that was triggered by a

--- a/pkg/apis/stork/v1alpha1/migrationschedule.go
+++ b/pkg/apis/stork/v1alpha1/migrationschedule.go
@@ -16,6 +16,7 @@ type MigrationScheduleSpec struct {
 	Template           MigrationTemplateSpec `json:"template"`
 	SchedulePolicyName string                `json:"schedulePolicyName"`
 	Suspend            *bool                 `json:"suspend"`
+	AutoSuspend        bool                  `json:"autoSuspend"`
 }
 
 // MigrationTemplateSpec describes the data a Migration should have when created

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -149,7 +149,7 @@ func setKind(snap *stork_api.ApplicationBackup) {
 // performRuleRecovery terminates potential background commands running pods for
 // all applicationBackup objects
 func (a *ApplicationBackupController) performRuleRecovery() error {
-	applicationBackups, err := storkops.Instance().ListApplicationBackups(v1.NamespaceAll)
+	applicationBackups, err := storkops.Instance().ListApplicationBackups(v1.NamespaceAll, metav1.ListOptions{})
 	if err != nil {
 		logrus.Errorf("Failed to list all application backups during rule recovery: %v", err)
 		return err

--- a/pkg/applicationmanager/controllers/backupsync.go
+++ b/pkg/applicationmanager/controllers/backupsync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/blob"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -37,7 +38,7 @@ func (b *BackupSyncController) startBackupSync() {
 	for {
 		select {
 		case <-time.After(b.SyncInterval):
-			backupLocations, err := storkops.Instance().ListBackupLocations("")
+			backupLocations, err := storkops.Instance().ListBackupLocations("", metav1.ListOptions{})
 			if err != nil {
 				logrus.Errorf("Error getting backup location to sync: %v", err)
 				continue

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -209,47 +209,57 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 		return nil
 	}
 
-	// TODO: verify if appActivated flags need to be set as default
 	migration.Spec = setDefaults(migration.Spec)
 
 	if migration.GetAnnotations() != nil {
-		remoteConfig, err := getClusterPairSchedulerConfig(migration.Spec.ClusterPair, migration.Namespace)
-		if err != nil {
-			return err
-		}
-		remoteOps, err := storkops.NewForConfig(remoteConfig)
-		if err != nil {
-			m.recorder.Event(migration,
-				v1.EventTypeWarning,
-				string(stork_api.MigrationStatusFailed),
-				err.Error())
-			return nil
-		}
-		// get remote cluster migration schedule object
-		migrSched, err := remoteOps.GetMigrationSchedule(migration.GetAnnotations()[StorkMigrationName], migration.Namespace)
-		if err != nil {
-			m.recorder.Event(migration,
-				v1.EventTypeWarning,
-				string(stork_api.MigrationStatusFailed),
-				err.Error())
-			return nil
-		}
-		// check status of migrated app on remote cluster
-		if migrSched.Status.ApplicationActivated {
-			migration.Status.Status = stork_api.MigrationStatusFailed
-			migration.Status.Stage = stork_api.MigrationStageFinal
-			migration.Status.FinishTimestamp = metav1.Now()
-			err = fmt.Errorf("migrated applications are active on remote cluster")
-			log.MigrationLog(migration).Errorf(err.Error())
-			m.recorder.Event(migration,
-				v1.EventTypeWarning,
-				string(stork_api.MigrationStatusFailed),
-				err.Error())
-			err = m.client.Update(context.Background(), migration)
+		if schedName, ok := migration.GetAnnotations()[StorkMigrationScheduleName]; ok {
+			remoteConfig, err := getClusterPairSchedulerConfig(migration.Spec.ClusterPair, migration.Namespace)
 			if err != nil {
-				log.MigrationLog(migration).Errorf("Error updating")
+				return err
 			}
-			return nil
+			remoteOps, err := storkops.NewForConfig(remoteConfig)
+			if err != nil {
+				m.recorder.Event(migration,
+					v1.EventTypeWarning,
+					string(stork_api.MigrationStatusFailed),
+					err.Error())
+				return nil
+			}
+			autoSuspend := true
+			// get remote cluster migration schedule object
+			remoteMigrSched, err := remoteOps.GetMigrationSchedule(schedName, migration.Namespace)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					// migrSchedule object not present on remote,
+					// that means autosuspend feature is disabled
+					autoSuspend = false
+				} else {
+					m.recorder.Event(migration,
+						v1.EventTypeWarning,
+						string(stork_api.MigrationStatusFailed),
+						err.Error())
+					return nil
+				}
+			}
+			// check status of migrated app on remote cluster
+			// if apps are online mark status of current migration as failed
+			// if its in progress state
+			if autoSuspend && remoteMigrSched.Status.ApplicationActivated && migration.Status.Stage != stork_api.MigrationStageFinal {
+				migration.Status.Status = stork_api.MigrationStatusFailed
+				migration.Status.Stage = stork_api.MigrationStageFinal
+				migration.Status.FinishTimestamp = metav1.Now()
+				err = fmt.Errorf("migrated applications are active on remote cluster")
+				log.MigrationLog(migration).Errorf(err.Error())
+				m.recorder.Event(migration,
+					v1.EventTypeWarning,
+					string(stork_api.MigrationStatusFailed),
+					err.Error())
+				err = m.client.Update(context.Background(), migration)
+				if err != nil {
+					log.MigrationLog(migration).Errorf("Error updating")
+				}
+				return nil
+			}
 		}
 	}
 

--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -35,6 +35,12 @@ const (
 	skipResource                = "stork.libopenstorage.org/skip-resource"
 	appsReplicas                = "stork.libopenstorage.org/replicas"
 	domainsMaxRetries           = 5
+
+	// StorkMigrationScheduleCopied indicating migrated migrationscheduleobject
+	StorkMigrationScheduleCopied = "stork.libopenstorage.org/static-copy-"
+	// StorkMigrationScheduleName is the annotation to keep track of child migration
+	// objects triggered by migration schedule
+	StorkMigrationScheduleName = "stork.libopenstorage.org/migration-schedule-name"
 )
 
 // NewMigrationSchedule creates a new instance of MigrationScheduleController.
@@ -113,7 +119,7 @@ func (m *MigrationScheduleController) handle(ctx context.Context, migrationSched
 	}
 	migrationSchedule.Spec = setScheduleDefaults(migrationSchedule.Spec)
 	if migrationSchedule.GetAnnotations() != nil {
-		if _, ok := migrationSchedule.GetAnnotations()[StorkMigrationAnnotation]; ok {
+		if _, ok := migrationSchedule.GetAnnotations()[StorkMigrationScheduleCopied]; ok {
 			// check status of all migrated app in cluster
 			logrus.Infof("Migration schedule is on dr cluster")
 			isActivated, err := getMigratedAppStatus(migrationSchedule)
@@ -151,47 +157,50 @@ func (m *MigrationScheduleController) handle(ctx context.Context, migrationSched
 				err.Error())
 			return nil
 		}
-		migrSched, err := remoteOps.GetMigrationSchedule(migrationSchedule.Name, migrationSchedule.Namespace)
-		if errors.IsNotFound(err) {
-			// TODO:generate event?
-			namespace, err := core.Instance().GetNamespace(migrationSchedule.Namespace)
-			if err != nil {
-				return err
-			}
-			namespace.ResourceVersion = ""
-			_, err = coreOps.CreateNamespace(namespace)
-			if err != nil && !errors.IsAlreadyExists(err) {
-				return err
-			}
-			// create new
-			remoteMigrSched := migrationSchedule.DeepCopy()
-			remoteMigrSched.ResourceVersion = ""
-			if remoteMigrSched.Annotations == nil {
-				remoteMigrSched.Annotations = make(map[string]string)
-			}
-			remoteMigrSched.Annotations[StorkMigrationAnnotation] = "true"
-			suspend := true
-			remoteMigrSched.Spec.Suspend = &suspend
-			remoteMigrSched.Status = stork_api.MigrationScheduleStatus{}
-			if _, err := remoteOps.CreateMigrationSchedule(remoteMigrSched); err != nil {
-				return err
-			}
+		if migrationSchedule.Spec.AutoSuspend {
+			var remoteMigrSched *stork_api.MigrationSchedule
+			remoteMigrSched, err = remoteOps.GetMigrationSchedule(migrationSchedule.Name, migrationSchedule.Namespace)
+			if errors.IsNotFound(err) {
+				namespace, err := core.Instance().GetNamespace(migrationSchedule.Namespace)
+				if err != nil {
+					return err
+				}
+				namespace.ResourceVersion = ""
+				_, err = coreOps.CreateNamespace(namespace)
+				if err != nil && !errors.IsAlreadyExists(err) {
+					return err
+				}
+				// create new migrationschedule on remote cluster
+				remoteMigrSched = migrationSchedule.DeepCopy()
+				remoteMigrSched.ResourceVersion = ""
+				remoteMigrSched.UID = ""
+				if remoteMigrSched.Annotations == nil {
+					remoteMigrSched.Annotations = make(map[string]string)
+				}
+				remoteMigrSched.Annotations[StorkMigrationScheduleCopied] = "true"
+				suspend := true
+				remoteMigrSched.Spec.Suspend = &suspend
+				remoteMigrSched.Status = stork_api.MigrationScheduleStatus{}
+				if _, err := remoteOps.CreateMigrationSchedule(remoteMigrSched); err != nil {
+					return err
+				}
 
-		} else if err != nil {
-			return err
-		}
-		if migrSched.Status.ApplicationActivated {
-			suspend := true
-			migrationSchedule.Spec.Suspend = &suspend
-			msg := "Suspending migration schedule since migrated apps on remote cluster are active"
-			m.recorder.Event(migrationSchedule,
-				v1.EventTypeWarning,
-				"Suspended",
-				msg)
-			log.MigrationScheduleLog(migrationSchedule).Warn(msg)
-			// deactivate apps in namespace
-			// TODO: suspend deploy/sts,crds
-			return m.client.Update(context.TODO(), migrationSchedule)
+			} else if err != nil {
+				return err
+			}
+			if remoteMigrSched.Status.ApplicationActivated {
+				suspend := true
+				migrationSchedule.Spec.Suspend = &suspend
+				msg := "Suspending migration schedule since migrated apps on remote cluster are active"
+				m.recorder.Event(migrationSchedule,
+					v1.EventTypeWarning,
+					"Suspended",
+					msg)
+				log.MigrationScheduleLog(migrationSchedule).Warn(msg)
+				// deactivate apps in namespace
+				// TODO: suspend deploy/sts,crds
+				return m.client.Update(context.TODO(), migrationSchedule)
+			}
 		}
 	}
 	// First update the status of any pending migrations
@@ -441,7 +450,7 @@ func (m *MigrationScheduleController) startMigration(
 	for k, v := range migrationSchedule.Annotations {
 		migration.Annotations[k] = v
 	}
-	migration.Annotations[StorkMigrationName] = migrationSchedule.GetName()
+	migration.Annotations[StorkMigrationScheduleName] = migrationSchedule.GetName()
 	log.MigrationScheduleLog(migrationSchedule).Infof("Starting migration %s", migrationName)
 	_, err = storkops.Instance().CreateMigration(migration)
 	return err

--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -37,7 +37,7 @@ const (
 	domainsMaxRetries           = 5
 
 	// StorkMigrationScheduleCopied indicating migrated migrationscheduleobject
-	StorkMigrationScheduleCopied = "stork.libopenstorage.org/static-copy-"
+	StorkMigrationScheduleCopied = "stork.libopenstorage.org/static-copy"
 	// StorkMigrationScheduleName is the annotation to keep track of child migration
 	// objects triggered by migration schedule
 	StorkMigrationScheduleName = "stork.libopenstorage.org/migration-schedule-name"
@@ -121,7 +121,7 @@ func (m *MigrationScheduleController) handle(ctx context.Context, migrationSched
 	if migrationSchedule.GetAnnotations() != nil {
 		if _, ok := migrationSchedule.GetAnnotations()[StorkMigrationScheduleCopied]; ok {
 			// check status of all migrated app in cluster
-			logrus.Infof("Migration schedule is on dr cluster")
+			logrus.Infof("Migration schedule is on dr cluster, checking migrated app status")
 			isActivated, err := getMigratedAppStatus(migrationSchedule)
 			if err != nil {
 				return err
@@ -134,6 +134,7 @@ func (m *MigrationScheduleController) handle(ctx context.Context, migrationSched
 				msg)
 			log.MigrationScheduleLog(migrationSchedule).Warn(msg)
 			return m.client.Update(context.TODO(), migrationSchedule)
+
 		}
 	}
 	if !(*migrationSchedule.Spec.Suspend) {

--- a/pkg/storkctl/applicationbackup.go
+++ b/pkg/storkctl/applicationbackup.go
@@ -10,6 +10,7 @@ import (
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/portworx/sched-ops/task"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd/util"
@@ -118,7 +119,7 @@ func newGetApplicationBackupCommand(cmdFactory Factory, ioStreams genericcliopti
 			} else {
 				var tempApplicationBackups storkv1.ApplicationBackupList
 				for _, ns := range namespaces {
-					applicationBackups, err = storkops.Instance().ListApplicationBackups(ns)
+					applicationBackups, err = storkops.Instance().ListApplicationBackups(ns, metav1.ListOptions{})
 					if err != nil {
 						util.CheckErr(err)
 						return

--- a/pkg/storkctl/applicationbackupschedule.go
+++ b/pkg/storkctl/applicationbackupschedule.go
@@ -7,6 +7,7 @@ import (
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd/util"
@@ -120,7 +121,7 @@ func newGetApplicationBackupScheduleCommand(cmdFactory Factory, ioStreams generi
 			} else {
 				var tempApplicationBackupSchedules storkv1.ApplicationBackupScheduleList
 				for _, ns := range namespaces {
-					applicationBackupSchedules, err = storkops.Instance().ListApplicationBackupSchedules(ns)
+					applicationBackupSchedules, err = storkops.Instance().ListApplicationBackupSchedules(ns, metav1.ListOptions{})
 					if err != nil {
 						util.CheckErr(err)
 						return
@@ -181,7 +182,7 @@ func newDeleteApplicationBackupScheduleCommand(cmdFactory Factory, ioStreams gen
 				}
 				applicationBackupSchedules = args
 			} else {
-				applicationBackupScheduleList, err := storkops.Instance().ListApplicationBackupSchedules(cmdFactory.GetNamespace())
+				applicationBackupScheduleList, err := storkops.Instance().ListApplicationBackupSchedules(cmdFactory.GetNamespace(), metav1.ListOptions{})
 				if err != nil {
 					util.CheckErr(err)
 					return
@@ -230,7 +231,7 @@ func getApplicationBackupSchedules(backupLocation string, args []string, namespa
 		}
 		applicationBackupSchedules = append(applicationBackupSchedules, applicationBackupSchedule)
 	} else {
-		applicationBackupScheduleList, err := storkops.Instance().ListApplicationBackupSchedules(namespace)
+		applicationBackupScheduleList, err := storkops.Instance().ListApplicationBackupSchedules(namespace, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storkctl/applicationrestore.go
+++ b/pkg/storkctl/applicationrestore.go
@@ -10,6 +10,7 @@ import (
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/portworx/sched-ops/task"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd/util"
@@ -116,7 +117,7 @@ func newGetApplicationRestoreCommand(cmdFactory Factory, ioStreams genericcliopt
 			} else {
 				var tempApplicationRestores storkv1.ApplicationRestoreList
 				for _, ns := range namespaces {
-					applicationRestores, err = storkops.Instance().ListApplicationRestores(ns)
+					applicationRestores, err = storkops.Instance().ListApplicationRestores(ns, metav1.ListOptions{})
 					if err != nil {
 						util.CheckErr(err)
 						return

--- a/pkg/storkctl/backuplocation.go
+++ b/pkg/storkctl/backuplocation.go
@@ -6,6 +6,7 @@ import (
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd/util"
@@ -54,7 +55,7 @@ func newGetBackupLocationCommand(cmdFactory Factory, ioStreams genericclioptions
 
 				var tempBackupLocations storkv1.BackupLocationList
 				for _, ns := range namespaces {
-					backupLocations, err := storkops.Instance().ListBackupLocations(ns)
+					backupLocations, err := storkops.Instance().ListBackupLocations(ns, metav1.ListOptions{})
 					if err != nil {
 						util.CheckErr(err)
 						return

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -434,7 +434,7 @@ func updateIBPObjects(kind string, namespace string, activate bool, ioStreams ge
 }
 
 func updateCronJobObjects(namespace string, activate bool, ioStreams genericclioptions.IOStreams) {
-	cronJobs, err := batch.Instance().ListCronJobs(namespace)
+	cronJobs, err := batch.Instance().ListCronJobs(namespace, metav1.ListOptions{})
 	if err != nil {
 		util.CheckErr(err)
 		return

--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -606,7 +606,7 @@ func deletePolicyAndApplicationBackupSchedule(t *testing.T, namespace string, po
 		applicationBackupScheduleName, namespace))
 
 	time.Sleep(10 * time.Second)
-	applicationBackupList, err := storkops.Instance().ListApplicationBackups(namespace)
+	applicationBackupList, err := storkops.Instance().ListApplicationBackups(namespace, meta.ListOptions{})
 	require.NoError(t, err, fmt.Sprintf("Error getting list of applicationBackups for namespace: %v", namespace))
 	// sometimes length of backuplist is expected+1 depending on the timing issue
 	require.True(t, len(applicationBackupList.Items) <= expectedBackups+1, fmt.Sprintf("Should have %v ApplicationBackups triggered by schedule in namespace %v", expectedBackups, namespace))
@@ -1262,7 +1262,7 @@ func applicationBackupMultiple(t *testing.T) {
 
 func deleteAllBackupsNamespace(namespace string) error {
 	logrus.Infof("Deleting all backups in namespace: %s", namespace)
-	allAppBackups, err := storkops.Instance().ListApplicationBackups(namespace)
+	allAppBackups, err := storkops.Instance().ListApplicationBackups(namespace, meta.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("Failed to list backups before deleting: %v", err)
 	}
@@ -1286,7 +1286,7 @@ func deleteAndWaitForBackupDeletion(namespace string) error {
 			return "", false, err
 		}
 
-		allAppBackups, err := storkops.Instance().ListApplicationBackups(namespace)
+		allAppBackups, err := storkops.Instance().ListApplicationBackups(namespace, meta.ListOptions{})
 		if err != nil || len(allAppBackups.Items) != 0 {
 			logrus.Infof("Failed to delete all app backups in %s. Error: %v. Number of backups: %v", namespace, err, len(allAppBackups.Items))
 			return "", true, fmt.Errorf("All backups not deleted yet")
@@ -1402,7 +1402,7 @@ func getSyncedBackupWithAnnotation(appBackup *storkv1.ApplicationBackup, lookUpA
 	var backupToRestore *storkv1.ApplicationBackup
 	var err error
 	listBackupsTask := func() (interface{}, bool, error) {
-		allAppBackups, err = storkops.Instance().ListApplicationBackups(appBackup.Namespace)
+		allAppBackups, err = storkops.Instance().ListApplicationBackups(appBackup.Namespace, meta.ListOptions{})
 		if err != nil {
 			logrus.Infof("Failed to list app backups on first cluster post migrate and sync. Error: %v", err)
 			return "", true, fmt.Errorf("Failed to list app backups on first cluster")

--- a/vendor/github.com/portworx/sched-ops/k8s/apps/statefulsets.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apps/statefulsets.go
@@ -18,7 +18,7 @@ import (
 // StatefulSetOps is an interface to perform k8s stateful set operations
 type StatefulSetOps interface {
 	// ListStatefulSets lists all the statefulsets for a given namespace
-	ListStatefulSets(namespace string) (*appsv1.StatefulSetList, error)
+	ListStatefulSets(namespace string, options metav1.ListOptions) (*appsv1.StatefulSetList, error)
 	// GetStatefulSet returns a statefulset for given name and namespace
 	GetStatefulSet(name, namespace string) (*appsv1.StatefulSet, error)
 	// CreateStatefulSet creates the given statefulset
@@ -44,12 +44,12 @@ type StatefulSetOps interface {
 }
 
 // ListStatefulSets lists all the statefulsets for a given namespace
-func (c *Client) ListStatefulSets(namespace string) (*appsv1.StatefulSetList, error) {
+func (c *Client) ListStatefulSets(namespace string, options metav1.ListOptions) (*appsv1.StatefulSetList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
 
-	return c.apps.StatefulSets(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.apps.StatefulSets(namespace).List(context.TODO(), options)
 }
 
 // GetStatefulSet returns a statefulset for given name and namespace

--- a/vendor/github.com/portworx/sched-ops/k8s/batch/cron.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/batch/cron.go
@@ -23,7 +23,7 @@ type CronOps interface {
 	// ValidateCronJob validates the given cronJob
 	ValidateCronJob(cronJob *v1beta1.CronJob, timeout, retryInterval time.Duration) error
 	// ListCronJobs list cronjobs in given namespace
-	ListCronJobs(namespace string) (*v1beta1.CronJobList, error)
+	ListCronJobs(namespace string, filterOptions metav1.ListOptions) (*v1beta1.CronJobList, error)
 }
 
 var NamespaceDefault = "default"
@@ -89,10 +89,10 @@ func (c *Client) ValidateCronJob(cronJob *v1beta1.CronJob, timeout, retryInterva
 }
 
 // ListCronJobs returns the cronJobs in given namespace
-func (c *Client) ListCronJobs(namespace string) (*v1beta1.CronJobList, error) {
+func (c *Client) ListCronJobs(namespace string, filterOptions metav1.ListOptions) (*v1beta1.CronJobList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
 
-	return c.batchv1beta1.CronJobs(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.batchv1beta1.CronJobs(namespace).List(context.TODO(), filterOptions)
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/common/pod.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/common/pod.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	schederrors "github.com/portworx/sched-ops/k8s/errors"
+	"github.com/portworx/sched-ops/task"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -46,6 +49,91 @@ func GeneratePodsOverviewString(pods []corev1.Pod) string {
 	}
 
 	return buffer.String()
+}
+
+// DeletePods deletes the given pods
+func DeletePods(client v1.CoreV1Interface, pods []corev1.Pod, force bool) error {
+	deleteOptions := metav1.DeleteOptions{}
+	if force {
+		gracePeriodSec := int64(0)
+		deleteOptions.GracePeriodSeconds = &gracePeriodSec
+	}
+
+	for _, pod := range pods {
+		if err := client.Pods(pod.Namespace).Delete(context.TODO(), pod.Name, deleteOptions); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WaitForPodsToBeDeleted waits for pods to be deleted
+func WaitForPodsToBeDeleted(client v1.CoreV1Interface, podsToDelete []corev1.Pod, timeout time.Duration) error {
+	var wg sync.WaitGroup
+	errChan := make(chan error)
+
+	// Wait for pods to be deleted
+	for index, pod := range podsToDelete {
+		wg.Add(1)
+		go func(pod corev1.Pod, index int) {
+			defer wg.Done()
+			if err := WaitForPodDeletion(client, pod, timeout); err != nil {
+				errChan <- fmt.Errorf("Failed to delete pod %s, Err: %v", pod.Name, err)
+			}
+		}(pod, index)
+
+	}
+	wg.Wait()
+	close(errChan)
+
+	ok := true
+	var errorString string
+	for err := range errChan {
+		errorString += fmt.Sprintf("%v\n", err)
+		ok = false
+	}
+
+	if !ok {
+		return fmt.Errorf("Failed to delete pods:\n%s", errorString)
+	}
+	return nil
+}
+
+// WaitForPodDeletion waits for given timeout for given pod to be deleted
+func WaitForPodDeletion(client v1.CoreV1Interface, pod corev1.Pod, timeout time.Duration) error {
+	t := func() (interface{}, bool, error) {
+		p, err := GetPodByName(client, pod.Name, pod.Namespace)
+		if err != nil {
+			if err == schederrors.ErrPodsNotFound {
+				return nil, false, nil
+			}
+
+			return nil, true, err
+		}
+
+		if p != nil && p.UID == pod.UID {
+			return nil, true, fmt.Errorf("pod %s:%s is still present in the system", p.Namespace, p.Name)
+		}
+
+		return nil, false, nil
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, timeout, 5*time.Second); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetPodByName returns pod for the given pod name and namespace
+func GetPodByName(client v1.CoreV1Interface, podName string, namespace string) (*corev1.Pod, error) {
+	pod, err := client.Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, schederrors.ErrPodsNotFound
+	}
+
+	return pod, nil
 }
 
 // IsPodReady checks if all containers in a pod are ready (passed readiness probe).

--- a/vendor/github.com/portworx/sched-ops/k8s/core/configmaps.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/configmaps.go
@@ -21,6 +21,8 @@ type ConfigMapOps interface {
 	UpdateConfigMap(configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
 	// WatchConfigMap sets up a watcher that listens for changes on the config map
 	WatchConfigMap(configMap *corev1.ConfigMap, fn WatchFunc) error
+	//ListConfigMap returns the list of ConfigMaps
+	ListConfigMap(namespace string, filterOptions metav1.ListOptions) (*corev1.ConfigMapList, error)
 }
 
 // GetConfigMap gets the config map object for the given name and namespace
@@ -95,4 +97,14 @@ func (c *Client) WatchConfigMap(configMap *corev1.ConfigMap, fn WatchFunc) error
 	// fire off watch function
 	go c.handleWatch(watchInterface, configMap, "", fn, listOptions)
 	return nil
+}
+
+// ListConfigMap returns the list of ConfigMaps
+func (c *Client) ListConfigMap(namespace string, filterOptions metav1.ListOptions) (*corev1.ConfigMapList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubernetes.CoreV1().ConfigMaps(namespace).List(context.TODO(), filterOptions)
+
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/core/persistentvolumeclaims.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/persistentvolumeclaims.go
@@ -269,7 +269,9 @@ func (c *Client) GetPersistentVolumeClaimParams(pvc *corev1.PersistentVolumeClai
 		return nil, fmt.Errorf("failed to get storage resource for pvc: %v", result.Name)
 	}
 
-	params["size"] = capacity.String()
+	// We explicitly send the unit with so the client can compare it with correct units
+	requestGB := uint64(roundUpSize(capacity.Value(), 1024*1024*1024))
+	params["size"] = fmt.Sprintf("%dG", requestGB)
 
 	sc, err := c.GetStorageClassForPVC(result)
 	if err != nil {

--- a/vendor/github.com/portworx/sched-ops/k8s/kdmp/backuplocationmaintenance.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kdmp/backuplocationmaintenance.go
@@ -14,7 +14,7 @@ type BackupLocationMaintenanceOps interface {
 	// GetBackupLocationMaintenance gets the BackupLocationMaintenanc CR
 	GetBackupLocationMaintenance(string, string) (*kdmpv1alpha1.BackupLocationMaintenance, error)
 	// ListBackupLocationMaintenance lists all the BackupLocationMaintenance CRs
-	ListBackupLocationMaintenance(string) (*kdmpv1alpha1.BackupLocationMaintenanceList, error)
+	ListBackupLocationMaintenance(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.BackupLocationMaintenanceList, error)
 	// UpdateBackupLocationMaintenance updates the BackupLocationMaintenance CR
 	UpdateBackupLocationMaintenance(*kdmpv1alpha1.BackupLocationMaintenance) (*kdmpv1alpha1.BackupLocationMaintenance, error)
 	// DeleteBackupLocationMaintenance deletes the BackupLocationMaintenance CR
@@ -38,11 +38,11 @@ func (c *Client) GetBackupLocationMaintenance(name, namespace string) (*kdmpv1al
 }
 
 // ListBackupLocationMaintenance lists all the BackupLocationMaintenance CR
-func (c *Client) ListBackupLocationMaintenance(namespace string) (*kdmpv1alpha1.BackupLocationMaintenanceList, error) {
+func (c *Client) ListBackupLocationMaintenance(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.BackupLocationMaintenanceList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.kdmp.KdmpV1alpha1().BackupLocationMaintenances(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.kdmp.KdmpV1alpha1().BackupLocationMaintenances(namespace).List(context.TODO(), filterOptions)
 }
 
 // DeleteBackupLocationMaintenance deletes the BackupLocationMaintenance CR

--- a/vendor/github.com/portworx/sched-ops/k8s/kdmp/dataexport.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kdmp/dataexport.go
@@ -19,7 +19,7 @@ type DataExportOps interface {
 	// GetDataExport gets the DataExport CR
 	GetDataExport(string, string) (*kdmpv1alpha1.DataExport, error)
 	// ListDataExport lists all the DataExport CRs
-	ListDataExport(string) (*kdmpv1alpha1.DataExportList, error)
+	ListDataExport(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.DataExportList, error)
 	// UpdateDataExport updates the DataExport CR
 	UpdateDataExport(*kdmpv1alpha1.DataExport) (*kdmpv1alpha1.DataExport, error)
 	// DeleteDataExport deletes the DataExport CR
@@ -45,11 +45,11 @@ func (c *Client) GetDataExport(name, namespace string) (*kdmpv1alpha1.DataExport
 }
 
 // ListDataExport lists all the DataExport CR
-func (c *Client) ListDataExport(namespace string) (*kdmpv1alpha1.DataExportList, error) {
+func (c *Client) ListDataExport(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.DataExportList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.kdmp.KdmpV1alpha1().DataExports(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.kdmp.KdmpV1alpha1().DataExports(namespace).List(context.TODO(), filterOptions)
 }
 
 // DeleteDataExport deletes the DataExport CR

--- a/vendor/github.com/portworx/sched-ops/k8s/kdmp/volumebackup.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kdmp/volumebackup.go
@@ -14,7 +14,7 @@ type VolumeBackupOps interface {
 	// GetVolumeBackup gets the VolumeBackup CR
 	GetVolumeBackup(string, string) (*kdmpv1alpha1.VolumeBackup, error)
 	// ListVolumeBackup lists all the VolumeBackup CRs
-	ListVolumeBackup(string) (*kdmpv1alpha1.VolumeBackupList, error)
+	ListVolumeBackup(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.VolumeBackupList, error)
 	// UpdateVolumeBackup updates the VolumeBackup CR
 	UpdateVolumeBackup(*kdmpv1alpha1.VolumeBackup) (*kdmpv1alpha1.VolumeBackup, error)
 	// DeleteVolumeBackup deletes the VolumeBackup CR
@@ -38,11 +38,11 @@ func (c *Client) GetVolumeBackup(name, namespace string) (*kdmpv1alpha1.VolumeBa
 }
 
 // ListVolumeBackup lists all the VolumeBackup CR
-func (c *Client) ListVolumeBackup(namespace string) (*kdmpv1alpha1.VolumeBackupList, error) {
+func (c *Client) ListVolumeBackup(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.VolumeBackupList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.kdmp.KdmpV1alpha1().VolumeBackups(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.kdmp.KdmpV1alpha1().VolumeBackups(namespace).List(context.TODO(), filterOptions)
 }
 
 // DeleteVolumeBackup deletes the VolumeBackup CR

--- a/vendor/github.com/portworx/sched-ops/k8s/kdmp/volumebackupdelete.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kdmp/volumebackupdelete.go
@@ -14,7 +14,7 @@ type VolumeBackupDeleteOps interface {
 	// GetVolumeBackupDelete gets the VolumeBackupDelete CR
 	GetVolumeBackupDelete(string, string) (*kdmpv1alpha1.VolumeBackupDelete, error)
 	// ListVolumeBackupDelete lists all the VolumeBackupDelete CRs
-	ListVolumeBackupDelete(string) (*kdmpv1alpha1.VolumeBackupDeleteList, error)
+	ListVolumeBackupDelete(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.VolumeBackupDeleteList, error)
 	// UpdateVolumeBackupDelete updates the VolumeBackupDelete CR
 	UpdateVolumeBackupDelete(*kdmpv1alpha1.VolumeBackupDelete) (*kdmpv1alpha1.VolumeBackupDelete, error)
 	// DeleteVolumeBackupDelete deletes the VolumeBackupDelete CR
@@ -38,11 +38,11 @@ func (c *Client) GetVolumeBackupDelete(name, namespace string) (*kdmpv1alpha1.Vo
 }
 
 // ListVolumeBackupDelete lists all the VolumeBackupDelete CR
-func (c *Client) ListVolumeBackupDelete(namespace string) (*kdmpv1alpha1.VolumeBackupDeleteList, error) {
+func (c *Client) ListVolumeBackupDelete(namespace string, filterOptions metav1.ListOptions) (*kdmpv1alpha1.VolumeBackupDeleteList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.kdmp.KdmpV1alpha1().VolumeBackupDeletes(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.kdmp.KdmpV1alpha1().VolumeBackupDeletes(namespace).List(context.TODO(), filterOptions)
 }
 
 // DeleteVolumeBackupDelete deletes the VolumeBackupDelete CR

--- a/vendor/github.com/portworx/sched-ops/k8s/rbac/rolebindings.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/rbac/rolebindings.go
@@ -17,6 +17,8 @@ type RoleBindingOps interface {
 	GetRoleBinding(name, namespace string) (*rbacv1.RoleBinding, error)
 	// DeleteRoleBinding deletes the given role binding
 	DeleteRoleBinding(name, namespace string) error
+	// ListRoleBinding returns the list of role bindings
+	ListRoleBinding(namespace string, filterOptions metav1.ListOptions) (*rbacv1.RoleBindingList, error)
 }
 
 // CreateRoleBinding creates the given role binding
@@ -55,4 +57,13 @@ func (c *Client) DeleteRoleBinding(name, namespace string) error {
 	return c.rbac.RoleBindings(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
+}
+
+// ListRoleBinding returns the list of role bindings
+func (c *Client) ListRoleBinding(namespace string, filterOptions metav1.ListOptions) (*rbacv1.RoleBindingList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.rbac.RoleBindings(namespace).List(context.TODO(), filterOptions)
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/rbac/roles.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/rbac/roles.go
@@ -17,6 +17,8 @@ type RoleOps interface {
 	GetRole(name, namespace string) (*rbac_v1.Role, error)
 	// DeleteRole deletes the given role
 	DeleteRole(name, namespace string) error
+	// ListRoles returns the list of roles
+	ListRoles(namespace string, filterOptions metav1.ListOptions) (*rbac_v1.RoleList, error)
 }
 
 // CreateRole creates the given role
@@ -55,4 +57,13 @@ func (c *Client) DeleteRole(name, namespace string) error {
 	return c.rbac.Roles(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
+}
+
+// ListRoles returns the list of roles
+func (c *Client) ListRoles(namespace string, filterOptions metav1.ListOptions) (*rbac_v1.RoleList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.rbac.Roles(namespace).List(context.TODO(), filterOptions)
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/applicationbackuprestore.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/applicationbackuprestore.go
@@ -20,7 +20,7 @@ type ApplicationBackupRestoreOps interface {
 	// GetApplicationBackup gets the ApplicationBackup
 	GetApplicationBackup(string, string) (*storkv1alpha1.ApplicationBackup, error)
 	// ListApplicationBackups lists all the ApplicationBackups
-	ListApplicationBackups(string) (*storkv1alpha1.ApplicationBackupList, error)
+	ListApplicationBackups(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationBackupList, error)
 	// UpdateApplicationBackup updates the ApplicationBackup
 	UpdateApplicationBackup(*storkv1alpha1.ApplicationBackup) (*storkv1alpha1.ApplicationBackup, error)
 	// DeleteApplicationBackup deletes the ApplicationBackup
@@ -34,7 +34,7 @@ type ApplicationBackupRestoreOps interface {
 	// GetApplicationRestore gets the ApplicationRestore
 	GetApplicationRestore(string, string) (*storkv1alpha1.ApplicationRestore, error)
 	// ListApplicationRestores lists all the ApplicationRestores
-	ListApplicationRestores(string) (*storkv1alpha1.ApplicationRestoreList, error)
+	ListApplicationRestores(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationRestoreList, error)
 	// UpdateApplicationRestore updates the ApplicationRestore
 	UpdateApplicationRestore(*storkv1alpha1.ApplicationRestore) (*storkv1alpha1.ApplicationRestore, error)
 	// DeleteApplicationRestore deletes the ApplicationRestore
@@ -50,7 +50,7 @@ type ApplicationBackupRestoreOps interface {
 	// UpdateApplicationBackupSchedule updates the ApplicationBackupSchedule
 	UpdateApplicationBackupSchedule(*storkv1alpha1.ApplicationBackupSchedule) (*storkv1alpha1.ApplicationBackupSchedule, error)
 	// ListApplicationBackupSchedules lists all the ApplicationBackupSchedules
-	ListApplicationBackupSchedules(string) (*storkv1alpha1.ApplicationBackupScheduleList, error)
+	ListApplicationBackupSchedules(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationBackupScheduleList, error)
 	// DeleteApplicationBackupSchedule deletes the ApplicationBackupSchedule
 	DeleteApplicationBackupSchedule(string, string) error
 	// ValidateApplicationBackupSchedule validates the given ApplicationBackupSchedule. It checks the status of each of
@@ -80,11 +80,11 @@ func (c *Client) GetApplicationBackup(name string, namespace string) (*storkv1al
 }
 
 // ListApplicationBackups lists all the ApplicationBackups
-func (c *Client) ListApplicationBackups(namespace string) (*storkv1alpha1.ApplicationBackupList, error) {
+func (c *Client) ListApplicationBackups(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationBackupList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.StorkV1alpha1().ApplicationBackups(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ApplicationBackups(namespace).List(context.TODO(), filterOptions)
 }
 
 // DeleteApplicationBackup deletes the ApplicationBackup
@@ -143,11 +143,11 @@ func (c *Client) GetApplicationRestore(name string, namespace string) (*storkv1a
 }
 
 // ListApplicationRestores lists all the ApplicationRestores
-func (c *Client) ListApplicationRestores(namespace string) (*storkv1alpha1.ApplicationRestoreList, error) {
+func (c *Client) ListApplicationRestores(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationRestoreList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.StorkV1alpha1().ApplicationRestores(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ApplicationRestores(namespace).List(context.TODO(), filterOptions)
 }
 
 // CreateApplicationRestore creates the ApplicationRestore
@@ -216,11 +216,11 @@ func (c *Client) GetApplicationBackupSchedule(name string, namespace string) (*s
 }
 
 // ListApplicationBackupSchedules lists all the ApplicationBackupSchedules
-func (c *Client) ListApplicationBackupSchedules(namespace string) (*storkv1alpha1.ApplicationBackupScheduleList, error) {
+func (c *Client) ListApplicationBackupSchedules(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ApplicationBackupScheduleList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.StorkV1alpha1().ApplicationBackupSchedules(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().ApplicationBackupSchedules(namespace).List(context.TODO(), filterOptions)
 }
 
 // CreateApplicationBackupSchedule creates an ApplicationBackupSchedule

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/backuplocation.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/backuplocation.go
@@ -18,7 +18,7 @@ type BackupLocationOps interface {
 	// GetBackupLocation gets the BackupLocation
 	GetBackupLocation(string, string) (*storkv1alpha1.BackupLocation, error)
 	// ListBackupLocations lists all the BackupLocations
-	ListBackupLocations(string) (*storkv1alpha1.BackupLocationList, error)
+	ListBackupLocations(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.BackupLocationList, error)
 	// UpdateBackupLocation updates the BackupLocation
 	UpdateBackupLocation(*storkv1alpha1.BackupLocation) (*storkv1alpha1.BackupLocation, error)
 	// DeleteBackupLocation deletes the BackupLocation
@@ -54,11 +54,11 @@ func (c *Client) GetBackupLocation(name string, namespace string) (*storkv1alpha
 }
 
 // ListBackupLocations lists all the BackupLocations
-func (c *Client) ListBackupLocations(namespace string) (*storkv1alpha1.BackupLocationList, error) {
+func (c *Client) ListBackupLocations(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.BackupLocationList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	backupLocations, err := c.stork.StorkV1alpha1().BackupLocations(namespace).List(context.TODO(), metav1.ListOptions{})
+	backupLocations, err := c.stork.StorkV1alpha1().BackupLocations(namespace).List(context.TODO(), filterOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/namespacedschedulepolicy.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/namespacedschedulepolicy.go
@@ -14,7 +14,7 @@ type NamespacedSchedulePolicyOps interface {
 	// GetNamespacedSchedulePolicy gets the NamespacedSchedulePolicy
 	GetNamespacedSchedulePolicy(string, string) (*storkv1alpha1.NamespacedSchedulePolicy, error)
 	// ListNamespacedSchedulePolicies lists all the NamespacedSchedulePolicies
-	ListNamespacedSchedulePolicies(string) (*storkv1alpha1.NamespacedSchedulePolicyList, error)
+	ListNamespacedSchedulePolicies(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.NamespacedSchedulePolicyList, error)
 	// UpdateNamespacedSchedulePolicy updates the NamespacedSchedulePolicy
 	UpdateNamespacedSchedulePolicy(*storkv1alpha1.NamespacedSchedulePolicy) (*storkv1alpha1.NamespacedSchedulePolicy, error)
 	// DeleteNamespacedSchedulePolicy deletes the NamespacedSchedulePolicy
@@ -38,11 +38,11 @@ func (c *Client) GetNamespacedSchedulePolicy(name string, namespace string) (*st
 }
 
 // ListNamespacedSchedulePolicies lists all the NamespacedSchedulePolicies
-func (c *Client) ListNamespacedSchedulePolicies(namespace string) (*storkv1alpha1.NamespacedSchedulePolicyList, error) {
+func (c *Client) ListNamespacedSchedulePolicies(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.NamespacedSchedulePolicyList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.stork.StorkV1alpha1().NamespacedSchedulePolicies(namespace).List(context.TODO(), metav1.ListOptions{})
+	return c.stork.StorkV1alpha1().NamespacedSchedulePolicies(namespace).List(context.TODO(), filterOptions)
 }
 
 // UpdateNamespacedSchedulePolicy updates the NamespacedSchedulePolicy

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/rule.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/rule.go
@@ -17,6 +17,8 @@ type RuleOps interface {
 	UpdateRule(rule *storkv1alpha1.Rule) (*storkv1alpha1.Rule, error)
 	// DeleteRule deletes the given stork rule
 	DeleteRule(name, namespace string) error
+	// ListRules returns the list of rules
+	ListRules(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.RuleList, error)
 }
 
 // GetRule fetches the given stork rule
@@ -51,4 +53,12 @@ func (c *Client) DeleteRule(name, namespace string) error {
 	return c.stork.StorkV1alpha1().Rules(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
+}
+
+// ListRules returns the list of rules
+func (c *Client) ListRules(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.RuleList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.stork.StorkV1alpha1().Rules(namespace).List(context.TODO(), filterOptions)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -455,7 +455,7 @@ github.com/portworx/kdmp/pkg/version
 github.com/portworx/kvdb
 github.com/portworx/kvdb/common
 github.com/portworx/kvdb/mem
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20211116074603-2b6905763b23
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8
 ## explicit
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
Add support to detect whether application are active on remote cluster and suspend migration 

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Stork will auto-detect application activated on DR cluster and suspend migrating app on primary cluster. It will also create migration schedule CR on DR site to ease failback workflow
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.9.0

Integration test:
```
21:45:25 --- PASS: TestSnapshotMigration (507.69s)
21:45:25     --- PASS: TestSnapshotMigration/testMigration (507.69s)
21:45:25         --- PASS: TestSnapshotMigration/testMigration/suspendMigrationTest (504.28s)
21:45:25 PASS
21:45:25 
```

