### PR TITLE
pb-2260: Return default objLockInfo struct instead of error for gke and azure bucket in GetObjLockInfo

### DIFF
--- a/pkg/objectstore/azure/azure.go
+++ b/pkg/objectstore/azure/azure.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/objectstore/common"
+	"github.com/sirupsen/logrus"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/azureblob"
 )
@@ -60,5 +61,6 @@ func CreateBucket(backupLocation *stork_api.BackupLocation) error {
 
 // GetObjLockInfo fetches the object lock configuration of a bucket
 func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockInfo, error) {
-	return nil, fmt.Errorf("object lock is not supported for azure provider")
+	logrus.Infof("object lock is not supported for azure provider")
+	return &common.ObjLockInfo{}, nil
 }

--- a/pkg/objectstore/google/google.go
+++ b/pkg/objectstore/google/google.go
@@ -2,12 +2,12 @@ package google
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"cloud.google.com/go/storage"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/objectstore/common"
+	"github.com/sirupsen/logrus"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/gcp"
@@ -64,5 +64,6 @@ func CreateBucket(backupLocation *stork_api.BackupLocation) error {
 
 // GetObjLockInfo fetches the object lock configuration of a bucket
 func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockInfo, error) {
-	return nil, fmt.Errorf("object lock is not supported for google provider")
+	logrus.Infof("object lock is not supported for google provider")
+	return &common.ObjLockInfo{}, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
pb-2260: Return default objLockInfo struct instead of error for gke and azure bucket in GetObjLockInfo
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

Testing:
Before fix:
<img width="2048" alt="Screenshot 2022-03-24 at 12 41 25 AM" src="https://user-images.githubusercontent.com/52188641/159784738-d4bfec2b-fe35-4597-a641-7ff186b4655e.png">

After fix:
<img width="2048" alt="Screenshot 2022-03-24 at 1 22 17 AM" src="https://user-images.githubusercontent.com/52188641/159784781-f6961bc4-b343-4a3f-8c12-9a725ea67530.png">

