### PR TITLE
stor-545: Added provisioner and volumesnapshot fields in applicationbackup CR.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.0
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
-	github.com/portworx/kdmp v0.4.1-0.20211028102921-794b776e5a55
+	github.com/portworx/kdmp v0.4.1-0.20211102174416-fa9a0135538b
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20211026113317-db80e47fe929
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1114,6 +1114,8 @@ github.com/portworx/kdmp v0.4.1-0.20211026115601-1947a1f37ee3 h1:5LuzfTtlCJ7zzJQ
 github.com/portworx/kdmp v0.4.1-0.20211026115601-1947a1f37ee3/go.mod h1:BZ9ApnLFaMdxC4jd1inOw4ICfUI8AzyicAo+wL9ZSZY=
 github.com/portworx/kdmp v0.4.1-0.20211028102921-794b776e5a55 h1:u4uDBnWS2tWyQUh6Wn9Wi1uoEPA45Sfyvx+gj97R3dg=
 github.com/portworx/kdmp v0.4.1-0.20211028102921-794b776e5a55/go.mod h1:BZ9ApnLFaMdxC4jd1inOw4ICfUI8AzyicAo+wL9ZSZY=
+github.com/portworx/kdmp v0.4.1-0.20211102174416-fa9a0135538b h1:fXPxP8kVX4tzPP2T3v9vlucJxRfGJllWj9yux4f5FYA=
+github.com/portworx/kdmp v0.4.1-0.20211102174416-fa9a0135538b/go.mod h1:BZ9ApnLFaMdxC4jd1inOw4ICfUI8AzyicAo+wL9ZSZY=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20191223203141-f42097b1fcd8/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200311180812-b2c72382d652 h1:NElBL34RIHlZKGtDVXT/srxuVZ1+tqmnCdm1K+MC+fU=

--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -95,6 +95,8 @@ type ApplicationBackupVolumeInfo struct {
 	TotalSize                uint64                      `json:"totalSize"`
 	ActualSize               uint64                      `json:"actualSize"`
 	StorageClass             string                      `json:"storageClass"`
+	Provisioner              string                      `json:"provisioner"`
+	VolumeSnapshot           string                      `json:"volumeSnapshot"`
 }
 
 // ApplicationBackupStatusType is the status of the application backup

--- a/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/dataexport.go
+++ b/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/dataexport.go
@@ -122,6 +122,7 @@ type ExportStatus struct {
 	TransferID           string           `json:"transferID,omitempty"`
 	ProgressPercentage   int              `json:"progressPercentage,omitempty"`
 	Size                 uint64           `json:"size,omitempty"`
+	VolumeSnapshot       string           `json:"volumeSnapshot,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackup.go
@@ -251,7 +251,7 @@ func jobFor(
 		"--volume-backup-name",
 		backupName,
 		"--repository",
-		toRepoName(jobOption.SourcePVCName, jobOption.Namespace),
+		toRepoName(jobOption.RepoPVCName, jobOption.Namespace),
 		"--credentials",
 		jobOption.DataExportName,
 		"--backup-location",

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackuplive.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackuplive.go
@@ -50,7 +50,7 @@ func jobForLiveBackup(
 		"--backup-namespace",
 		jobOption.Namespace,
 		"--repository",
-		toRepoName(jobOption.SourcePVCName, jobOption.Namespace),
+		toRepoName(jobOption.RepoPVCName, jobOption.Namespace),
 		"--source-path-glob",
 		backupPath,
 	}, " ")

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
@@ -35,6 +35,7 @@ type JobOpts struct {
 	CertSecretName              string
 	CertSecretNamespace         string
 	MaintenanceType             string
+	RepoPVCName                 string
 }
 
 // WithBackupObjectName is job parameter.
@@ -176,6 +177,17 @@ func WithDestinationPVC(name string) JobOption {
 			return fmt.Errorf("destination pvc name should be set")
 		}
 		opts.DestinationPVCName = strings.TrimSpace(name)
+		return nil
+	}
+}
+
+// WithRepoPVC is job parameter.
+func WithRepoPVC(name string) JobOption {
+	return func(opts *JobOpts) error {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("repo pvc name should be set")
+		}
+		opts.RepoPVCName = strings.TrimSpace(name)
 		return nil
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -425,7 +425,7 @@ github.com/pierrec/lz4/internal/xxh32
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20211028102921-794b776e5a55
+# github.com/portworx/kdmp v0.4.1-0.20211102174416-fa9a0135538b
 ## explicit
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1


### PR DESCRIPTION
**What type of PR is this?**
bug
**What this PR does / why we need it**:
stor-545: Added provisioner and volumesnapshot fields in applicationbackup CR.

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.8
Testing:
ApplicationBackup CR:
```
 Status:             InProgress
  Total Size:         0
  Trigger Timestamp:  2021-11-02T16:51:32Z
  Volumes:
    Options:                      <nil>
    Actual Size:                  120861181
    Backup ID:                    5018c04eb784902b997bdba8da2b95bc
    Driver Name:                  kdmp
    Namespace:                    mysql-6
    Persistent Volume Claim:      pxcentral-mysql-pvc
    Persistent Volume Claim UID:  588851a3-f5db-48aa-86c7-3e8057abe2ce
    Provisioner:                  pure-csi <<<<<<<<<<<<<
    Reason:                       Backup successful for volume
    Status:                       Successful
    Storage Class:                pure-block
    Total Size:                   120861181
    Volume:                       pvc-588851a3-f5db-48aa-86c7-3e8057abe2ce
    Volume Snapshot:              pxcentral-mysql-pvc-61f68fec <<<<<<<<<<<<<<<
    Zones:                        <nil>
Events:
  Type    Reason      Age   From   Message
  ----    ------      ----  ----   -------
  Normal  Successful  1s    stork  Volume pvc-588851a3-f5db-48aa-86c7-3e8057abe2ce backed up successfully
  ```
Dataexport CR:
```
Spec:
  Destination:
    API Version:           stork.libopenstorage.org/v1alpha1
    Kind:                  BackupLocation
    Name:                  aws-csi-bl-f12a8a6
    Namespace:             mysql-6
  Snapshot Storage Class:  pure-snapshotclass
  Source:
    Name:       pxcentral-mysql-pvc
    Namespace:  mysql-6
  Type:         kopia
Status:
  Reason:                  failed to start a data transfer job, dataexport [backup-072358d-588851a-mysql-6]: job Already Running
  Snapshot ID:             pxcentral-mysql-pvc-61f68fec
  Snapshot Namespace:      mysql-6
  Snapshot PVC Name:       pxcentral-mysql-pvc-61f68fec
  Snapshot PVC Namespace:  mysql-6
  Stage:                   TransferScheduled
  Status:                  Failed
  Transfer ID:             mysql-6/backup-072358d-588851a-mysql-6
  Volume Snapshot:         pxcentral-mysql-pvc-61f68fec <<<<<<<<<
Events:                    <none>
```
