### PR TITLE
Reduce vdbench workload for integration tests

### DIFF
--- a/test/integration_test/specs/vdbench-repl-2-app/px-vdbench-app.yml
+++ b/test/integration_test/specs/vdbench-repl-2-app/px-vdbench-app.yml
@@ -26,7 +26,7 @@ spec:
               memory: 256Mi
               cpu: 100m
           command: ["./bench_runner.sh"]
-          args: ["Writes", "21600"]
+          args: ["Writes", "12300"]
           volumeMounts:
             - name: vdbench-persistent-storage
               mountPath: /datadir1


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Reduce the vdbench load so that nodes don't become unresponsive in the test k8s cluster.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no
```

**Does this change need to be cherry-picked to a release branch?**:
master

