### PR TITLE
Pb 2219: Add changes to use the registry name and image secret for kopia executor from stork deployment spec.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -14,6 +14,7 @@ import (
 	storkvolume "github.com/libopenstorage/stork/drivers/volume"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/errors"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
 	"github.com/portworx/kdmp/pkg/controllers/dataexport"
@@ -308,6 +309,13 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		}
 
 		dataExport.Labels = labels
+		dataExport.Spec.TriggeredFrom = kdmputils.TriggeredFromStork
+		storkPodNs, err := k8sutils.GetStorkPodNamespace()
+		if err != nil {
+			logrus.Errorf("error in getting stork pod namespace: %v", err)
+			return nil, err
+		}
+		dataExport.Spec.TriggeredFromNs = storkPodNs
 		dataExport.Annotations = make(map[string]string)
 		dataExport.Annotations[skipResourceAnnotation] = "true"
 		dataExport.Annotations[backupObjectUIDKey] = string(backup.Annotations[pxbackupObjectUIDKey])
@@ -763,6 +771,13 @@ func (k *kdmp) StartRestore(
 		// create kdmp cr
 		dataExport := &kdmpapi.DataExport{}
 		dataExport.Labels = labels
+		dataExport.Spec.TriggeredFrom = kdmputils.TriggeredFromStork
+		storkPodNs, err := k8sutils.GetStorkPodNamespace()
+		if err != nil {
+			logrus.Errorf("error in getting stork pod namespace: %v", err)
+			return nil, err
+		}
+		dataExport.Spec.TriggeredFromNs = storkPodNs
 		dataExport.Annotations = make(map[string]string)
 		dataExport.Annotations[skipResourceAnnotation] = "true"
 		dataExport.Annotations[backupObjectUIDKey] = backupUID

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/portworx/kdmp v0.4.1-0.20220309093511-f7b925b9e53e
 	github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194 // indirect
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.0
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
-	github.com/portworx/kdmp v0.4.1-0.20220117074354-94dab8b8d98e
+	github.com/portworx/kdmp v0.4.1-0.20220309093511-f7b925b9e53e
 	github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194 // indirect
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145

--- a/go.sum
+++ b/go.sum
@@ -1227,6 +1227,8 @@ github.com/portworx/sched-ops v1.20.4-rc1.0.20220208024433-611d861089d4 h1:riohT
 github.com/portworx/sched-ops v1.20.4-rc1.0.20220208024433-611d861089d4/go.mod h1:5E/BwC3d4ysXce1fzNFjR2OU8rz7Kx6mt8T10HEiA0E=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8 h1:L85Dd2o3WmUDqHm4xnYG6rLO8FtBRo+GaGGFDIBJlbU=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8/go.mod h1:5E/BwC3d4ysXce1fzNFjR2OU8rz7Kx6mt8T10HEiA0E=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7 h1:wuoKM6KjyPZnC7dauNVrhBu2w3nhQBFkqDvqfu/WKRc=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7/go.mod h1:5E/BwC3d4ysXce1fzNFjR2OU8rz7Kx6mt8T10HEiA0E=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145 h1:J5D0JPZWueVAK8/Dr5s84I7/tCfin6NjIGbKKCSyyJ0=

--- a/go.sum
+++ b/go.sum
@@ -1193,6 +1193,8 @@ github.com/portworx/kdmp v0.4.1-0.20220117012639-8a539b868339 h1:9X1mPFlHROuThWw
 github.com/portworx/kdmp v0.4.1-0.20220117012639-8a539b868339/go.mod h1:RAXbeaO/JmwQPRJCDdOoY/UsmGPY/awWsL4FbDOqAVk=
 github.com/portworx/kdmp v0.4.1-0.20220117074354-94dab8b8d98e h1:kOzgFzeR41nTbxx5gnHuwhMFCbMBc6BzL7q9PxDTh6o=
 github.com/portworx/kdmp v0.4.1-0.20220117074354-94dab8b8d98e/go.mod h1:RAXbeaO/JmwQPRJCDdOoY/UsmGPY/awWsL4FbDOqAVk=
+github.com/portworx/kdmp v0.4.1-0.20220309093511-f7b925b9e53e h1:YWc0ISEUm3H4dLx0urwRPnywsmHz4KMGO9nlEpPg4tU=
+github.com/portworx/kdmp v0.4.1-0.20220309093511-f7b925b9e53e/go.mod h1:RAXbeaO/JmwQPRJCDdOoY/UsmGPY/awWsL4FbDOqAVk=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20191223203141-f42097b1fcd8/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200311180812-b2c72382d652 h1:NElBL34RIHlZKGtDVXT/srxuVZ1+tqmnCdm1K+MC+fU=

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -23,6 +23,8 @@ const (
 	retryInterval = 5 * time.Second
 	// StorkDeploymentName - stork deployment name
 	StorkDeploymentName = "stork"
+	storkPodLabelKey    = "name"
+	storkPodLabelValue  = "stork"
 	// DefaultAdminNamespace - default admin namespace, where stork will be installed
 	DefaultAdminNamespace = "kube-system"
 )
@@ -181,4 +183,25 @@ func GetImageRegistryFromDeployment(name, namespace string) (string, string, err
 		return registry, imageSecret[0].Name, nil
 	}
 	return registry, "", nil
+}
+
+// GetStorkPodNamespace - will return the stork pod namespace.
+func GetStorkPodNamespace() (string, error) {
+	var ns string
+	pods, err := core.Instance().ListPods(
+		map[string]string{
+			storkPodLabelKey: storkPodLabelValue,
+		},
+	)
+	if err != nil {
+		return ns, err
+	}
+	if len(pods.Items) > 0 {
+		ns = pods.Items[0].Namespace
+	}
+	if len(ns) == 0 {
+		return ns, fmt.Errorf("error: stork namespace is empty")
+	}
+	return ns, nil
+
 }

--- a/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/dataexport.go
+++ b/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/dataexport.go
@@ -95,11 +95,15 @@ type DataExport struct {
 
 // DataExportSpec defines configuration parameters for DataExport.
 type DataExportSpec struct {
-	Type                 DataExportType            `json:"type,omitempty"`
-	ClusterPair          string                    `json:"clusterPair,omitempty"`
-	SnapshotStorageClass string                    `json:"snapshotStorageClass,omitempty"`
-	Source               DataExportObjectReference `json:"source,omitempty"`
-	Destination          DataExportObjectReference `json:"destination,omitempty"`
+	Type                 DataExportType `json:"type,omitempty"`
+	ClusterPair          string         `json:"clusterPair,omitempty"`
+	SnapshotStorageClass string         `json:"snapshotStorageClass,omitempty"`
+	// TriggeredFrom is to know which module is created the dataexport CR.
+	// The use-case is to know from where to get the kopia executor image
+	TriggeredFrom   string                    `json:"triggerFrom,omitempty"`
+	TriggeredFromNs string                    `json:"triggerFromNs,omitempty"`
+	Source          DataExportObjectReference `json:"source,omitempty"`
+	Destination     DataExportObjectReference `json:"destination,omitempty"`
 }
 
 // DataExportObjectReference contains enough information to let you inspect the referred object.

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
@@ -1526,6 +1526,8 @@ func startTransferJob(
 		)
 	case drivers.KopiaBackup:
 		return drv.StartJob(
+			drivers.WithKopiaImageExecutorSource(dataExport.Spec.TriggeredFrom),
+			drivers.WithKopiaImageExecutorSourceNs(dataExport.Spec.TriggeredFromNs),
 			drivers.WithSourcePVC(srcPVCName),
 			drivers.WithRepoPVC(getRepoPVCName(dataExport, srcPVCName)),
 			drivers.WithNamespace(dataExport.Spec.Source.Namespace),
@@ -1542,6 +1544,8 @@ func startTransferJob(
 		)
 	case drivers.KopiaRestore:
 		return drv.StartJob(
+			drivers.WithKopiaImageExecutorSource(dataExport.Spec.TriggeredFrom),
+			drivers.WithKopiaImageExecutorSourceNs(dataExport.Spec.TriggeredFromNs),
 			drivers.WithDestinationPVC(dataExport.Spec.Destination.Name),
 			drivers.WithNamespace(dataExport.Spec.Destination.Namespace),
 			drivers.WithVolumeBackupName(dataExport.Spec.Source.Name),

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackup.go
@@ -274,6 +274,20 @@ func jobFor(
 		splitCmd = append(splitCmd, "--compression", jobOption.Compression)
 		cmd = strings.Join(splitCmd, " ")
 	}
+	imageRegistry, imageRegistrySecret, err := utils.GetKopiaExecutorImageRegistryAndSecret(
+		jobOption.KopiaImageExecutorSource,
+		jobOption.KopiaImageExecutorSourceNs,
+	)
+	if err != nil {
+		logrus.Errorf("jobFor: getting kopia image registry and image secret failed during backup: %v", err)
+		return nil, err
+	}
+	var kopiaExecutorImage string
+	if len(imageRegistry) != 0 {
+		kopiaExecutorImage = fmt.Sprintf("%s/%s", imageRegistry, utils.GetKopiaExecutorImageName())
+	} else {
+		kopiaExecutorImage = utils.GetKopiaExecutorImageName()
+	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -292,12 +306,12 @@ func jobFor(
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ImagePullSecrets:   utils.ToImagePullSecret(utils.KopiaExecutorImageSecret(jobOption.JobConfigMap, jobOption.JobConfigMapNs)),
+					ImagePullSecrets:   utils.ToImagePullSecret(imageRegistrySecret),
 					ServiceAccountName: jobName,
 					Containers: []corev1.Container{
 						{
 							Name:            "kopiaexecutor",
-							Image:           utils.KopiaExecutorImage(jobOption.JobConfigMap, jobOption.JobConfigMapNs),
+							Image:           kopiaExecutorImage,
 							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{
 								"/bin/sh",

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiadelete/kopiadelete.go
@@ -184,6 +184,21 @@ func jobFor(
 		jobOption.VolumeBackupDeleteNamespace,
 	}, " ")
 
+	imageRegistry, imageRegistrySecret, err := utils.GetKopiaExecutorImageRegistryAndSecret(
+		jobOption.KopiaImageExecutorSource,
+		jobOption.KopiaImageExecutorSourceNs,
+	)
+	if err != nil {
+		logrus.Errorf("jobFor: getting kopia image registry and image secret failed during delete: %v", err)
+		return nil, err
+	}
+	var kopiaExecutorImage string
+	if len(imageRegistry) != 0 {
+		kopiaExecutorImage = fmt.Sprintf("%s/%s", imageRegistry, utils.GetKopiaExecutorImageName())
+	} else {
+		kopiaExecutorImage = utils.GetKopiaExecutorImageName()
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -202,11 +217,11 @@ func jobFor(
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: jobOption.ServiceAccountName,
-					ImagePullSecrets:   utils.ToImagePullSecret(utils.KopiaExecutorImageSecret(jobOption.JobConfigMap, jobOption.JobConfigMapNs)),
+					ImagePullSecrets:   utils.ToImagePullSecret(imageRegistrySecret),
 					Containers: []corev1.Container{
 						{
 							Name:  "kopiaexecutor",
-							Image: utils.KopiaExecutorImage(jobOption.JobConfigMap, jobOption.JobConfigMapNs),
+							Image: kopiaExecutorImage,
 							// TODO: Need to revert it to NotPresent. For now keep it as PullAlways.
 							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiarestore/kopiarestore.go
@@ -191,6 +191,21 @@ func jobFor(
 		vb.Status.SnapshotID,
 	}, " ")
 
+	imageRegistry, imageRegistrySecret, err := utils.GetKopiaExecutorImageRegistryAndSecret(
+		jobOption.KopiaImageExecutorSource,
+		jobOption.KopiaImageExecutorSourceNs,
+	)
+	if err != nil {
+		logrus.Errorf("jobFor: getting kopia image registry and image secret failed during restore: %v", err)
+		return nil, err
+	}
+	var kopiaExecutorImage string
+	if len(imageRegistry) != 0 {
+		kopiaExecutorImage = fmt.Sprintf("%s/%s", imageRegistry, utils.GetKopiaExecutorImageName())
+	} else {
+		kopiaExecutorImage = utils.GetKopiaExecutorImageName()
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -208,12 +223,12 @@ func jobFor(
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
-					ImagePullSecrets:   utils.ToImagePullSecret(utils.KopiaExecutorImageSecret(jobOption.JobConfigMap, jobOption.JobConfigMapNs)),
+					ImagePullSecrets:   utils.ToImagePullSecret(imageRegistrySecret),
 					ServiceAccountName: jobName,
 					Containers: []corev1.Container{
 						{
 							Name:            "kopiaexecutor",
-							Image:           utils.KopiaExecutorImage(jobOption.JobConfigMap, jobOption.JobConfigMapNs),
+							Image:           kopiaExecutorImage,
 							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{
 								"/bin/sh",

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
@@ -40,8 +40,32 @@ type JobOpts struct {
 	PodDataPath                 string
 	// JobConfigMap holds any config needs to be provided to job
 	// from the caller. Eg: executor image name, secret, etc..
-	JobConfigMap   string
-	JobConfigMapNs string
+	JobConfigMap               string
+	JobConfigMapNs             string
+	KopiaImageExecutorSource   string
+	KopiaImageExecutorSourceNs string
+}
+
+// WithKopiaImageExecutorSource is job parameter.
+func WithKopiaImageExecutorSource(source string) JobOption {
+	return func(opts *JobOpts) error {
+		if strings.TrimSpace(source) == "" {
+			return fmt.Errorf("kopia image executor source should be set")
+		}
+		opts.KopiaImageExecutorSource = strings.TrimSpace(source)
+		return nil
+	}
+}
+
+// WithKopiaImageExecutorSourceNs is job parameter.
+func WithKopiaImageExecutorSourceNs(namespace string) JobOption {
+	return func(opts *JobOpts) error {
+		if strings.TrimSpace(namespace) == "" {
+			return fmt.Errorf("kopia image executor source namespace should be set")
+		}
+		opts.KopiaImageExecutorSourceNs = strings.TrimSpace(namespace)
+		return nil
+	}
 }
 
 // WithBackupObjectName is job parameter.

--- a/vendor/github.com/portworx/sched-ops/k8s/apps/statefulsets.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/apps/statefulsets.go
@@ -271,8 +271,9 @@ func (c *Client) ValidatePVCsForStatefulSet(ss *appsv1.StatefulSet, timeout, ret
 			return nil, true, err
 		}
 
-		if len(pvcList.Items) < int(*ss.Spec.Replicas) {
-			return nil, true, fmt.Errorf("Expected PVCs: %v, Actual: %v", *ss.Spec.Replicas, len(pvcList.Items))
+		expectedPVCCount := len(ss.Spec.VolumeClaimTemplates) * int(*ss.Spec.Replicas)
+		if len(pvcList.Items) < expectedPVCCount {
+			return nil, true, fmt.Errorf("Expected PVCs: %v, Actual: %v", expectedPVCCount, len(pvcList.Items))
 		}
 
 		for _, pvc := range pvcList.Items {

--- a/vendor/github.com/portworx/sched-ops/k8s/core/pods.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/pods.go
@@ -24,6 +24,8 @@ type PodOps interface {
 	CreatePod(pod *corev1.Pod) (*corev1.Pod, error)
 	// UpdatePod updates the given pod
 	UpdatePod(pod *corev1.Pod) (*corev1.Pod, error)
+	// ListPods returns pods from all namespaces matching the given label
+	ListPods(map[string]string) (*corev1.PodList, error)
 	// GetPods returns pods for the given namespace
 	GetPods(string, map[string]string) (*corev1.PodList, error)
 	// GetPodsByNode returns all pods in given namespace and given k8s node name.
@@ -91,6 +93,17 @@ func (c *Client) UpdatePod(pod *corev1.Pod) (*corev1.Pod, error) {
 	}
 
 	return c.kubernetes.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+}
+
+// ListPods returns pods from all namespaces matching the given label
+func (c *Client) ListPods(labelSelector map[string]string) (*corev1.PodList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	opts := metav1.ListOptions{
+		LabelSelector: mapToCSV(labelSelector),
+	}
+	return c.kubernetes.CoreV1().Pods("").List(context.TODO(), opts)
 }
 
 // GetPods returns pods for the given namespace

--- a/vendor/github.com/portworx/torpedo/drivers/scheduler/k8s/k8s.go
+++ b/vendor/github.com/portworx/torpedo/drivers/scheduler/k8s/k8s.go
@@ -51,8 +51,6 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storageapi "k8s.io/api/storage/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -391,13 +389,6 @@ func decodeSpec(specContents []byte) (runtime.Object, error) {
 		if err := apapi.AddToScheme(schemeObj); err != nil {
 			return nil, err
 		}
-		if err := apiextensionsv1beta1.AddToScheme(schemeObj); err != nil {
-			return nil, err
-		}
-
-		if err := apiextensionsv1.AddToScheme(schemeObj); err != nil {
-			return nil, err
-		}
 
 		codecs := serializer.NewCodecFactory(schemeObj)
 		obj, _, err = codecs.UniversalDeserializer().Decode([]byte(specContents), nil, nil)
@@ -468,10 +459,6 @@ func validateSpec(in interface{}) (interface{}, error) {
 	} else if specObj, ok := in.(*corev1.LimitRange); ok {
 		return specObj, nil
 	} else if specObj, ok := in.(*networkingv1beta1.Ingress); ok {
-		return specObj, nil
-	} else if specObj, ok := in.(*apiextensionsv1beta1.CustomResourceDefinition); ok {
-		return specObj, nil
-	} else if specObj, ok := in.(*apiextensionsv1.CustomResourceDefinition); ok {
 		return specObj, nil
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -461,7 +461,7 @@ github.com/portworx/kdmp/pkg/version
 github.com/portworx/kvdb
 github.com/portworx/kvdb/common
 github.com/portworx/kvdb/mem
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7
 ## explicit
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -434,7 +434,7 @@ github.com/pierrec/lz4/internal/xxh32
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20220117074354-94dab8b8d98e
+# github.com/portworx/kdmp v0.4.1-0.20220309093511-f7b925b9e53e
 ## explicit
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
```
    pb-2219: Add changes to use the registry name and image secret for kopia
    executor from stork deployment spec.

        - Add GetStorkPodNamespace to get the stork pod namespace, even
          if it is not installed in the kube-system.
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Issue: In the current releases, customer need to configure the kopia executor image registry and secret details in the configmap after installing the stork.
User Impact: User need to configure the registy and image secret in the configmap separately.
Resolution: Now these details will be picked up from the strok deployment spec. If it is different registry for kopia executor, customer need to set the details in ENV variable in stork deployment spec.
KOPIA-EXECUTOR-IMAGE-REGISTRY
KOPIA-EXECUTOR-IMAGE-REGISTRY-SECRET

```

**Does this change need to be cherry-picked to a release branch?**:
for now it will be in master.

