### PR TITLE
PWX-23244: Allow pods using FA/FB pvcs in scheduling decisions

### DIFF
--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -235,7 +235,7 @@ func (c *ClusterPairController) cleanup(clusterPair *stork_api.ClusterPair) erro
 			}
 		}
 	}
-	if !skipDelete {
+	if !skipDelete && clusterPair.Status.RemoteStorageID != "" {
 		return c.volDriver.DeletePair(clusterPair)
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
Allow scheduling decision for pods using FA/FB pvcs

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: Unable to recognise storage driver for FA/FB pvc
User Impact:  Pods using FA/FB backed pvcs getting scheduled on non-px nod
Resolution: Pods using FA/FB backed pvcs will now allowed to be scheduled by stork scheduler

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.9

Extender integration job: http://jenkins.pwx.dev.purestorage.com/job/Stork/job/stork-dev-test/118/consoleFull