### PR TITLE
pb-2061: removed the incorrect error handling while calling runtimeclient.ObjectKeyFromObject function.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -345,9 +345,6 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 				string(stork_api.ApplicationBackupStatusFailed),
 				message)
 			key := runtimeclient.ObjectKeyFromObject(backup)
-			if err != nil {
-				return err
-			}
 			err = a.client.Get(context.TODO(), key, backup)
 			if err != nil {
 				return err
@@ -851,9 +848,6 @@ func (a *ApplicationBackupController) runPreExecRule(backup *stork_api.Applicati
 	// Get the latest object so that the rules engine can update annotations if
 	// required
 	key := runtimeclient.ObjectKeyFromObject(backup)
-	if err != nil {
-		return nil, false, err
-	}
 	err = a.client.Get(context.TODO(), key, backup)
 	if err != nil {
 		return nil, false, err
@@ -885,12 +879,6 @@ func (a *ApplicationBackupController) runPreExecRule(backup *stork_api.Applicati
 	// Get the latest object again since the rules engine could have updated
 	// annotations
 	key = runtimeclient.ObjectKeyFromObject(backup)
-	if err != nil {
-		for _, channel := range terminationChannels {
-			channel <- true
-		}
-		return nil, false, err
-	}
 	err = a.client.Get(context.TODO(), key, backup)
 	if err != nil {
 		for _, channel := range terminationChannels {


### PR DESCRIPTION
**What type of PR is this?**
bug
**What this PR does / why we need it**:
pb-2061: removed the incorrect error handling while calling runtimeclient.ObjectKeyFromObject function.
This makes the invalid rule command execution during backup to hang.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.8

Testing:
<img width="669" alt="Screenshot 2021-11-19 at 11 16 08 PM" src="https://user-images.githubusercontent.com/52188641/142673448-7aded8c2-2510-4a7c-8072-e6d93406ef71.png">

