### PR TITLE
pb-2156: Added logic to default to KDMP for OCP rdb and cephfs provisioner

### DIFF
--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -36,6 +36,8 @@ const (
 	// KDMPDriverName is the name of the kdmp driver implementation
 	KDMPDriverName             = "kdmp"
 	pureCSIProvisioner         = "pure-csi"
+	ocpCephfsProvisioner       = "openshift-storage.cephfs.csi.ceph.com"
+	ocpRbdProvisioner          = "openshift-storage.rbd.csi.ceph.com"
 	vSphereCSIProvisioner      = "csi.vsphere.vmware.com"
 	efsCSIProvisioner          = "efs.csi.aws.com"
 	azureFileCSIProvisioner    = "file.csi.azure.com"
@@ -723,6 +725,10 @@ func IsCSIDriverWithoutSnapshotSupport(pv *v1.PersistentVolume) bool {
 			if pv.Spec.CSI.VolumeAttributes[pureBackendParam] == pureFileParam {
 				return true
 			}
+		}
+		// For now, it is decided to take generic backup for OCP provisoiners.
+		if driverName == ocpCephfsProvisioner || driverName == ocpRbdProvisioner {
+			return true
 		}
 		// vsphere, efs, azure file and google file does not support snapshot.
 		// So defaulting to kdmp by not setting volumesnapshot class.


### PR DESCRIPTION
**What type of PR is this?**
bug
**What this PR does / why we need it**:
pb-2156: Added logic to default to KDMP for OCP rdb and cephfs provisioner.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
Yes
```release-note
Issue: On some OCP setup, we hit timeout for clone(restore) operation.
User Impact: User will not be able to take backup on OCP setup.
Resolution: For now, default to generic, if it is OCP provisioner.

```

**Does this change need to be cherry-picked to a release branch?**:
2.8 branch

**Testing:**
Testing on the OCP that it is default to the KDMP directly.
