### PR TITLE
[PB-2148]: Implementing job framework to make pvc bound in case of waitforfirstconsumer case for generic backups.

### DIFF
--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -15,12 +15,17 @@ import (
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/crypto"
 	"github.com/libopenstorage/stork/pkg/objectstore"
+	"github.com/portworx/kdmp/pkg/drivers/utils"
+	"github.com/portworx/sched-ops/k8s/batch"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/storage"
+	"github.com/portworx/sched-ops/task"
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -35,6 +40,7 @@ const (
 	snapshotClassNamePrefix = "stork-csi-snapshot-class-"
 	annPVBindCompleted      = "pv.kubernetes.io/bind-completed"
 	annPVBoundByController  = "pv.kubernetes.io/bound-by-controller"
+	skipResourceAnnotation  = "stork.libopenstorage.org/skip-resource"
 
 	// snapshotTimeout represents the duration to wait before timing out on snapshot completion
 	snapshotTimeout = time.Minute * 5
@@ -46,6 +52,15 @@ const (
 	snapDeleteAnnotation = "snapshotScheduledForDeletion"
 	// snapRestoreAnnotation needs to be set if volume snapshot is scheduled for restore
 	snapRestoreAnnotation = "snapshotScheduledForRestore"
+	// kdmp config map
+	kdmpConfig = "kdmp-config"
+	// pvcNameLenLimitForJob is the max length of PVC name that the bound job
+	// will incorporate in their names
+	pvcNameLenLimitForJob = 237
+	// shortRetryTimeout gets used for retry timeout
+	shortRetryTimeout = 30 * time.Second
+	// shortRetryTimeout gets used for retry timeout interval
+	shortRetryTimeoutInterval = 2 * time.Second
 )
 
 type csiBackupObject struct {
@@ -316,7 +331,7 @@ func (c *csiDriver) RestoreVolumeClaim(opts ...Option) (*v1.PersistentVolumeClai
 	}
 
 	// Make the pvc size  same as the restore size from the volumesnapshot
-	if !snapshot.Status.RestoreSize.IsZero() {
+	if snapshot.Status.RestoreSize != nil && !snapshot.Status.RestoreSize.IsZero() {
 		quantity, err := resource.ParseQuantity(snapshot.Status.RestoreSize.String())
 		if err != nil {
 			return nil, err
@@ -382,11 +397,11 @@ func (c *csiDriver) RestoreStatus(pvcName, namespace string) (RestoreInfo, error
 	}
 
 	switch {
-	case c.pvcWaitingForFirstConsumer(pvc):
-		restoreInfo.VolumeName = pvc.Spec.VolumeName
-		restoreInfo.Size = size
-		restoreInfo.Status = StatusReady
 	case c.pvcBindFinished(pvc):
+		err := c.deletejob(pvc, namespace)
+		if err != nil {
+			restoreInfo.Reason = fmt.Sprintf("Delete job for volume bind for PVC %s failed: %v", pvc.Name, err)
+		}
 		restoreInfo.VolumeName = pvc.Spec.VolumeName
 		restoreInfo.Size = size
 		restoreInfo.Status = StatusReady
@@ -397,6 +412,12 @@ func (c *csiDriver) RestoreStatus(pvcName, namespace string) (RestoreInfo, error
 		restoreInfo.Size = size
 		restoreInfo.Status = StatusInProgress
 		restoreInfo.Reason = formatReasonErrorMessage(fmt.Sprintf("Volume restore in progress: PVC %s is pending", pvc.Name), vsError, vscError)
+		if c.pvcWaitingForFirstConsumer(pvc) {
+			_, err := c.createJob(pvc, namespace)
+			if err != nil {
+				restoreInfo.Reason = fmt.Sprintf("Create job for volume bind for PVC %s failed: %v", pvc.Name, err)
+			}
+		}
 	}
 
 	if time.Now().After(pvc.CreationTimestamp.Add(restoreTimeout)) {
@@ -916,18 +937,23 @@ func (c *csiDriver) RetainLocalSnapshots(
 				}
 			}
 
-			if index < len(vsCRList)-localCSIRetention {
-				retain = false
-			} else {
-				retain = true
+			// Waiting for vs to get bound with vsc as in cleanup path by the time deletesnapshot is running,
+			// vsc may not be bound to vs.
+			err = c.waitForVolumeSnapshotBound(vs, namespace)
+			if err == nil {
+				if index < len(vsCRList)-localCSIRetention {
+					retain = false
+				} else {
+					retain = true
+				}
+				err = c.DeleteSnapshot(
+					vs.Name,
+					namespace,
+					retain, // retain snapshot content
+				)
 			}
-			err = c.DeleteSnapshot(
-				vs.Name,
-				namespace,
-				retain, // retain snapshot content
-			)
 			if err != nil {
-				return err
+				logrus.Errorf("failed to delete the old snapshot %s: %v", vs.Name, err)
 			}
 			logrus.Debugf("successfully deleted the recreated snapshot resources for snapshot %s/%s", namespace, snapName)
 			if !retain {
@@ -1007,6 +1033,11 @@ func (c *csiDriver) RestoreFromLocalSnapshot(backupLocation *storkapi.BackupLoca
 		}
 	}
 
+	err = c.waitForVolumeSnapshotBound(vs, namespace)
+	if err != nil {
+		return status, fmt.Errorf("volumesnapshot %s failed to get bound: %v", vs.Name, err)
+	}
+
 	// create a new pvc for restore from the snapshot
 	pvc, err = c.RestoreVolumeClaim(
 		RestoreSnapshotName(vs.Name),
@@ -1051,4 +1082,175 @@ func (c *csiDriver) CleanUpRestoredResources(backupLocation *storkapi.BackupLoca
 	}
 
 	return nil
+}
+
+func (c *csiDriver) createJob(pvc *v1.PersistentVolumeClaim, namespace string) (*batchv1.Job, error) {
+	jobName := toBoundJobPVCName(pvc.Name, string(pvc.GetUID()))
+	// if already the job is running or in completed state , no need to rerun the job
+	job, err := batch.Instance().GetJob(jobName, namespace)
+	if err == nil {
+		return job, nil
+	}
+
+	// Setup service account
+	if err := utils.SetupServiceAccount(jobName, namespace, roleFor()); err != nil {
+		errMsg := fmt.Sprintf("error creating service account %s/%s: %v", namespace, jobName, err)
+		logrus.Errorf(errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	jobSpec, err := buildJobSpec(pvc, namespace)
+	if err != nil {
+		errMsg := fmt.Sprintf("error creating job spec %s/%s: %v", namespace, jobName, err)
+		logrus.Errorf(errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	if job, err = batch.Instance().CreateJob(jobSpec); err != nil && !k8s_errors.IsAlreadyExists(err) {
+		errMsg := fmt.Sprintf("creation of job %s failed: %v", jobName, err)
+		logrus.Errorf(errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	return job, nil
+}
+
+func roleFor() *rbacv1.Role {
+	return &rbacv1.Role{
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"security.openshift.io"},
+				Resources:     []string{"securitycontextconstraints"},
+				ResourceNames: []string{"hostaccess"},
+				Verbs:         []string{"use"},
+			},
+		},
+	}
+}
+
+func (c *csiDriver) deletejob(pvc *v1.PersistentVolumeClaim, namespace string) error {
+	jobName := toBoundJobPVCName(pvc.Name, string(pvc.GetUID()))
+	t := func() (interface{}, bool, error) {
+		if err := batch.Instance().DeleteJobWithForce(jobName, namespace); err != nil && !k8s_errors.IsNotFound(err) {
+			return nil, true, fmt.Errorf("deletion of job %s/%s failed: %v", namespace, jobName, err)
+		}
+		if err := utils.CleanServiceAccount(jobName, namespace); err != nil {
+			return nil, true, fmt.Errorf("deletion of service account %s/%s failed: %v", namespace, jobName, err)
+		}
+
+		if _, err := batch.Instance().GetJob(jobName, namespace); err != nil && !k8s_errors.IsNotFound(err) {
+			if err == nil {
+				errMsg := fmt.Sprintf("job %s/%s still exists after deletion: %v", namespace, jobName, err)
+				return nil, true, fmt.Errorf(errMsg)
+			}
+		}
+
+		if _, err := core.Instance().GetServiceAccount(jobName, namespace); err != nil && !k8s_errors.IsNotFound(err) {
+			if err == nil {
+				errMsg := fmt.Sprintf("service account %s/%s still exists after deletion: %v", namespace, jobName, err)
+				return nil, true, fmt.Errorf(errMsg)
+			}
+		}
+
+		pods, err := core.Instance().GetPodsUsingPVC(pvc.Name, namespace)
+		if err == nil && len(pods) > 0 {
+			logrus.Debugf("pvc %s/%s is still getting used by job pod %s", namespace, pvc.Name, pods[0].Name)
+			return nil, true, fmt.Errorf("pvc %s/%s is still getting used by job pod %s", namespace, pvc.Name, pods[0].Name)
+		}
+
+		return nil, false, nil
+	}
+	if _, err := task.DoRetryWithTimeout(t, shortRetryTimeout, shortRetryTimeoutInterval); err != nil {
+		return fmt.Errorf("timed out waiting for cleaning up job %s related resources used for volume bind for pvc: %v", jobName, err)
+	}
+	return nil
+}
+
+func buildJobSpec(
+	pvc *v1.PersistentVolumeClaim,
+	namespace string,
+) (*batchv1.Job, error) {
+	jobName := toBoundJobPVCName(pvc.Name, string(pvc.GetUID()))
+	cmd := strings.Join([]string{
+		"sleep 5",
+	}, " ")
+
+	jobPodBackOffLimit := int32(1)
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				utils.SkipResourceAnnotation: "true",
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &jobPodBackOffLimit,
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					RestartPolicy:      v1.RestartPolicyOnFailure,
+					ImagePullSecrets:   utils.ToImagePullSecret(utils.KopiaExecutorImageSecret(kdmpConfig, "kube-system")),
+					ServiceAccountName: jobName,
+					Containers: []v1.Container{
+						{
+							Name:            "kopiaexecutor",
+							Image:           utils.KopiaExecutorImage(kdmpConfig, "kube-system"),
+							ImagePullPolicy: v1.PullAlways,
+							Command: []string{
+								"/bin/sh",
+								"-x",
+								"-c",
+								cmd,
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      "vol",
+									MountPath: "/data",
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "vol",
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									ClaimName: pvc.Name,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return job, nil
+}
+
+func (c *csiDriver) waitForVolumeSnapshotBound(vs *kSnapshotv1beta1.VolumeSnapshot, namespace string) error {
+	t := func() (interface{}, bool, error) {
+		curVS, err := c.snapshotClient.SnapshotV1beta1().VolumeSnapshots(namespace).Get(context.TODO(), vs.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to get volumesnapshot object %v/%v: %v", namespace, vs.Name, err)
+		}
+		if curVS.Status == nil || curVS.Status.BoundVolumeSnapshotContentName == nil {
+			return nil, true, fmt.Errorf("failed to find get status for snapshot: %s/%s, status: %+v", namespace, vs.Name, vs.Status)
+		}
+		return nil, false, nil
+	}
+	if _, err := task.DoRetryWithTimeout(t, shortRetryTimeout, shortRetryTimeoutInterval); err != nil {
+		return fmt.Errorf("timed out waiting for vs %s to get bound: %v", vs.Name, err)
+	}
+	return nil
+}
+
+func toBoundJobPVCName(pvcName string, pvcUID string) string {
+	truncatedPVCName := pvcName
+	if len(pvcName) > pvcNameLenLimitForJob {
+		truncatedPVCName = pvcName[:pvcNameLenLimitForJob]
+	}
+	uidToken := strings.Split(pvcUID, "-")
+	return fmt.Sprintf("%s-%s-%s", "bound", truncatedPVCName, uidToken[0])
 }


### PR DESCRIPTION
signed-off-by: Diptiranjan

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
If volumebindingmode is WaitForFirstConsumer, in case of csi/generic volume drivers we create the pvc from the local snapshot in case of restore. Now a temp job has been added just to mount the pvc and do nothing more so that we have a real PV associated with the pvc once the volume restore is declared as successful.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
yes, WaitForFirstConsumer as volumebindingmode is supported with generic backup and restores.
-->
```release-note
Issue: Generic backup and restore was failing if volume binding mode was WaitForFirstConsumer and if the volume supports csi snapshots.
User Impact: Generic backup and restore functionality were not working
Resolution: Fixed with the new volume binding job framework

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 2.8
-->

**Test**
Covered following scenarios

1. Generic Backup and restore of csi volumes with snapshotting with volumebinding mode as WaitForFirstConsumer.
2.  Generic Backup and restore of csi volumes with snapshotting with volumebinding mode as immediate.
3. Native backup and restore of gke volumes with snapshotting with volumebinding mode as WaitForFirstConsumer.
