### PR TITLE
vendoring in latest kdmp.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.0
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
-	github.com/portworx/kdmp v0.4.1-0.20211203152743-0f6d3019a80f
+	github.com/portworx/kdmp v0.4.1-0.20211209055933-05337ade13d2
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20211116074603-2b6905763b23
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1142,6 +1142,8 @@ github.com/portworx/kdmp v0.4.1-0.20211129123505-52090dfc4813 h1:EX+Xl60VCKP+o/O
 github.com/portworx/kdmp v0.4.1-0.20211129123505-52090dfc4813/go.mod h1:RAXbeaO/JmwQPRJCDdOoY/UsmGPY/awWsL4FbDOqAVk=
 github.com/portworx/kdmp v0.4.1-0.20211203152743-0f6d3019a80f h1:8DDtPCE86fgJIGlnWNjMqipgN3HDQzXGh2R5NRhVq5M=
 github.com/portworx/kdmp v0.4.1-0.20211203152743-0f6d3019a80f/go.mod h1:RAXbeaO/JmwQPRJCDdOoY/UsmGPY/awWsL4FbDOqAVk=
+github.com/portworx/kdmp v0.4.1-0.20211209055933-05337ade13d2 h1:B/AOEHs85X9yaWJDrY0/ltLa+tHTvLSkItluDnc1VqI=
+github.com/portworx/kdmp v0.4.1-0.20211209055933-05337ade13d2/go.mod h1:RAXbeaO/JmwQPRJCDdOoY/UsmGPY/awWsL4FbDOqAVk=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20191223203141-f42097b1fcd8/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200311180812-b2c72382d652 h1:NElBL34RIHlZKGtDVXT/srxuVZ1+tqmnCdm1K+MC+fU=

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/dataexport.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/dataexport.go
@@ -11,6 +11,7 @@ import (
 	"github.com/portworx/kdmp/pkg/utils"
 	"github.com/portworx/kdmp/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
+	"github.com/portworx/sched-ops/k8s/kdmp"
 	"github.com/sirupsen/logrus"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -73,8 +74,7 @@ func (c *Controller) Init(mgr manager.Manager) error {
 func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	logrus.Tracef("Reconciling DataExport %s/%s", request.Namespace, request.Name)
 
-	dataExport := &kdmpapi.DataExport{}
-	err := c.client.Get(context.TODO(), request.NamespacedName, dataExport)
+	dataExport, err := kdmp.Instance().GetDataExport(request.Name, request.Namespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -425,7 +425,7 @@ github.com/pierrec/lz4/internal/xxh32
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20211203152743-0f6d3019a80f
+# github.com/portworx/kdmp v0.4.1-0.20211209055933-05337ade13d2
 ## explicit
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
vendoring in kdmp changes for reading dataexport CR using schedops api.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 2.8
-->

