### PR TITLE
PB-1679: cluster-scope resource collection

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -182,6 +182,10 @@ func setDefaults(spec stork_api.MigrationSpec) stork_api.MigrationSpec {
 		defaultBool := false
 		spec.PurgeDeletedResources = &defaultBool
 	}
+	if spec.SkipServiceUpdate == nil {
+		defaultBool := false
+		spec.SkipServiceUpdate = &defaultBool
+	}
 	return spec
 }
 

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -297,7 +297,6 @@ func (r *ResourceCollector) GetResources(
 		return nil, err
 	}
 	allObjects := make([]runtime.Unstructured, 0)
-
 	// Map to prevent collection of duplicate objects
 	resourceMap := make(map[types.UID]bool)
 	var crdResources []metav1.GroupVersionKind
@@ -481,7 +480,7 @@ func (r *ResourceCollector) objectToBeCollected(
 		return false, err
 	}
 
-	if include, err := r.includeObject(object, includeObjects); err != nil {
+	if include, err := r.includeObject(object, includeObjects, namespace); err != nil {
 		return false, err
 	} else if !include {
 		return false, nil
@@ -653,6 +652,7 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 func (r *ResourceCollector) includeObject(
 	object runtime.Unstructured,
 	includeObjects map[stork_api.ObjectInfo]bool,
+	namespace string,
 ) (bool, error) {
 	if len(includeObjects) == 0 {
 		return true, nil
@@ -683,6 +683,9 @@ func (r *ResourceCollector) includeObject(
 		if info.Group == "" {
 			info.Group = "core"
 		}
+		if namespace != "" {
+			info.Namespace = namespace
+		}
 		if val, present := includeObjects[info]; !present || !val {
 			return false, nil
 		}
@@ -712,7 +715,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		return false, err
 	}
 
-	if include, err := r.includeObject(object, includeObjects); err != nil {
+	if include, err := r.includeObject(object, includeObjects, ""); err != nil {
 		return true, err
 	} else if !include {
 		return true, nil


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Allow cluster-scope resource selection which belongs to namespace in `IncludeResources`
Fix nil pointer error for skipServiceUpdate flag in migration controller
 
**Does this PR change a user-facing CRD or CLI?**:
bo

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6
