### PR TITLE
Removed incorrect return statement in the backupVolumes function

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -498,7 +498,7 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 		for _, namespace := range backup.Spec.Namespaces {
 			pvcList, err := core.Instance().GetPersistentVolumeClaims(namespace, backup.Spec.Selectors)
 			if err != nil {
-				return fmt.Errorf("error getting list of volumes to migrate: %v", err)
+				return fmt.Errorf("error getting list of volumes to backup: %v", err)
 			}
 
 			for _, pvc := range pvcList.Items {
@@ -518,7 +518,6 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 						if !isResourceTypePVC {
 							break
 						}
-						return err
 					}
 				}
 


### PR DESCRIPTION
**What type of PR is this?**
bug
**What this PR does / why we need it**:
Removed incorrect return statement in the backupVolumes function

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
2.6 

**Testing:**
Tested the failing usecase listed in the pb-1732 bug.

<img width="1792" alt="Screenshot 2021-07-11 at 12 21 21 PM" src="https://user-images.githubusercontent.com/52188641/125185455-84e12a80-e242-11eb-9450-1022563b472d.png">



