### PR TITLE
stor:468 Changed the field name GenericBackupRepoKey to RepositoryPassword in backuplocation CR

### DIFF
--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -34,14 +34,14 @@ type BackupLocation struct {
 type BackupLocationItem struct {
 	Type BackupLocationType `json:"type"`
 	// Path is either the bucket or any other path for the backup location
-	Path                 string        `json:"path"`
-	EncryptionKey        string        `json:"encryptionKey"`
-	S3Config             *S3Config     `json:"s3Config,omitempty"`
-	AzureConfig          *AzureConfig  `json:"azureConfig,omitempty"`
-	GoogleConfig         *GoogleConfig `json:"googleConfig,omitempty"`
-	SecretConfig         string        `json:"secretConfig"`
-	Sync                 bool          `json:"sync"`
-	GenericBackupRepoKey string        `json:"genericBackupRepoKey"`
+	Path               string        `json:"path"`
+	EncryptionKey      string        `json:"encryptionKey"`
+	S3Config           *S3Config     `json:"s3Config,omitempty"`
+	AzureConfig        *AzureConfig  `json:"azureConfig,omitempty"`
+	GoogleConfig       *GoogleConfig `json:"googleConfig,omitempty"`
+	SecretConfig       string        `json:"secretConfig"`
+	Sync               bool          `json:"sync"`
+	RepositoryPassword string        `json:"repositoryPassword"`
 }
 
 // BackupLocationType is the type of the backup location


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
 Changed the field name GenericBackupRepoKey to RepositoryPassword in backuplocation CR

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.7.0

