### PR TITLE
PB-1363: Unable to take csi + px volume backups

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -604,7 +604,7 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 	vsContentMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)
 	vsClassMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshotClass)
 	for _, vInfo := range backup.Status.Volumes {
-		if vInfo.DriverName != storkCSIDriverName {
+		if vInfo.DriverName != storkCSIDriverName || vInfo.Status == storkapi.ApplicationBackupStatusSuccessful {
 			continue
 		}
 
@@ -789,6 +789,9 @@ func (c *csi) CancelBackup(backup *storkapi.ApplicationBackup) error {
 	if backup.Status.Status == storkapi.ApplicationBackupStatusInProgress {
 		// set of all snapshot classes deleted
 		for _, vInfo := range backup.Status.Volumes {
+			if vInfo.DriverName != storkCSIDriverName {
+				continue
+			}
 			snapshotName := vInfo.BackupID
 
 			// Delete VS


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Backing up csi + px volumes sometime causes issue when csi volume get backed up early than px and csi driver does not found snapshot anymore in next reconciler.

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
yes
```release-note
Fix issue while backing up CSI + Non-CSI volumes 
error: Snapshot backup-812c34fec43d-7555000cfcee lost during backup
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.6.6
