### PR TITLE
Remove check for pods to be on unique nodes, reduce num files in vdbench

### DIFF
--- a/test/integration_test/extender_test.go
+++ b/test/integration_test/extender_test.go
@@ -79,7 +79,7 @@ func statefulsetTest(t *testing.T) {
 
 	scheduledNodes, err := schedulerDriver.GetNodesForApp(ctxs[0])
 	require.NoError(t, err, "Error getting node for app")
-	require.Equal(t, 3, len(scheduledNodes), "App should be scheduled on one node")
+	require.GreaterOrEqual(t, 3, len(scheduledNodes), "App should be scheduled on one node")
 
 	// TODO: torpedo doesn't return correct volumes here
 	volumeNames := getVolumeNames(t, ctxs[0])

--- a/test/integration_test/specs/vdbench-repl-2-app/px-vdbench-app.yml
+++ b/test/integration_test/specs/vdbench-repl-2-app/px-vdbench-app.yml
@@ -46,6 +46,6 @@ metadata:
   name: vdbench-config
 data:
     File-Writes: |
-        fsd=fsd-datadir1,anchor=/datadir1,depth=1,width=1,files=1000,size=100M
+        fsd=fsd-datadir1,anchor=/datadir1,depth=1,width=1,files=100,size=100M
         fwd=fwd1,fsd=fsd*,rdpct=0,xfersize=(4k,100),fileio=random,threads=4,fileselect=random
         rd=rd1,fwd=fwd*,elapsed=21600,interval=1,fwdrate=max,format=yes


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Stork does not guarantee pods to be deployed on different nodes all the time. So this check is not valid.

**Does this PR change a user-facing CRD or CLI?**:
No.

**Is a release note needed?**:
No.

**Does this change need to be cherry-picked to a release branch?**:
master
