### PR TITLE
pb-2179: Added changes required for the supporting object lock for backupschedule deletion.

### DIFF
--- a/pkg/objectstore/azure/azure.go
+++ b/pkg/objectstore/azure/azure.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/objectstore/common"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/azureblob"
 )
@@ -55,4 +56,9 @@ func CreateBucket(backupLocation *stork_api.BackupLocation) error {
 		}
 	}
 	return err
+}
+
+// GetObjLockInfo fetches the object lock configuration of a bucket
+func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockInfo, error) {
+	return nil, fmt.Errorf("object lock is not supported for azure provider")
 }

--- a/pkg/objectstore/common/common.go
+++ b/pkg/objectstore/common/common.go
@@ -1,0 +1,9 @@
+package common
+
+// ObjLockInfo struct
+type ObjLockInfo struct {
+	LockMode             string
+	LockEnabled          bool
+	RetentionPeriodDays  int64
+	RetentionPeriodYears int64
+}

--- a/pkg/objectstore/google/google.go
+++ b/pkg/objectstore/google/google.go
@@ -2,10 +2,12 @@ package google
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"cloud.google.com/go/storage"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/objectstore/common"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/gcp"
@@ -58,4 +60,9 @@ func CreateBucket(backupLocation *stork_api.BackupLocation) error {
 		}
 	}
 	return err
+}
+
+// GetObjLockInfo fetches the object lock configuration of a bucket
+func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockInfo, error) {
+	return nil, fmt.Errorf("object lock is not supported for google provider")
 }

--- a/pkg/objectstore/objectstore.go
+++ b/pkg/objectstore/objectstore.go
@@ -5,6 +5,7 @@ import (
 
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/objectstore/azure"
+	"github.com/libopenstorage/stork/pkg/objectstore/common"
 	"github.com/libopenstorage/stork/pkg/objectstore/google"
 	"github.com/libopenstorage/stork/pkg/objectstore/s3"
 	"gocloud.dev/blob"
@@ -43,5 +44,22 @@ func CreateBucket(backupLocation *stork_api.BackupLocation) error {
 		return s3.CreateBucket(backupLocation)
 	default:
 		return fmt.Errorf("invalid backupLocation type: %v", backupLocation.Location.Type)
+	}
+}
+
+// GetObjLockInfo fetches the object lock configuration of a S3 bucket
+func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockInfo, error) {
+	if backupLocation == nil {
+		return nil, fmt.Errorf("nil backupLocation")
+	}
+	switch backupLocation.Location.Type {
+	case stork_api.BackupLocationGoogle:
+		return google.GetObjLockInfo(backupLocation)
+	case stork_api.BackupLocationAzure:
+		return azure.GetObjLockInfo(backupLocation)
+	case stork_api.BackupLocationS3:
+		return s3.GetObjLockInfo(backupLocation)
+	default:
+		return nil, fmt.Errorf("invalid backupLocation type: %v", backupLocation.Location.Type)
 	}
 }

--- a/pkg/objectstore/s3/s3.go
+++ b/pkg/objectstore/s3/s3.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -9,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/objectstore/common"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/s3blob"
 )
@@ -62,7 +64,7 @@ func CreateBucket(backupLocation *stork_api.BackupLocation) error {
 }
 
 // GetObjLockInfo fetches the object lock configuration of a S3 bucket
-func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*s3.GetObjectLockConfigurationOutput, error) {
+func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockInfo, error) {
 	sess, err := getSession(backupLocation)
 	if err != nil {
 		return nil, err
@@ -75,12 +77,31 @@ func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*s3.GetObjectLock
 	out, err := s3.New(sess).GetObjectLockConfiguration(input)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "ObjectLockConfigurationNotFoundError" {
+			// When a minio server doesn't have object-lock implemented
+			// then Minio backed backuplocation throws this error for
+			// normal buckets too hence we need to ignore this for now.
+			if awsErr.Code() == "ObjectLockConfigurationNotFoundError" || awsErr.Code() == "MethodNotAllowed" {
 				// for a non-objectlocked bucket we needn't throw error
 				return nil, nil
 			}
 		}
 		return nil, err
 	}
-	return out, err
+	objLockInfo := &common.ObjLockInfo{}
+	if (out != nil) && (out.ObjectLockConfiguration != nil) {
+		if aws.StringValue(out.ObjectLockConfiguration.ObjectLockEnabled) == "Enabled" {
+			objLockInfo.LockEnabled = true
+		}
+		if out.ObjectLockConfiguration.Rule != nil &&
+			out.ObjectLockConfiguration.Rule.DefaultRetention != nil {
+			objLockInfo.LockMode = aws.StringValue(out.ObjectLockConfiguration.Rule.DefaultRetention.Mode)
+			objLockInfo.RetentionPeriodYears = aws.Int64Value(out.ObjectLockConfiguration.Rule.DefaultRetention.Years)
+			objLockInfo.RetentionPeriodDays = aws.Int64Value(out.ObjectLockConfiguration.Rule.DefaultRetention.Days)
+		} else {
+			//This is an invalid object-lock config, no default-retention but object-loc enabled
+			objLockInfo.LockEnabled = false
+			return nil, fmt.Errorf("invalid config: object lock is enabled but default retention period is not set on the bucket")
+		}
+	}
+	return objLockInfo, err
 }


### PR DESCRIPTION
**What type of PR is this?**
>bug
**What this PR does / why we need it**:
```
pb-2179: Added changes required for the supporting object lock for backupschedule deletion.

        - Adding the "object-lock-retention-period" annotation to the
          applicationbackup CR created by applicationbackupschedule in stork
        - This retention period annotation value will be used in the backupscync
          logic to update the retention period of the synced backup object.
        - Added GetObjLockInfo in stork objectstore as it needs to be called in
          stork as well as px-backup
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no ( From stork, we are not claiming the object lock support, So nothing need to documented.)

**Does this change need to be cherry-picked to a release branch?**:
Currently pushing it to master branch.

Testing:
Will post the testing result in the px-backup PR.