### PR TITLE
Stork scheduler support with k8s 1.22

### DIFF
--- a/specs/stork-deployment.yaml
+++ b/specs/stork-deployment.yaml
@@ -8,22 +8,23 @@ data:
   # of Kubernetes, so please update those as required. The requirement to manually specify this
   # list will go away with Kubernetes v1.10 where it will use the defaults if nothing is
   # specified.
-  policy.cfg: |-
-    {
-      "kind": "Policy",
-      "apiVersion": "v1",
-      "extenders": [
-        {
-          "urlPrefix": "http://stork-service.kube-system.svc.cluster.local:8099",
-          "apiVersion": "v1beta1",
-          "filterVerb": "filter",
-          "prioritizeVerb": "prioritize",
-          "weight": 5,
-          "enableHttps": false,
-          "nodeCacheCapable": false
-        }
-      ]
-    }
+  stork-config.yaml: |-
+    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: true
+      resourceNamespace: kube-system
+      resourceName: stork-scheduler
+    profiles:
+      - schedulerName: stork
+    extenders:
+      - urlPrefix: http://stork-service.kube-system:8099
+        filterVerb: filter
+        prioritizeVerb: prioritize
+        weight: 5
+        enableHTTPS: false
+        httpTimeout: 300000s
+        nodeCacheCapable: false
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/specs/stork-deployment.yaml
+++ b/specs/stork-deployment.yaml
@@ -9,12 +9,16 @@ data:
   # list will go away with Kubernetes v1.10 where it will use the defaults if nothing is
   # specified.
   stork-config.yaml: |-
-    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
     kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: true
       resourceNamespace: kube-system
       resourceName: stork-scheduler
+      leaseDuration: 15s
+      renewDeadline: 10s
+      retryPeriod: 2s
+      resourceLock: leases
     profiles:
       - schedulerName: stork
     extenders:

--- a/specs/stork-scheduler.yaml
+++ b/specs/stork-scheduler.yaml
@@ -101,9 +101,7 @@ spec:
         - /usr/local/bin/kube-scheduler
         - --address=0.0.0.0
         - --leader-elect=true
-        - --scheduler-name=stork
-        - --policy-configmap=stork-config
-        - --policy-configmap-namespace=kube-system
+        - --config=/etc/kubernetes/stork-config.yaml
         - --lock-object-name=stork-scheduler
         image: gcr.io/google_containers/kube-scheduler-amd64:<kube_version>
         livenessProbe:
@@ -121,6 +119,9 @@ spec:
             cpu: '0.1'
         securityContext:
           privileged: false
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: scheduler-config          
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -133,3 +134,8 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       hostPID: false
       serviceAccountName: stork-scheduler-account
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: stork-config
+        name: scheduler-config      

--- a/specs/stork-scheduler.yaml
+++ b/specs/stork-scheduler.yaml
@@ -29,7 +29,7 @@ rules:
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "namespaces"]
     verbs: ["delete", "get", "list", "watch"]
   - apiGroups: [""]
     resources: ["bindings", "pods/binding"]
@@ -100,10 +100,8 @@ spec:
       - command:
         - /usr/local/bin/kube-scheduler
         - --address=0.0.0.0
-        - --leader-elect=true
         - --config=/etc/kubernetes/stork-config.yaml
-        - --lock-object-name=stork-scheduler
-        image: gcr.io/google_containers/kube-scheduler-amd64:<kube_version>
+        image: k8s.gcr.io/kube-scheduler-amd64:<kube_version>
         livenessProbe:
           httpGet:
             path: /healthz
@@ -121,7 +119,7 @@ spec:
           privileged: false
         volumeMounts:
         - mountPath: /etc/kubernetes
-          name: scheduler-config          
+          name: scheduler-config
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -138,4 +136,4 @@ spec:
       - configMap:
           defaultMode: 420
           name: stork-config
-        name: scheduler-config      
+        name: scheduler-config

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -166,6 +166,7 @@ apt-get -y update
 apt-get -y install jq
 
 sed -i 's|'openstorage/stork:.*'|'"$image_name"'|g'  /specs/stork-deployment.yaml
+sed -i 's/<kube_version>/'"$kube_scheduler_version"'/g' /specs/stork-scheduler.yaml
 
 # Replace volume driver in stork
 if [ "$volume_driver" != "pxd" ] ; then
@@ -211,6 +212,25 @@ for i in $(seq 1 100) ; do
         sleep 10
     fi
 done
+
+if [ "$volume_driver" == "pxd" ] || [ "$volume_driver" == "linstor" ] ; then
+	echo "Creating stork scheduler"
+	kubectl apply -f /specs/stork-scheduler.yaml
+# Delete the pods to make sure we are waiting for the status from the
+# new pods
+kubectl delete pods -n kube-system -l name=stork-scheduler
+
+	echo "Waiting for stork-scheduler to be in running state"
+	for i in $(seq 1 100) ; do
+		replicas=$(kubectl get deployment -n kube-system stork-scheduler -o json | jq ".status.readyReplicas")
+		if [ "$replicas" == "3" ]; then
+			break
+		else
+			echo "Stork scheduler is not ready yet"
+			sleep 10
+		fi
+	done
+fi
 
 if [ "$run_cluster_domain_test" == "true" ] ; then
 	sed -i 's/'enable_cluster_domain'/'\""true"\"'/g' /testspecs/stork-test-pod.yaml


### PR DESCRIPTION
**What type of PR is this?**

>enhancement

**What this PR does / why we need it**:
      From kuberentes deprecated version 1.22 onward `schduler-name` flag is depreacted, now custom scheduler needs to be registered via `KubeSchedulerConfiguration` . </p>

This PR add doc spec changes needed for stork-scheduler with 1.22 kube-scheduler image
k8s changelog : https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#changelog-since-v1210

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Issue: Stork-scheduler pods are unable to come up on k8s 1.22 with image scheduler image `k8s.gcr.io/kube-scheduler-amd64:1.22`
User Impact: User has to use older k8s scheduler image on k8s 1.22 version
Resolution: Customer can use updated configs and scheduler deployment for k8s  1.22 onwards

```

**Does this change need to be cherry-picked to a release branch?**:
no, since this is spec changes it will go with px installer portal