### PR TITLE
Increase timeout for cassandara apps

### DIFF
--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -84,7 +84,7 @@ const (
 
 	defaultWaitTimeout       time.Duration = 10 * time.Minute
 	clusterDomainWaitTimeout time.Duration = 10 * time.Minute
-	groupSnapshotWaitTimeout time.Duration = 15 * time.Minute
+	groupSnapshotWaitTimeout time.Duration = 25 * time.Minute
 	defaultWaitInterval      time.Duration = 10 * time.Second
 	backupWaitInterval       time.Duration = 2 * time.Second
 

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	migrationRetryInterval = 10 * time.Second
-	migrationRetryTimeout  = 5 * time.Minute
+	migrationRetryTimeout  = 10 * time.Minute
 )
 
 func testMigration(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
A lot of integration tests are failing because cassandra apps are taking longer to come up after migration (possibly 

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No
```

**Does this change need to be cherry-picked to a release branch?**:
Master

