### PR TITLE
Reading rule CR from kube-system ns when multiple ns are selected for…

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -788,15 +788,16 @@ func (a *ApplicationBackupController) runPreExecRule(backup *stork_api.Applicati
 	}
 
 	terminationChannels := make([]chan bool, 0)
-	for _, ns := range backup.Spec.Namespaces {
-		r, err := storkops.Instance().GetRule(backup.Spec.PreExecRule, ns)
-		if err != nil {
-			for _, channel := range terminationChannels {
-				channel <- true
-			}
-			return nil, false, err
+	r, err := storkops.Instance().GetRule(backup.Spec.PreExecRule, backup.Namespace)
+	if err != nil {
+		// TODO: For now keep this as is from the existing code, not sure the use of this for loop
+		// as it currently doesn't get executed
+		for _, channel := range terminationChannels {
+			channel <- true
 		}
-
+		return nil, false, err
+	}
+	for _, ns := range backup.Spec.Namespaces {
 		ch, err := rule.ExecuteRule(r, rule.PreExecRule, backup, ns)
 		if err != nil {
 			for _, channel := range terminationChannels {
@@ -829,12 +830,11 @@ func (a *ApplicationBackupController) runPreExecRule(backup *stork_api.Applicati
 }
 
 func (a *ApplicationBackupController) runPostExecRule(backup *stork_api.ApplicationBackup) error {
+	r, err := storkops.Instance().GetRule(backup.Spec.PostExecRule, backup.Namespace)
+	if err != nil {
+		return err
+	}
 	for _, ns := range backup.Spec.Namespaces {
-		r, err := storkops.Instance().GetRule(backup.Spec.PostExecRule, ns)
-		if err != nil {
-			return err
-		}
-
 		_, err = rule.ExecuteRule(r, rule.PostExecRule, backup, ns)
 		if err != nil {
 			return fmt.Errorf("error executing PreExecRule for namespace %v: %v", ns, err)


### PR DESCRIPTION
**What type of PR is this?**
Original approved PR is having merge issues due to 2.6 changes synced into it. 
Approved PR for ref: https://github.com/libopenstorage/stork/pull/837

Raising another PR with cherry-picked 

**What this PR does / why we need it**:
When a user intends to take backup of multiple ns with rules, Rule CR is created in kube-system ns. Changed the flow to read from kube-system rather than the application ns

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```
When a user intends to take backup of multiple ns with rules, Rule CR is created in kube-system ns.
```

**Does this change need to be cherry-picked to a release branch?**:
Yes, 2.6

