### PR TITLE
pb-2172: Added fixes related to handling of rule command executor image.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -218,7 +218,9 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 	if backup.DeletionTimestamp != nil {
 		if controllers.ContainsFinalizer(backup, controllers.FinalizerCleanup) {
 			canDelete, err := a.deleteBackup(backup)
-			logrus.Errorf("%s: cleanup: %s", reflect.TypeOf(a), err)
+			if err != nil {
+				logrus.Errorf("%s: cleanup: %s", reflect.TypeOf(a), err)
+			}
 			if !canDelete {
 				return nil
 			}

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -3,9 +3,11 @@ package k8sutils
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/portworx/sched-ops/k8s/apiextensions"
+	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/sched-ops/k8s/core"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -19,6 +21,10 @@ import (
 const (
 	crdTimeout    = 1 * time.Minute
 	retryInterval = 5 * time.Second
+	// StorkDeploymentName - stork deployment name
+	StorkDeploymentName = "stork"
+	// DefaultAdminNamespace - default admin namespace, where stork will be installed
+	DefaultAdminNamespace = "kube-system"
 )
 
 // GetPVCsForGroupSnapshot returns all PVCs in given namespace that match the given matchLabels. All PVCs need to be bound.
@@ -153,4 +159,26 @@ func CreateCRD(resource apiextensions.CustomResource) error {
 		return err
 	}
 	return nil
+}
+
+// GetImageRegistryFromDeployment - extract image registry and image registry secret from deployment spec
+func GetImageRegistryFromDeployment(name, namespace string) (string, string, error) {
+	deploy, err := apps.Instance().GetDeployment(name, namespace)
+	if err != nil {
+		return "", "", err
+	}
+	imageFields := strings.Split(deploy.Spec.Template.Spec.Containers[0].Image, "/")
+	var registry string
+	// Here the assumtption is that the image format will be <registry-name>/<repo-name>/image:tag
+	// or <repo-name>/image:tag. If repo name contains any path (<registry-name>/<repo-name>/<extra-dir-name>/image:tag), below logic will not work.
+	if len(imageFields) == 3 {
+		registry = imageFields[0]
+	} else {
+		registry = ""
+	}
+	imageSecret := deploy.Spec.Template.Spec.ImagePullSecrets
+	if imageSecret != nil {
+		return registry, imageSecret[0].Name, nil
+	}
+	return registry, "", nil
 }


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
pb-2172: Added fixes related to handling of rule command executor image.

        - Added CMD-EXECUTOR-IMAGE-REGISTRY and CMD-EXECUTOR-IMAGE-REGISTRY-SECRET environment variable
          to get the custom regitry name and secret for rule command executor pod image.
        - Added the annotation to get the image registry secret value,
          if some one pass the custom image registry value as annotation in the rule CR.
        - Added logic to take the image registry name and secret value
          from the stork deployment if the both the env and rule annotation is missing.
        - Also, add a fix to fail the backup and delete the rule command
          executor pod, if the rule command executor pod is struck in Pending phase for more
          than five minutes. Some times, it gets struck in pending state,
          if there is any issue with the image registry or secret value.
        - Minor fix in printing a err in handle function.
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Issue: If the rule command executor image is not passed as annotation in rule CR, the rule command executor pod hangs forever.
User Impact: The used does not know that there is a issue in the image setting for rule command executor.
Resolution: Now we will fails the backup and delete the rule command executor pod, if it is struck in pending state for more than five mintues.

```

**Does this change need to be cherry-picked to a release branch?**:
Yes, Next release of stork that will happen for 2.2.0 px-backup.

**Testing:**
- With the debug statements, verified the registry name are picked correctly from the stork deployment spec as a default value.
- Stimulated the backup with incorrect rule command executor image name:
![Screenshot 2022-02-27 at 8 39 42 PM](https://user-images.githubusercontent.com/52188641/155888555-adb76228-bfbb-4565-9c79-211515643fbc.png)

