### PR TITLE
pb-2241: fixed a nil pointer access in GetObjLockInfo function.

### DIFF
--- a/pkg/objectstore/s3/s3.go
+++ b/pkg/objectstore/s3/s3.go
@@ -74,6 +74,7 @@ func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockIn
 		Bucket: &backupLocation.Location.Path,
 	}
 
+	objLockInfo := &common.ObjLockInfo{}
 	out, err := s3.New(sess).GetObjectLockConfiguration(input)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
@@ -82,12 +83,11 @@ func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockIn
 			// normal buckets too hence we need to ignore this for now.
 			if awsErr.Code() == "ObjectLockConfigurationNotFoundError" || awsErr.Code() == "MethodNotAllowed" {
 				// for a non-objectlocked bucket we needn't throw error
-				return nil, nil
+				return objLockInfo, nil
 			}
 		}
 		return nil, err
 	}
-	objLockInfo := &common.ObjLockInfo{}
 	if (out != nil) && (out.ObjectLockConfiguration != nil) {
 		if aws.StringValue(out.ObjectLockConfiguration.ObjectLockEnabled) == "Enabled" {
 			objLockInfo.LockEnabled = true


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
pb-2241: fixed a nil pointer access in GetObjLockInfo function.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

**Testing:**
Verified the fix with px-backup code by creating backuplocation with portworx colo lab minio that does not support objectlock.