### PR TITLE
pb-2101: Fixed the issue in isCSISnapshotClassRequired function such that for non CSI volumes, it will directly go the kdmp backup

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -198,17 +198,7 @@ func isCSISnapshotClassRequired(pvc *v1.PersistentVolumeClaim) bool {
 		// So added check. For other we will try to create CSI snapshot and if it fails, we will take generic backup.
 		return true
 	}
-	// TODO: If storage class is not present, need to make volume inspect call to portworx and check.
-	storageClassName := k8shelper.GetPersistentVolumeClaimClass(pvc)
-	if storageClassName != "" {
-		storageClass, err := storage.Instance().GetStorageClass(storageClassName)
-		if err == nil {
-			if _, ok := storageClass.Parameters[proxyEndpoint]; ok {
-				return false
-			}
-		}
-	}
-	return true
+	return false
 }
 
 func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,

--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -108,6 +108,9 @@ func (c *csiDriver) CreateSnapshot(opts ...Option) (string, string, string, erro
 		// for this snapshot. If none is set then the volume snapshot will fail
 		o.SnapshotClassName = ""
 	} else {
+		if pv.Spec.CSI == nil {
+			return "", "", "", fmt.Errorf("pv [%v] does not contain CSI section", pv.Name)
+		}
 		// For other snapshot class names ensure the volume snapshot class has
 		// been created
 		if err := c.ensureVolumeSnapshotClassCreated(pv.Spec.CSI.Driver, o.SnapshotClassName); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it**:
bug

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.8

Tested the fix on ocp setup of QA.
