### PR TITLE
STOR-415: Remove svc ports while cloning service resources

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1373,6 +1373,13 @@ func (m *MigrationController) applyResources(
 			continue
 		}
 		log.MigrationLog(migration).Infof("Applying %v %v", pv.Kind, pv.GetName())
+
+		if pv.GetAnnotations() == nil {
+			pv.Annotations = make(map[string]string)
+		}
+		pv.Annotations[StorkMigrationAnnotation] = "true"
+		pv.Annotations[StorkMigrationName] = migration.GetName()
+		pv.Annotations[StorkMigrationTime] = time.Now().Format(nameTimeSuffixFormat)
 		_, err = adminClient.CoreV1().PersistentVolumes().Create(context.TODO(), &pv, metav1.CreateOptions{})
 		if err != nil {
 			if err != nil && errors.IsAlreadyExists(err) {
@@ -1433,6 +1440,12 @@ func (m *MigrationController) applyResources(
 		}
 		if isDeleted {
 			log.MigrationLog(migration).Infof("Applying %v %v", pvc.Kind, pvc.GetName())
+			if pvc.GetAnnotations() == nil {
+				pvc.Annotations = make(map[string]string)
+			}
+			pvc.Annotations[StorkMigrationAnnotation] = "true"
+			pvc.Annotations[StorkMigrationName] = migration.GetName()
+			pvc.Annotations[StorkMigrationTime] = time.Now().Format(nameTimeSuffixFormat)
 			_, err = adminClient.CoreV1().PersistentVolumeClaims(pvc.GetNamespace()).Create(context.TODO(), &pvc, metav1.CreateOptions{})
 			if err != nil {
 				log.MigrationLog(migration).Errorf("Error creating %v/%v during migration: %v", pvc.GetNamespace(), pvc.GetName(), err)

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -494,8 +494,12 @@ func validateMigrationCleanup(t *testing.T, name, namespace string, pvcs *v1.Per
 	require.Error(t, err, "expected ss:%v error not found", name)
 
 	for _, pvc := range pvcs.Items {
-		_, err := core.Instance().GetPersistentVolumeClaim(pvc.Name, pvc.Namespace)
-		require.Error(t, err, "expected pvc:%v error not found", pvc.Name)
+		resp, err := core.Instance().GetPersistentVolumeClaim(pvc.Name, pvc.Namespace)
+		if err == nil {
+			require.NotNil(t, resp.DeletionTimestamp)
+		} else {
+			require.Error(t, err, "expected pvc to be deleted:%v", resp.Name)
+		}
 	}
 
 	err = setSourceKubeConfig()

--- a/test/integration_test/snapshot_restore_test.go
+++ b/test/integration_test/snapshot_restore_test.go
@@ -15,8 +15,8 @@ func testSnapshotRestore(t *testing.T) {
 	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
 
 	t.Run("simpleSnapshotRestoreTest", simpleSnapshotRestoreTest)
-	t.Run("groupSnapshotRestoreTest", groupSnapshotRestoreTest)
 	if !testing.Short() {
+		t.Run("groupSnapshotRestoreTest", groupSnapshotRestoreTest)
 		t.Run("cloudSnapshotRestoreTest", cloudSnapshotRestoreTest)
 		t.Run("groupCloudSnapshotRestoreTest", groupCloudSnapshotRestoreTest)
 	}

--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -40,8 +40,11 @@ func testSnapshot(t *testing.T) {
 	t.Run("cloudSnapshotTest", cloudSnapshotTest)
 	t.Run("snapshotScaleTest", snapshotScaleTest)
 	t.Run("cloudSnapshotScaleTest", cloudSnapshotScaleTest)
-	t.Run("groupSnapshotTest", groupSnapshotTest)
-	t.Run("groupSnapshotScaleTest", groupSnapshotScaleTest)
+
+	if !testing.Short() {
+		t.Run("groupSnapshotTest", groupSnapshotTest)
+		t.Run("groupSnapshotScaleTest", groupSnapshotScaleTest)
+	}
 	t.Run("scheduleTests", snapshotScheduleTests)
 	// TODO: waiting for https://portworx.atlassian.net/browse/STOR-281 to be resolved
 	if authTokenConfigMap == "" {


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
While cloning service resources stork now will empty `ports` field before creating service resource

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
ApplicationClone now set `ports` field of service to nil/empty before cloning to destination namespace
```

**Does this change need to be cherry-picked to a release branch?**:
2.6.4

Output: 
```
# storkctl get applicationclone -nkube-system
NAME              SOURCE      DESTINATION      STAGE   STATUS       VOLUMES   RESOURCES   CREATED               ELAPSED
clone-cassandra   cassandra   cassandra-test   Final   Successful   3/3       8           21 Jul 21 17:43 UTC   38s
# kubectl get svc -ncassandra
NAME        TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
cassandra   ClusterIP   None         <none>        9042/TCP   137m
# kubectl get svc -ncassandra-test
NAME        TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
cassandra   ClusterIP   None         <none>        <none>    8s

```
