### PR TITLE
[PB-2104]: Using "," as the delimiter for the composite string of volumesnapshot.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -315,7 +315,7 @@ func (k *kdmp) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.
 				} else {
 					volumeSnapshot := k.getSnapshotClassName(backup)
 					if len(volumeSnapshot) > 0 {
-						vInfo.VolumeSnapshot = fmt.Sprintf("%s.%s", volumeSnapshot, dataExport.Status.VolumeSnapshot)
+						vInfo.VolumeSnapshot = fmt.Sprintf("%s,%s", volumeSnapshot, dataExport.Status.VolumeSnapshot)
 					}
 				}
 			}
@@ -904,8 +904,8 @@ func getVolumeSnapshotClassFromBackupVolumeInfo(bkvpInfo *storkapi.ApplicationBa
 	if bkvpInfo.VolumeSnapshot == "" {
 		return vsClass
 	}
-	subStrings := strings.Split(bkvpInfo.VolumeSnapshot, ".")
-	vsClass = strings.Join(subStrings[0:len(subStrings)-1], ".")
+	subStrings := strings.Split(bkvpInfo.VolumeSnapshot, ",")
+	vsClass = strings.Join(subStrings[0:len(subStrings)-1], ",")
 
 	return vsClass
 }


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
As volumesnapshotclass name and pvc name can contain ".", using "," as the delimeter for forming the composite string for volumesnapshot.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 2.8.2
-->

Tested:

1.Backup
2.Restore
3.Delete

backup
<img width="1773" alt="Screenshot 2021-12-06 at 8 06 59 PM" src="https://user-images.githubusercontent.com/51692470/144877316-6e1085cc-5089-4e77-bde5-72532bd901ea.png">

restore
<img width="1771" alt="Screenshot 2021-12-06 at 8 11 10 PM" src="https://user-images.githubusercontent.com/51692470/144877374-4cca34a3-4a45-4fe7-916b-ac4c0091bf68.png">

