### PR TITLE
Fixing kdmp restore across Azure regions

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -100,6 +100,7 @@ const (
 	boundByControllerKey      = "pv.kubernetes.io/bound-by-controller"
 	storageClassKey           = "volume.beta.kubernetes.io/storage-class"
 	storageProvisioner        = "volume.beta.kubernetes.io/storage-provisioner"
+	storageNodeAnnotation     = "volume.kubernetes.io/selected-node"
 )
 
 var volumeAPICallBackoff = wait.Backoff{
@@ -540,6 +541,7 @@ func (k *kdmp) getRestorePVCs(
 				delete(pvc.Annotations, boundByControllerKey)
 				delete(pvc.Annotations, storageClassKey)
 				delete(pvc.Annotations, storageProvisioner)
+				delete(pvc.Annotations, storageNodeAnnotation)
 				pvc.Annotations[KdmpAnnotation] = StorkAnnotation
 			}
 			o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pvc)
@@ -571,7 +573,6 @@ func (k *kdmp) StartRestore(
 		if err != nil {
 			return nil, err
 		}
-
 		val, ok := restore.Spec.NamespaceMapping[bkpvInfo.Namespace]
 		if !ok {
 			return nil, fmt.Errorf("restore namespace mapping not found: %s", bkpvInfo.Namespace)

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -542,7 +542,9 @@ func (a *ApplicationCloneController) prepareResources(
 			nil,
 			namespaceMapping,
 			pvNameMappings,
-			clone.Spec.IncludeOptionalResourceTypes)
+			clone.Spec.IncludeOptionalResourceTypes,
+			nil,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -529,6 +529,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 						restore.Spec.NamespaceMapping,
 						nil,
 						restore.Spec.IncludeOptionalResourceTypes,
+						nil,
 					)
 					if err != nil {
 						return err
@@ -1102,6 +1103,7 @@ func (a *ApplicationRestoreController) removeCSIVolumesBeforeApply(
 			if err != nil {
 				return nil, err
 			}
+
 			// Only add this object if it's not a generic CSI PVC
 			if !isGenericCSIPVC && !isGenericDriverPVC {
 				tempObjects = append(tempObjects, o)
@@ -1135,7 +1137,9 @@ func (a *ApplicationRestoreController) applyResources(
 			objectMap,
 			restore.Spec.NamespaceMapping,
 			pvNameMappings,
-			restore.Spec.IncludeOptionalResourceTypes)
+			restore.Spec.IncludeOptionalResourceTypes,
+			restore.Status.Volumes,
+		)
 		if err != nil {
 			return err
 		}
@@ -1150,7 +1154,6 @@ func (a *ApplicationRestoreController) applyResources(
 	if err != nil {
 		return err
 	}
-
 	// First delete the existing objects if they exist and replace policy is set
 	// to Delete
 	if restore.Spec.ReplacePolicy == storkapi.ApplicationRestoreReplacePolicyDelete {

--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -102,6 +102,7 @@ func (r *ResourceCollector) preparePVResourceForCollection(
 func (r *ResourceCollector) preparePVResourceForApply(
 	object runtime.Unstructured,
 	pvNameMappings map[string]string,
+	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
 ) (bool, error) {
 	var updatedName string
 	var present bool
@@ -120,10 +121,14 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	}
 
 	pv.Name = updatedName
-	driverName, err := volume.GetPVDriver(&pv)
-	if err != nil {
-		return false, err
+	var driverName string
+	for _, vol := range vInfo {
+		if vol.RestoreVolume == pv.Name {
+			driverName = vol.DriverName
+			break
+		}
 	}
+
 	driver, err := volume.Get(driverName)
 	if err != nil {
 		return false, err

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -710,6 +710,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 	namespaceMappings map[string]string,
 	pvNameMappings map[string]string,
 	optionalResourceTypes []string,
+	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
 ) (bool, error) {
 
 	objectType, err := meta.TypeAccessor(object)
@@ -747,7 +748,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		}
 		return true, nil
 	case "PersistentVolume":
-		return r.preparePVResourceForApply(object, pvNameMappings)
+		return r.preparePVResourceForApply(object, pvNameMappings, vInfo)
 	case "PersistentVolumeClaim":
 		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings)
 	case "ClusterRoleBinding":


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
- As part of the restore, fetch the driver from the vol info instead of calling GetPVDriver()
- Removed volume.kubernetes.io/selected-node annotation from the PVC spec or else Azure PVC
  always tries to get bounded to the same node which might not be present


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes

Manual test
1. Took a backup on Azure useast region
2. Tried to restore the backup to uswest region cluster
3. Backup was successful

Content fof PV onbaackup cluster
```
ka get pv pvc-f959288c-1393-4955-914b-0c4480361c36 -oyaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/bound-by-controller: "yes"
    pv.kubernetes.io/provisioned-by: kubernetes.io/azure-disk
    volumehelper.VolumeDynamicallyCreatedByKey: azure-disk-dynamic-provisioner
  creationTimestamp: "2021-12-01T21:06:18Z"
  finalizers:
  - kubernetes.io/pv-protection
  labels:
    failure-domain.beta.kubernetes.io/region: eastus
    failure-domain.beta.kubernetes.io/zone: eastus-1
  name: pvc-f959288c-1393-4955-914b-0c4480361c36
  resourceVersion: "2602978"
  uid: f9675f6a-27df-4bea-9fcd-922cd389f387
spec:
  accessModes:
  - ReadWriteOnce
  azureDisk:
    cachingMode: ReadOnly
    diskName: kubernetes-dynamic-pvc-f959288c-1393-4955-914b-0c4480361c36
    diskURI: /subscriptions/72c299a4-a431-4b8e-80ef-6855109979d9/resourceGroups/mc_alexrg_alex-eastus_eastus/providers/Microsoft.Compute/disks/kubernetes-dynamic-pvc-f959288c-1393-4955-914b-0c4480361c36
    fsType: ""
    kind: Managed
    readOnly: false
  capacity:
    storage: 2Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: nginx-data
    namespace: nginx
    resourceVersion: "2602970"
    uid: f959288c-1393-4955-914b-0c4480361c36
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: failure-domain.beta.kubernetes.io/region
          operator: In
          values:
          - eastus
        - key: failure-domain.beta.kubernetes.io/zone
          operator: In
          values:
          - eastus-1
  persistentVolumeReclaimPolicy: Delete
  storageClassName: default
  volumeMode: Filesystem
status:
  phase: Bound
```

Content of PV on restore cluster
```
kr get pv pvc-2bfaa9bd-f43f-456d-88b6-979d2d67e59e -oyaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/bound-by-controller: "yes"
    pv.kubernetes.io/provisioned-by: kubernetes.io/azure-disk
    volumehelper.VolumeDynamicallyCreatedByKey: azure-disk-dynamic-provisioner
  creationTimestamp: "2021-12-03T05:55:41Z"
  finalizers:
  - kubernetes.io/pv-protection
  labels:
    failure-domain.beta.kubernetes.io/region: westus2
    failure-domain.beta.kubernetes.io/zone: westus2-3
  name: pvc-2bfaa9bd-f43f-456d-88b6-979d2d67e59e
  resourceVersion: "260292"
  uid: f4150545-31c6-4c87-b678-bab8a92b2312
spec:
  accessModes:
  - ReadWriteOnce
  azureDisk:
    cachingMode: ReadOnly
    diskName: kubernetes-dynamic-pvc-2bfaa9bd-f43f-456d-88b6-979d2d67e59e
    diskURI: /subscriptions/72c299a4-a431-4b8e-80ef-6855109979d9/resourceGroups/mc_alexrg_alex-westus2_westus2/providers/Microsoft.Compute/disks/kubernetes-dynamic-pvc-2bfaa9bd-f43f-456d-88b6-979d2d67e59e
    fsType: ""
    kind: Managed
    readOnly: false
  capacity:
    storage: 2Gi
  claimRef:
    apiVersion: v1
    kind: PersistentVolumeClaim
    name: nginx-data
    namespace: rest-test5
    resourceVersion: "260282"
    uid: 2bfaa9bd-f43f-456d-88b6-979d2d67e59e
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: failure-domain.beta.kubernetes.io/region
          operator: In
          values:
          - westus2
        - key: failure-domain.beta.kubernetes.io/zone
          operator: In
          values:
          - westus2-3
  persistentVolumeReclaimPolicy: Delete
  storageClassName: default
  volumeMode: Filesystem
status:
  phase: Bound
prashanthkumar@prashanthkumar--MacBookPr

```
