### PR TITLE
STOR-441: Migrations are deleting the backing PX volume.

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1383,11 +1383,7 @@ func (m *MigrationController) applyResources(
 		_, err = adminClient.CoreV1().PersistentVolumes().Create(context.TODO(), &pv, metav1.CreateOptions{})
 		if err != nil {
 			if err != nil && errors.IsAlreadyExists(err) {
-				if migration.Spec.IncludeVolumes == nil || *migration.Spec.IncludeVolumes {
-					err = nil
-				} else {
-					_, err = adminClient.CoreV1().PersistentVolumes().Update(context.TODO(), &pv, metav1.UpdateOptions{})
-				}
+				_, err = adminClient.CoreV1().PersistentVolumes().Update(context.TODO(), &pv, metav1.UpdateOptions{})
 			}
 		}
 		if err != nil {
@@ -1430,11 +1426,11 @@ func (m *MigrationController) applyResources(
 				}
 				createTime := obj.GetCreationTimestamp()
 				if deleteStart.Before(&createTime) {
-					logrus.Warnf("Object[%v] got re-created after deletion. Not retrying deletion, deleteStart time:[%v], create time:[%v]",
+					log.MigrationLog(migration).Warnf("Object[%v] got re-created after deletion. Not retrying deletion, deleteStart time:[%v], create time:[%v]",
 						obj.GetName(), deleteStart, createTime)
 					break
 				}
-				logrus.Warnf("Object %v still present, retrying in %v", pvc.GetName(), deletedRetryInterval)
+				log.MigrationLog(migration).Infof("Object %v still present, retrying in %v", pvc.GetName(), deletedRetryInterval)
 				time.Sleep(deletedRetryInterval)
 			}
 		}
@@ -1562,11 +1558,11 @@ func (m *MigrationController) applyResources(
 							}
 							createTime := obj.GetCreationTimestamp()
 							if deleteStart.Before(&createTime) {
-								logrus.Warnf("Object[%v] got re-created after deletion. So, Ignore wait. deleteStart time:[%v], create time:[%v]",
+								log.MigrationLog(migration).Warnf("Object[%v] got re-created after deletion. So, Ignore wait. deleteStart time:[%v], create time:[%v]",
 									obj.GetName(), deleteStart, createTime)
 								break
 							}
-							logrus.Warnf("Object %v still present, retrying in %v", metadata.GetName(), deletedRetryInterval)
+							log.MigrationLog(migration).Warnf("Object %v still present, retrying in %v", metadata.GetName(), deletedRetryInterval)
 							time.Sleep(deletedRetryInterval)
 						}
 						_, err = dynamicClient.Create(context.TODO(), unstructured, metav1.CreateOptions{})


### PR DESCRIPTION



**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
With the recent changes for updating the PVC size as a part of Migrations we are now doing the following
- Update the reclaim policy on the PV to Retain
- Delete the PVC
- Recreate the PVC and PV
However due to a bug the Retain policy was not set and the volume was getting deleted.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No


**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.6

