### PR TITLE
STOR-393: Add a SAN to the webhook certificate created by stork.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -739,6 +739,7 @@ func (p *portworx) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*stor
 		if volumeName != "" {
 			volumeInfo, err := p.InspectVolume(volumeName)
 			if err != nil {
+				logrus.Warnf("Failed to inspect volume %v: %v", volumeName, err)
 				// If the inspect volume fails return with atleast some info
 				volumeInfo = &storkvolume.Info{
 					VolumeName: volumeName,

--- a/pkg/metrics/volumesnapshotschedule.go
+++ b/pkg/metrics/volumesnapshotschedule.go
@@ -31,7 +31,7 @@ func watchVolumeSnapshotScheduleCR(object runtime.Object) error {
 		volumeSnapshotScheduleStatusCounter.Delete(labels)
 		return nil
 	}
-	if *suspend {
+	if suspend != nil && *suspend {
 		volumeSnapshotScheduleStatusCounter.With(labels).Set(1)
 	} else {
 		volumeSnapshotScheduleStatusCounter.With(labels).Set(0)

--- a/pkg/webhookadmission/utils.go
+++ b/pkg/webhookadmission/utils.go
@@ -81,7 +81,7 @@ func CreateMutateWebhook(caBundle []byte, ns string) error {
 
 // GenerateCertificate Self Signed certificate using given CN, returns x509 cert
 // and priv key in PEM format
-func GenerateCertificate(cn string) ([]byte, []byte, error) {
+func GenerateCertificate(cn string, dnsName string) ([]byte, []byte, error) {
 	var err error
 	pemCert := &bytes.Buffer{}
 
@@ -104,6 +104,7 @@ func GenerateCertificate(cn string) ([]byte, []byte, error) {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  true,
+		DNSNames:              []string{dnsName},
 	}
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {


### PR DESCRIPTION



**What type of PR is this?**
bug


**What this PR does / why we need it**:
Since K8s v1.10 migrated to go 1.15, self-signed certificates should have alt sub added otherwise it will fail with error - 
```
W0525 09:17:10.265434       1 dispatcher.go:170] Failed calling webhook, failing open webhook.stork.libopenstorage.org: failed calling webhook "webhook.stork.libopenstorage.org": Post "https://stork-service.kube-system.svc:443/mutate?timeout=30s": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```
- Stork now creates a valid cert.
- It also creates a new k8s secret with the cert and deletes the old one. 

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
Stork webhook controller would not work since the associated certificate did not have a valid SAN set. Now stork creates a valid cert and it will also update the certs that were already created. 
```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.6

