### PR TITLE
Upgrade openssl libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL name="Stork" \
        summary="Storage Operator Runtime for Kubernetes" \
        description="Stork is a Cloud Native storage operator runtime scheduler plugin"
 
-RUN microdnf clean all && microdnf install -y python3.9 ca-certificates tar gzip
+RUN microdnf clean all && microdnf install -y python3.9 ca-certificates tar gzip openssl
 
 RUN python3 -m pip install awscli  && python3 -m pip install rsa --upgrade
 


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
Upgrade openssl libs to latest for RHEL 8 Ubi image for CVE reported `CVE-2022-0778`

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes,2.9

