### PR TITLE
Always sync volumesnapshotschedule and volumesnapshot status

### DIFF
--- a/pkg/snapshot/controllers/snapshotschedule.go
+++ b/pkg/snapshot/controllers/snapshotschedule.go
@@ -190,8 +190,7 @@ func (s *SnapshotScheduleController) updateVolumeSnapshotStatus(snapshotSchedule
 	updated := false
 	for _, policyVolumeSnapshot := range snapshotSchedule.Status.Items {
 		for _, snapshot := range policyVolumeSnapshot {
-			// Get the updated status if we see it as not completed
-			if !s.isVolumeSnapshotComplete(snapshot.Status) {
+			if snapshot.Status != snapv1.VolumeSnapshotConditionReady {
 				pendingVolumeSnapshotStatus, err := getVolumeSnapshotStatus(snapshot.Name, snapshotSchedule.Namespace)
 				if err != nil {
 					return err


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Make sure `volumesnapshotschedule` snapshot status always in-sync with `volumesnapshots` triggered by it 

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Issue: SnapshotSchedule have incorrect sync status with snapshot triggered if underlying driver went offline at time of SnapshotCreate API call 
User Impact: SnapshotSchedule will have Error status but Snapshot object would have successful status for same snapshot
Resolution: Fixed issue to make volumesnapshotschedule and volumesnapshot object status always in-sync
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.9.0

