### PR TITLE
PWX-23117, PWX-23215: Multiple 2.9.0 fixes

### DIFF
--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -204,7 +204,7 @@ func getClusterPairSchedulerConfig(clusterPairName string, namespace string) (*r
 func getClusterPairStorageStatus(clusterPairName string, namespace string) (stork_api.ClusterPairStatusType, error) {
 	clusterPair, err := storkops.Instance().GetClusterPair(clusterPairName, namespace)
 	if err != nil {
-		return stork_api.ClusterPairStatusInitial, fmt.Errorf("error getting clusterpair: %v", err)
+		return stork_api.ClusterPairStatusInitial, fmt.Errorf("error getting clusterpair %v (%v): %v", clusterPairName, namespace, err)
 	}
 	return clusterPair.Status.StorageStatus, nil
 }

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -222,6 +222,10 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 		if schedName, ok := migration.GetAnnotations()[StorkMigrationScheduleName]; ok {
 			remoteConfig, err := getClusterPairSchedulerConfig(migration.Spec.ClusterPair, migration.Namespace)
 			if err != nil {
+				m.recorder.Event(migration,
+					v1.EventTypeWarning,
+					string(stork_api.MigrationStatusFailed),
+					err.Error())
 				return err
 			}
 			remoteOps, err := storkops.NewForConfig(remoteConfig)

--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -140,6 +140,10 @@ func (m *MigrationScheduleController) handle(ctx context.Context, migrationSched
 	if !(*migrationSchedule.Spec.Suspend) {
 		remoteConfig, err := getClusterPairSchedulerConfig(migrationSchedule.Spec.Template.Spec.ClusterPair, migrationSchedule.Namespace)
 		if err != nil {
+			m.recorder.Event(migrationSchedule,
+				v1.EventTypeWarning,
+				string(stork_api.MigrationStatusFailed),
+				err.Error())
 			return err
 		}
 		remoteOps, err := storkops.NewForConfig(remoteConfig)


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
PWX-23117: Raise an event if Migration/MigrationSchedule object is pointing to an invalid or a non-existed ClusterPair
PWX-23215: Set the elapsed time for Volumes or Resources only if they are getting migrated. 

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
Improvement: Stork will now raise an event when a Migration or a MigrationSchedule object is referring to a non-existed or invalid ClusterPair
```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.9

