### PR TITLE
Set the new storage class on the PVC during ApplicationRestore

### DIFF
--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -541,6 +541,7 @@ func (a *ApplicationCloneController) prepareResources(
 			objects,
 			nil,
 			namespaceMapping,
+			nil, // no support for storage class mapping
 			pvNameMappings,
 			clone.Spec.IncludeOptionalResourceTypes,
 			nil,

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -527,6 +527,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 						objects,
 						objectMap,
 						restore.Spec.NamespaceMapping,
+						nil, // no need to set storage class mappings at this stage
 						nil,
 						restore.Spec.IncludeOptionalResourceTypes,
 						nil,
@@ -1136,6 +1137,7 @@ func (a *ApplicationRestoreController) applyResources(
 			objects,
 			objectMap,
 			restore.Spec.NamespaceMapping,
+			restore.Spec.StorageClassMapping,
 			pvNameMappings,
 			restore.Spec.IncludeOptionalResourceTypes,
 			restore.Status.Volumes,

--- a/pkg/resourcecollector/persistentvolumeclaim.go
+++ b/pkg/resourcecollector/persistentvolumeclaim.go
@@ -50,6 +50,7 @@ func (r *ResourceCollector) preparePVCResourceForApply(
 	object runtime.Unstructured,
 	allObjects []runtime.Unstructured,
 	pvNameMappings map[string]string,
+	storageClassMappings map[string]string,
 ) (bool, error) {
 	var pvc v1.PersistentVolumeClaim
 	var updatedName string
@@ -70,6 +71,11 @@ func (r *ResourceCollector) preparePVCResourceForApply(
 		}
 	}
 	pvc.Spec.VolumeName = updatedName
+	if len(storageClassMappings) > 0 && pvc.Spec.StorageClassName != nil {
+		if newSc, exists := storageClassMappings[*pvc.Spec.StorageClassName]; exists && len(newSc) > 0 {
+			pvc.Spec.StorageClassName = &newSc
+		}
+	}
 	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pvc)
 	if err != nil {
 		return false, err

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -708,6 +708,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 	allObjects []runtime.Unstructured,
 	includeObjects map[stork_api.ObjectInfo]bool,
 	namespaceMappings map[string]string,
+	storageClassMappings map[string]string,
 	pvNameMappings map[string]string,
 	optionalResourceTypes []string,
 	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
@@ -750,7 +751,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 	case "PersistentVolume":
 		return r.preparePVResourceForApply(object, pvNameMappings, vInfo)
 	case "PersistentVolumeClaim":
-		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings)
+		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings, storageClassMappings)
 	case "ClusterRoleBinding":
 		return false, r.prepareClusterRoleBindingForApply(object, namespaceMappings)
 	case "RoleBinding":


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
During an ApplicationRestore, if the storage class mapping was provided, stork would not set the new
storage class on the destination side where the PVC was being restored

- If the storage class mapping is set on ApplicationRestore on the PVC's
source storage class is found in this mapping, then on the destination cluster where
the PVC is being recreated set the new storage class obtained from this mapping.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
Improvement: STORK now supports choosing a different storage class for a PVC which is being restored using the ApplicationRestore CR. This is currently supported only for Portworx and KDMP driver
User Impact: Users can backup a Portworx volume that was created using a specific storage class and volume parameters and restore it to a Portworx volume with a different storage and respective volume parameters. For ex. A repl=3 Portworx volume can be backed up and restored in to a repl=2 Portworx volume
```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.8

