### PR TITLE
Stor-423: add support to migrate mongoDB crd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test:
 
 integration-test:
 	@echo "Building stork integration tests"
-	@cd test/integration_test && GOOS=linux go test -tags integrationtest -v -c -o stork.test
+	@cd test/integration_test && GOOS=linux go test -tags integrationtest $(BUILD_OPTIONS) -v -c -o stork.test
 
 integration-test-container:
 	@echo "Building container: docker build --tag $(STORK_TEST_IMG) -f Dockerfile ."

--- a/pkg/appregistration/appregistration.go
+++ b/pkg/appregistration/appregistration.go
@@ -27,6 +27,8 @@ const (
 	KafkaApp = "kafka"
 	// PostgressApp registration name
 	PostgressApp = "postgress"
+	// MongoDBCommunityApp registration name
+	MongoDBCommunityApp = "mongodbcommunity"
 )
 
 // GetSupportedCRD returns the list of supported CRDs.
@@ -302,6 +304,22 @@ func GetSupportedCRD() map[string][]stork_api.ApplicationResource {
 			},
 		},
 	}
+	// mongdb app crds
+	defCRD[MongoDBCommunityApp] = []stork_api.ApplicationResource{
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "MongoDBCommunity",
+				Group:   "mongodbcommunity.mongodb.com",
+				Version: "v1",
+			},
+			KeepStatus: false,
+			SuspendOptions: stork_api.SuspendOptions{
+				Path: "spec.members",
+				Type: "int",
+			},
+		},
+	}
+
 	return defCRD
 }
 
@@ -403,5 +421,11 @@ func GetSupportedGVR() map[schema.GroupVersionResource]string {
 			Group:    "weblogic.oracle",
 			Version:  "v8",
 		}: "DomainsList",
+		// mongodb crds
+		{
+			Resource: "MongoDBCommunity",
+			Group:    "mongodbcommunity.mongodb.com",
+			Version:  "v1",
+		}: "MongoDBCommunityList",
 	}
 }

--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -205,7 +205,7 @@ func (e *Extender) processFilterRequest(w http.ResponseWriter, req *http.Request
 	} else if len(driverVolumes) > 0 {
 		driverNodes, err := e.Driver.GetNodes()
 		if err != nil {
-			storklog.PodLog(pod).Errorf("Error getting list of driver nodes, returning all nodes")
+			storklog.PodLog(pod).Errorf("Error getting list of driver nodes, returning all nodes, err: %v", err)
 		} else {
 			for _, volumeInfo := range driverVolumes {
 				onlineNodeFound := false

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -897,7 +897,7 @@ func (m *MigrationController) prepareResources(
 			if err != nil {
 				return fmt.Errorf("error preparing PV resource %v: %v", metadata.GetName(), err)
 			}
-		case "Deployment", "StatefulSet", "DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer":
+		case "Deployment", "StatefulSet", "DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer", "ReplicaSet":
 			err := m.prepareApplicationResource(migration, o)
 			if err != nil {
 				return fmt.Errorf("error preparing %v resource %v: %v", o.GetObjectKind().GroupVersionKind().Kind, metadata.GetName(), err)
@@ -1353,6 +1353,7 @@ func (m *MigrationController) applyResources(
 	ruleset := inflect.NewDefaultRuleset()
 	ruleset.AddPlural("quota", "quotas")
 	ruleset.AddPlural("prometheus", "prometheuses")
+	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
 
 	var pvObjects, pvcObjects []runtime.Unstructured
 	for _, o := range objects {

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -897,6 +897,7 @@ func (r *ResourceCollector) getDynamicClient(
 	ruleset := inflect.NewDefaultRuleset()
 	ruleset.AddPlural("quota", "quotas")
 	ruleset.AddPlural("prometheus", "prometheuses")
+	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
 	resource := &metav1.APIResource{
 		Name:       ruleset.Pluralize(strings.ToLower(objectType.GetKind())),
 		Namespaced: len(metadata.GetNamespace()) > 0,

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -25,6 +25,7 @@ import (
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/schedule"
 	"github.com/libopenstorage/stork/pkg/storkctl"
+	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/dynamic"
@@ -60,6 +61,8 @@ import (
 
 const (
 	nodeDriverName              = "ssh"
+	cmName                      = "stork-version"
+	defaultAdminNamespace       = "kube-system"
 	schedulerDriverName         = "k8s"
 	remotePairName              = "remoteclusterpair"
 	srcConfig                   = "sourceconfigmap"
@@ -193,7 +196,19 @@ func setup() error {
 	if err = volumeDriver.Init(schedulerDriverName, nodeDriverName, authToken, provisioner, genericCsiConfigMap); err != nil {
 		return fmt.Errorf("Error initializing volume driver %v: %v", volumeDriverName, err)
 	}
-
+	cm, err := core.Instance().GetConfigMap(cmName, defaultAdminNamespace)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("Unable to get stork version configmap: %v", err)
+	}
+	if cm != nil {
+		ver, ok := cm.Data["version"]
+		if !ok {
+			return fmt.Errorf("stork version not found in configmap: %s", cmName)
+		}
+		if ver != version.Version {
+			return fmt.Errorf("stork version mismatch, found: %s, expected: %s", ver, version.Version)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
>feature
>integration-test

**What this PR does / why we need it**:
Add support to backup/migrate mongoldb community CR
Also adds integration test to verify stork version from configmap

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6.4

*Note* :  Same Version Integration test image  has to be used for running integration test eg. integration test build on top of master will be used to validate stork:master image 
