### PR TITLE
Modified the decision making process for choosing a driver for a PVC.

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -31,8 +31,6 @@ import (
 )
 
 const (
-	// driverName is the name of the aws driver implementation
-	driverName = "aws"
 	// provisioner names for ebs volumes
 	provisionerName = "kubernetes.io/aws-ebs"
 	// CSI provisioner name for ebs volumes
@@ -105,7 +103,7 @@ func (a *aws) Init(_ interface{}) error {
 }
 
 func (a *aws) String() string {
-	return driverName
+	return storkvolume.AWSDriverName
 }
 
 func (a *aws) Stop() error {
@@ -192,7 +190,7 @@ func (a *aws) StartBackup(backup *storkapi.ApplicationBackup,
 		volumeInfo.PersistentVolumeClaim = pvc.Name
 		volumeInfo.PersistentVolumeClaimUID = string(pvc.UID)
 		volumeInfo.Namespace = pvc.Namespace
-		volumeInfo.DriverName = driverName
+		volumeInfo.DriverName = storkvolume.AWSDriverName
 
 		pvName, err := core.Instance().GetVolumeForPersistentVolumeClaim(&pvc)
 		if err != nil {
@@ -356,7 +354,7 @@ func (a *aws) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 
 	for _, vInfo := range backup.Status.Volumes {
-		if vInfo.DriverName != driverName {
+		if vInfo.DriverName != storkvolume.AWSDriverName {
 			continue
 		}
 		snapshot, err := a.getEBSSnapshot(vInfo.BackupID, nil)
@@ -396,7 +394,7 @@ func (a *aws) DeleteBackup(backup *storkapi.ApplicationBackup) (bool, error) {
 	}
 
 	for _, vInfo := range backup.Status.Volumes {
-		if vInfo.DriverName != driverName {
+		if vInfo.DriverName != storkvolume.AWSDriverName {
 			continue
 		}
 		input := &ec2.DeleteSnapshotInput{
@@ -457,7 +455,7 @@ func (a *aws) StartRestore(
 		volumeInfo.PersistentVolumeClaimUID = backupVolumeInfo.PersistentVolumeClaimUID
 		volumeInfo.SourceNamespace = backupVolumeInfo.Namespace
 		volumeInfo.SourceVolume = backupVolumeInfo.Volume
-		volumeInfo.DriverName = driverName
+		volumeInfo.DriverName = storkvolume.AWSDriverName
 		volumeInfo.RestoreVolume = a.generatePVName()
 
 		tags := storkvolume.GetApplicationRestoreLabels(restore, volumeInfo)
@@ -548,7 +546,7 @@ func (a *aws) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkap
 
 	volumeInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
 	for _, vInfo := range restore.Status.Volumes {
-		if vInfo.DriverName != driverName {
+		if vInfo.DriverName != storkvolume.AWSDriverName {
 			continue
 		}
 		ebsVolume, err := a.getEBSVolume(vInfo.RestoreVolume, nil)
@@ -633,7 +631,7 @@ func init() {
 	if err != nil {
 		logrus.Debugf("Error init'ing aws driver: %v", err)
 	}
-	if err := storkvolume.Register(driverName, a); err != nil {
+	if err := storkvolume.Register(storkvolume.AWSDriverName, a); err != nil {
 		logrus.Panicf("Error registering aws volume driver: %v", err)
 	}
 }

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -29,8 +29,6 @@ import (
 )
 
 const (
-	// driverName is the name of the azure driver implementation
-	driverName = "azure"
 	// provisioner names for azure disks
 	provisionerName = "kubernetes.io/azure-disk"
 	// CSI provisioner names for azure disks
@@ -136,7 +134,7 @@ func (a *azure) getMetadata() (map[string]string, error) {
 }
 
 func (a *azure) String() string {
-	return driverName
+	return storkvolume.AzureDriverName
 }
 
 func (a *azure) Stop() error {
@@ -255,7 +253,7 @@ func (a *azure) StartBackup(
 			PersistentVolumeClaim:    pvc.Name,
 			PersistentVolumeClaimUID: string(pvc.UID),
 			Namespace:                pvc.Namespace,
-			DriverName:               driverName,
+			DriverName:               storkvolume.AzureDriverName,
 			Volume:                   pvc.Spec.VolumeName,
 			Options: map[string]string{
 				resourceGroupKey: a.resourceGroup,
@@ -327,7 +325,7 @@ func (a *azure) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi
 	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 
 	for _, vInfo := range backup.Status.Volumes {
-		if vInfo.DriverName != driverName {
+		if vInfo.DriverName != storkvolume.AzureDriverName {
 			continue
 		}
 		snapshot, err := a.snapshotClient.Get(context.TODO(), a.resourceGroup, vInfo.BackupID)
@@ -367,7 +365,7 @@ func (a *azure) DeleteBackup(backup *storkapi.ApplicationBackup) (bool, error) {
 	}
 
 	for _, vInfo := range backup.Status.Volumes {
-		if vInfo.DriverName != driverName {
+		if vInfo.DriverName != storkvolume.AzureDriverName {
 			continue
 		}
 		_, err := a.snapshotClient.Delete(context.TODO(), a.resourceGroup, vInfo.BackupID)
@@ -474,7 +472,7 @@ func (a *azure) StartRestore(
 			PersistentVolumeClaimUID: backupVolumeInfo.PersistentVolumeClaimUID,
 			SourceNamespace:          backupVolumeInfo.Namespace,
 			SourceVolume:             backupVolumeInfo.Volume,
-			DriverName:               driverName,
+			DriverName:               storkvolume.AzureDriverName,
 		}
 		volumeInfos = append(volumeInfos, volumeInfo)
 
@@ -524,7 +522,7 @@ func (a *azure) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*stork
 
 	volumeInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
 	for _, vInfo := range restore.Status.Volumes {
-		if vInfo.DriverName != driverName {
+		if vInfo.DriverName != storkvolume.AzureDriverName {
 			continue
 		}
 		disk, err := a.diskClient.Get(context.TODO(), a.resourceGroup, vInfo.RestoreVolume)
@@ -607,7 +605,7 @@ func init() {
 	if err != nil {
 		logrus.Debugf("Error init'ing azure driver: %v", err)
 	}
-	if err := storkvolume.Register(driverName, a); err != nil {
+	if err := storkvolume.Register(storkvolume.AzureDriverName, a); err != nil {
 		logrus.Panicf("Error registering azure volume driver: %v", err)
 	}
 }

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -28,8 +28,6 @@ import (
 )
 
 const (
-	// driverName is the name of the gcp driver implementation
-	driverName = "gce"
 	// provisioner names for gce volumes
 	provisionerName = "kubernetes.io/gce-pd"
 	// CSI provisioner name for for gce volumes
@@ -82,7 +80,7 @@ func (g *gcp) Init(_ interface{}) error {
 }
 
 func (g *gcp) String() string {
-	return driverName
+	return storkvolume.GCEDriverName
 }
 
 func (g *gcp) Stop() error {
@@ -169,7 +167,7 @@ func (g *gcp) StartBackup(backup *storkapi.ApplicationBackup,
 		volumeInfo.PersistentVolumeClaim = pvc.Name
 		volumeInfo.PersistentVolumeClaimUID = string(pvc.UID)
 		volumeInfo.Namespace = pvc.Namespace
-		volumeInfo.DriverName = driverName
+		volumeInfo.DriverName = storkvolume.GCEDriverName
 		volumeInfo.Options = map[string]string{
 			"projectID": g.projectID,
 		}
@@ -319,7 +317,7 @@ func (g *gcp) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 
 	for _, vInfo := range backup.Status.Volumes {
-		if vInfo.DriverName != driverName {
+		if vInfo.DriverName != storkvolume.GCEDriverName {
 			continue
 		}
 		snapshot, err := g.service.Snapshots.Get(g.projectID, vInfo.BackupID).Do()
@@ -359,7 +357,7 @@ func (g *gcp) DeleteBackup(backup *storkapi.ApplicationBackup) (bool, error) {
 	}
 
 	for _, vInfo := range backup.Status.Volumes {
-		if vInfo.DriverName != driverName {
+		if vInfo.DriverName != storkvolume.GCEDriverName {
 			continue
 		}
 		_, err := g.service.Snapshots.Delete(vInfo.Options["projectID"], vInfo.BackupID).Do()
@@ -428,7 +426,7 @@ func (g *gcp) StartRestore(
 			PersistentVolumeClaimUID: backupVolumeInfo.PersistentVolumeClaimUID,
 			SourceNamespace:          backupVolumeInfo.Namespace,
 			SourceVolume:             backupVolumeInfo.Volume,
-			DriverName:               driverName,
+			DriverName:               storkvolume.GCEDriverName,
 			Zones:                    backupVolumeInfo.Zones,
 		}
 		volumeInfos = append(volumeInfos, volumeInfo)
@@ -494,7 +492,7 @@ func (g *gcp) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkap
 
 	volumeInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
 	for _, vInfo := range restore.Status.Volumes {
-		if vInfo.DriverName != driverName {
+		if vInfo.DriverName != storkvolume.GCEDriverName {
 			continue
 		}
 		var status string
@@ -606,7 +604,7 @@ func init() {
 	if err != nil {
 		logrus.Debugf("Error init'ing gcp driver: %v", err)
 	}
-	if err := storkvolume.Register(driverName, g); err != nil {
+	if err := storkvolume.Register(storkvolume.GCEDriverName, g); err != nil {
 		logrus.Panicf("Error registering gcp volume driver: %v", err)
 	}
 }

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -27,8 +27,6 @@ import (
 )
 
 const (
-	driverName = "linstor"
-
 	// pvcProvisionerAnnotation is the annotation on PVC which has the provisioner name
 	pvcProvisionerAnnotation = "volume.beta.kubernetes.io/storage-provisioner"
 	// pvProvisionedByAnnotation is the annotation on PV which has the provisioner name
@@ -116,7 +114,7 @@ func (l *linstor) startNodeCache() error {
 }
 
 func (l *linstor) String() string {
-	return driverName
+	return storkvolume.LinstorDriverName
 }
 
 func (l *linstor) InspectNode(id string) (*storkvolume.NodeInfo, error) {
@@ -402,7 +400,7 @@ func (l *linstor) GetClusterID() (string, error) {
 
 func init() {
 	l := &linstor{}
-	if err := storkvolume.Register(driverName, l); err != nil {
+	if err := storkvolume.Register(storkvolume.LinstorDriverName, l); err != nil {
 		logrus.Panicf("Error registering linstor volume driver: %v", err)
 	}
 }


### PR DESCRIPTION


**What type of PR is this?**
>feature


**What this PR does / why we need it**:
- Create an ordered list of drivers defined in STORK. For every PVC
  stork will check these drivers can handle this PVC. If all the drivers
  fail the last one in the list - KDMP will pick it up.
- The goal is KDMP should handle all kinds of PVCs for all the different
  workflows that stork supports.
- This also means that for currently non-supported APIs by KDMP driver
  the respective operation will fail if none of the other drivers support that PVC.



**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No


**Does this change need to be cherry-picked to a release branch?**:
No

