### PR TITLE
pb-2015: remove the storage-class and storage-provisioner annotation from pvc while restore it.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -93,6 +93,10 @@ const (
 	pureBackendParam          = "backend"
 	pureFileParam             = "file"
 	proxyEndpoint             = "proxy_endpoint"
+	bindCompletedKey          = "pv.kubernetes.io/bind-completed"
+	boundByControllerKey      = "pv.kubernetes.io/bound-by-controller"
+	storageClassKey           = "volume.beta.kubernetes.io/storage-class"
+	storageProvisioner        = "volume.beta.kubernetes.io/storage-provisioner"
 )
 
 var volumeAPICallBackoff = wait.Backoff{
@@ -539,8 +543,10 @@ func (k *kdmp) getRestorePVCs(
 				pvc.Spec.VolumeName = ""
 			}
 			if pvc.Annotations != nil {
-				delete(pvc.Annotations, "pv.kubernetes.io/bind-completed")
-				delete(pvc.Annotations, "pv.kubernetes.io/bound-by-controller")
+				delete(pvc.Annotations, bindCompletedKey)
+				delete(pvc.Annotations, boundByControllerKey)
+				delete(pvc.Annotations, storageClassKey)
+				delete(pvc.Annotations, storageProvisioner)
 				pvc.Annotations[KdmpAnnotation] = StorkAnnotation
 			}
 			o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pvc)


### PR DESCRIPTION
**What type of PR is this?**
bug
**What this PR does / why we need it**:
```
pb-2015: remove the storage-class and storage-provisioner annotation
    from pvc while restore it.

        - Even though we updated the spec.storageclass of the pvc to the
          new storage class from the storage class, while restoring
          ,it was not getting bound. The k8s was referring to the old
          storage class from the annotation and pvc was struck in
          pending state.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, to 2.8 branch 

Testing:
```
root@ip-70-0-97-59:~# kubectl  get all -n efs-pxd
NAME                           READY   STATUS    RESTARTS   AGE
pod/jenkins-56d74cb6fc-5gdz6   1/1     Running   0          26s

NAME              TYPE           CLUSTER-IP       EXTERNAL-IP                                                               PORT(S)          AGE
service/jenkins   LoadBalancer   10.100.151.176   af3cf706587fc400eaa1273bdefa1cb8-1805921432.us-east-2.elb.amazonaws.com   8080:30292/TCP   27s

NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/jenkins   1/1     1            1           27s

NAME                                 DESIRED   CURRENT   READY   AGE
replicaset.apps/jenkins-56d74cb6fc   1         1         1       27s
root@ip-70-0-97-59:~# kubectl get pvc -n efs-pxd
NAME               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
jenkins-home-pvc   Bound    pvc-8dee8e62-ad05-4ad4-93ac-d89be4aa01a2   10Gi       RWX            px-shared-sc   2m33s
root@ip-70-0-97-59:~#
```
![image](https://user-images.githubusercontent.com/52188641/141601219-c197ebe1-ca00-42a6-bd48-80df384d2f9c.png)
![Screenshot 2021-11-13 at 3 18 06 AM](https://user-images.githubusercontent.com/52188641/141601241-fc75194d-f001-405b-86ac-ae154b0854dd.png)

