### PR TITLE
[PB-2133]: Checking for waitforfirstConsumer if pvc's storage class has that set as volumebindingmode.

### DIFF
--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -16,13 +16,16 @@ import (
 	"github.com/libopenstorage/stork/pkg/crypto"
 	"github.com/libopenstorage/stork/pkg/objectstore"
 	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/sched-ops/k8s/storage"
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	k8shelper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
 
 const (
@@ -362,6 +365,10 @@ func (c *csiDriver) RestoreStatus(pvcName, namespace string) (RestoreInfo, error
 	}
 
 	switch {
+	case c.pvcWaitingForFirstConsumer(pvc):
+		restoreInfo.VolumeName = pvc.Spec.VolumeName
+		restoreInfo.Size = size
+		restoreInfo.Status = StatusReady
 	case c.pvcBindFinished(pvc):
 		restoreInfo.VolumeName = pvc.Spec.VolumeName
 		restoreInfo.Size = size
@@ -525,6 +532,21 @@ func (c *csiDriver) pvcBindFinished(pvc *v1.PersistentVolumeClaim) bool {
 	bindCompleted := pvc.Annotations[annPVBindCompleted]
 	boundByController := pvc.Annotations[annPVBoundByController]
 	return pvc.Status.Phase == v1.ClaimBound && bindCompleted == "yes" && boundByController == "yes"
+}
+
+func (c *csiDriver) pvcWaitingForFirstConsumer(pvc *v1.PersistentVolumeClaim) bool {
+	var sc *storagev1.StorageClass
+	var err error
+	storageClassName := k8shelper.GetPersistentVolumeClaimClass(pvc)
+	if storageClassName != "" {
+		sc, err = storage.Instance().GetStorageClass(storageClassName)
+		if err != nil {
+			logrus.Warnf("did not get the storageclass %s for pvc %s/%s, err: %v", storageClassName, pvc.Namespace, pvc.Name, err)
+			return false
+		}
+		return *sc.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer
+	}
+	return false
 }
 
 func (c *csiDriver) getSnapshotContentError(vscName string) string {


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
In case of restores from csi snapshot if the pvc is in pending state but storage class volumebindingmode is set as
WaitForFirstConsumer, restore status is declared successful.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: If csi restore fails with timeout because pvc was remaining in pending state waiting for the first consumer.
User Impact:
Resolution: Now the pvc restore status will be successful which will in turn get consumed by the app.

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.8 .
-->

**Test**
1. Tested with generic backup/restore of an elasticsearch ns having `pd.csi.storage.gke.io` as storage class provisioner.
2. Also tested csi backup/restore of pure-block volumes.
