### PR TITLE
Skipping namespaces which are not part of restore ns mapping

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1000,10 +1000,10 @@ func (a *ApplicationRestoreController) skipVolumesFromRestoreList(
 	newVolInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 	for _, bkupVolInfo := range backup.Status.Volumes {
 		restoreVolInfo := &storkapi.ApplicationRestoreVolumeInfo{}
-
 		val, ok := restore.Spec.NamespaceMapping[bkupVolInfo.Namespace]
 		if !ok {
-			return newVolInfos, existingInfos, fmt.Errorf("restore namespace mapping not found: %s", bkupVolInfo.Namespace)
+			logrus.Infof("skipping namespace %s for restore", bkupVolInfo.Namespace)
+			continue
 		}
 
 		// get corresponding pvc object from objects list


### PR DESCRIPTION
**What type of PR is this?**
- Bug

**What this PR does / why we need it**:
As part of the restore, skip those ns which are not part of source ns mapping as part of restore ns mapping provided. 

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No


**Does this change need to be cherry-picked to a release branch?**:
Yes, 2.8

