### PR TITLE
stor-458: Added following changes in stork CRD for data mover feature.

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -35,6 +35,7 @@ type ApplicationBackupSpec struct {
 	Options          map[string]string `json:"options"`
 	IncludeResources []ObjectInfo      `json:"includeResources"`
 	ResourceTypes    []string          `json:"resourceTypes"`
+	backupType       string            `json:"backupType"`
 }
 
 // ApplicationBackupReclaimPolicyType is the reclaim policy for the application backup
@@ -88,6 +89,7 @@ type ApplicationBackupVolumeInfo struct {
 	Options               map[string]string           `jons:"options"`
 	TotalSize             uint64                      `json:"totalSize"`
 	ActualSize            uint64                      `json:"actualSize"`
+	StorageClass          string                      `json:"storageClass"`
 }
 
 // ApplicationBackupStatusType is the status of the application backup

--- a/pkg/apis/stork/v1alpha1/applicationbackupschedule.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackupschedule.go
@@ -17,6 +17,7 @@ type ApplicationBackupScheduleSpec struct {
 	SchedulePolicyName string                        `json:"schedulePolicyName"`
 	Suspend            *bool                         `json:"suspend"`
 	ReclaimPolicy      ReclaimPolicyType             `json:"reclaimPolicy"`
+	backupType         string                        `json:"backupTypes"`
 }
 
 // ApplicationBackupTemplateSpec describes the data a ApplicationBackup should have when created


### PR DESCRIPTION



**What type of PR is this?**
Data mover feature
**What this PR does / why we need it**:
```
    stor-458: Added following changes in stork CRD for data mover feature.

      - Added backupType in ApplicationBackup and ApplicationBackupSchedule
        CR definitions.
      - Added storageClass in ApplicationBackupVolumeInfo definition.
 ```
**Does this PR change a user-facing CRD or CLI?**:
**ApplicationBackup CR:**
backupType - to set the backup type as "Generic" or "Normal"
storageClass - added this in volumeInfo struct, to store the storageClass used for the PVC. It will be later used in generic restore operation.
**ApplicationBackupSchedule CR:**
backupType - to set the backup type as "Generic" or "Normal"


**Is a release note needed?**:
Yes. Will add proper release Note details in the ticket.

**Does this change need to be cherry-picked to a release branch?**:
Yes, stor-2.7.0
