### PR TITLE
[PB-2030]: pv/pvc should be included as resources in kdmp restore list.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1216,7 +1216,7 @@ func (a *ApplicationRestoreController) restoreResources(
 
 func (a *ApplicationRestoreController) addCSIVolumeResources(restore *storkapi.ApplicationRestore) error {
 	for _, vrInfo := range restore.Status.Volumes {
-		if vrInfo.DriverName != "csi" {
+		if vrInfo.DriverName != "csi" && vrInfo.DriverName != "kdmp" {
 			continue
 		}
 


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->
```release-note

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 2.8
-->

** Test **
`2030-restore` is the restore with the fix.

<img width="1792" alt="Screenshot 2021-11-16 at 8 31 46 AM" src="https://user-images.githubusercontent.com/51692470/141888229-6c9d83f5-3093-49e7-857e-17e4b9fe8f2c.png">
