### PR TITLE
pb-2151: Added check to make sure zone array is not empty in preparePVCResourceForApply

### DIFF
--- a/pkg/resourcecollector/persistentvolumeclaim.go
+++ b/pkg/resourcecollector/persistentvolumeclaim.go
@@ -83,9 +83,14 @@ func (r *ResourceCollector) preparePVCResourceForApply(
 		if vol.PersistentVolumeClaim == pvc.Name {
 			for _, node := range nodes.Items {
 				nodeZone := node.Labels[v1.LabelTopologyZone]
-				if nodeZone == vol.Zones[0] {
-					pvc.Annotations[pvutil.AnnSelectedNode] = node.Name
-					break
+				if len(vol.Zones) != 0 {
+					if nodeZone == vol.Zones[0] {
+						if pvc.Annotations == nil {
+							pvc.Annotations = make(map[string]string)
+						}
+						pvc.Annotations[pvutil.AnnSelectedNode] = node.Name
+						break
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
bug
**What this PR does / why we need it**:
pb-2151: Added check to make sure zone array is not empty in preparePVCResourceForApply.
For kdmp, we will not have zones set. So added check for the zone array before accessing it.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
2.8
