### PR TITLE
[PB-2094]: Preventing readding of volumesnapshotname in the applicationrestore CR.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -273,7 +273,6 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		snapshotClassRequired := isCSISnapshotClassRequired(&pvc)
 		if snapshotClassRequired {
 			dataExport.Spec.SnapshotStorageClass = k.getSnapshotClassName(backup)
-			volumeInfo.VolumeSnapshot = k.getSnapshotClassName(backup)
 		}
 		_, err = kdmpShedOps.Instance().CreateDataExport(dataExport)
 		if err != nil {
@@ -323,7 +322,10 @@ func (k *kdmp) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.
 				if len(dataExport.Status.VolumeSnapshot) == 0 {
 					vInfo.VolumeSnapshot = ""
 				} else {
-					vInfo.VolumeSnapshot = fmt.Sprintf("%s.%s", vInfo.VolumeSnapshot, dataExport.Status.VolumeSnapshot)
+					volumeSnapshot := k.getSnapshotClassName(backup)
+					if len(volumeSnapshot) > 0 {
+						vInfo.VolumeSnapshot = fmt.Sprintf("%s.%s", volumeSnapshot, dataExport.Status.VolumeSnapshot)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
Avoiding readding the volumesnapshot name in each backupstatus call.

**Does this PR change a user-facing CRD or CLI?**:
<!--
 no
-->

**Is a release note needed?**:
<!--
no
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 2.8.1
-->

** Test **
GetBackupstatus was called multiple times during the backup of following 2 volumes.

![Screenshot 2021-12-03 at 1 51 43 PM](https://user-images.githubusercontent.com/51692470/144570005-24e89a0c-31f3-4bc3-8871-532e0f0e3ec0.png)

