### PR TITLE
vendor changes for openstorage repo from release-9.1 branch.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7
 	github.com/kubernetes-sigs/aws-ebs-csi-driver v0.9.0
-	github.com/libopenstorage/openstorage v8.0.1-0.20211010162107-3409854b020f+incompatible
+	github.com/libopenstorage/openstorage v8.0.1-0.20211105030910-665c2f474186+incompatible
 	github.com/libopenstorage/secrets v0.0.0-20200207034622-cdb443738c67
 	github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452
 	github.com/openshift/api v0.0.0-20210105115604-44119421ec6b

--- a/go.sum
+++ b/go.sum
@@ -842,6 +842,8 @@ github.com/libopenstorage/openstorage v8.0.1-0.20211001213756-2d80c383c962+incom
 github.com/libopenstorage/openstorage v8.0.1-0.20211001213756-2d80c383c962+incompatible/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/libopenstorage/openstorage v8.0.1-0.20211010162107-3409854b020f+incompatible h1:JOLZVPbk7DElie8S4xspHFArdCaykmwio7X25EY7xPU=
 github.com/libopenstorage/openstorage v8.0.1-0.20211010162107-3409854b020f+incompatible/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
+github.com/libopenstorage/openstorage v8.0.1-0.20211105030910-665c2f474186+incompatible h1:VCQ9C2TLcV3A3zKn89/2NDdjkgONPDotYfHlkmNJcvw=
+github.com/libopenstorage/openstorage v8.0.1-0.20211105030910-665c2f474186+incompatible/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/libopenstorage/openstorage-sdk-clients v0.109.0/go.mod h1:vo0c/nLG2HIyQva4Avwx61U1kWcw4HGQh3sjzV2DEEs=
 github.com/libopenstorage/operator v0.0.0-20191009190641-8642de5d0812/go.mod h1:Qh+VXOB6hj60VmlgsmY+R1w+dFuHK246UueM4SAqZG0=
 github.com/libopenstorage/operator v0.0.0-20200725001727-48d03e197117/go.mod h1:Qh+VXOB6hj60VmlgsmY+R1w+dFuHK246UueM4SAqZG0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -319,7 +319,7 @@ github.com/libopenstorage/autopilot-api/pkg/client/clientset/versioned/scheme
 github.com/libopenstorage/autopilot-api/pkg/client/clientset/versioned/typed/autopilot/v1alpha1
 # github.com/libopenstorage/gossip v0.0.0-20190507031959-c26073a01952
 github.com/libopenstorage/gossip/types
-# github.com/libopenstorage/openstorage v8.0.1-0.20211010162107-3409854b020f+incompatible
+# github.com/libopenstorage/openstorage v8.0.1-0.20211105030910-665c2f474186+incompatible
 ## explicit
 github.com/libopenstorage/openstorage/api
 github.com/libopenstorage/openstorage/api/client


### PR DESCRIPTION
**What type of PR is this?**
Vendor changes for openstorage

**What this PR does / why we need it**:
when i vendor the stork to px-backup, it is changing the openstorage repo version to older version that does not have the changes done by @ram-infrac to make the VerifyRule as public. So updating it to latest version of release9.1 branch.
https://github.com/libopenstorage/openstorage/commit/1c90dd1f3a9036df229094290cfa08e1652b27ec

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

