### PR TITLE
pb-2125: Added check for nil SC in getRestorePVCs

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -518,8 +518,10 @@ func (k *kdmp) getRestorePVCs(
 			// default storageclass configured on the cluster.
 			// Default storage class will not selected, if the storageclass
 			// is empty. So setting it to nil.
-			if len(*pvc.Spec.StorageClassName) == 0 {
-				pvc.Spec.StorageClassName = nil
+			if pvc.Spec.StorageClassName != nil {
+				if len(*pvc.Spec.StorageClassName) == 0 {
+					pvc.Spec.StorageClassName = nil
+				}
 			}
 			pvc.Spec.VolumeName = ""
 			if pvc.Annotations != nil {


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
pb-2125: Added check for nil SC in getRestorePVCs

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
no
**Does this change need to be cherry-picked to a release branch?**:
2.8
Testing: 
In Tripti's setup, the pvc in the cassandra namespace was not having SC in the spec but had SC in the annotation. Because of that when she selected default option in the restore, we end up in nil SC. 
So added nil check where we are checking for empty SC.
```
[root@ip-70-0-76-117 ~]# kubectl get pvc cassandra-data-cassandra-0 -n cassandra -o yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-class: azurefile-csi-premium
    volume.beta.kubernetes.io/storage-provisioner: file.csi.azure.com
  creationTimestamp: "2021-12-07T18:42:04Z"
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    app: cassandra
  name: cassandra-data-cassandra-0
  namespace: cassandra
  resourceVersion: "159647"
  uid: 398cb028-1c9e-4b47-a2e8-e6864099a704
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 500Gi
  volumeMode: Filesystem
  volumeName: pvc-398cb028-1c9e-4b47-a2e8-e6864099a704
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 500Gi
  phase: Bound
[root@ip-70-0-76-117 ~]#
```