### PR TITLE
pb-2116: Added kubernetes.io/azure-file provison in csiDriverWithoutSnapshotSupport 

### DIFF
--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -34,12 +34,15 @@ const (
 	// LinstorDriverName is the name of the Linstor driver implementation
 	LinstorDriverName = "linstor"
 	// KDMPDriverName is the name of the kdmp driver implementation
-	KDMPDriverName              = "kdmp"
-	pureCSIProvisioner          = "pure-csi"
-	vSphereCSIProvisioner       = "csi.vsphere.vmware.com"
-	efsCSIProvisioner           = "efs.csi.aws.com"
-	azureFileCSIProvisioner     = "file.csi.azure.com"
-	googleFileCSIProvisioner    = "com.google.csi.filestore"
+	KDMPDriverName             = "kdmp"
+	pureCSIProvisioner         = "pure-csi"
+	vSphereCSIProvisioner      = "csi.vsphere.vmware.com"
+	efsCSIProvisioner          = "efs.csi.aws.com"
+	azureFileCSIProvisioner    = "file.csi.azure.com"
+	azureFileIntreeProvisioner = "kubernetes.io/azure-file"
+	googleFileCSIProvisioner   = "com.google.csi.filestore"
+	// Note: filestore.csi.storage.gke.io this provisoner supports snapshot. So not adding in csiDriverWithoutSnapshotSupport list
+	gkeFileCSIProvisioner       = "filestore.csi.storage.gke.io"
 	pureBackendParam            = "backend"
 	pureFileParam               = "file"
 	csiDriverWithOutSnapshotKey = "CSI_DRIVER_WITHOUT_SNAPSHOT"
@@ -59,7 +62,13 @@ var (
 		CSIDriverName,
 		KDMPDriverName,
 	}
-	csiDriverWithoutSnapshotSupport = []string{vSphereCSIProvisioner, efsCSIProvisioner, azureFileCSIProvisioner, googleFileCSIProvisioner}
+	csiDriverWithoutSnapshotSupport = []string{
+		vSphereCSIProvisioner,
+		efsCSIProvisioner,
+		azureFileCSIProvisioner,
+		azureFileIntreeProvisioner,
+		googleFileCSIProvisioner,
+	}
 )
 
 // Driver defines an external volume driver interface.

--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -99,6 +99,11 @@ func (c *csiDriver) CreateSnapshot(opts ...Option) (string, string, string, erro
 		return "", "", "", fmt.Errorf("error getting pv %v: %v", pvName, err)
 	}
 
+	// In case the PV does not contain CSI secion itself, we will error out.
+	if pv.Spec.CSI == nil {
+		return "", "", "", fmt.Errorf("pv [%v] does not contain CSI section", pv.Name)
+	}
+
 	if o.SnapshotClassName == "" {
 		return "", "", "", fmt.Errorf("snapshot class cannot be empty, use 'default' to choose the default snapshot class")
 	}
@@ -108,9 +113,6 @@ func (c *csiDriver) CreateSnapshot(opts ...Option) (string, string, string, erro
 		// for this snapshot. If none is set then the volume snapshot will fail
 		o.SnapshotClassName = ""
 	} else {
-		if pv.Spec.CSI == nil {
-			return "", "", "", fmt.Errorf("pv [%v] does not contain CSI section", pv.Name)
-		}
 		// For other snapshot class names ensure the volume snapshot class has
 		// been created
 		if err := c.ensureVolumeSnapshotClassCreated(pv.Spec.CSI.Driver, o.SnapshotClassName); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
 pb-2116: Added kubernetes.io/azure-file provison in
    csiDriverWithoutSnapshotSupport

        - moved the check to pv.Spec.CSI secion in CreateSnapshot up,
          immediately after getting the pv content.
        - Added a note to mention that filestore.csi.storage.gke.io gke
          filestore support snapshot.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.8 release branch

