### PR TITLE
STOR-573 apply updatedObjects in parallel during migration

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -189,6 +189,11 @@ func main() {
 			Name:  "kdmp-controller",
 			Usage: "Start the kdmp controller (default: true)",
 		},
+		cli.IntFlag{
+			Name:  "migration-max-threads",
+			Value: 4,
+			Usage: "Max threads for apply resources during migration (default: 4)",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -435,7 +440,7 @@ func runStork(mgr manager.Manager, d volume.Driver, recorder record.EventRecorde
 				Recorder:          recorder,
 				ResourceCollector: resourceCollector,
 			}
-			if err := migration.Init(mgr, adminNamespace); err != nil {
+			if err := migration.Init(mgr, adminNamespace, c.Int("migration-max-threads")); err != nil {
 				log.Fatalf("Error initializing migration: %v", err)
 			}
 		}

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"strconv"
 	"strings"
@@ -1811,6 +1812,10 @@ func (m *MigrationController) applyResources(
 	numObjects := len(updatedObjects)
 	objectChan := make(chan runtime.Unstructured, 100)
 	errorChan := make(chan error, 100)
+
+	// Shuffle Object order before applying so we can get parallelism between resource types
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(updatedObjects), func(i, j int) { updatedObjects[i], updatedObjects[j] = updatedObjects[j], updatedObjects[i] })
 
 	logrus.Infof("Updating %v objects with %v workers", numObjects, m.migrationMaxThreads)
 	for w := 0; w < m.migrationMaxThreads; w++ {

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -21,7 +21,7 @@ type Migration struct {
 }
 
 // Init init
-func (m *Migration) Init(mgr manager.Manager, migrationAdminNamespace string) error {
+func (m *Migration) Init(mgr manager.Manager, migrationAdminNamespace string, migrationMaxThreads int) error {
 	m.clusterPairController = controllers.NewClusterPair(mgr, m.Driver, m.Recorder)
 	err := m.clusterPairController.Init(mgr)
 	if err != nil {
@@ -29,7 +29,7 @@ func (m *Migration) Init(mgr manager.Manager, migrationAdminNamespace string) er
 	}
 
 	m.migrationController = controllers.NewMigration(mgr, m.Driver, m.Recorder, m.ResourceCollector)
-	err = m.migrationController.Init(mgr, migrationAdminNamespace)
+	err = m.migrationController.Init(mgr, migrationAdminNamespace, migrationMaxThreads)
 	if err != nil {
 		return fmt.Errorf("error initializing migration controller: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
improvement


**What this PR does / why we need it**:
Use go routines to parallelize applying resources during migration for improved performance

**Does this PR change a user-facing CRD or CLI?**:
New int arg for stork "migration-max-threads" (default 4)

**Is a release note needed?**:
```release-note
Issue: 
    New "migration-max-threads" arg for stork (default 4) allowing parallel application of  kubernetes resources during migration.
User Impact:
    Improved migration performance for large number of kubernetes resources.


```

**Does this change need to be cherry-picked to a release branch?**:
no

**RESULTS**
1k config maps on 4 core vms
  1 thread: 15m
10 thread: 15m

So far no difference, could be the type of resources I used, they are very small, or the VM cluster environment. Will continue experimenting. Aditya suggested we may be bottlenecked on the k8 client side, I'll dig into where we're spending time.

**RESULTS 2**
Tested with 100 config maps, 100 secrets, 500 services and scrambled the order we apply resources to allow mixing of resource types being applied at the same time. Used repeated migration of the same resources (didn't delete everything in-between)
1 thread:  8.5m
4 threads: 7m

I did test applying resources with a script applying secrets at the same time, and it was inconsistently ~15% faster than serially. Kubernetes just doesn't handle many updates effectively in parallel as far as I can tell.

Conclusion: We can get some improvement with this parallelization, but it's not 4x with 4 threads like we hoped.