### PR TITLE
stor-485: add completed backup volume to backup list

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -604,7 +604,12 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 	vsContentMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)
 	vsClassMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshotClass)
 	for _, vInfo := range backup.Status.Volumes {
-		if vInfo.DriverName != storkCSIDriverName || vInfo.Status == storkapi.ApplicationBackupStatusSuccessful {
+		if vInfo.DriverName != storkCSIDriverName {
+			continue
+		}
+		// if backup is done for volume add it to vol list
+		if vInfo.Status == storkapi.ApplicationBackupStatusSuccessful {
+			volumeInfos = append(volumeInfos, vInfo)
 			continue
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Fix `stor-485` where completed backup of csi volumes got omitted from list

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
