### PR TITLE
revert clusterrolebinding collection based on user access to SA

### DIFF
--- a/pkg/resourcecollector/clusterrole.go
+++ b/pkg/resourcecollector/clusterrole.go
@@ -18,15 +18,9 @@ func (r *ResourceCollector) subjectInNamespace(subject *rbacv1.Subject, namespac
 		if subject.Name == "default" {
 			return false, nil
 		}
-		// check if user has an access to sa in namespace
-		_, err := r.coreOps.GetServiceAccount(subject.Name, namespace)
-		if err != nil && !apierrors.IsNotFound(err) {
-			if apierrors.IsForbidden(err) {
-				return false, nil
-			}
-			return false, err
+		if subject.Namespace == namespace {
+			return true, nil
 		}
-		return true, nil
 	case rbacv1.UserKind:
 		// For User we need to parse the username to get the namespace
 		userNamespace, _, err := serviceaccount.SplitUsername(subject.Name)


### PR DESCRIPTION
\**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Revert permission based cluster-role/binding listing and collection, this was causing to  restore of rolebinding/clusterrolebinding with empty `subjects`

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.8

