### PR TITLE
[PB-2010]: support for replace policy in generic restore.

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -562,6 +562,10 @@ func (a *aws) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkap
 		if vInfo.DriverName != storkvolume.AWSDriverName {
 			continue
 		}
+		if vInfo.Status == storkapi.ApplicationRestoreStatusSuccessful || vInfo.Status == storkapi.ApplicationRestoreStatusFailed || vInfo.Status == storkapi.ApplicationRestoreStatusRetained {
+			volumeInfos = append(volumeInfos, vInfo)
+			continue
+		}
 		ebsVolume, err := a.getEBSVolume(vInfo.RestoreVolume, nil)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -538,6 +538,10 @@ func (a *azure) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*stork
 		if vInfo.DriverName != storkvolume.AzureDriverName {
 			continue
 		}
+		if vInfo.Status == storkapi.ApplicationRestoreStatusSuccessful || vInfo.Status == storkapi.ApplicationRestoreStatusFailed || vInfo.Status == storkapi.ApplicationRestoreStatusRetained {
+			volumeInfos = append(volumeInfos, vInfo)
+			continue
+		}
 		disk, err := a.diskClient.Get(context.TODO(), a.resourceGroup, vInfo.RestoreVolume)
 		if err != nil {
 			if azureErr, ok := err.(autorest.DetailedError); ok {

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -508,6 +508,10 @@ func (g *gcp) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkap
 		if vInfo.DriverName != storkvolume.GCEDriverName {
 			continue
 		}
+		if vInfo.Status == storkapi.ApplicationRestoreStatusSuccessful || vInfo.Status == storkapi.ApplicationRestoreStatusFailed || vInfo.Status == storkapi.ApplicationRestoreStatusRetained {
+			volumeInfos = append(volumeInfos, vInfo)
+			continue
+		}
 		var status string
 		if len(vInfo.Zones) == 0 {
 			return nil, fmt.Errorf("zones missing for restore volume %v",

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3413,6 +3413,10 @@ func (p *portworx) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*st
 		if vInfo.DriverName != storkvolume.PortworxDriverName {
 			continue
 		}
+		if vInfo.Status == storkapi.ApplicationRestoreStatusSuccessful || vInfo.Status == storkapi.ApplicationRestoreStatusFailed || vInfo.Status == storkapi.ApplicationRestoreStatusRetained {
+			volumeInfos = append(volumeInfos, vInfo)
+			continue
+		}
 		token, err := p.getUserToken(vInfo.Options, "" /*templatized params already converted*/)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch portworx user token: %v", err)

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package crypto

--- a/pkg/extender/extender_test.go
+++ b/pkg/extender/extender_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package extender

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package log

--- a/pkg/metrics/applicationbackup_test.go
+++ b/pkg/metrics/applicationbackup_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package metrics

--- a/pkg/metrics/applicationclone_test.go
+++ b/pkg/metrics/applicationclone_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package metrics

--- a/pkg/metrics/applicationrestore_test.go
+++ b/pkg/metrics/applicationrestore_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package metrics

--- a/pkg/metrics/clusterpair_test.go
+++ b/pkg/metrics/clusterpair_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package metrics

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package metrics

--- a/pkg/metrics/migration_test.go
+++ b/pkg/metrics/migration_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package metrics

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package monitor

--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package schedule

--- a/pkg/storkctl/applicationbackup_test.go
+++ b/pkg/storkctl/applicationbackup_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/applicationbackupschedule_test.go
+++ b/pkg/storkctl/applicationbackupschedule_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/applicationclone_test.go
+++ b/pkg/storkctl/applicationclone_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/applicationregistration_test.go
+++ b/pkg/storkctl/applicationregistration_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/applicationrestore_test.go
+++ b/pkg/storkctl/applicationrestore_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/backuplocation_test.go
+++ b/pkg/storkctl/backuplocation_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/clusterdomainsstatus_test.go
+++ b/pkg/storkctl/clusterdomainsstatus_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/clusterdomainupdate_test.go
+++ b/pkg/storkctl/clusterdomainupdate_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/clusterpair_test.go
+++ b/pkg/storkctl/clusterpair_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/common_test.go
+++ b/pkg/storkctl/common_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/factory_test.go
+++ b/pkg/storkctl/factory_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/fake_api_server_test.go
+++ b/pkg/storkctl/fake_api_server_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/groupsnapshot_test.go
+++ b/pkg/storkctl/groupsnapshot_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/migration_test.go
+++ b/pkg/storkctl/migration_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/pvc_test.go
+++ b/pkg/storkctl/pvc_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/schedulepolicy_test.go
+++ b/pkg/storkctl/schedulepolicy_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/snapshot_test.go
+++ b/pkg/storkctl/snapshot_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/snapshotschedule_test.go
+++ b/pkg/storkctl/snapshotschedule_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/pkg/storkctl/version_test.go
+++ b/pkg/storkctl/version_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storkctl

--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/applicationclone_test.go
+++ b/test/integration_test/applicationclone_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/clusterdomain_test.go
+++ b/test/integration_test/clusterdomain_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/cmdexecutor_test.go
+++ b/test/integration_test/cmdexecutor_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/extender_test.go
+++ b/test/integration_test/extender_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/health_monitor_test.go
+++ b/test/integration_test/health_monitor_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/migration_backup_test.go
+++ b/test/integration_test/migration_backup_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/migration_failover_failback_test.go
+++ b/test/integration_test/migration_failover_failback_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/snapshot_restore_test.go
+++ b/test/integration_test/snapshot_restore_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest

--- a/test/integration_test/webhook_test.go
+++ b/test/integration_test/webhook_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
Supporting replace policy as DELETE and RETAIN for generic backup's restore.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->
```release-note

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes,2.8
-->

**Test**
```

1. FA - Replace policy with DELETE
Before restore 
➜  ~ kr get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxcentral-mysql-pvc   Bound    pvc-1127ddc3-45d0-4cc3-b276-36ad3877cb8e   10Gi       RWO            pure-block     26s

After restore
➜  ~ kr get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxcentral-mysql-pvc   Bound    pvc-4e1d72f8-6fbd-4041-aa39-3ba10f502dd3   10Gi       RWO            pure-block     49s

2. FA - Replace policy with RETAIN

Before restore
➜  ~ kr get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxcentral-mysql-pvc   Bound    pvc-4e1d72f8-6fbd-4041-aa39-3ba10f502dd3   10Gi       RWO            pure-block     2m36s

After restore
➜  ~ kr get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxcentral-mysql-pvc   Bound    pvc-4e1d72f8-6fbd-4041-aa39-3ba10f502dd3   10Gi       RWO            pure-block     3m42s

3. FB - Replace policy with DELETE

Before restore
➜  ~ kr get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxcentral-mysql-pvc   Bound    pvc-aba4e4b4-fd4e-4d76-adaf-a095094dbffe   10Gi       RWO            pure-file      2m53s

After restore
➜  ~ kr get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxcentral-mysql-pvc   Bound    pvc-63344411-6010-4ca7-ae25-d794d1197066   10Gi       RWO            pure-file      21s

4. FB - Replace policy with REPLACE

Before restore
➜  ~ kr get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxcentral-mysql-pvc   Bound    pvc-63344411-6010-4ca7-ae25-d794d1197066   10Gi       RWO            pure-file      21s

After restore
➜  ~ kr get pvc
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pxcentral-mysql-pvc   Bound    pvc-63344411-6010-4ca7-ae25-d794d1197066   10Gi       RWO            pure-file      3m7s

```
