### PR TITLE
pb-2110: Fixed the issue in return value of IsCSIDriverWithoutSnapshotSupport api for non-csi case

### DIFF
--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -738,6 +738,7 @@ func IsCSIDriverWithoutSnapshotSupport(pv *v1.PersistentVolume) bool {
 				}
 			}
 		}
+		return false
 	}
-	return false
+	return true
 }


### PR DESCRIPTION
**What type of PR is this?**
> bug

**What this PR does / why we need it**:
pb-2110: Fixed the issue in return value of IsCSIDriverWithoutSnapshotSupport api for non-csi case

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.8
Testing:
- Tested it on the QA system where it was failing. Now backup went through for azure file SC.
```
[root@ip-70-0-76-117 ~]# kubectl describe sc azurefile
Name:                  azurefile
IsDefaultClass:        No
Annotations:           <none>
Provisioner:           kubernetes.io/azure-file
Parameters:            skuName=Standard_LRS
AllowVolumeExpansion:  True
MountOptions:
  mfsymlinks
  actimeo=30
ReclaimPolicy:      Delete
VolumeBindingMode:  Immediate
Events:             <none>
[root@ip-70-0-76-117 ~]#
```
![Screenshot 2021-12-08 at 7 24 00 PM](https://user-images.githubusercontent.com/52188641/145221941-3c1b0353-89b8-49f0-8d22-1a8d4b111378.png)

