### PR TITLE
PWX:22836 - Support child server activate/deactivate for CR resources

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationregistration.go
+++ b/pkg/apis/stork/v1alpha1/applicationregistration.go
@@ -33,10 +33,10 @@ type ApplicationResource struct {
 	SuspendOptions SuspendOptions `json:"suspendOptions"`
 	// PodsPath to help activate/deactivate crd upon migration
 	PodsPath string `json:"podsPath"`
-	// Some CRs can have child servers which can be enabled/disabled
+	// Some CRs can have nested servers which can be enabled/disabled
 	// in addition to parent server
-	// CustomSuspendOptions allow way to suspend such CR server
-	CustomSuspendOptions []SuspendOptions `json:"customSuspendOptions"`
+	// NestedSuspendOptions allow way to suspend such CR server
+	NestedSuspendOptions []SuspendOptions `json:"customSuspendOptions"`
 }
 
 // SuspendOptions to disable CRD upon migration/restore/clone

--- a/pkg/apis/stork/v1alpha1/applicationregistration.go
+++ b/pkg/apis/stork/v1alpha1/applicationregistration.go
@@ -29,10 +29,14 @@ type ApplicationResource struct {
 	// KeepStatus if set to true collect status
 	// while doing backup/migration/restore etc
 	KeepStatus bool `json:"keepStatus"`
-	// SuspendOptions to disable CRD upon migration/restore/clone
+	// SuspendOptions to disable parent CR upon migration/restore/clone
 	SuspendOptions SuspendOptions `json:"suspendOptions"`
 	// PodsPath to help activate/deactivate crd upon migration
 	PodsPath string `json:"podsPath"`
+	// Some CRs can have child servers which can be enabled/disabled
+	// in addition to parent server
+	// CustomSuspendOptions allow way to suspend such CR server
+	CustomSuspendOptions []SuspendOptions `json:"customSuspendOptions"`
 }
 
 // SuspendOptions to disable CRD upon migration/restore/clone

--- a/pkg/appregistration/appregistration.go
+++ b/pkg/appregistration/appregistration.go
@@ -256,18 +256,6 @@ func GetSupportedCRD() map[string][]stork_api.ApplicationResource {
 				Path: "spec.pause",
 				Type: "bool",
 			},
-			CustomSuspendOptions: []stork_api.SuspendOptions{
-				{
-					Path:  "spec.haproxy.enabled",
-					Type:  "bool",
-					Value: "false",
-				},
-				{
-					Path:  "spec.logcollector.enabled",
-					Type:  "bool",
-					Value: "false",
-				},
-			},
 		},
 	}
 	// prometheus app crds

--- a/pkg/appregistration/appregistration.go
+++ b/pkg/appregistration/appregistration.go
@@ -256,6 +256,18 @@ func GetSupportedCRD() map[string][]stork_api.ApplicationResource {
 				Path: "spec.pause",
 				Type: "bool",
 			},
+			CustomSuspendOptions: []stork_api.SuspendOptions{
+				{
+					Path:  "spec.haproxy.enabled",
+					Type:  "bool",
+					Value: "false",
+				},
+				{
+					Path:  "spec.logcollector.enabled",
+					Type:  "bool",
+					Value: "false",
+				},
+			},
 		},
 	}
 	// prometheus app crds


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
This PR add support for providing multiple suspend option for single CR via `customsuspendoption`

**Does this PR change a user-facing CRD or CLI?**:
yes
```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationRegistration
metadata:
  name: perconadb
resources:
- customSuspendOptions:
  - path: spec.haproxy.enabled
    type: bool
    value: "false"
  group: pxc.percona.com
  keepStatus: false
  kind: PerconaXtraDBCluster
  podsPath: ""
  suspendOptions:
    path: spec.pxc.size
    type: int
    value: ""
  version: v1
  ```

**Is a release note needed?**:
yes

```release-note
Issue: Support child server activate/deactivate for CR resources
User Impact: Unable to migrate CR's that requires multiple suspend  path for child servers in passive mode
Resolution: User can now provide multiple suspend options for single CR resource via CustomSuspend option

```

**Does this change need to be cherry-picked to a release branch?**:
yes, TBD

