### PR TITLE
stor-529: Calling cleanupResources as part of finalizer handlers in applicationbackup controller code.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -220,6 +220,12 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 			if !canDelete {
 				return nil
 			}
+			// Calling cleanupResources which will cleanup the resources created by applicationbackup controller.
+			// In the case of kdmp driver, it will cleanup the dataexport CRs.
+			err = a.cleanupResources(backup)
+			if err != nil {
+				return err
+			}
 		}
 
 		if backup.GetFinalizers() != nil {
@@ -1237,11 +1243,6 @@ func (a *ApplicationBackupController) backupResources(
 			string(stork_api.ApplicationBackupStatusFailed),
 			message)
 		log.ApplicationBackupLog(backup).Errorf(message)
-		return err
-	}
-	// Before moving it to success case, cleanup generic backup CR, if any
-	err = a.cleanupResources(backup)
-	if err != nil {
 		return err
 	}
 	backup.Status.BackupPath = GetObjectPath(backup)


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
stor-529: Calling cleanupResources as part of finalizer handlers in applicationbackup controller code.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

**Testing:** 
With change tried four backups from px-backup and verified that data export CR are getting deleted properly.
<img width="1771" alt="Screenshot 2021-10-19 at 6 39 30 PM" src="https://user-images.githubusercontent.com/52188641/137916058-c1509b55-34d3-45fa-a61d-4b40ff637ce9.png">

