### PR TITLE
[STOR-551]: pvc creation for kdmp restore should happen in kdmp controller.

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -441,6 +441,7 @@ func (a *aws) GetPreRestoreResources(
 func (a *aws) StartRestore(
 	restore *storkapi.ApplicationRestore,
 	volumeBackupInfos []*storkapi.ApplicationBackupVolumeInfo,
+	preRestoreObjects []runtime.Unstructured,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
 	if a.client == nil {
 		if err := a.Init(nil); err != nil {

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -446,6 +446,7 @@ func (a *azure) GetPreRestoreResources(
 func (a *azure) StartRestore(
 	restore *storkapi.ApplicationRestore,
 	volumeBackupInfos []*storkapi.ApplicationBackupVolumeInfo,
+	preRestoreObjects []runtime.Unstructured,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
 	if !a.initDone {
 		if err := a.Init(nil); err != nil {

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -1182,6 +1182,7 @@ func (c *csi) createRestoreSnapshotsAndPVCs(
 func (c *csi) StartRestore(
 	restore *storkapi.ApplicationRestore,
 	volumeBackupInfos []*storkapi.ApplicationBackupVolumeInfo,
+	preRestoreObjects []runtime.Unstructured,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
 	if c.snapshotClient == nil {
 		if err := c.Init(nil); err != nil {

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -410,6 +410,7 @@ func (g *gcp) GetPreRestoreResources(
 func (g *gcp) StartRestore(
 	restore *storkapi.ApplicationRestore,
 	volumeBackupInfos []*storkapi.ApplicationBackupVolumeInfo,
+	preRestoreObjects []runtime.Unstructured,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
 	if g.service == nil {
 		if err := g.Init(nil); err != nil {

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3245,6 +3245,7 @@ func (p *portworx) GetPreRestoreResources(
 func (p *portworx) StartRestore(
 	restore *storkapi.ApplicationRestore,
 	volumeBackupInfos []*storkapi.ApplicationBackupVolumeInfo,
+	preRestoreObjects []runtime.Unstructured,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
 	if !p.initDone {
 		if err := p.initPortworxClients(); err != nil {

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -178,7 +178,7 @@ type BackupRestorePluginInterface interface {
 	GetPreRestoreResources(*storkapi.ApplicationBackup, *storkapi.ApplicationRestore, []runtime.Unstructured) ([]runtime.Unstructured, error)
 	// Start restore of volumes specified by the spec. Should only restore
 	// volumes, not the specs associated with them
-	StartRestore(*storkapi.ApplicationRestore, []*storkapi.ApplicationBackupVolumeInfo) ([]*storkapi.ApplicationRestoreVolumeInfo, error)
+	StartRestore(*storkapi.ApplicationRestore, []*storkapi.ApplicationBackupVolumeInfo, []runtime.Unstructured) ([]*storkapi.ApplicationRestoreVolumeInfo, error)
 	// Get the status of restore of the volumes specified in the status
 	// for the restore spec
 	GetRestoreStatus(*storkapi.ApplicationRestore) ([]*storkapi.ApplicationRestoreVolumeInfo, error)
@@ -441,6 +441,7 @@ func (b *BackupRestoreNotSupported) GetPreRestoreResources(
 func (b *BackupRestoreNotSupported) StartRestore(
 	*storkapi.ApplicationRestore,
 	[]*storkapi.ApplicationBackupVolumeInfo,
+	[]runtime.Unstructured,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
 	return nil, &errors.ErrNotSupported{}
 }

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.0
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
-	github.com/portworx/kdmp v0.4.1-0.20211105091220-547d951f9801
+	github.com/portworx/kdmp v0.4.1-0.20211105105618-b8788d21fc2a
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20211026113317-db80e47fe929
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1123,6 +1123,8 @@ github.com/portworx/kdmp v0.4.1-0.20211103043446-cc5455f203d0 h1:+e0W73p9QiLldPX
 github.com/portworx/kdmp v0.4.1-0.20211103043446-cc5455f203d0/go.mod h1:BZ9ApnLFaMdxC4jd1inOw4ICfUI8AzyicAo+wL9ZSZY=
 github.com/portworx/kdmp v0.4.1-0.20211105091220-547d951f9801 h1:yUyIeVG+WOY7baSWb+n6vTVuVyPjlg/uIcmiyE3KIHo=
 github.com/portworx/kdmp v0.4.1-0.20211105091220-547d951f9801/go.mod h1:cbaFBCLFTtF0taXtGR2zGD89k0gl7fNl+n4Vi9p4gmI=
+github.com/portworx/kdmp v0.4.1-0.20211105105618-b8788d21fc2a h1:VJrqIk7w5HmQKM+afMwDYdz5ApHET+EI/chphR9qWpc=
+github.com/portworx/kdmp v0.4.1-0.20211105105618-b8788d21fc2a/go.mod h1:cbaFBCLFTtF0taXtGR2zGD89k0gl7fNl+n4Vi9p4gmI=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20191223203141-f42097b1fcd8/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200311180812-b2c72382d652 h1:NElBL34RIHlZKGtDVXT/srxuVZ1+tqmnCdm1K+MC+fU=

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -498,8 +498,12 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 				log.ApplicationRestoreLog(restore).Errorf("Error getting PreRestore Resources: %v", err)
 				return err
 			}
-			if err := a.applyResources(restore, preRestoreObjects); err != nil {
-				return err
+
+			// pvc creation is not part of kdmp
+			if driverName != "kdmp" {
+				if err := a.applyResources(restore, preRestoreObjects); err != nil {
+					return err
+				}
 			}
 
 			// Pre-delete resources for CSI driver
@@ -540,7 +544,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 				}
 			}
 
-			restoreVolumeInfos, err := driver.StartRestore(restore, vInfos)
+			restoreVolumeInfos, err := driver.StartRestore(restore, vInfos, preRestoreObjects)
 			if err != nil {
 				message := fmt.Sprintf("Error starting Application Restore for volumes: %v", err)
 				log.ApplicationRestoreLog(restore).Errorf(message)

--- a/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/dataexport.go
+++ b/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/dataexport.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -112,17 +113,19 @@ type DataExportObjectReference struct {
 
 // ExportStatus indicates a current state of the data transfer.
 type ExportStatus struct {
-	Stage                DataExportStage  `json:"stage,omitempty"`
-	Status               DataExportStatus `json:"status,omitempty"`
-	Reason               string           `json:"reason,omitempty"`
-	SnapshotID           string           `json:"snapshotID,omitempty"`
-	SnapshotNamespace    string           `json:"snapshotNamespace,omitempty"`
-	SnapshotPVCName      string           `json:"snapshotPVCName,omitempty"`
-	SnapshotPVCNamespace string           `json:"snapshotPVCNamespace,omitempty"`
-	TransferID           string           `json:"transferID,omitempty"`
-	ProgressPercentage   int              `json:"progressPercentage,omitempty"`
-	Size                 uint64           `json:"size,omitempty"`
-	VolumeSnapshot       string           `json:"volumeSnapshot,omitempty"`
+	Stage                DataExportStage           `json:"stage,omitempty"`
+	Status               DataExportStatus          `json:"status,omitempty"`
+	Reason               string                    `json:"reason,omitempty"`
+	SnapshotID           string                    `json:"snapshotID,omitempty"`
+	SnapshotNamespace    string                    `json:"snapshotNamespace,omitempty"`
+	SnapshotPVCName      string                    `json:"snapshotPVCName,omitempty"`
+	SnapshotPVCNamespace string                    `json:"snapshotPVCNamespace,omitempty"`
+	TransferID           string                    `json:"transferID,omitempty"`
+	ProgressPercentage   int                       `json:"progressPercentage,omitempty"`
+	Size                 uint64                    `json:"size,omitempty"`
+	VolumeSnapshot       string                    `json:"volumeSnapshot,omitempty"`
+	RestorePVC           *v1.PersistentVolumeClaim `json:"restorePVC,omitempty"`
+	LocalSnapshotRestore bool                      `json:"localSnapshotRestore,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
@@ -244,6 +244,31 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 				}
 				return false, c.updateStatus(dataExport, data)
 			}
+
+			// Create the pvc from the spec provided in the dataexport CR
+			pvcSpec := dataExport.Status.RestorePVC
+			_, err = c.createPVC(dataExport)
+			if err != nil {
+				msg := fmt.Sprintf("Error creating pvc %s/%s for restore: %v", pvcSpec.Namespace, pvcSpec.Name, err)
+				logrus.Errorf(msg)
+				data := updateDataExportDetail{
+					status: kdmpapi.DataExportStatusFailed,
+					reason: msg,
+				}
+				return false, c.updateStatus(dataExport, data)
+			}
+
+			_, err = checkPVC(dataExport.Spec.Destination, true)
+			if err != nil {
+				msg := fmt.Sprintf("Destination pvc %s/%s is not bound yet: %v", pvcSpec.Namespace, pvcSpec.Name, err)
+				logrus.Errorf(msg)
+				data := updateDataExportDetail{
+					status: kdmpapi.DataExportStatusFailed,
+					reason: msg,
+				}
+				return false, c.updateStatus(dataExport, data)
+			}
+
 			// This will create a unique secret per PVC being restored
 			// For restore create the secret in the ns where PVC is referenced
 			err = CreateCredentialsSecret(
@@ -1007,6 +1032,18 @@ func (c *Controller) restoreSnapshot(ctx context.Context, snapshotDriver snapsho
 	return pvc, nil
 }
 
+func (c *Controller) createPVC(dataExport *kdmpapi.DataExport) (*corev1.PersistentVolumeClaim, error) {
+	pvc := dataExport.Status.RestorePVC
+	newPVC, err := core.Instance().CreatePersistentVolumeClaim(pvc)
+	if err != nil {
+		if k8sErrors.IsAlreadyExists(err) {
+			return pvc, nil
+		}
+		return nil, fmt.Errorf("failed to create PVC %s: %s", pvc.Name, err.Error())
+	}
+	return newPVC, nil
+}
+
 func (c *Controller) checkClaims(de *kdmpapi.DataExport) error {
 	if !hasSnapshotStage(de) && de.Spec.Source.Namespace != de.Spec.Destination.Namespace {
 		return fmt.Errorf("source and destination volume claims should be in the same namespace if no snapshot class is provided")
@@ -1077,9 +1114,6 @@ func (c *Controller) checkGenericRestore(de *kdmpapi.DataExport) error {
 
 	if !isPVCRef(de.Spec.Destination) && !isAPIVersionKindNotSetRef(de.Spec.Destination) {
 		return fmt.Errorf("destination is expected to be PersistentVolumeClaim")
-	}
-	if _, err := checkPVC(de.Spec.Destination, true); err != nil {
-		return fmt.Errorf("destination: %s", err)
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -425,7 +425,7 @@ github.com/pierrec/lz4/internal/xxh32
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20211105091220-547d951f9801
+# github.com/portworx/kdmp v0.4.1-0.20211105105618-b8788d21fc2a
 ## explicit
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
pvc creation for kdmp drivers has been moved to kdmp controller.

**Does this PR change a user-facing CRD or CLI?**:
<!--
 no.
-->

**Is a release note needed?**:
<!--
no
-->

**Does this change need to be cherry-picked to a release branch?**:
<!--
no
-->
<img width="1789" alt="Screenshot 2021-11-03 at 8 36 19 PM" src="https://user-images.githubusercontent.com/51692470/140087393-edc0015a-f62d-49bd-91c8-dbc3df07a95d.png">

