### PR TITLE
stor-547: Fixing crash when taking a backup of CSI and PXD vols

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -110,8 +110,20 @@ func (a *aws) Stop() error {
 	return nil
 }
 
-func (a *aws) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
+func (a *aws) OwnsPVCForBackup(
+	coreOps core.Ops,
+	pvc *v1.PersistentVolumeClaim,
+	cmBackupType string,
+	crBackupType string,
+) bool {
+	if cmBackupType == storkapi.ApplicationBackupGeneric {
+		// If user has forced the backupType in config map, default to generic always
+		return false
+	}
+	return a.OwnsPVC(coreOps, pvc)
+}
 
+func (a *aws) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 	provisioner := ""
 	// Check for the provisioner in the PVC annotation. If not populated
 	// try getting the provisioner from the Storage class.

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -141,8 +141,20 @@ func (a *azure) Stop() error {
 	return nil
 }
 
-func (a *azure) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
+func (a *azure) OwnsPVCForBackup(
+	coreOps core.Ops,
+	pvc *v1.PersistentVolumeClaim,
+	cmBackupType string,
+	crBackupType string,
+) bool {
+	if cmBackupType == storkapi.ApplicationBackupGeneric {
+		// If user has forced the backupType in config map, default to generic always
+		return false
+	}
+	return a.OwnsPVC(coreOps, pvc)
+}
 
+func (a *azure) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 	provisioner := ""
 	// Check for the provisioner in the PVC annotation. If not populated
 	// try getting the provisioner from the Storage class.

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -206,6 +206,19 @@ func (c *csi) Stop() error {
 	return nil
 }
 
+func (c *csi) OwnsPVCForBackup(
+	coreOps core.Ops,
+	pvc *v1.PersistentVolumeClaim,
+	cmBackupType string,
+	crBackupType string,
+) bool {
+	if cmBackupType == storkapi.ApplicationBackupGeneric || crBackupType == storkapi.ApplicationBackupGeneric {
+		// If user has forced the backupType in config map or applicationbackup CR, default to generic always
+		return false
+	}
+	return c.OwnsPVC(coreOps, pvc)
+}
+
 func (c *csi) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 	// Try to get info from the PV since storage class could be deleted
 	pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -87,8 +87,20 @@ func (g *gcp) Stop() error {
 	return nil
 }
 
-func (g *gcp) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
+func (g *gcp) OwnsPVCForBackup(
+	coreOps core.Ops,
+	pvc *v1.PersistentVolumeClaim,
+	cmBackupType string,
+	crBackupType string,
+) bool {
+	if cmBackupType == storkapi.ApplicationBackupGeneric {
+		// If user has forced the backupType in config map, default to generic always
+		return false
+	}
+	return g.OwnsPVC(coreOps, pvc)
+}
 
+func (g *gcp) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 	provisioner := ""
 	// Check for the provisioner in the PVC annotation. If not populated
 	// try getting the provisioner from the Storage class.

--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -122,6 +122,12 @@ func (k *kdmp) Stop() error {
 	return nil
 }
 
+func (k *kdmp) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, cmBackupType string, crBackupType string) bool {
+	// KDMP can handle any PVC type. KDMP driver will always be a fallback
+	// option when none of the other supported drivers by stork own the PVC
+	return true
+}
+
 func (k *kdmp) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 	// KDMP can handle any PVC type. KDMP driver will always be a fallback
 	// option when none of the other supported drivers by stork own the PVC

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -296,6 +296,10 @@ func (l *linstor) GetVolumeClaimTemplates(templates []v1.PersistentVolumeClaim) 
 	return linstorTemplates, nil
 }
 
+func (l *linstor) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, cmBackupType string, crBackupType string) bool {
+	return l.OwnsPVC(coreOps, pvc)
+}
+
 func (l *linstor) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 	provisioner := ""
 	// Check for the provisioner in the PVC annotation. If not populated

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -255,6 +255,11 @@ func (m Driver) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*storkvo
 	return volumes, nil
 }
 
+// OwnsPVCForBackup returns true because it owns all PVCs created by tests
+func (m *Driver) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, cmBackupType string, crBackupType string) bool {
+	return m.OwnsPVC(coreOps, pvc)
+}
+
 // OwnsPVC returns true because it owns all PVCs created by tests
 func (m *Driver) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 	return true

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -656,6 +656,10 @@ func (p *portworx) GetClusterID() (string, error) {
 	return cluster.Id, nil
 }
 
+func (p *portworx) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, cmBackupType string, crBackupType string) bool {
+	return p.OwnsPVC(coreOps, pvc)
+}
+
 func (p *portworx) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 
 	provisioner := ""


### PR DESCRIPTION
**What type of PR is this?**
-Bug

**What this PR does / why we need it**:
Fixed crash when taking backup of Pure-block and Portworx Volumes

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.8

![Screenshot 2021-11-06 at 4 52 40 PM (2)](https://user-images.githubusercontent.com/51692473/140608023-090d81d3-7e3d-4803-8b23-4c3388a37e36.png)

```

prashanthkumar@prashanthkumar--MacBookPro16 pso % k get pvc -npb-1
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxcentral-mysql-pvc   Bound    pvc-9d1638e9-4095-46a7-b5f7-c50711e4648b   10Gi       RWO            pure-block     3h7m

prashanthkumar@prashanthkumar--MacBookPro16 pso % k get pvc -npx-backup
NAME                                                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxc-mongodb-data-pxc-backup-mongodb-0                     Bound    pvc-24f57544-5fec-461c-8a4c-1506a3249492   64Gi       RWO            px-repl3-sc    2d17h
pxc-mongodb-data-pxc-backup-mongodb-1                     Bound    pvc-bb51122f-4f47-4595-a2b9-23972690cacd   64Gi       RWO            px-repl3-sc    2d17h
pxc-mongodb-data-pxc-backup-mongodb-2                     Bound    pvc-5021833f-2fd1-42f2-ad88-6ef779ec9063   64Gi       RWO            px-repl3-sc    2d17h
pxcentral-keycloak-data-pxcentral-keycloak-postgresql-0   Bound    pvc-bd1ae58a-f60f-4259-87c7-8a0e95a044db   10Gi       RWO            px-repl3-sc    2d17h
pxcentral-mysql-pvc                                       Bound    pvc-9ac836a9-1eb0-47e2-8b2f-15bc0a625bb1   100Gi      RWO            px-repl3-sc    2d17h
theme-pxcentral-keycloak-0                                Bound    pvc-29c5093f-c2ea-4689-a41e-69e4d963d06a   5Gi        RWO            px-repl3-sc    2d17h
prashanthkumar@prashanthkumar--MacBookPro16 pso %
```
