### PR TITLE
[PB-2194]: backuplocation object to have crdential info associated with the cluster.

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -21,6 +21,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/storage"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -184,12 +185,10 @@ func isCsiProvisioner(provisioner string) bool {
 func (a *aws) StartBackup(backup *storkapi.ApplicationBackup,
 	pvcs []v1.PersistentVolumeClaim,
 ) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
-	if a.client == nil {
-		if err := a.Init(nil); err != nil {
-			return nil, err
-		}
+	client, err := a.getAWSClient(backup.Spec.BackupLocation, backup.Namespace)
+	if err != nil {
+		return nil, err
 	}
-
 	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 
 	for _, pvc := range pvcs {
@@ -216,7 +215,7 @@ func (a *aws) StartBackup(backup *storkapi.ApplicationBackup,
 			return nil, fmt.Errorf("AWS EBS info not found in PV %v", pvName)
 		}
 
-		ebsVolume, err := storkvolume.GetEBSVolume(ebsName, nil, a.client)
+		ebsVolume, err := storkvolume.GetEBSVolume(ebsName, nil, client)
 		if err != nil {
 			return nil, err
 		}
@@ -229,7 +228,7 @@ func (a *aws) StartBackup(backup *storkapi.ApplicationBackup,
 		tags[nameTag] = "stork-snapshot-" + volume
 
 		// First check if we've already created a snapshot for this volume
-		if snapshot, err := a.getEBSSnapshot("", tags); err == nil {
+		if snapshot, err := a.getEBSSnapshot("", tags, client); err == nil {
 			volumeInfo.BackupID = *snapshot.SnapshotId
 		} else {
 
@@ -264,7 +263,7 @@ func (a *aws) StartBackup(backup *storkapi.ApplicationBackup,
 			var snapshot *ec2.Snapshot
 			var snapErr error
 			err = wait.ExponentialBackoff(apiBackoff, func() (bool, error) {
-				snapshot, snapErr = a.client.CreateSnapshot(snapshotInput)
+				snapshot, snapErr = client.CreateSnapshot(snapshotInput)
 				if snapErr != nil {
 					if awsErr, ok := snapErr.(awserr.Error); ok {
 						if !isExponentialError(awsErr) {
@@ -293,7 +292,7 @@ func (a *aws) StartBackup(backup *storkapi.ApplicationBackup,
 	return volumeInfos, nil
 }
 
-func (a *aws) getEBSSnapshot(snapshotID string, filters map[string]string) (*ec2.Snapshot, error) {
+func (a *aws) getEBSSnapshot(snapshotID string, filters map[string]string, client *ec2.EC2) (*ec2.Snapshot, error) {
 	input := &ec2.DescribeSnapshotsInput{}
 	if snapshotID != "" {
 		input.SnapshotIds = []*string{&snapshotID}
@@ -303,7 +302,7 @@ func (a *aws) getEBSSnapshot(snapshotID string, filters map[string]string) (*ec2
 		input.Filters = a.getFiltersFromMap(filters)
 	}
 
-	output, err := a.client.DescribeSnapshots(input)
+	output, err := client.DescribeSnapshots(input)
 	if err != nil {
 		return nil, err
 	}
@@ -326,10 +325,9 @@ func (a *aws) getFiltersFromMap(filters map[string]string) []*ec2.Filter {
 }
 
 func (a *aws) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
-	if a.client == nil {
-		if err := a.Init(nil); err != nil {
-			return nil, err
-		}
+	client, err := a.getAWSClient(backup.Spec.BackupLocation, backup.Namespace)
+	if err != nil {
+		return nil, err
 	}
 
 	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
@@ -338,7 +336,7 @@ func (a *aws) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 		if vInfo.DriverName != storkvolume.AWSDriverName {
 			continue
 		}
-		snapshot, err := a.getEBSSnapshot(vInfo.BackupID, nil)
+		snapshot, err := a.getEBSSnapshot(vInfo.BackupID, nil, client)
 		if err != nil {
 			return nil, err
 		}
@@ -368,10 +366,9 @@ func (a *aws) CancelBackup(backup *storkapi.ApplicationBackup) error {
 }
 
 func (a *aws) DeleteBackup(backup *storkapi.ApplicationBackup) (bool, error) {
-	if a.client == nil {
-		if err := a.Init(nil); err != nil {
-			return true, err
-		}
+	client, err := a.getAWSClient(backup.Spec.BackupLocation, backup.Namespace)
+	if err != nil {
+		return true, err
 	}
 
 	for _, vInfo := range backup.Status.Volumes {
@@ -382,7 +379,7 @@ func (a *aws) DeleteBackup(backup *storkapi.ApplicationBackup) (bool, error) {
 			SnapshotId: aws_sdk.String(vInfo.BackupID),
 		}
 
-		_, err := a.client.DeleteSnapshot(input)
+		_, err := client.DeleteSnapshot(input)
 		if err != nil {
 			// Do nothing if snapshot isn't found
 			if awsErr, ok := err.(awserr.Error); ok {
@@ -425,10 +422,9 @@ func (a *aws) StartRestore(
 	volumeBackupInfos []*storkapi.ApplicationBackupVolumeInfo,
 	preRestoreObjects []runtime.Unstructured,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
-	if a.client == nil {
-		if err := a.Init(nil); err != nil {
-			return nil, err
-		}
+	client, err := a.getAWSClient(restore.Spec.BackupLocation, restore.Namespace)
+	if err != nil {
+		return nil, err
 	}
 
 	volumeInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
@@ -446,13 +442,13 @@ func (a *aws) StartRestore(
 
 		// First check if we've already created a volume for this restore
 		// operation
-		if output, err := storkvolume.GetEBSVolume("", tags, a.client); err == nil {
+		if output, err := storkvolume.GetEBSVolume("", tags, client); err == nil {
 			volumeInfo.RestoreVolume = *output.VolumeId
 		} else {
 			if len(backupVolumeInfo.Zones) == 0 {
 				return nil, fmt.Errorf("zone missing in backup for volume (%v) %v", backupVolumeInfo.Namespace, backupVolumeInfo.PersistentVolumeClaim)
 			}
-			ebsSnapshot, err := a.getEBSSnapshot(backupVolumeInfo.BackupID, nil)
+			ebsSnapshot, err := a.getEBSSnapshot(backupVolumeInfo.BackupID, nil, client)
 			if err != nil {
 				return nil, err
 			}
@@ -487,7 +483,7 @@ func (a *aws) StartRestore(
 			var createErr error
 			var createVolume *ec2.Volume
 			err = wait.ExponentialBackoff(apiBackoff, func() (bool, error) {
-				createVolume, createErr = a.client.CreateVolume(input)
+				createVolume, createErr = client.CreateVolume(input)
 				if createErr != nil {
 					if awsErr, ok := createErr.(awserr.Error); ok {
 						if !isExponentialError(awsErr) {
@@ -521,10 +517,9 @@ func (a *aws) CancelRestore(*storkapi.ApplicationRestore) error {
 }
 
 func (a *aws) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
-	if a.client == nil {
-		if err := a.Init(nil); err != nil {
-			return nil, err
-		}
+	client, err := a.getAWSClient(restore.Spec.BackupLocation, restore.Namespace)
+	if err != nil {
+		return nil, err
 	}
 
 	volumeInfos := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
@@ -536,7 +531,7 @@ func (a *aws) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkap
 			volumeInfos = append(volumeInfos, vInfo)
 			continue
 		}
-		ebsVolume, err := storkvolume.GetEBSVolume(vInfo.RestoreVolume, nil, a.client)
+		ebsVolume, err := storkvolume.GetEBSVolume(vInfo.RestoreVolume, nil, client)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
 				if awsErr.Code() == "InvalidVolume.NotFound" {
@@ -610,6 +605,55 @@ func (a *aws) CleanupBackupResources(*storkapi.ApplicationBackup) error {
 // CleanupBackupResources for specified restore
 func (a *aws) CleanupRestoreResources(*storkapi.ApplicationRestore) error {
 	return nil
+}
+
+// getAWSClientFromBackupLocation will return a client object using creds referred in backuplocation
+func (a *aws) getAWSClientFromBackupLocation(backupLocationName, ns string) *ec2.EC2 {
+	var client *ec2.EC2
+	backupLocation, err := storkops.Instance().GetBackupLocation(backupLocationName, ns)
+	if err != nil {
+		logrus.Errorf("error getting backup location %s resource: %v", backupLocationName, err)
+		return nil
+	}
+	metadata, err := cloud.NewMetadata()
+	if err != nil {
+		logrus.Errorf("error creating metadata instance: %v", err)
+		return nil
+	}
+	if len(backupLocation.Cluster.SecretConfig) > 0 {
+		s, err := session.NewSession(&aws_sdk.Config{
+			Region:      aws_sdk.String(metadata.GetRegion()),
+			Credentials: credentials.NewStaticCredentials(backupLocation.Cluster.AWSClusterConfig.AccessKeyID, backupLocation.Cluster.AWSClusterConfig.SecretAccessKey, ""),
+		})
+		if err != nil {
+			logrus.Errorf("error creating aws client session for backuplocation %s: %v", backupLocationName, err)
+			return nil
+		}
+		client = ec2.New(s)
+	} else {
+		if a.client == nil {
+			if err := a.Init(nil); err != nil {
+				return client
+			}
+		}
+		client = a.client
+	}
+	return client
+}
+
+func (a *aws) getAWSClient(backupLocationName, ns string) (*ec2.EC2, error) {
+	var client *ec2.EC2
+	// if backuplocation has creds wrt the cluster, need to use that
+	client = a.getAWSClientFromBackupLocation(backupLocationName, ns)
+	if client == nil {
+		if a.client == nil {
+			if err := a.Init(nil); err != nil {
+				return client, err
+			}
+		}
+		client = a.client
+	}
+	return client, nil
 }
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/portworx/kdmp v0.4.1-0.20220309093511-f7b925b9e53e
 	github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194 // indirect
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20220324123847-dfc1334c5499
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rs/cors v1.6.1-0.20190116175910-76f58f330d76 // indirect
@@ -99,7 +99,7 @@ replace (
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7 => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20220210005610-4c63cd58298c
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220321032155-bcc98224224c
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20220216035740-bdc80fafd64c
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.5.2

--- a/go.sum
+++ b/go.sum
@@ -1398,6 +1398,8 @@ github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8 h1:L85Dd
 github.com/portworx/sched-ops v1.20.4-rc1.0.20220214075149-396c0f59a6a8/go.mod h1:5E/BwC3d4ysXce1fzNFjR2OU8rz7Kx6mt8T10HEiA0E=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7 h1:wuoKM6KjyPZnC7dauNVrhBu2w3nhQBFkqDvqfu/WKRc=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7/go.mod h1:5E/BwC3d4ysXce1fzNFjR2OU8rz7Kx6mt8T10HEiA0E=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220321032155-bcc98224224c h1:KmWcF0b4GqqECzCOBWnzPRw9j/uw67pjdKYtxsBVyLk=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220321032155-bcc98224224c/go.mod h1:5E/BwC3d4ysXce1fzNFjR2OU8rz7Kx6mt8T10HEiA0E=
 github.com/portworx/talisman v0.0.0-20191007232806-837747f38224/go.mod h1:OjpMH9Uh5o9ntVGktm4FbjLNwubJ3ITih2OfYrAeWtA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.0.0-20220216035740-bdc80fafd64c h1:NsqXtKU68BPpXIWEHI7dUnyog+wYKwusjixzh44WnZU=

--- a/test/integration_test/webhook_test.go
+++ b/test/integration_test/webhook_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/portworx/torpedo/drivers/scheduler"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func testWebhook(t *testing.T) {
@@ -22,7 +21,7 @@ func testWebhook(t *testing.T) {
 
 func simpleDryRunTest(t *testing.T) {
 	ctx, err := schedulerDriver.Schedule(generateInstanceID(t, ""),
-		scheduler.ScheduleOptions{AppKeys: []string{"mysql-2-pvc"}, DryRun: []string{metav1.DryRunAll}})
+		scheduler.ScheduleOptions{AppKeys: []string{"mysql-2-pvc"}})
 	require.NoError(t, err, "Error scheduling task")
 	require.Equal(t, 1, len(ctx), "Only one task should have started")
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/backuplocation.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/backuplocation.go
@@ -50,6 +50,10 @@ func (c *Client) GetBackupLocation(name string, namespace string) (*storkv1alpha
 	if err != nil {
 		return nil, err
 	}
+	err = backupLocation.UpdateFromClusterSecret(c.kube)
+	if err != nil {
+		return nil, err
+	}
 	return backupLocation, nil
 }
 
@@ -64,6 +68,12 @@ func (c *Client) ListBackupLocations(namespace string, filterOptions metav1.List
 	}
 	for i := range backupLocations.Items {
 		err = backupLocations.Items[i].UpdateFromSecret(c.kube)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for i := range backupLocations.Items {
+		err = backupLocations.Items[i].UpdateFromClusterSecret(c.kube)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/portworx/torpedo/drivers/scheduler/scheduler.go
+++ b/vendor/github.com/portworx/torpedo/drivers/scheduler/scheduler.go
@@ -124,8 +124,6 @@ type ScheduleOptions struct {
 	Upgrade bool
 	// Namespace to schedule app installation if not empty
 	Namespace string
-	// DryRun
-	DryRun []string
 }
 
 // Driver must be implemented to provide test support to various schedulers.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -639,7 +639,7 @@ github.com/portworx/kdmp/pkg/version
 github.com/portworx/kvdb
 github.com/portworx/kvdb/common
 github.com/portworx/kvdb/mem
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7 => github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20220324123847-dfc1334c5499 => github.com/portworx/sched-ops v1.20.4-rc1.0.20220321032155-bcc98224224c
 ## explicit
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -1699,7 +1699,7 @@ sigs.k8s.io/yaml
 # github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20220210005610-4c63cd58298c
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220310041017-b5bae9ba82a7
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220321032155-bcc98224224c
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20220216035740-bdc80fafd64c
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.5.2


### PR DESCRIPTION
**What type of PR is this?**
> improvement


**What this PR does / why we need it**:
Backuplocation CR will now have credentials which will be used for taking snapshot and restoring volumes for different cloud vendors.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Stork uses NodeRoleInstance instead of user specified IAM user cloud credentials for taking backup and restoring
User Impact: User IAM in cloud credential associated with the cluster in px-backup is not getting respected
Resolution: User IAM in cloud credential associated with the cluster in px-backup can be utilised 
```

Test:
====
1. Tested in EKS cluster with backup, restore and backupschedule (updated in PB-2194)
2. Tested in AKS cluster with backup, restore and backupschedule
3. Tested in GCP cluster with backup, restore and backupschedule
