### PR TITLE
STOR-516 only try to create a clusterpair if a token is provided

### DIFF
--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -107,7 +107,7 @@ func (c *ClusterPairController) handle(ctx context.Context, clusterPair *stork_a
 		return nil
 	}
 
-	if len(clusterPair.Spec.Options) == 0 {
+	if _, ok := clusterPair.Spec.Options["token"]; !ok {
 		clusterPair.Status.StorageStatus = stork_api.ClusterPairStatusNotProvided
 		c.recorder.Event(clusterPair,
 			v1.EventTypeNormal,


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
Stork will try to create a clusterpair if there are ANY storage options provided, and our docs suggest adding 'mode: DisasterRecovery'. Which causes the storage status to ERROR in a Metro DR pair, when it should be notProvided. I made it so we only attempt to create a pair if a token is provided.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
