### PR TITLE
[PB-2270]: Initializing cred values from backuplocation only if cluster secret is provided.

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -630,13 +630,6 @@ func (a *aws) getAWSClientFromBackupLocation(backupLocationName, ns string) *ec2
 			return nil
 		}
 		client = ec2.New(s)
-	} else {
-		if a.client == nil {
-			if err := a.Init(nil); err != nil {
-				return client
-			}
-		}
-		client = a.client
 	}
 	return client
 }

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -634,21 +634,20 @@ func (a *azure) getAzureClientFromBackupLocation(backupLocationName, ns string) 
 	backupLocation, err := storkops.Instance().GetBackupLocation(backupLocationName, ns)
 	if err != nil {
 		logrus.Errorf("error getting backup location %s resource: %v", backupLocationName, err)
-		return nil
+		return azureSessionWithCred
 	}
 
-	azureSessionWithCred.clientID = backupLocation.Cluster.AzureClusterConfig.ClientID
-	azureSessionWithCred.clientSecret = backupLocation.Cluster.AzureClusterConfig.ClientSecret
-	azureSessionWithCred.subscriptionID = backupLocation.Cluster.AzureClusterConfig.SubscriptionID
-	azureSessionWithCred.tenantID = backupLocation.Cluster.AzureClusterConfig.TenantID
-
-	if len(backupLocation.Cluster.SecretConfig) > 0 {
+	if len(backupLocation.Cluster.SecretConfig) > 0 && backupLocation.Cluster.AzureClusterConfig != nil {
+		azureSessionWithCred.clientID = backupLocation.Cluster.AzureClusterConfig.ClientID
+		azureSessionWithCred.clientSecret = backupLocation.Cluster.AzureClusterConfig.ClientSecret
+		azureSessionWithCred.subscriptionID = backupLocation.Cluster.AzureClusterConfig.SubscriptionID
+		azureSessionWithCred.tenantID = backupLocation.Cluster.AzureClusterConfig.TenantID
 		config := auth.NewClientCredentialsConfig(azureSessionWithCred.clientID, azureSessionWithCred.clientSecret, azureSessionWithCred.tenantID)
 		config.AADEndpoint = azure_rest.PublicCloud.ActiveDirectoryEndpoint
 		authorizer, err := config.Authorizer()
 		if err != nil {
 			logrus.Errorf("error creating azure client session for backuplocation %s: %v", backupLocationName, err)
-			return nil
+			return azureSessionWithCred
 		}
 		azureSessionWithCred.snapshotClient = compute.NewSnapshotsClient(azureSessionWithCred.subscriptionID)
 		azureSessionWithCred.diskClient = compute.NewDisksClient(azureSessionWithCred.subscriptionID)


### PR DESCRIPTION
signed-off-by: Diptiranjan


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
This fix has 2 purposes.With the support cluster credentials in a secret,
it is required for
1. Backward compatibility
2. When the IAM or SA does not have permission to create secret.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
no
-->

*Test*
Have tested with px-backup 2.1.2 and px-backup master with the stork fix on AKS cluster.

