### PR TITLE
Update PerconaXtraDBCluster suspend option to gracefully shutdown cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,6 @@ script:
       docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}";
       make deploy;
       make integration-test-deploy;
-    fi &&
-    if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "master" ]; then
-      aws s3 cp --acl public-read bin/linux/storkctl s3://${BUCKET_NAME}/storkctl/master/linux/;
-      aws s3 cp --acl public-read bin/windows/storkctl.exe s3://${BUCKET_NAME}/storkctl/master/windows/;
-      aws s3 cp --acl public-read bin/darwin/storkctl s3://${BUCKET_NAME}/storkctl/master/darwin/;
     fi
 notifications:
   email:

--- a/pkg/appregistration/appregistration.go
+++ b/pkg/appregistration/appregistration.go
@@ -253,8 +253,8 @@ func GetSupportedCRD() map[string][]stork_api.ApplicationResource {
 			},
 			KeepStatus: false,
 			SuspendOptions: stork_api.SuspendOptions{
-				Path: "spec.pxc.size",
-				Type: "int",
+				Path: "spec.pause",
+				Type: "bool",
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Allow PerconaXtraDBCluster to shut-down gracefully via `spec.Pause` option -
https://www.percona.com/doc/kubernetes-operator-for-pxc/pause.html

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: Incorrect suspendOption provided PerconaXtraDBCluster CR, causing not to shut-down all pods created by cluster via storkctl activate/deactivate migration cmd
User Impact: Unable to activate/deactivate PerconaXtraDBCluster cluster gracefully 
Resolution: Since PerconaXtraDBCluster has multiple child server, proper way to gracefully shutdown it is via `spec.Pause` path. User either can change appreg option for PerconaXtraDBCluster or delete entry and allow stork to recreate AppReg for them
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.9
