### PR TITLE
Update stork crds to v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.0
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20210614212742-d19cd551f94a
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20210805192436-d51186f75dc4
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.9.0
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1064,6 +1064,8 @@ github.com/portworx/sched-ops v1.20.4-rc1.0.20210503012502-d83d87d42ead h1:3YTLD
 github.com/portworx/sched-ops v1.20.4-rc1.0.20210503012502-d83d87d42ead/go.mod h1:fZ+nl20syzzXqeVuF41XfOJAmLXRV5+CFteuBkijB7A=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20210614212742-d19cd551f94a h1:N+zSnQ2r2ps+fh7wi1pq2dcB6wYjTAUF0HSZ9Uny/qs=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20210614212742-d19cd551f94a/go.mod h1:+R+28pHhZ2Go7LquCo1+9ctpxwFGWak7zNcTFyXVh4k=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20210805192436-d51186f75dc4 h1:T8YXH0Rc/fZMWsTjIiGVB7ypuav7QuXRcV4Cfk3wLaE=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20210805192436-d51186f75dc4/go.mod h1:+R+28pHhZ2Go7LquCo1+9ctpxwFGWak7zNcTFyXVh4k=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145 h1:J5D0JPZWueVAK8/Dr5s84I7/tCfin6NjIGbKKCSyyJ0=

--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -35,7 +35,7 @@ type ApplicationBackupSpec struct {
 	Options          map[string]string `json:"options"`
 	IncludeResources []ObjectInfo      `json:"includeResources"`
 	ResourceTypes    []string          `json:"resourceTypes"`
-	backupType       string            `json:"backupType"`
+	BackupType       string            `json:"backupType"`
 }
 
 // ApplicationBackupReclaimPolicyType is the reclaim policy for the application backup

--- a/pkg/apis/stork/v1alpha1/applicationbackupschedule.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackupschedule.go
@@ -17,7 +17,7 @@ type ApplicationBackupScheduleSpec struct {
 	SchedulePolicyName string                        `json:"schedulePolicyName"`
 	Suspend            *bool                         `json:"suspend"`
 	ReclaimPolicy      ReclaimPolicyType             `json:"reclaimPolicy"`
-	backupType         string                        `json:"backupTypes"`
+	BackupType         string                        `json:"backupType"`
 }
 
 // ApplicationBackupTemplateSpec describes the data a ApplicationBackup should have when created

--- a/pkg/applicationmanager/controllers/applicationbackupschedule.go
+++ b/pkg/applicationmanager/controllers/applicationbackupschedule.go
@@ -9,8 +9,10 @@ import (
 
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/controllers"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/schedule"
+	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
@@ -378,10 +380,20 @@ func (s *ApplicationBackupScheduleController) createCRD() error {
 		Scope:   apiextensionsv1beta1.NamespaceScoped,
 		Kind:    reflect.TypeOf(stork_api.ApplicationBackupSchedule{}).Name(),
 	}
-	err := apiextensions.Instance().CreateCRD(resource)
+	ok, err := version.RequiresV1Registration()
+	if err != nil {
+		return err
+	}
+	if ok {
+		err := k8sutils.CreateCRD(resource)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+		return apiextensions.Instance().ValidateCRD(resource.Plural+"."+resource.Group, validateCRDTimeout, validateCRDInterval)
+	}
+	err = apiextensions.Instance().CreateCRDV1beta1(resource)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
-
-	return apiextensions.Instance().ValidateCRD(resource, validateCRDTimeout, validateCRDInterval)
+	return apiextensions.Instance().ValidateCRDV1beta1(resource, validateCRDTimeout, validateCRDInterval)
 }

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -8,9 +8,11 @@ import (
 	"github.com/libopenstorage/stork/drivers/volume"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/controllers"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	"github.com/libopenstorage/stork/pkg/rule"
+	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
@@ -803,10 +805,20 @@ func (a *ApplicationCloneController) createCRD() error {
 		Scope:   apiextensionsv1beta1.NamespaceScoped,
 		Kind:    reflect.TypeOf(stork_api.ApplicationClone{}).Name(),
 	}
-	err := apiextensions.Instance().CreateCRD(resource)
+	ok, err := version.RequiresV1Registration()
+	if err != nil {
+		return err
+	}
+	if ok {
+		err := k8sutils.CreateCRD(resource)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+		return apiextensions.Instance().ValidateCRD(resource.Plural+"."+resource.Group, validateCRDTimeout, validateCRDInterval)
+	}
+	err = apiextensions.Instance().CreateCRDV1beta1(resource)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
-
-	return apiextensions.Instance().ValidateCRD(resource, validateCRDTimeout, validateCRDInterval)
+	return apiextensions.Instance().ValidateCRDV1beta1(resource, validateCRDTimeout, validateCRDInterval)
 }

--- a/pkg/applicationmanager/controllers/applicationregistration.go
+++ b/pkg/applicationmanager/controllers/applicationregistration.go
@@ -100,6 +100,7 @@ func RegisterDefaultCRDs() error {
 	// create appreg for already registered crd
 	crds, err := apiextensions.Instance().ListCRDs()
 	if err != nil {
+		logrus.Errorf("unable to list crds: %v", err)
 		return err
 	}
 
@@ -108,7 +109,7 @@ func RegisterDefaultCRDs() error {
 		if _, ok := skipCrds[crd.Spec.Group]; ok {
 			continue
 		}
-		if err := registerCRD(crd); err != nil {
+		if err := registerCRDV1(crd); err != nil {
 			return err
 		}
 	}
@@ -148,9 +149,8 @@ func watchCRDs(fn WatchFunc) error {
 		return err
 	}
 	listOptions := metav1.ListOptions{Watch: true}
-	watchInterface, err := srcClnt.ApiextensionsV1beta1().CustomResourceDefinitions().Watch(context.TODO(), listOptions)
+	watchInterface, err := srcClnt.ApiextensionsV1().CustomResourceDefinitions().Watch(context.TODO(), listOptions)
 	if err != nil {
-		logrus.WithError(err).Error("error invoking the watch api for crds", err)
 		return err
 	}
 	// fire of watch interface

--- a/pkg/clusterdomains/controllers/clusterdomainstatus.go
+++ b/pkg/clusterdomains/controllers/clusterdomainstatus.go
@@ -11,6 +11,8 @@ import (
 	"github.com/libopenstorage/stork/drivers/volume"
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/controllers"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
+	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/portworx/sched-ops/task"
@@ -187,12 +189,22 @@ func (c *ClusterDomainsStatusController) createCRD() error {
 		Kind:       reflect.TypeOf(storkv1.ClusterDomainsStatus{}).Name(),
 		ShortNames: []string{storkv1.ClusterDomainsStatusShortName},
 	}
-	err := apiextensions.Instance().CreateCRD(resource)
+	ok, err := version.RequiresV1Registration()
+	if err != nil {
+		return err
+	}
+	if ok {
+		err := k8sutils.CreateCRD(resource)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+		return apiextensions.Instance().ValidateCRD(resource.Plural+"."+resource.Group, validateCRDTimeout, validateCRDInterval)
+	}
+	err = apiextensions.Instance().CreateCRDV1beta1(resource)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
-
-	return apiextensions.Instance().ValidateCRD(resource, validateCRDTimeout, validateCRDInterval)
+	return apiextensions.Instance().ValidateCRDV1beta1(resource, validateCRDTimeout, validateCRDInterval)
 }
 
 func getNameForClusterDomainsStatus(clusterID string) string {

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/core"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -111,4 +112,45 @@ func ValidateCRDV1(client *clientset.Clientset, crdName string) error {
 		}
 		return false, nil
 	})
+}
+
+// CreateCRD creates the given custom resource
+func CreateCRD(resource apiextensions.CustomResource) error {
+	scope := apiextensionsv1.NamespaceScoped
+	if string(resource.Scope) == string(apiextensionsv1.ClusterScoped) {
+		scope = apiextensionsv1.ClusterScoped
+	}
+	ignoreSchemaValidation := true
+	crdName := fmt.Sprintf("%s.%s", resource.Plural, resource.Group)
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: resource.Group,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: resource.Version,
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							XPreserveUnknownFields: &ignoreSchemaValidation,
+						},
+					},
+				},
+			},
+			Scope: scope,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular:   resource.Name,
+				Plural:     resource.Plural,
+				Kind:       resource.Kind,
+				ShortNames: resource.ShortNames,
+			},
+		},
+	}
+	err := apiextensions.Instance().RegisterCRD(crd)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/apis/stork"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	fakeclient "github.com/libopenstorage/stork/pkg/client/clientset/versioned/fake"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -68,7 +69,7 @@ func resetTest() {
 		Scope:   apiextensionsv1beta1.NamespaceScoped,
 		Kind:    reflect.TypeOf(stork_api.ApplicationBackup{}).Name(),
 	}
-	err := apiextensions.Instance().CreateCRD(bkp)
+	err := k8sutils.CreateCRD(bkp)
 	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		os.Exit(1)
 	}
@@ -81,7 +82,7 @@ func resetTest() {
 		Scope:   apiextensionsv1beta1.NamespaceScoped,
 		Kind:    reflect.TypeOf(stork_api.ApplicationRestore{}).Name(),
 	}
-	err = apiextensions.Instance().CreateCRD(restore)
+	err = k8sutils.CreateCRD(restore)
 	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		os.Exit(1)
 	}
@@ -94,7 +95,7 @@ func resetTest() {
 		Scope:   apiextensionsv1beta1.NamespaceScoped,
 		Kind:    reflect.TypeOf(stork_api.ApplicationClone{}).Name(),
 	}
-	err = apiextensions.Instance().CreateCRD(clone)
+	err = k8sutils.CreateCRD(clone)
 	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		os.Exit(1)
 	}
@@ -107,7 +108,7 @@ func resetTest() {
 		Scope:   apiextensionsv1beta1.NamespaceScoped,
 		Kind:    reflect.TypeOf(stork_api.ClusterPair{}).Name(),
 	}
-	err = apiextensions.Instance().CreateCRD(pair)
+	err = k8sutils.CreateCRD(pair)
 	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		os.Exit(1)
 	}
@@ -120,7 +121,7 @@ func resetTest() {
 		Scope:   apiextensionsv1beta1.NamespaceScoped,
 		Kind:    reflect.TypeOf(stork_api.Migration{}).Name(),
 	}
-	err = apiextensions.Instance().CreateCRD(migr)
+	err = k8sutils.CreateCRD(migr)
 	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		os.Exit(1)
 	}

--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -9,6 +9,8 @@ import (
 	"github.com/libopenstorage/stork/drivers/volume"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/controllers"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
+	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
@@ -223,12 +225,22 @@ func (c *ClusterPairController) createCRD() error {
 		Scope:   apiextensionsv1beta1.NamespaceScoped,
 		Kind:    reflect.TypeOf(stork_api.ClusterPair{}).Name(),
 	}
-	err := apiextensions.Instance().CreateCRD(resource)
+	ok, err := version.RequiresV1Registration()
+	if err != nil {
+		return err
+	}
+	if ok {
+		err := k8sutils.CreateCRD(resource)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+		return apiextensions.Instance().ValidateCRD(resource.Plural+"."+resource.Group, validateCRDTimeout, validateCRDInterval)
+	}
+	err = apiextensions.Instance().CreateCRDV1beta1(resource)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
-
-	return apiextensions.Instance().ValidateCRD(resource, validateCRDTimeout, validateCRDInterval)
+	return apiextensions.Instance().ValidateCRDV1beta1(resource, validateCRDTimeout, validateCRDInterval)
 }
 
 func (c *ClusterPairController) createBackupLocationOnRemote(remoteConfig *restclient.Config, clusterPair *stork_api.ClusterPair) error {

--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -10,8 +10,10 @@ import (
 	"github.com/libopenstorage/stork/drivers/volume"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/controllers"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/schedule"
+	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
@@ -401,10 +403,20 @@ func (m *MigrationScheduleController) createCRD() error {
 		Scope:   apiextensionsv1beta1.NamespaceScoped,
 		Kind:    reflect.TypeOf(stork_api.MigrationSchedule{}).Name(),
 	}
-	err := apiextensions.Instance().CreateCRD(resource)
+	ok, err := version.RequiresV1Registration()
+	if err != nil {
+		return err
+	}
+	if ok {
+		err := k8sutils.CreateCRD(resource)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+		return apiextensions.Instance().ValidateCRD(resource.Plural+"."+resource.Group, validateCRDTimeout, validateCRDInterval)
+	}
+	err = apiextensions.Instance().CreateCRDV1beta1(resource)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
-
-	return apiextensions.Instance().ValidateCRD(resource, validateCRDTimeout, validateCRDInterval)
+	return apiextensions.Instance().ValidateCRDV1beta1(resource, validateCRDTimeout, validateCRDInterval)
 }

--- a/pkg/snapshot/controllers/snapshotrestore.go
+++ b/pkg/snapshot/controllers/snapshotrestore.go
@@ -12,7 +12,9 @@ import (
 	"github.com/libopenstorage/stork/drivers/volume"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/controllers"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
+	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/core"
 	k8sextops "github.com/portworx/sched-ops/k8s/externalstorage"
@@ -380,12 +382,22 @@ func (c *SnapshotRestoreController) createCRD() error {
 		Scope:   apiextensionsv1beta1.NamespaceScoped,
 		Kind:    reflect.TypeOf(stork_api.VolumeSnapshotRestore{}).Name(),
 	}
-	err := apiextensions.Instance().CreateCRD(resource)
+	ok, err := version.RequiresV1Registration()
+	if err != nil {
+		return err
+	}
+	if ok {
+		err := k8sutils.CreateCRD(resource)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+		return apiextensions.Instance().ValidateCRD(resource.Plural+"."+resource.Group, validateCRDTimeout, validateCRDInterval)
+	}
+	err = apiextensions.Instance().CreateCRDV1beta1(resource)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
-
-	return apiextensions.Instance().ValidateCRD(resource, validateCRDTimeout, validateCRDInterval)
+	return apiextensions.Instance().ValidateCRDV1beta1(resource, validateCRDTimeout, validateCRDInterval)
 }
 
 func (c *SnapshotRestoreController) handleDelete(snapRestore *stork_api.VolumeSnapshotRestore) error {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,57 @@
 package version
 
+import (
+	"fmt"
+	"regexp"
+
+	version "github.com/hashicorp/go-version"
+	coreops "github.com/portworx/sched-ops/k8s/core"
+)
+
 // Version will be overridden with the current version at build time using the -X linker flag
 var Version string
+
+var (
+	kbVerRegex = regexp.MustCompile(`^(v\d+\.\d+\.\d+)(.*)`)
+)
+
+// RequiresV1Registration returns true if crd nees to be registered as apiVersion V1
+func RequiresV1Registration() (bool, error) {
+	k8sVersion, _, err := GetFullVersion()
+	if err != nil {
+		return false, err
+	}
+	k8sVer1_16, err := version.NewVersion("1.16")
+	if err != nil {
+		return false, err
+
+	}
+	if k8sVersion.GreaterThanOrEqual(k8sVer1_16) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// GetFullVersion returns the full kubernetes server version
+func GetFullVersion() (*version.Version, string, error) {
+	k8sVersion, err := coreops.Instance().GetVersion()
+	if err != nil {
+		return nil, "", fmt.Errorf("unable to get kubernetes version: %v", err)
+	}
+	matches := kbVerRegex.FindStringSubmatch(k8sVersion.GitVersion)
+	if len(matches) < 2 {
+		return nil, "", fmt.Errorf("invalid kubernetes version received: %v", k8sVersion.GitVersion)
+	}
+
+	ver, err := version.NewVersion(matches[1])
+	if len(matches) == 3 {
+		return ver, matches[2], err
+	}
+	return ver, "", err
+}
+
+// GetVersion returns the kubernetes server version
+func GetVersion() (*version.Version, error) {
+	ver, _, err := GetFullVersion()
+	return ver, err
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/apiextensions/apiextensions.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apiextensions/apiextensions.go
@@ -21,6 +21,7 @@ var (
 // Ops is an interface to perform kubernetes related operations on the crd resources.
 type Ops interface {
 	CRDOps
+	CRDV1beta1Ops
 
 	// SetConfig sets the config and resets the client.
 	SetConfig(config *rest.Config)

--- a/vendor/github.com/portworx/sched-ops/k8s/apiextensions/crds.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apiextensions/crds.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -13,81 +13,28 @@ import (
 
 // CRDOps is an interface to perfrom k8s Customer Resource operations
 type CRDOps interface {
-	// CreateCRD creates the given custom resource
-	// This API will be deprecated soon. Use RegisterCRD instead
-	CreateCRD(resource CustomResource) error
 	// RegisterCRD creates the given custom resource
-	RegisterCRD(crd *apiextensionsv1beta1.CustomResourceDefinition) error
+	RegisterCRD(crd *apiextensionsv1.CustomResourceDefinition) error
 	// UpdateCRD updates the existing crd
-	UpdateCRD(crd *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error)
-	// GetCRD returns a crd by name
-	GetCRD(name string, options metav1.GetOptions) (*apiextensionsv1beta1.CustomResourceDefinition, error)
-	// ValidateCRD checks if the given CRD is registered
-	ValidateCRD(resource CustomResource, timeout, retryInterval time.Duration) error
+	UpdateCRD(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error)
+	// GetCRD returns a crd by complete name (plural.group)
+	GetCRD(name string, options metav1.GetOptions) (*apiextensionsv1.CustomResourceDefinition, error)
+	// ValidateCRD checks if the given CRD is registered. The given name should be
+	// the complete name (plural.group) Eg: storageclusters.core.libopenstorage.org
+	ValidateCRD(name string, timeout, retryInterval time.Duration) error
 	// DeleteCRD deletes the CRD for the given complete name (plural.group)
-	DeleteCRD(fullName string) error
+	DeleteCRD(name string) error
 	// ListCRDs list all the CRDs
-	ListCRDs() (*apiextensionsv1beta1.CustomResourceDefinitionList, error)
-}
-
-// CustomResource is for creating a Kubernetes TPR/CRD
-type CustomResource struct {
-	// Name of the custom resource
-	Name string
-	// ShortNames are short names for the resource.  It must be all lowercase.
-	ShortNames []string
-	// Plural of the custom resource in plural
-	Plural string
-	// Group the custom resource belongs to
-	Group string
-	// Version which should be defined in a const above
-	Version string
-	// Scope of the CRD. Namespaced or cluster
-	Scope apiextensionsv1beta1.ResourceScope
-	// Kind is the serialized interface of the resource.
-	Kind string
-}
-
-// CreateCRD creates the given custom resource
-// This API will be deprecated soon. Use RegisterCRD instead
-func (c *Client) CreateCRD(resource CustomResource) error {
-	if err := c.initClient(); err != nil {
-		return err
-	}
-
-	crdName := fmt.Sprintf("%s.%s", resource.Plural, resource.Group)
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: crdName,
-		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   resource.Group,
-			Version: resource.Version,
-			Scope:   resource.Scope,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Singular:   resource.Name,
-				Plural:     resource.Plural,
-				Kind:       resource.Kind,
-				ShortNames: resource.ShortNames,
-			},
-		},
-	}
-
-	_, err := c.extension.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	ListCRDs() (*apiextensionsv1.CustomResourceDefinitionList, error)
 }
 
 // RegisterCRD creates the given custom resource
-func (c *Client) RegisterCRD(crd *apiextensionsv1beta1.CustomResourceDefinition) error {
+func (c *Client) RegisterCRD(crd *apiextensionsv1.CustomResourceDefinition) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
 
-	_, err := c.extension.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
+	_, err := c.extension.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -95,31 +42,31 @@ func (c *Client) RegisterCRD(crd *apiextensionsv1beta1.CustomResourceDefinition)
 }
 
 // UpdateCRD updates the existing crd
-func (c *Client) UpdateCRD(crd *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+func (c *Client) UpdateCRD(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
 
-	return c.extension.ApiextensionsV1beta1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
+	return c.extension.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
 }
 
-// GetCRD returns a crd by name
-func (c *Client) GetCRD(name string, options metav1.GetOptions) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+// GetCRD returns a crd by complete name (plural.group)
+func (c *Client) GetCRD(name string, options metav1.GetOptions) (*apiextensionsv1.CustomResourceDefinition, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
-	return c.extension.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), name, options)
+	return c.extension.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), name, options)
 }
 
-// ValidateCRD checks if the given CRD is registered
-func (c *Client) ValidateCRD(resource CustomResource, timeout, retryInterval time.Duration) error {
+// ValidateCRD checks if the given CRD is registered. The given name should be
+// the complete name (plural.group) Eg: storageclusters.core.libopenstorage.org
+func (c *Client) ValidateCRD(name string, timeout, retryInterval time.Duration) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
 
-	crdName := fmt.Sprintf("%s.%s", resource.Plural, resource.Group)
 	return wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
-		crd, err := c.extension.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crdName, metav1.GetOptions{})
+		crd, err := c.extension.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return false, nil
 		} else if err != nil {
@@ -127,12 +74,12 @@ func (c *Client) ValidateCRD(resource CustomResource, timeout, retryInterval tim
 		}
 		for _, cond := range crd.Status.Conditions {
 			switch cond.Type {
-			case apiextensionsv1beta1.Established:
-				if cond.Status == apiextensionsv1beta1.ConditionTrue {
+			case apiextensionsv1.Established:
+				if cond.Status == apiextensionsv1.ConditionTrue {
 					return true, nil
 				}
-			case apiextensionsv1beta1.NamesAccepted:
-				if cond.Status == apiextensionsv1beta1.ConditionFalse {
+			case apiextensionsv1.NamesAccepted:
+				if cond.Status == apiextensionsv1.ConditionFalse {
 					return false, fmt.Errorf("name conflict: %v", cond.Reason)
 				}
 			}
@@ -142,23 +89,23 @@ func (c *Client) ValidateCRD(resource CustomResource, timeout, retryInterval tim
 }
 
 // DeleteCRD deletes the CRD for the given complete name (plural.group)
-func (c *Client) DeleteCRD(fullName string) error {
+func (c *Client) DeleteCRD(name string) error {
 	if err := c.initClient(); err != nil {
 		return err
 	}
 
-	return c.extension.ApiextensionsV1beta1().
+	return c.extension.ApiextensionsV1().
 		CustomResourceDefinitions().
-		Delete(context.TODO(), fullName, metav1.DeleteOptions{PropagationPolicy: &deleteForegroundPolicy})
+		Delete(context.TODO(), name, metav1.DeleteOptions{PropagationPolicy: &deleteForegroundPolicy})
 }
 
 // ListCRDs list all CRD resources
-func (c *Client) ListCRDs() (*apiextensionsv1beta1.CustomResourceDefinitionList, error) {
+func (c *Client) ListCRDs() (*apiextensionsv1.CustomResourceDefinitionList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
 	}
 
-	return c.extension.ApiextensionsV1beta1().
+	return c.extension.ApiextensionsV1().
 		CustomResourceDefinitions().
 		List(context.TODO(), metav1.ListOptions{})
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/apiextensions/crds_v1beta1.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apiextensions/crds_v1beta1.go
@@ -1,0 +1,164 @@
+package apiextensions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// CRDV1beta1Ops is an interface to perfrom k8s Customer Resource operations
+type CRDV1beta1Ops interface {
+	// CreateCRDV1beta1 creates the given custom resource
+	// This API will be deprecated soon. Use RegisterCRDV1beta1 instead
+	CreateCRDV1beta1(resource CustomResource) error
+	// RegisterCRDV1beta1 creates the given custom resource
+	RegisterCRDV1beta1(crd *apiextensionsv1beta1.CustomResourceDefinition) error
+	// UpdateCRDV1beta1 updates the existing crd
+	UpdateCRDV1beta1(crd *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error)
+	// GetCRDV1beta1 returns a crd by name
+	GetCRDV1beta1(name string, options metav1.GetOptions) (*apiextensionsv1beta1.CustomResourceDefinition, error)
+	// ValidateCRDV1beta1 checks if the given CRD is registered
+	ValidateCRDV1beta1(resource CustomResource, timeout, retryInterval time.Duration) error
+	// DeleteCRDV1beta1 deletes the CRD for the given complete name (plural.group)
+	DeleteCRDV1beta1(fullName string) error
+	// ListCRDsV1beta1 list all the CRDs
+	ListCRDsV1beta1() (*apiextensionsv1beta1.CustomResourceDefinitionList, error)
+}
+
+// CustomResource is for creating a Kubernetes TPR/CRD
+type CustomResource struct {
+	// Name of the custom resource
+	Name string
+	// ShortNames are short names for the resource.  It must be all lowercase.
+	ShortNames []string
+	// Plural of the custom resource in plural
+	Plural string
+	// Group the custom resource belongs to
+	Group string
+	// Version which should be defined in a const above
+	Version string
+	// Scope of the CRD. Namespaced or cluster
+	Scope apiextensionsv1beta1.ResourceScope
+	// Kind is the serialized interface of the resource.
+	Kind string
+}
+
+// CreateCRDV1beta1 creates the given custom resource
+// This API will be deprecated soon. Use RegisterCRD instead
+func (c *Client) CreateCRDV1beta1(resource CustomResource) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	crdName := fmt.Sprintf("%s.%s", resource.Plural, resource.Group)
+	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   resource.Group,
+			Version: resource.Version,
+			Scope:   resource.Scope,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Singular:   resource.Name,
+				Plural:     resource.Plural,
+				Kind:       resource.Kind,
+				ShortNames: resource.ShortNames,
+			},
+		},
+	}
+
+	_, err := c.extension.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RegisterCRDV1beta1 creates the given custom resource
+func (c *Client) RegisterCRDV1beta1(crd *apiextensionsv1beta1.CustomResourceDefinition) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	_, err := c.extension.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), crd, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateCRDV1beta1 updates the existing crd
+func (c *Client) UpdateCRDV1beta1(crd *apiextensionsv1beta1.CustomResourceDefinition) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.extension.ApiextensionsV1beta1().CustomResourceDefinitions().Update(context.TODO(), crd, metav1.UpdateOptions{})
+}
+
+// GetCRDV1beta1 returns a crd by name
+func (c *Client) GetCRDV1beta1(name string, options metav1.GetOptions) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.extension.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), name, options)
+}
+
+// ValidateCRDV1beta1 checks if the given CRD is registered
+func (c *Client) ValidateCRDV1beta1(resource CustomResource, timeout, retryInterval time.Duration) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	crdName := fmt.Sprintf("%s.%s", resource.Plural, resource.Group)
+	return wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
+		crd, err := c.extension.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), crdName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+		for _, cond := range crd.Status.Conditions {
+			switch cond.Type {
+			case apiextensionsv1beta1.Established:
+				if cond.Status == apiextensionsv1beta1.ConditionTrue {
+					return true, nil
+				}
+			case apiextensionsv1beta1.NamesAccepted:
+				if cond.Status == apiextensionsv1beta1.ConditionFalse {
+					return false, fmt.Errorf("name conflict: %v", cond.Reason)
+				}
+			}
+		}
+		return false, nil
+	})
+}
+
+// DeleteCRDV1beta1 deletes the CRD for the given complete name (plural.group)
+func (c *Client) DeleteCRDV1beta1(fullName string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	return c.extension.ApiextensionsV1beta1().
+		CustomResourceDefinitions().
+		Delete(context.TODO(), fullName, metav1.DeleteOptions{PropagationPolicy: &deleteForegroundPolicy})
+}
+
+// ListCRDsV1beta1 list all CRD resources
+func (c *Client) ListCRDsV1beta1() (*apiextensionsv1beta1.CustomResourceDefinitionList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.extension.ApiextensionsV1beta1().
+		CustomResourceDefinitions().
+		List(context.TODO(), metav1.ListOptions{})
+}

--- a/vendor/k8s.io/code-generator/generate-internal-groups.sh
+++ b/vendor/k8s.io/code-generator/generate-internal-groups.sh
@@ -114,7 +114,7 @@ if [ "${GENS}" = "all" ] || grep -qw "openapi" <<<"${GENS}"; then
   echo "Generating OpenAPI definitions for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/openapi"
   declare -a OPENAPI_EXTRA_PACKAGES
   "${GOPATH}/bin/openapi-gen" \
-           --input-dirs "$(codegen::join , "${EXT_FQ_APIS[@]}" "${OPENAPI_EXTRA_PACKAGES[@]}")" \
+           --input-dirs "$(codegen::join , "${EXT_FQ_APIS[@]}" "${OPENAPI_EXTRA_PACKAGES[@]+"${OPENAPI_EXTRA_PACKAGES[@]}"}")" \
            --input-dirs "k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/version" \
            --output-package "${OUTPUT_PKG}/openapi" \
            -O zz_generated.openapi \

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -443,7 +443,7 @@ github.com/pmezard/go-difflib/difflib
 github.com/portworx/kvdb
 github.com/portworx/kvdb/common
 github.com/portworx/kvdb/mem
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20210614212742-d19cd551f94a
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20210805192436-d51186f75dc4
 ## explicit
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
From 1.22 k8s version, v1alpha/v1beta crds are deprecated. This PR add supports for registering stork crds as v1

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Update stork crds to V1 
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6.6


**Note:**
vendor PR's need to be merged and re-vendor before closing this - 
https://github.com/libopenstorage/external-storage/tree/v0.20.4-openstorage-rc4 (tag is created)
https://github.com/portworx/sched-ops/pull/251 (not-needed-anymore)

with k8s version <1.22 https://jenkins.portworx.dev/job/Stork/view/Stork%202.8/job/stork-2.6.3-px-2.8-rel/29/

k8s version 1.22 : 
```
--- PASS: TestApplicationClone (2677.56s)
    --- PASS: TestApplicationClone/deploymentTest (201.43s)
    --- PASS: TestApplicationClone/statefulsetTest (382.05s)
    --- PASS: TestApplicationClone/statefulsetRuleTest (392.25s)
    --- PASS: TestApplicationClone/preExecRuleMissingTest (241.50s)
    --- PASS: TestApplicationClone/postExecRuleMissingTest (241.71s)
    --- PASS: TestApplicationClone/disallowedNamespaceTest (241.53s)
    --- PASS: TestApplicationClone/failingPreExecRuleTest (241.62s)
    --- PASS: TestApplicationClone/failingPostExecRuleTest (241.77s)
    --- PASS: TestApplicationClone/labelSelectorTest (493.70s)
--- PASS: TestClusterDomains (0.20s)
        --- PASS: TestSnapshotMigration/testSnapshot/simpleSnapshotTest (61.52s)
        --- PASS: TestSnapshotMigration/testSnapshot/cloudSnapshotTest (70.48s)
        --- PASS: TestSnapshotMigration/testSnapshot/snapshotScaleTest (61.16s)
        --- PASS: TestSnapshotMigration/testSnapshot/groupSnapshotScaleTest (0.00s)
            --- PASS: TestSnapshotMigration/testSnapshot/scheduleTests/intervalTest (460.48s)
            --- PASS: TestSnapshotMigration/testSnapshot/scheduleTests/weeklyTest (357.09s)
            --- PASS: TestSnapshotMigration/testSnapshot/scheduleTests/monthlyTest (316.69s)
            --- PASS: TestSnapshotMigration/testSnapshot/scheduleTests/invalidPolicyTest (280.70s)
        --- PASS: TestSnapshotMigration/testSnapshot/storageclassTests (25.14s)
    --- PASS: TestSnapshotMigration/testMigration (8394.81s)
        --- PASS: TestSnapshotMigration/testMigration/deploymentTest (234.36s)
        --- PASS: TestSnapshotMigration/testMigration/deploymentMigrationReverseTest (496.96s)
        --- PASS: TestSnapshotMigration/testMigration/statefulsetTest (565.28s)
        --- PASS: TestSnapshotMigration/testMigration/statefulsetStartAppFalseTest (1273.76s)
        --- PASS: TestSnapshotMigration/testMigration/statefulsetRuleTest (428.54s)
        --- PASS: TestSnapshotMigration/testMigration/preExecRuleMissingTest (402.38s)
        --- PASS: TestSnapshotMigration/testMigration/postExecRuleMissingTest (403.95s)
        --- PASS: TestSnapshotMigration/testMigration/disallowedNamespaceTest (393.16s)
        --- PASS: TestSnapshotMigration/testMigration/failingPreExecRuleTest (402.49s)
        --- PASS: TestSnapshotMigration/testMigration/failingPostExecRuleTest (162.68s)
        --- PASS: TestSnapshotMigration/testMigration/labelSelectorTest (761.85s)
        --- PASS: TestSnapshotMigration/testMigration/intervalScheduleTest (476.36s)
        --- PASS: TestSnapshotMigration/testMigration/dailyScheduleTest (554.75s)
        --- PASS: TestSnapshotMigration/testMigration/weeklyScheduleTest (555.72s)
        --- PASS: TestSnapshotMigration/testMigration/monthlyScheduleTest (544.42s)
        --- PASS: TestSnapshotMigration/testMigration/scheduleInvalidTest (192.63s)
        --- PASS: TestSnapshotMigration/testMigration/clusterPairFailuresTest (277.80s)
        --- PASS: TestSnapshotMigration/testMigration/scaleTest (264.54s)
--- PASS: TestExtender (1126.79s)
    --- PASS: TestExtender/pvcOwnershipTest (426.40s)
    --- PASS: TestExtender/noPVCTest (50.16s)
    --- PASS: TestExtender/singlePVCTest (90.33s)
    --- PASS: TestExtender/statefulsetTest (110.30s)
    --- PASS: TestExtender/multiplePVCTest (60.50s)
    --- PASS: TestExtender/driverNodeErrorTest (389.09s)
--- PASS: TestHealthMonitor (1219.07s)
    --- PASS: TestHealthMonitor/stopDriverTest (457.08s)
    --- PASS: TestHealthMonitor/stopKubeletTest (516.63s)
    --- PASS: TestHealthMonitor/healthCheckFixTest (245.33s)
```