### PR TITLE
Adding env variable to specify market place deployment

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -66,6 +66,9 @@ const (
 	cmName                     = "stork-version"
 	eventComponentName         = "stork"
 	debugFilePath              = "/var/cores"
+	awsKopiaExecutorImage      = "709825985650.dkr.ecr.us-east-1.amazonaws.com/portworx/kopiaexecutor"
+	awsKopiaExecutorImageTag   = "1.0.0-a345bb2"
+	awsMarketPlace             = "aws"
 )
 
 var ext *extender.Extender
@@ -213,6 +216,7 @@ func run(c *cli.Context) {
 	} else if err != nil {
 		log.Warnf("Unable to create stork version configmap: %v", err)
 	}
+	marketPlace := os.Getenv("MARKET_PLACE")
 	kdmpConfig := &api_v1.ConfigMap{}
 	kdmpConfig.Name = stork_driver.KdmpConfigmapName
 	kdmpConfig.Namespace = stork_driver.KdmpConfigmapNamespace
@@ -222,7 +226,11 @@ func run(c *cli.Context) {
 	kdmpConfig.Data[drivers.KopiaExecutorLimitCPU] = drivers.DefaultKopiaExecutorLimitCPU
 	kdmpConfig.Data[drivers.KopiaExecutorLimitMemory] = drivers.DefaultKopiaExecutorLimitMemory
 	kdmpConfig.Data[drivers.KopiaExecutorImageSecretKey] = ""
-	kdmpConfig.Data[drivers.KopiaExecutorImageKey] = strings.Join([]string{drivers.KopiaExecutorImage, kdmpversion.Get().GitVersion}, ":")
+	if marketPlace == awsMarketPlace {
+		kdmpConfig.Data[drivers.KopiaExecutorImageKey] = strings.Join([]string{awsKopiaExecutorImage, awsKopiaExecutorImageTag}, ":")
+	} else {
+		kdmpConfig.Data[drivers.KopiaExecutorImageKey] = strings.Join([]string{drivers.KopiaExecutorImage, kdmpversion.Get().GitVersion}, ":")
+	}
 	kdmpConfig.Data[jobratelimit.BackupJobLimitKey] = strconv.Itoa(jobratelimit.DefaultBackupJobLimit)
 	kdmpConfig.Data[jobratelimit.RestoreJobLimitKey] = strconv.Itoa(jobratelimit.DefaultRestoreJobLimit)
 	kdmpConfig.Data[jobratelimit.DeleteJobLimitKey] = strconv.Itoa(jobratelimit.DefaultDeleteJobLimit)


### PR DESCRIPTION
**What type of PR is this?**
Enhancement

**What this PR does / why we need it**:
 - user can set env MARKET_PLACE=aws to specify the stork being deployed on
   AWS marketplace so that appropriate kopia executor image is picked from
   market place repository

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No


**Does this change need to be cherry-picked to a release branch?**:
Yes, 2.8

Manual test
1. Set the following env in stork deployment spec
```
env:
        - name: MARKET_PLACE
          value: aws
```

2. Deployed stork and could see kopia executor image is pointing to marketplace repository
```

kubectl describe cm kdmp-config -nkube-system
Name:         kdmp-config
Namespace:    kube-system
Labels:       <none>
Annotations:  <none>

Data
====
KDMP_BACKUP_JOB_LIMIT:
----
5
KDMP_KOPIAEXECUTOR_IMAGE:
----
709825985650.dkr.ecr.us-east-1.amazonaws.com/portworx/kopiaexecutor:1.0.0-099827f
KDMP_KOPIAEXECUTOR_LIMIT_CPU:
----
0.2
KDMP_KOPIAEXECUTOR_LIMIT_MEMORY:
----
1Gi
KDMP_KOPIAEXECUTOR_REQUEST_CPU:
----
0.1
KDMP_RESTORE_JOB_LIMIT:
----
5
KDMP_DELETE_JOB_LIMIT:
----
5
KDMP_KOPIAEXECUTOR_IMAGE_SECRET:
----

KDMP_KOPIAEXECUTOR_REQUEST_MEMORY:
----
700Mi
KDMP_MAINTENANCE_JOB_LIMIT:
----
5
Events:  <none>
```
3. Started a generic backup and could see backup pod picking the same image
```

QoS Class:       Burstable
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason   Age    From     Message
  ----    ------   ----   ----     -------
  Normal  Pulling  3m49s  kubelet  Pulling image "709825985650.dkr.ecr.us-east-1.amazonaws.com/portworx/kopiaexecutor:1.0.0-099827f"
  Normal  Pulled   3m40s  kubelet  Successfully pulled image "709825985650.dkr.ecr.us-east-1.amazonaws.com/portworx/kopiaexecutor:1.0.0-099827f" in 8.398250085s
  Normal  Created  3m38s  kubelet  Created container kopiaexecutor
  Normal  Started  3m38s  kubelet  Started container kopiaexecutor

```