### PR TITLE
PB-2079: collect clusterrolebinding subjects if sa is not found

### DIFF
--- a/pkg/resourcecollector/clusterrole.go
+++ b/pkg/resourcecollector/clusterrole.go
@@ -20,8 +20,8 @@ func (r *ResourceCollector) subjectInNamespace(subject *rbacv1.Subject, namespac
 		}
 		// check if user has an access to sa in namespace
 		_, err := r.coreOps.GetServiceAccount(subject.Name, namespace)
-		if err != nil {
-			if apierrors.IsForbidden(err) || apierrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
+			if apierrors.IsForbidden(err) {
 				return false, nil
 			}
 			return false, err


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Collect clusterrolebiding subjects if SA is missing on destination cluster

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no


**Does this change need to be cherry-picked to a release branch?**:
2.8
