### PR TITLE
STOR-444: Update FinishTimestamp for failed ApplicationBackups

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -445,6 +445,12 @@ func (a *ApplicationBackupController) updateBackupCRInVolumeStage(
 		// volume stage again
 		if backup.Status.Stage == stork_api.ApplicationBackupStageFinal ||
 			backup.Status.Stage == stork_api.ApplicationBackupStageApplications {
+			// updated timestamp for failed backups
+			if backup.Status.Status == stork_api.ApplicationBackupStatusFailed {
+				backup.Status.FinishTimestamp = metav1.Now()
+				backup.Status.LastUpdateTimestamp = metav1.Now()
+				backup.Status.Reason = reason
+			}
 			return backup, nil
 		}
 		backup.Status.Status = status

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -351,16 +351,16 @@ func updateCRDObjects(ns string, activate bool, ioStreams genericclioptions.IOSt
 					}
 					err := unstructured.SetNestedField(o.Object, disableVersion, specPath...)
 					if err != nil {
-						printMsg(fmt.Sprintf("Error updating \"%v\" for %v %v/%v to %v : %v", crd.SuspendOptions.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), !activate, err), ioStreams.ErrOut)
+						printMsg(fmt.Sprintf("Error updating \"%v\" for %v %v/%v to %v : %v", crd.SuspendOptions.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), disableVersion, err), ioStreams.ErrOut)
 						continue
 					}
 
 					_, err = client.Update(context.TODO(), &o, metav1.UpdateOptions{}, "")
 					if err != nil {
-						printMsg(fmt.Sprintf("Error updating \"%v\" for %v %v/%v to %v : %v", crd.SuspendOptions.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), !activate, err), ioStreams.ErrOut)
+						printMsg(fmt.Sprintf("Error updating \"%v\" for %v %v/%v to %v : %v", crd.SuspendOptions.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), disableVersion, err), ioStreams.ErrOut)
 						continue
 					}
-					printMsg(fmt.Sprintf("Updated \"%v\" for %v %v/%v to %v : %v", crd.SuspendOptions.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), !activate, err), ioStreams.ErrOut)
+					printMsg(fmt.Sprintf("Updated \"%v\" for %v %v/%v to %v : %v", crd.SuspendOptions.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), disableVersion, err), ioStreams.ErrOut)
 					if !activate {
 						if crd.PodsPath == "" {
 							continue


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
Fixes -
```
  stor-444: Update FinishTimestamp for failed ApplicationBackups
  stor-448: Update labels & annot of namespace based on replace policy
  stor-443: Update activate/deactivate message for crds
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
stor-444: Update FinishTimestamp for failed ApplicationBackups
  stor-448: Update labels & annot of namespace based on replace policy
  stor-443: Correct activate/deactivate migration messages for crds
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
2.7.0

