### PR TITLE
Uploading CRs in csi generic backup as part of local retention policy.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -168,6 +168,8 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		dataExport.Labels = labels
 		dataExport.Annotations = make(map[string]string)
 		dataExport.Annotations[skipResourceAnnotation] = "true"
+		dataExport.Annotations[backupObjectUIDKey] = string(backup.UID)
+		dataExport.Annotations[pvcUIDKey] = string(pvc.UID)
 		dataExport.Name = getGenericCRName(prefixBackup, string(backup.UID), string(pvc.UID), pvc.Namespace)
 		dataExport.Namespace = pvc.Namespace
 		dataExport.Spec.Type = kdmpapi.DataExportKopia

--- a/go.sum
+++ b/go.sum
@@ -856,7 +856,9 @@ github.com/libopenstorage/stork v1.4.1-0.20210903185636-5a1f8a4142bf/go.mod h1:Q
 github.com/libopenstorage/stork v1.4.1-0.20210923201245-97089f8df635/go.mod h1:MbN4lDn47O/Ryr81dWS1wb83K9FqeKMga+waSIc4J5I=
 github.com/libopenstorage/stork v1.4.1-0.20210925152742-aaa75e7c457f/go.mod h1:V9fTbUFPOO/Ap3rfwz4bQJTB8L8rya1YiIbAfFhSPLA=
 github.com/libopenstorage/stork v1.4.1-0.20211005135736-c670be7925d2/go.mod h1:iPI/Hy/+nR+O0swmX0IBkD7QjjFNYoWvdafVrPSauPg=
+github.com/libopenstorage/stork v1.4.1-0.20211005182718-1c9b1186e228/go.mod h1:iPI/Hy/+nR+O0swmX0IBkD7QjjFNYoWvdafVrPSauPg=
 github.com/libopenstorage/stork v1.4.1-0.20211007173333-ae7f793dcb5c/go.mod h1:xrUHkvEq/8Pw74Wje2bLgd40Iv92gCUf1ck1jUg8YI8=
+github.com/libopenstorage/stork v1.4.1-0.20211012172837-b4d489e3aac8/go.mod h1:UyIEpfnhai7e9wlrSL4wgd1QXrAzN1zhaE2eMvckhx8=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
@@ -1098,6 +1100,7 @@ github.com/portworx/kdmp v0.4.1-0.20211006042942-e0dcc6f202ac h1:nDUsVuH0tCllnhu
 github.com/portworx/kdmp v0.4.1-0.20211006042942-e0dcc6f202ac/go.mod h1:XuR8mr500GAXdW/lW2ASeyney3f/SlfP4140YjAIeec=
 github.com/portworx/kdmp v0.4.1-0.20211007020540-ca77d6d2ade1 h1:EfEeCKufcwwZjFC7Ssqewy+T6J0u4+MUYYvcZGH1cv8=
 github.com/portworx/kdmp v0.4.1-0.20211007020540-ca77d6d2ade1/go.mod h1:bTzLxUEmYhrft5MWnDRekNeU3KDngbzosbnY88p5jwA=
+github.com/portworx/kdmp v0.4.1-0.20211008122639-3554850ec03c/go.mod h1:a1NbL4OPJE9JfcMIB1BdJbZEVZocd8+aYNVnLLDDLHE=
 github.com/portworx/kdmp v0.4.1-0.20211012182015-04afc246c869 h1:88rrqF0Hv6O1Uagk4bjlJ0oTULIvBqBtVE9oZ8YLL/U=
 github.com/portworx/kdmp v0.4.1-0.20211012182015-04afc246c869/go.mod h1:ethpTE5btKfTpuuC0T3bQHTBCLymlUaBAa2pRoCJixM=
 github.com/portworx/kdmp v0.4.1-0.20211014134259-35fa348614f8 h1:n0hcYfJ+zbqU51Tngy1LlTYnh8AXClg5YujLy7imao8=

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -543,6 +543,12 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 					}
 				}
 
+				// Don't backup PVCs with skip resource annotation set
+				if resourcecollector.SkipResource(pvc.Annotations) {
+					logrus.Debugf("skipping pvc %s/%s as skip resource annotation is set", pvc.Namespace, pvc.Name)
+					continue
+				}
+
 				// Don't backup pending or deleting PVCs
 				if pvc.Status.Phase != v1.ClaimBound || pvc.DeletionTimestamp != nil {
 					continue

--- a/pkg/snapshotter/options.go
+++ b/pkg/snapshotter/options.go
@@ -30,6 +30,8 @@ type Options struct {
 	RestoreSnapshotName string
 	// Annotations are the annotations that can be applied on the snapshot related objects
 	Annotations map[string]string
+	// Labels are the labels that can be applied on the snapshot related objects
+	Labels map[string]string
 }
 
 // Name is used to set a snapshot name.
@@ -117,6 +119,17 @@ func Annotations(annotations map[string]string) Option {
 		opts.Annotations = make(map[string]string)
 		for k, v := range annotations {
 			opts.Annotations[k] = v
+		}
+		return nil
+	}
+}
+
+// Labels are the labels applied on snapshot related objects
+func Labels(labels map[string]string) Option {
+	return func(opts *Options) error {
+		opts.Labels = make(map[string]string)
+		for k, v := range labels {
+			opts.Labels[k] = v
 		}
 		return nil
 	}

--- a/pkg/snapshotter/snapshotter.go
+++ b/pkg/snapshotter/snapshotter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -76,6 +77,16 @@ type Driver interface {
 	RestoreStatus(pvcName, namespace string) (RestoreInfo, error)
 	// CancelRestore cancels a restore operation
 	CancelRestore(pvcName, namespace string) error
+	// Upload objects to cloud
+	UploadSnapshotObjects(backupLocation *storkapi.BackupLocation, snapshotInfoList []SnapshotInfo, objectPath, objectName string) error
+	// Download objects from cloud
+	DownloadSnapshotObjects(backupLocation *storkapi.BackupLocation, objectPath string) ([]SnapshotInfo, error)
+	// Delete objects in cloud
+	DeleteSnapshotObject(backupLocation *storkapi.BackupLocation, objectPath string) error
+	// Recreate snapshot resources before doing snapshot restore
+	RecreateSnapshotResources(snapshotInfo SnapshotInfo, snapshotDriverName, snapshotClassName, namespace string, retain bool) error
+	// Retain local snapshots if required
+	RetainLocalSnapshots(backupLocation *storkapi.BackupLocation, snapshotDriverName, snapshotClassName, namespace, pvcUID, objectPath string, retain bool) error
 }
 
 // Snapshotter inteface returns a Driver object


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
Following are done as part of this PR.

1. For CSI volumes supporting snapshotting, upload the volumesnapshot resources to the cloud.
2. snapshotter package has to support upload, download and delete of the volumesnapshot and related resources for csi volumes.
3. As part of the cleanup in generic backup, make sure the local retention policy is honoured and only the required number of local snapshots are retained.


**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->
```release-note

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
no
-->

```
Test:

1. With local retention as 1

After first backup, 

➜  ~ km get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxcentral-mysql-pvc   Bound    pvc-4aa3e132-e4a7-480d-9d30-6c3d22cfddc8   10Gi       RWO            pure-block     14h
➜  ~
➜  ~
➜  ~ echo "volumesnapshotclass: "; km get volumesnapshotclass;echo; echo "volumesnapshot:"; km get volumesnapshot;  echo; echo "volumesnapshotcontent"; km get volumesnapshotcontent
volumesnapshotclass:
NAME                                DRIVER     DELETIONPOLICY   AGE
stork-csi-snapshot-class-pure-csi   pure-csi   Retain           6d4h

volumesnapshot:
No resources found in mysql namespace.

volumesnapshotcontent
NAME                                               READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER     VOLUMESNAPSHOTCLASS                 VOLUMESNAPSHOT                 AGE
snapcontent-25d774c9-c1b4-494b-90a4-09ef2be2974b   true         0             Retain           pure-csi   stork-csi-snapshot-class-pure-csi   pxcentral-mysql-pvc-fa730512   3m13s

2. After second backup
➜  ~ echo "volumesnapshotclass: "; km get volumesnapshotclass;echo; echo "volumesnapshot:"; km get volumesnapshot;  echo; echo "volumesnapshotcontent"; km get volumesnapshotcontent
volumesnapshotclass:
NAME                                DRIVER     DELETIONPOLICY   AGE
stork-csi-snapshot-class-pure-csi   pure-csi   Retain           6d4h

volumesnapshot:
No resources found in mysql namespace.

volumesnapshotcontent
NAME                                               READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER     VOLUMESNAPSHOTCLASS                 VOLUMESNAPSHOT                 AGE
snapcontent-9367ad25-ce41-4c72-8d62-624b3395b5d4   true         0             Retain           pure-csi   stork-csi-snapshot-class-pure-csi   pxcentral-mysql-pvc-25d38d4c   5m58s

3. After third backup

➜  ~ echo "volumesnapshotclass: "; km get volumesnapshotclass;echo; echo "volumesnapshot:"; km get volumesnapshot;  echo; echo "volumesnapshotcontent"; km get volumesnapshotcontent
volumesnapshotclass:
NAME                                DRIVER     DELETIONPOLICY   AGE
stork-csi-snapshot-class-pure-csi   pure-csi   Retain           6d5h

volumesnapshot:
No resources found in mysql namespace.

volumesnapshotcontent
NAME                                               READYTOUSE   RESTORESIZE   DELETIONPOLICY   DRIVER     VOLUMESNAPSHOTCLASS                 VOLUMESNAPSHOT                 AGE
snapcontent-8e68e9be-e2dd-46a7-87c2-fde2af461be8   true         0             Retain           pure-csi   stork-csi-snapshot-class-pure-csi   pxcentral-mysql-pvc-bc38c23d   6m57s

```