### PR TITLE
pb-2020: Added check in assigning SnapshotStorageClass in dataexport CR.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -676,7 +676,9 @@ func (k *kdmp) StartRestore(
 		dataExport.Status.RestorePVC = pvc
 		dataExport.Status.LocalSnapshotRestore = k.doLocalRestore(restore, bkpvInfo)
 		dataExport.Spec.Type = kdmpapi.DataExportKopia
-		dataExport.Spec.SnapshotStorageClass = getVolumeSnapshotClassFromBackupVolumeInfo(bkpvInfo)
+		if dataExport.Status.LocalSnapshotRestore {
+			dataExport.Spec.SnapshotStorageClass = getVolumeSnapshotClassFromBackupVolumeInfo(bkpvInfo)
+		}
 		dataExport.Spec.Source = kdmpapi.DataExportObjectReference{
 			Kind:       reflect.TypeOf(kdmpapi.VolumeBackup{}).Name(),
 			Name:       volBackup.Name,


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
```
    pb-2020: Added check in assigning SnapshotStorageClass in dataexport CR.

        - Assigng the SnapshotStorageClass in DE CR only when
          LocalSnapshotRestore is true, in which case, we will try the
          local snapshot restore.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes 2.8

Testing:
1) created a backup of FA volume with offload to S3 option. It was kdmp backup with local snapshot.
2) Triggered a restore to px-replicated storage class. Since it is a different provisioner, it should select the local restore and move directly to the kopia restore.

<img width="2048" alt="Screenshot 2021-11-15 at 1 55 52 AM" src="https://user-images.githubusercontent.com/52188641/141698428-2894529e-40c9-42ff-8710-d60458bf762e.png">
<img width="2048" alt="Screenshot 2021-11-15 at 2 08 29 AM" src="https://user-images.githubusercontent.com/52188641/141698436-6fde2968-8dd2-435f-983e-f5cb1644b183.png">
<img width="1289" alt="Screenshot 2021-11-15 at 2 09 52 AM" src="https://user-images.githubusercontent.com/52188641/141698442-fa4458dc-a8ee-42ff-936d-f5fdf422ac7c.png">


