### PR TITLE
pb-2157: retaining the rolebinding subjects if the namespace is not set during restore.

### DIFF
--- a/pkg/resourcecollector/role.go
+++ b/pkg/resourcecollector/role.go
@@ -3,6 +3,7 @@ package resourcecollector
 import (
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,10 +42,24 @@ func (r *ResourceCollector) prepareRoleBindingForApply(
 	if err != nil {
 		return err
 	}
+	subjectWithNs := make([]rbacv1.Subject, 0)
+	subjectWithoutNs := make([]rbacv1.Subject, 0)
+	// Create list of rolebinding subjects that has namspace and pass it to updateSubject to
+	// update destination namespace based on the namespace mapping.
+	for _, subject := range rb.Subjects {
+		if len(subject.Namespace) != 0 {
+			subjectWithNs = append(subjectWithNs, subject)
+		} else {
+			subjectWithoutNs = append(subjectWithoutNs, subject)
+		}
+	}
+	rb.Subjects = subjectWithNs
 	rb.Subjects, err = r.updateSubjects(rb.Subjects, namespaceMappings)
 	if err != nil {
 		return err
 	}
+	rb.Subjects = append(rb.Subjects, subjectWithoutNs...)
+	logrus.Infof("sivakumar --- update rb subjects %+v", rb.Subjects)
 	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&rb)
 	if err != nil {
 		return err

--- a/pkg/resourcecollector/role.go
+++ b/pkg/resourcecollector/role.go
@@ -3,7 +3,6 @@ package resourcecollector
 import (
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -59,7 +58,6 @@ func (r *ResourceCollector) prepareRoleBindingForApply(
 		return err
 	}
 	rb.Subjects = append(rb.Subjects, subjectWithoutNs...)
-	logrus.Infof("sivakumar --- update rb subjects %+v", rb.Subjects)
 	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&rb)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
pb-2157: retaining the rolebinding subjects if the namespace is not set during restore.

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
Issue: subject of rolebinding that does not have namespaces were not getting restored.
User Impact: Subjects in the rolebinding are missing after restore.
Resolution: Currently retaining the subject if they do not have namespace

**Does this change need to be cherry-picked to a release branch?**:
2.8

```
source namespace:
[root@central-legend-seed-0 ~]# kubectl  describe  rolebindings px-backup-role-binding -n central
Name:         px-backup-role-binding
Labels:       app.kubernetes.io/component=px-backup
              app.kubernetes.io/instance=px-central
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=px-central
              app.kubernetes.io/version=2.1.1
              helm.sh/chart=px-central-2.1.1
Annotations:  meta.helm.sh/release-name: px-central
              meta.helm.sh/release-namespace: central
Role:
  Kind:  Role
  Name:  px-backup-role
Subjects:
  Kind            Name                 Namespace
  ----            ----                 ---------
  ServiceAccount  px-backup-account    central
  ServiceAccount  px-backup-account-1
[root@central-legend-seed-0 ~]#
```
```
restored namespace:
[root@central-legend-seed-0 ~]# kubectl  describe  rolebindings -n jan13-res6
Name:         px-backup-role-binding
Labels:       app.kubernetes.io/component=px-backup
              app.kubernetes.io/instance=px-central
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=px-central
              app.kubernetes.io/version=2.1.1
              helm.sh/chart=px-central-2.1.1
Annotations:  meta.helm.sh/release-name: px-central
              meta.helm.sh/release-namespace: central
Role:
  Kind:  Role
  Name:  px-backup-role
Subjects:
  Kind            Name                 Namespace
  ----            ----                 ---------
  ServiceAccount  px-backup-account    jan13-res6
  ServiceAccount  px-backup-account-1
[root@central-legend-seed-0 ~]#
```