### PR TITLE
pb-1908: Added backup and restore CR name and pvc name in the dataexport CR.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -51,6 +51,9 @@ const (
 	secretNamespace         = "kube-system"
 	pxbackupAnnotation      = "portworx.io/created-by"
 	pxbackupAnnotationValue = "px-backup"
+	backupCRNameKey         = "kdmp.portworx.com/backup-cr-name"
+	restoreCRNameKey        = "kdmp.portworx.com/restore-cr-name"
+	pvcNameKey              = "kdmp.portworx.com/pvc-name"
 )
 
 var volumeAPICallBackoff = wait.Backoff{
@@ -145,6 +148,10 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 
 		// create kdmp cr
 		dataExport := &kdmpapi.DataExport{}
+		labels := make(map[string]string)
+		labels[backupCRNameKey] = backup.Name
+		labels[pvcNameKey] = pvc.Name
+		dataExport.Labels = labels
 		dataExport.Annotations = make(map[string]string)
 		dataExport.Annotations[skipResourceAnnotation] = "true"
 		dataExport.Name = getGenericCRName(backup.Name, pvc.Namespace, pvc.Name)
@@ -471,6 +478,10 @@ func (k *kdmp) StartRestore(
 
 		// create kdmp cr
 		dataExport := &kdmpapi.DataExport{}
+		labels := make(map[string]string)
+		labels[backupCRNameKey] = restore.Name
+		labels[pvcNameKey] = bkpvInfo.PersistentVolumeClaim
+		dataExport.Labels = labels
 		dataExport.Annotations = make(map[string]string)
 		dataExport.Annotations[skipResourceAnnotation] = "true"
 		dataExport.Name = getGenericCRName(restore.Name, bkpvInfo.Namespace, bkpvInfo.PersistentVolumeClaim)

--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8shelper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	_ "github.com/aquilax/truncate"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.3.0
 	github.com/LINBIT/golinstor v0.27.0
 	github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e // indirect
+	github.com/aquilax/truncate v1.0.0
 	github.com/aws/aws-sdk-go v1.35.37
 	github.com/banzaicloud/k8s-objectmatcher v1.5.1 // indirect
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/ant31/crd-validation v0.0.0-20180702145049-30f8a35d0ac2/go.mod h1:X0n
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/aquilax/truncate v1.0.0 h1:UgIGS8U/aZ4JyOJ2h3xcF5cSQ06+gGBnjxH2RUHJe0U=
+github.com/aquilax/truncate v1.0.0/go.mod h1:BeMESIDMlvlS3bmg4BVvBbbZUNwWtS8uzYPAKXwwhLw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/vendor/github.com/aquilax/truncate/.gitignore
+++ b/vendor/github.com/aquilax/truncate/.gitignore
@@ -1,0 +1,12 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/vendor/github.com/aquilax/truncate/.travis.yml
+++ b/vendor/github.com/aquilax/truncate/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+
+go:
+      - "1.12.x"

--- a/vendor/github.com/aquilax/truncate/LICENSE
+++ b/vendor/github.com/aquilax/truncate/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Evgeniy Vasilev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/aquilax/truncate/README.md
+++ b/vendor/github.com/aquilax/truncate/README.md
@@ -1,0 +1,46 @@
+# truncate
+[![Build Status](https://travis-ci.org/aquilax/truncate.svg?branch=master)](https://travis-ci.org/aquilax/truncate) [![GoDoc](https://godoc.org/github.com/aquilax/truncate?status.svg)](https://godoc.org/github.com/aquilax/truncate)
+
+Go library for truncating strings
+
+
+Sample usage:
+
+```go
+package truncate_test
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/aquilax/truncate"
+)
+
+func ExampleTruncate() {
+	text := "This is a long text"
+	truncated := truncate.Truncate(text, 17, "...", truncate.PositionEnd)
+	fmt.Printf("%s : %d characters", truncated, utf8.RuneCountInString(truncated))
+	// Output: This is a long... : 17 characters
+}
+
+func ExampleTruncate_second() {
+	text := "This is a long text"
+	truncated := truncate.Truncate(text, 15, "...", truncate.PositionStart)
+	fmt.Printf("%s : %d characters", truncated, utf8.RuneCountInString(truncated))
+	// Output: ... a long text : 15 characters
+}
+
+func ExampleTruncate_third() {
+	text := "This is a long text"
+	truncated := truncate.Truncate(text, 5, "zzz", truncate.PositionMiddle)
+	fmt.Printf("%s : %d characters", truncated, utf8.RuneCountInString(truncated))
+	// Output: Tzzzt : 5 characters
+}
+
+func ExampleTruncator() {
+	text := "This is a long text"
+	truncated := truncate.Truncator(text, 9, truncate.CutStrategy{})
+	fmt.Printf("%s : %d characters", truncated, utf8.RuneCountInString(truncated))
+	// Output: This is a : 9 characters
+}
+```

--- a/vendor/github.com/aquilax/truncate/go.mod
+++ b/vendor/github.com/aquilax/truncate/go.mod
@@ -1,0 +1,1 @@
+module github.com/aquilax/truncate

--- a/vendor/github.com/aquilax/truncate/truncate.go
+++ b/vendor/github.com/aquilax/truncate/truncate.go
@@ -1,0 +1,100 @@
+// Package truncate provides set of strategies to truncate strings
+package truncate
+
+import (
+	"math"
+	"unicode/utf8"
+)
+
+type TruncatePosition int
+
+const DEFAULT_OMISSION = "…"
+
+const (
+	PositionStart TruncatePosition = iota
+	PositionMiddle
+	PositionEnd
+)
+
+// Strategy is an interface for truncation strategy
+type Strategy interface {
+	Truncate(string, int) string
+}
+
+// Truncator cuts a string to length using the truncation strategy
+func Truncator(str string, length int, strategy Strategy) string {
+	return strategy.Truncate(str, length)
+}
+
+// CutStrategy simply truncates the string to the desired length
+type CutStrategy struct{}
+
+func (CutStrategy) Truncate(str string, length int) string {
+	return Truncate(str, length, "", PositionEnd)
+}
+
+// CutEllipsisStrategy simply truncates the string to the desired length and adds ellipsis at the end
+type CutEllipsisStrategy struct{}
+
+func (s CutEllipsisStrategy) Truncate(str string, length int) string {
+	return Truncate(str, length, DEFAULT_OMISSION, PositionEnd)
+}
+
+// CutEllipsisLeadingStrategy simply truncates the string from the start the desired length and adds ellipsis at the front
+type CutEllipsisLeadingStrategy struct{}
+
+func (s CutEllipsisLeadingStrategy) Truncate(str string, length int) string {
+	return Truncate(str, length, DEFAULT_OMISSION, PositionStart)
+}
+
+// EllipsisMiddleStrategy truncates the string to the desired length and adds ellipsis in the middle
+type EllipsisMiddleStrategy struct{}
+
+func (e EllipsisMiddleStrategy) Truncate(str string, length int) string {
+	return Truncate(str, length, DEFAULT_OMISSION, PositionMiddle)
+}
+
+// Truncate truncates string according the parameters
+func Truncate(str string, length int, omission string, pos TruncatePosition) string {
+	r := []rune(str)
+	sLen := len(r)
+	if length >= sLen {
+		return str
+	}
+	switch pos {
+	case PositionStart:
+		return truncateStart(r, length, omission)
+	case PositionMiddle:
+		return truncateMiddle(r, length, omission)
+	default:
+		return truncateEnd(r, length, omission)
+	}
+}
+
+func truncateStart(r []rune, length int, omission string) string {
+	return string(omission + string(r[len(r)-length+utf8.RuneCountInString(omission):]))
+}
+
+func truncateEnd(r []rune, length int, omission string) string {
+	return string(string(r[:length-utf8.RuneCountInString(omission)]) + omission)
+}
+
+func truncateMiddle(r []rune, length int, omission string) string {
+	sLen := len(r)
+	oLen := utf8.RuneCountInString(omission)
+	// Make sure we have one character before and after
+	if length < oLen+2 {
+		return truncateEnd(r, length, "")
+	}
+	var delta int
+	if sLen%2 == 0 {
+		delta = int(math.Ceil(float64(length-oLen) / 2))
+	} else {
+		delta = int(math.Floor(float64(length-oLen) / 2))
+	}
+	result := make([]rune, length)
+	copy(result, r[0:delta])
+	copy(result[delta:], []rune(omission))
+	copy(result[delta+oLen:], r[sLen-length+oLen+delta:])
+	return string(result)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,6 +61,9 @@ github.com/MakeNowJust/heredoc
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
+# github.com/aquilax/truncate v1.0.0
+## explicit
+github.com/aquilax/truncate
 # github.com/aws/aws-sdk-go v1.35.37
 ## explicit
 github.com/aws/aws-sdk-go/aws


### PR DESCRIPTION
**What type of PR is this?**
bug.

**What this PR does / why we need it**:
pb-1908

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.7?

Note: There is a dependent PR in kdmp where these labels will be used. 
https://github.com/portworx/kdmp/pull/62