### PR TITLE
check destination svc annoatation before assigning keys

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1007,16 +1007,17 @@ func (m *MigrationController) checkAndUpdateService(
 	if err != nil {
 		return false, err
 	}
-	if curr.Annotations != nil {
-		if hash, ok := curr.Annotations[resourcecollector.StorkResourceHash]; ok {
-			old, err := strconv.ParseUint(hash, 10, 64)
-			if err != nil {
-				return false, err
-			}
-			if old == objHash {
-				log.MigrationLog(migration).Infof("Skipping service update, no changes found since last migration %d/%d", old, objHash)
-				return true, nil
-			}
+	if curr.Annotations == nil {
+		curr.Annotations = make(map[string]string)
+	}
+	if hash, ok := curr.Annotations[resourcecollector.StorkResourceHash]; ok {
+		old, err := strconv.ParseUint(hash, 10, 64)
+		if err != nil {
+			return false, err
+		}
+		if old == objHash {
+			log.MigrationLog(migration).Infof("skipping service update, no changes found since last migration %d/%d", old, objHash)
+			return true, nil
 		}
 	}
 	// update annotations


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Check svc annotation map before updating entries to svc annotation resources 

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.6.5

