### PR TITLE
Omit checking sha for stork version checks

### DIFF
--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -205,7 +206,7 @@ func setup() error {
 		if !ok {
 			return fmt.Errorf("stork version not found in configmap: %s", cmName)
 		}
-		if ver != version.Version {
+		if strings.Split(ver, "-")[0] != strings.Split(version.Version, "-")[0] {
 			return fmt.Errorf("stork version mismatch, found: %s, expected: %s", ver, version.Version)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
>bug
>integration-test

**What this PR does / why we need it**:
Only match stork version while starting integration tests

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.6.4

