### PR TITLE
Select only PVC's from includeResource if provided

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -470,7 +470,6 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 			backupVolumeInfoMappings[volumeBackup.DriverName] = append(backupVolumeInfoMappings[volumeBackup.DriverName], volumeBackup)
 		}
 	}
-
 	if restore.Status.Volumes == nil {
 		restore.Status.Volumes = make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
 	}
@@ -497,7 +496,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 
 			// Skip pv/pvc if replacepolicy is set to retain to avoid creating
 			if restore.Spec.ReplacePolicy == storkapi.ApplicationRestoreReplacePolicyRetain {
-				backupVolInfos, existingRestoreVolInfos, err = a.skipVolumesFromRestoreList(backup, restore, objects, driver)
+				backupVolInfos, existingRestoreVolInfos, err = a.skipVolumesFromRestoreList(restore, objects, driver, vInfos)
 				if err != nil {
 					log.ApplicationRestoreLog(restore).Errorf("Error while checking pvcs: %v", err)
 					return err
@@ -993,14 +992,14 @@ func isGenericCSIPersistentVolumeClaim(pvc *v1.PersistentVolumeClaim, volInfos [
 }
 
 func (a *ApplicationRestoreController) skipVolumesFromRestoreList(
-	backup *storkapi.ApplicationBackup,
 	restore *storkapi.ApplicationRestore,
 	objects []runtime.Unstructured,
 	driver volume.Driver,
+	volInfo []*storkapi.ApplicationBackupVolumeInfo,
 ) ([]*storkapi.ApplicationBackupVolumeInfo, []*storkapi.ApplicationRestoreVolumeInfo, error) {
 	existingInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
 	newVolInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
-	for _, bkupVolInfo := range backup.Status.Volumes {
+	for _, bkupVolInfo := range volInfo {
 		restoreVolInfo := &storkapi.ApplicationRestoreVolumeInfo{}
 		val, ok := restore.Spec.NamespaceMapping[bkupVolInfo.Namespace]
 		if !ok {


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
 As part of restore if a user selects a few PVC's to be restored, filter the
     non-selected PVCs from includeResource map. This is applicable for
     the case where Retain is selected.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.8

Screen shot with fix
Backup Object

![Screenshot 2021-12-14 at 6 34 59 PM (2)](https://user-images.githubusercontent.com/51692473/146005058-880b2c95-d9ca-4185-bf37-6c563cb200b9.png)

Restore object with single PVC succeeded
![Screenshot 2021-12-14 at 6 33 45 PM (2)](https://user-images.githubusercontent.com/51692473/146005112-e0d91742-5ead-4df9-9270-b8a98989257a.png)
