### PR TITLE
pb-2113: Setting storageclass to nil in pvc, if it is empty.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -514,6 +514,13 @@ func (k *kdmp) getRestorePVCs(
 			if val, ok := restore.Spec.StorageClassMapping[sc]; ok {
 				pvc.Spec.StorageClassName = &val
 			}
+			// If pvc storageClassName is empty, we want to pick up the
+			// default storageclass configured on the cluster.
+			// Default storage class will not selected, if the storageclass
+			// is empty. So setting it to nil.
+			if len(*pvc.Spec.StorageClassName) == 0 {
+				pvc.Spec.StorageClassName = nil
+			}
 			pvc.Spec.VolumeName = ""
 			if pvc.Annotations != nil {
 				delete(pvc.Annotations, bindCompletedKey)


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
pb-2113: Setting storageclass to nil in pvc, if it is empty.

        - The default storageclass configured on the setup, will be
          picked up, only when the storageclass is not set.
        - Emptystring as pvc storageclass will not select
              the default storageclass configured on the cluster.
```
**Does this PR change a user-facing CRD or CLI?**:
No
**Is a release note needed?**:
No
**Does this change need to be cherry-picked to a release branch?**:
2.8 release branch

**Testing:**
- Now the default storageclass is selected.
- The failure is because of access-mode issue, which is a known issue.
- Some cleanup in error message is needed in kdmp controller. Will raise a kdmp PR seperately.

**Note:**
```
root@ip-70-0-97-59:~# kubectl  get sc
NAME                 PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
csi-gce-pd           pd.csi.storage.gke.io          Delete          WaitForFirstConsumer   false                  9d
csi-gce-pd-ntfs      pd.csi.storage.gke.io          Delete          WaitForFirstConsumer   false                  9d
premium-rwo          pd.csi.storage.gke.io          Delete          WaitForFirstConsumer   true                   11d
premium-rwx          filestore.csi.storage.gke.io   Delete          WaitForFirstConsumer   true                   9d
standard (default)   kubernetes.io/gce-pd           Delete          Immediate              true                   11d
standard-rwo         pd.csi.storage.gke.io          Delete          WaitForFirstConsumer   true                   11d
standard-rwx         filestore.csi.storage.gke.io   Delete          WaitForFirstConsumer   true                   9d
root@ip-70-0-97-59:~#
```

```root@ip-70-0-97-59:~# kubectl  get pvc -n siva-res-no-sc-4
NAME                STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
filestore-nfs-pvc   Pending                                      standard       21m
root@ip-70-0-97-59:~# kubectl  describe pvc filestore-nfs-pvc -n siva-res-no-sc-4
Name:          filestore-nfs-pvc
Namespace:     siva-res-no-sc-4
StorageClass:  standard
Status:        Pending
Volume:
Labels:        <none>
Annotations:   stork.libopenstorage.org/created-by: stork.libopenstorage.org/kdmp
               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/gce-pd
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason              Age                   From                         Message
  ----     ------              ----                  ----                         -------
  Warning  ProvisioningFailed  3m34s (x17 over 25m)  persistentvolume-controller  Failed to provision volume with StorageClass "standard": invalid AccessModes [ReadWriteMany]: only AccessModes [ReadWriteOnce ReadOnlyMany] are supported
root@ip-70-0-97-59:~#
```
![Screenshot 2021-12-11 at 10 11 52 PM](https://user-images.githubusercontent.com/52188641/145684539-375d0eb9-b032-452c-8bc8-2f62dee2d2a9.png)

![Screenshot 2021-12-11 at 10 13 19 PM](https://user-images.githubusercontent.com/52188641/145684600-b90df406-9218-4e1e-a95b-00366bc6f67e.png)

https://kubernetes.io/blog/2017/03/dynamic-provisioning-and-storage-classes-kubernetes/
