### PR TITLE
pb-1978: Adding deletionTimestamp check before calling delete for dataexport CR.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -673,10 +673,18 @@ func (k *kdmp) CleanupBackupResources(backup *storkapi.ApplicationBackup) error 
 			continue
 		}
 		crName := getGenericCRName(prefixBackup, string(backup.UID), vInfo.PersistentVolumeClaimUID, vInfo.Namespace)
-		logrus.Tracef("deleting data export CR: %s/%s", vInfo.Namespace, crName)
-		// delete kdmp crs
-		if err := kdmpShedOps.Instance().DeleteDataExport(crName, vInfo.Namespace); err != nil && !k8serror.IsNotFound(err) {
-			logrus.Warnf("failed to delete data export CR: %v", err)
+		logrus.Infof("deleting data export CR: %s%s", vInfo.Namespace, crName)
+		de, err := kdmpShedOps.Instance().GetDataExport(crName, vInfo.Namespace)
+		if err != nil && !k8serror.IsNotFound(err) {
+			logrus.Tracef("failed in getting data export CR: %v", err)
+			return err
+		}
+		if de.DeletionTimestamp == nil {
+			// delete kdmp crs
+			if err := kdmpShedOps.Instance().DeleteDataExport(crName, vInfo.Namespace); err != nil && !k8serror.IsNotFound(err) {
+				logrus.Tracef("failed to delete data export CR: %v", err)
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
pb-1978: Adding deletionTimestamp check before calling delete for dataexport CR.
With this fix, the delete of dataexport CR was continously pushed from applicationbackup controller and that was updating the DE CR and was hitting revision mismatch error every time when we try to update the DE cr after removing the Finalizer.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes to 2.8.0

Testing:
1) With this fix, the Dataexports are getting deleted properly.