### PR TITLE
csidriverfix: handle completed backups

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -604,6 +604,23 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 	vsMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshot)
 	vsContentMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)
 	vsClassMap := make(map[string]*kSnapshotv1beta1.VolumeSnapshotClass)
+
+	// check if all csi vol backup is successful
+	isCompleted := true
+	currVolInfo := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
+	for _, vInfo := range backup.Status.Volumes {
+		if vInfo.DriverName != storkCSIDriverName {
+			continue
+		}
+		if vInfo.Status != storkapi.ApplicationBackupStatusSuccessful {
+			isCompleted = false
+			break
+		}
+		currVolInfo = append(currVolInfo, vInfo)
+	}
+	if isCompleted {
+		return currVolInfo, nil
+	}
 	for _, vInfo := range backup.Status.Volumes {
 		if vInfo.DriverName != storkCSIDriverName {
 			continue


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Currently CSI driver uploads all of snapshot CR to Objectstore and delete once done. This causes issue when other non px backup is still in progress & all CSI volume backup is completed, CSI driver will still look at snapshot which is deleted previously and cause application backup to fail. As separate clean up task we should introduce API for driver to clean-up post backup operation, since handling everything in `GetBackupStatus` is prone to error

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.7
