### PR TITLE
STOR-483: Skip filtering for volumes which do not have DataNodes populated

### DIFF
--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -216,7 +216,9 @@ func (e *Extender) processFilterRequest(w http.ResponseWriter, req *http.Request
 						}
 					}
 				}
-				if !onlineNodeFound {
+				if !onlineNodeFound && len(volumeInfo.DataNodes) > 0 {
+					// Volume has a list of DataNodes where it has a replica present and none of
+					// those nodes are online
 					storklog.PodLog(pod).Errorf("No online storage nodes have replica for volume, returning error")
 					msg := "No online node found with volume replica"
 					e.Recorder.Event(pod, v1.EventTypeWarning, schedulingFailureEventReason, msg)


### PR DESCRIPTION


**What type of PR is this?**
bug

**What this PR does / why we need it**:

- Certain storage providers like Portworx proxy volumes or Portworx direct access volumes
  do not have the volumeInfo.DataNodes populated. Do not filter out the request for
  such volumes.



**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
If a storage provider does not have the concept of replica nodes for a volume do not error out the filter request while scheduling pods using such storage provider's volumes.
```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.7

