### PR TITLE
Update service account resource instead of delete/create

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -995,18 +995,7 @@ func (m *MigrationController) checkAndUpdateDefaultSA(
 		return err
 	}
 
-	if sourceSA.GetName() != "default" {
-		// delete and recreate service account
-		if err := adminClient.CoreV1().ServiceAccounts(sourceSA.GetNamespace()).Delete(context.TODO(), sourceSA.GetName(), metav1.DeleteOptions{}); err != nil {
-			return err
-		}
-		if _, err := adminClient.CoreV1().ServiceAccounts(sourceSA.GetNamespace()).Create(context.TODO(), &sourceSA, metav1.CreateOptions{}); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	log.MigrationLog(migration).Infof("Updating default service account(namespace : %v) with image pull secrets", sourceSA.GetNamespace())
+	log.MigrationLog(migration).Infof("Updating service account(namespace/name : %s/%s) with image pull secrets", sourceSA.GetNamespace(), sourceSA.GetName())
 	// merge service account resource for default namespaces
 	destSA, err := adminClient.CoreV1().ServiceAccounts(sourceSA.GetNamespace()).Get(context.TODO(), sourceSA.GetName(), metav1.GetOptions{})
 	if err != nil {
@@ -1026,6 +1015,7 @@ func (m *MigrationController) checkAndUpdateDefaultSA(
 		}
 	}
 	// merge annotation for SA
+	log.MigrationLog(migration).Infof("Updating service account(namespace/name : %s/%s) annotations", sourceSA.GetNamespace(), sourceSA.GetName())
 	if destSA.Annotations != nil {
 		if sourceSA.Annotations == nil {
 			sourceSA.Annotations = make(map[string]string)


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Stork now update SA instead of recreating it now, we don't need to handle default SA seperately

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6
