### PR TITLE
   pb-1988: Added alreadyExists check for creation of volumeSnapshot and     PVC creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.0
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
-	github.com/portworx/kdmp v0.4.1-0.20211102174416-fa9a0135538b
+	github.com/portworx/kdmp v0.4.1-0.20211103043446-cc5455f203d0
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20211026113317-db80e47fe929
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1116,6 +1116,8 @@ github.com/portworx/kdmp v0.4.1-0.20211028102921-794b776e5a55 h1:u4uDBnWS2tWyQUh
 github.com/portworx/kdmp v0.4.1-0.20211028102921-794b776e5a55/go.mod h1:BZ9ApnLFaMdxC4jd1inOw4ICfUI8AzyicAo+wL9ZSZY=
 github.com/portworx/kdmp v0.4.1-0.20211102174416-fa9a0135538b h1:fXPxP8kVX4tzPP2T3v9vlucJxRfGJllWj9yux4f5FYA=
 github.com/portworx/kdmp v0.4.1-0.20211102174416-fa9a0135538b/go.mod h1:BZ9ApnLFaMdxC4jd1inOw4ICfUI8AzyicAo+wL9ZSZY=
+github.com/portworx/kdmp v0.4.1-0.20211103043446-cc5455f203d0 h1:+e0W73p9QiLldPXez85XncI/es4WBUnbDZDkMehQqmw=
+github.com/portworx/kdmp v0.4.1-0.20211103043446-cc5455f203d0/go.mod h1:BZ9ApnLFaMdxC4jd1inOw4ICfUI8AzyicAo+wL9ZSZY=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20191223203141-f42097b1fcd8/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200311180812-b2c72382d652 h1:NElBL34RIHlZKGtDVXT/srxuVZ1+tqmnCdm1K+MC+fU=

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/utils/utils.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/utils/utils.go
@@ -101,6 +101,10 @@ func IsJobPending(j *batchv1.Job) bool {
 	} else if len(pods.Items) == 0 {
 		return true
 	}
+	// some time even though the pod is created, initially ContainerStatuses is not available for sometime
+	if len(pods.Items[0].Status.ContainerStatuses) == 0 {
+		return true
+	}
 	for _, c := range pods.Items[0].Status.ContainerStatuses {
 		if c.State.Waiting != nil || c.State.Running != nil {
 			return true

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -425,7 +425,7 @@ github.com/pierrec/lz4/internal/xxh32
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20211102174416-fa9a0135538b
+# github.com/portworx/kdmp v0.4.1-0.20211103043446-cc5455f203d0
 ## explicit
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
```
    pb-1988: Added alreadyExists check for creation of volumeSnapshot and
    PVC creation

        - While deleting the snapshot CRs, setting the proper retain
          value. For latest snapshot, retain will be set true, so that local
              snapshot will be retained. For other snapshots, it will be set
              false, so that both the CR and local snapshot files are also
              will be deleted

```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.8

**Related kdmp PR:**
https://github.com/portworx/kdmp/pull/96
