### PR TITLE
STOR-538: Keep storage class name for migrated pvcs

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -60,8 +60,6 @@ const (
 	// StorkMigrationCRDDeactivateAnnotation is the annotation used to keep track of
 	// the value to be set for deactivating crds
 	StorkMigrationCRDDeactivateAnnotation = "stork.libopenstorage.org/migrationCRDDeactivate"
-	// storageClassAnnotation for pvc sc
-	storageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
 	// PVReclaimAnnotation for pvc's reclaim policy
 	PVReclaimAnnotation = "stork.libopenstorage.org/reclaimPolicy"
 
@@ -898,11 +896,6 @@ func (m *MigrationController) prepareResources(
 			if err != nil {
 				return fmt.Errorf("error preparing PV resource %v: %v", metadata.GetName(), err)
 			}
-		case "PersistentVolumeClaim":
-			err := m.preparePVCResource(migration, o)
-			if err != nil {
-				return fmt.Errorf("error preparing PV resource %v: %v", metadata.GetName(), err)
-			}
 		case "Deployment", "StatefulSet", "DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer", "ReplicaSet":
 			err := m.prepareApplicationResource(migration, o)
 			if err != nil {
@@ -1110,31 +1103,6 @@ func (m *MigrationController) preparePVResource(
 		return err
 	}
 	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pv)
-	if err != nil {
-		return err
-	}
-	object.SetUnstructuredContent(o)
-
-	return nil
-}
-
-func (m *MigrationController) preparePVCResource(
-	migration *stork_api.Migration,
-	object runtime.Unstructured,
-) error {
-	var pvc v1.PersistentVolumeClaim
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &pvc); err != nil {
-		return err
-	}
-
-	if pvc.Annotations != nil {
-		delete(pvc.Annotations, storageClassAnnotation)
-	}
-	sc := ""
-	if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
-		pvc.Spec.StorageClassName = &sc
-	}
-	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pvc)
 	if err != nil {
 		return err
 	}

--- a/test/integration_test/specs/cassandra/portworx/px-sc.yaml
+++ b/test/integration_test/specs/cassandra/portworx/px-sc.yaml
@@ -6,3 +6,4 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "2"
   priority_io: "high"
+allowVolumeExpansion: true

--- a/test/integration_test/specs/mysql-1-pvc/portworx/px-sc.yaml
+++ b/test/integration_test/specs/mysql-1-pvc/portworx/px-sc.yaml
@@ -5,3 +5,4 @@ metadata:
 provisioner: kubernetes.io/portworx-volume
 parameters:
    repl: "2"
+allowVolumeExpansion: true


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
From stork 2.6.4 onwards SC field for migrated pvcs has been removed. For migrated pvcs user can't perform resize 
operation since SC is missing. This PR keep SC field for migrated pvc and ensure pvc resize changes on source also reflects on DR 

Note: Stork does not support migration of StorageClass, if SC is missing on destination cluster one needs to create it to perform resize pvc operation

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Issue: Unable to resize migrated pvcs
User Impact: From stork 2.6.4 onwards SC field for migrated pvcs has been removed to support pvc size reflection on DR site. For migrated pvcs user can't perform resize operation since SC is missing, they have to manually point pvc spec to SC  
Resolution: Upgrade to stork 2.9.0 should resolve this issue. Kindly note that SC migration is not supported by stork, so if SC is missing on DR site or does not have allowVolumeExpansion set. Users will have to create/modify SC to perform pvc resize operation

```

**Does this change need to be cherry-picked to a release branch?**:
2.9.0



Integration-test : 
``` time="2022-01-28T13:16:20Z" level=info msg="[mysql-1-pvc] Destroyed PVCs for StatefulSet: cassandra"
18:46:20 --- PASS: TestSnapshotMigration (650.92s)
18:46:20     --- PASS: TestSnapshotMigration/testMigration (650.92s)
18:46:20         --- PASS: TestSnapshotMigration/testMigration/pvcResizeTest (647.49s)
18:46:20 PASS
18:46:20 
```