### PR TITLE
stor-467: Added genericBackupRepoKey field in backuplocation CR for

### DIFF
--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -34,13 +34,14 @@ type BackupLocation struct {
 type BackupLocationItem struct {
 	Type BackupLocationType `json:"type"`
 	// Path is either the bucket or any other path for the backup location
-	Path          string        `json:"path"`
-	EncryptionKey string        `json:"encryptionKey"`
-	S3Config      *S3Config     `json:"s3Config,omitempty"`
-	AzureConfig   *AzureConfig  `json:"azureConfig,omitempty"`
-	GoogleConfig  *GoogleConfig `json:"googleConfig,omitempty"`
-	SecretConfig  string        `json:"secretConfig"`
-	Sync          bool          `json:"sync"`
+	Path                 string        `json:"path"`
+	EncryptionKey        string        `json:"encryptionKey"`
+	S3Config             *S3Config     `json:"s3Config,omitempty"`
+	AzureConfig          *AzureConfig  `json:"azureConfig,omitempty"`
+	GoogleConfig         *GoogleConfig `json:"googleConfig,omitempty"`
+	SecretConfig         string        `json:"secretConfig"`
+	Sync                 bool          `json:"sync"`
+	GenericBackupRepoKey string        `json:"genericBackupRepoKey"`
 }
 
 // BackupLocationType is the type of the backup location


### PR DESCRIPTION
storing generic backup repo password.


**What type of PR is this?**
feature: Data mover (Generic backup support).

**What this PR does / why we need it**:
    stor-467: Added genericBackupRepoKey field in backuplocation CR for
    storing generic backup repo password.

**Does this PR change a user-facing CRD or CLI?**:
Yes, the backuplocation CR will now have a field to pass the generic backup repo password.

**Is a release note needed?**:
No.

**Does this change need to be cherry-picked to a release branch?**:
Yes, 2.7.x release.
