### PR TITLE
Add support for openstorage.portworx.io as jwt issuer

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -100,6 +100,8 @@ const (
 	pxJwtIssuerApps = "apps.portworx.io"
 	// [deprecated] auth issuer to use for below px 2.6.0
 	pxJwtIssuerStork = "stork.openstorage.io"
+	// auth issuer to use for px operator
+	pxJwtIssuerOperator = "operator.portworx.io"
 
 	snapshotDataNamePrefix = "k8s-volume-snapshot"
 	readySnapshotMsg       = "Snapshot created successfully and it is ready"
@@ -248,6 +250,8 @@ func (p *portworx) Init(_ interface{}) error {
 		p.jwtIssuer = pxJwtIssuerStork
 	case pxJwtIssuerApps:
 		p.jwtIssuer = pxJwtIssuerApps
+	case pxJwtIssuerOperator:
+		p.jwtIssuer = pxJwtIssuerOperator
 	case "":
 		// default to stork issuer for older versions of PX and backwards compatibility
 		p.jwtIssuer = pxJwtIssuerStork


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rohit@portworx.com>


**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
* Operator with security enabled generates tokens with jwt issuer as `operator.portworx.io` 
* Need to add support for this jwt issuer when initializing portworx volume driver
* Without this support stork defaults to `stork.openstorage.io` which results in failures when inspecting volumes/snapshots,
  e.g https://jenkins.portworx.dev/job/Stork/job/stork-2.7-px-2.9-csi-security/16/console



**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:


**Does this change need to be cherry-picked to a release branch?**:
2.8

