### PR TITLE
Portworx: Parse the storage class mapping while restoring a volume.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc6
 	github.com/kubernetes-sigs/aws-ebs-csi-driver v0.9.0
-	github.com/libopenstorage/openstorage v8.0.1-0.20210603043922-faf638fed3e5+incompatible
+	github.com/libopenstorage/openstorage v8.0.1-0.20211010162107-3409854b020f+incompatible
 	github.com/libopenstorage/secrets v0.0.0-20200207034622-cdb443738c67
 	github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452
 	github.com/openshift/api v0.0.0-20210105115604-44119421ec6b

--- a/go.sum
+++ b/go.sum
@@ -834,6 +834,12 @@ github.com/libopenstorage/openstorage v8.0.1-0.20200914191223-6fb8d163a67c+incom
 github.com/libopenstorage/openstorage v8.0.1-0.20200914191223-6fb8d163a67c+incompatible/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/libopenstorage/openstorage v8.0.1-0.20210603043922-faf638fed3e5+incompatible h1:/WHzMLA5HXNKrZa3gLb8rNDBDGgVSEeeFQ1p4ndKHvM=
 github.com/libopenstorage/openstorage v8.0.1-0.20210603043922-faf638fed3e5+incompatible/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
+github.com/libopenstorage/openstorage v8.0.1-0.20211001053059-4a89cb1aabc8+incompatible h1:yBUAQnWCECJhr6Bg6t7kdn2EKJaTcGHO4tzJxPGUn7g=
+github.com/libopenstorage/openstorage v8.0.1-0.20211001053059-4a89cb1aabc8+incompatible/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
+github.com/libopenstorage/openstorage v8.0.1-0.20211001213756-2d80c383c962+incompatible h1:YvMQKw0TSWrf0WBoH07MB7xTgN6TKSnfvyKyQyCme+o=
+github.com/libopenstorage/openstorage v8.0.1-0.20211001213756-2d80c383c962+incompatible/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
+github.com/libopenstorage/openstorage v8.0.1-0.20211010162107-3409854b020f+incompatible h1:JOLZVPbk7DElie8S4xspHFArdCaykmwio7X25EY7xPU=
+github.com/libopenstorage/openstorage v8.0.1-0.20211010162107-3409854b020f+incompatible/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/libopenstorage/openstorage-sdk-clients v0.109.0/go.mod h1:vo0c/nLG2HIyQva4Avwx61U1kWcw4HGQh3sjzV2DEEs=
 github.com/libopenstorage/operator v0.0.0-20191009190641-8642de5d0812/go.mod h1:Qh+VXOB6hj60VmlgsmY+R1w+dFuHK246UueM4SAqZG0=
 github.com/libopenstorage/operator v0.0.0-20200725001727-48d03e197117/go.mod h1:Qh+VXOB6hj60VmlgsmY+R1w+dFuHK246UueM4SAqZG0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -319,7 +319,7 @@ github.com/libopenstorage/autopilot-api/pkg/client/clientset/versioned/scheme
 github.com/libopenstorage/autopilot-api/pkg/client/clientset/versioned/typed/autopilot/v1alpha1
 # github.com/libopenstorage/gossip v0.0.0-20190507031959-c26073a01952
 github.com/libopenstorage/gossip/types
-# github.com/libopenstorage/openstorage v8.0.1-0.20210603043922-faf638fed3e5+incompatible
+# github.com/libopenstorage/openstorage v8.0.1-0.20211010162107-3409854b020f+incompatible
 ## explicit
 github.com/libopenstorage/openstorage/api
 github.com/libopenstorage/openstorage/api/client


### PR DESCRIPTION
**What type of PR is this?**
>feature


**What this PR does / why we need it**:
This change allows backing up a Portworx volume of a particular storage class
and properties, and restore that volume with a different storage class.
For ex. Backup a volume with HALevel=2 and restore it with HALevel=1

- Parse the storage class mapping from restore spec and find if a mapping
  for the current PVC's storage class is found.
- If found, fetch the actual contents of storage class and parse them into
  a RestoreVolumeSpec.
- Invoke the CloudBackupRestore API with this RestoreVolumeSpec.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
Add support for backing up a Portworx volume with a particular storage class
and properties, and restore it with a different storage class.
```

**Does this change need to be cherry-picked to a release branch?**:
No

