### PR TITLE
Putting the volumesnapshot class and backupUID in volume info as these are required in restore.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -246,7 +246,7 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		dataExport.Labels = labels
 		dataExport.Annotations = make(map[string]string)
 		dataExport.Annotations[skipResourceAnnotation] = "true"
-		dataExport.Annotations[backupObjectUIDKey] = string(backup.UID)
+		dataExport.Annotations[backupObjectUIDKey] = string(backup.Annotations[pxbackupObjectUIDKey])
 		dataExport.Annotations[pvcUIDKey] = string(pvc.UID)
 		dataExport.Name = getGenericCRName(prefixBackup, string(backup.UID), string(pvc.UID), pvc.Namespace)
 		dataExport.Namespace = pvc.Namespace
@@ -266,6 +266,7 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		snapshotClassRequired := isCSISnapshotClassRequired(&pvc)
 		if snapshotClassRequired {
 			dataExport.Spec.SnapshotStorageClass = k.getSnapshotClassName(backup)
+			volumeInfo.VolumeSnapshot = k.getSnapshotClassName(backup)
 		}
 		_, err = kdmpShedOps.Instance().CreateDataExport(dataExport)
 		if err != nil {
@@ -312,7 +313,7 @@ func (k *kdmp) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.
 				vInfo.Reason = "Backup successful for volume"
 				vInfo.TotalSize = dataExport.Status.Size
 				vInfo.ActualSize = dataExport.Status.Size
-				vInfo.VolumeSnapshot = dataExport.Status.VolumeSnapshot
+				vInfo.VolumeSnapshot = fmt.Sprintf("%s.%s", vInfo.VolumeSnapshot, dataExport.Status.VolumeSnapshot)
 			}
 		}
 		volumeInfos = append(volumeInfos, vInfo)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
Putting required fields in application backup CR to use it during restore.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->
```release-note

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 2.8.0
-->

```
volumebackup sample
		"volumes" : [
			{
				"name" : "pvc-a5c70bbc-f938-413b-b5da-d5a0a875245a",
				"namespace" : "dmysql",
				"backupId" : "c63f721394c77162ab0b2662245a1db3",
				"status" : {
					"status" : "Success",
					"reason" : "Backup successful for volume"
				},
				"driverName" : "kdmp",
				"totalSize" : "120861181",
				"storageClass" : "pure-block",
				"pvcId" : "a5c70bbc-f938-413b-b5da-d5a0a875245a",
				"pvc" : "pxcentral-mysql-pvc",
				"actualSize" : "120861181",
				"provisioner" : "pure-csi",
				"volumesnapshot" : "stork-csi-snapshot-class-pure-csi.pxcentral-mysql-pvc-e2dfb63d"
			}
		],

```
