### PR TITLE
pb-2266: Adding backupType in the applicationbackup CR created by schedule backups.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ vet:
 	go vet -tags integrationtest github.com/libopenstorage/stork/test/integration_test
 
 staticcheck:
-	GO111MODULE=off go get -u honnef.co/go/tools/cmd/staticcheck
+	GOFLAGS="" go install honnef.co/go/tools/cmd/staticcheck@v0.2.2
 	staticcheck $(PKGS)
 	staticcheck -tags integrationtest test/integration_test/*.go
 	staticcheck -tags unittest $(PKGS)

--- a/pkg/applicationmanager/controllers/applicationbackupschedule.go
+++ b/pkg/applicationmanager/controllers/applicationbackupschedule.go
@@ -47,6 +47,8 @@ const (
 	ObjectLockDefaultIncrementalCount = 5
 	// InsufficientRetentionPeriod status message signifies user has set a improper retention period on the bucket
 	InsufficientRetentionPeriod = "Failed due to insufficient bucket retention period"
+	backupTypeKey               = "portworx.io/backup-type"
+	genericBackupTypeValue      = "Generic"
 )
 
 // NewApplicationBackupSchedule creates a new instance of ApplicationBackupScheduleController.
@@ -345,6 +347,11 @@ func (s *ApplicationBackupScheduleController) startApplicationBackup(backupSched
 	}
 	backup.Annotations[ApplicationBackupScheduleNameAnnotation] = backupSchedule.Name
 	backup.Annotations[ApplicationBackupSchedulePolicyTypeAnnotation] = string(policyType)
+	if val, ok := backupSchedule.Annotations[backupTypeKey]; ok {
+		if val == genericBackupTypeValue {
+			backup.Spec.BackupType = genericBackupTypeValue
+		}
+	}
 	options, err := schedule.GetOptions(backupSchedule.Spec.SchedulePolicyName, backupSchedule.Namespace, policyType)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
pb-2266

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
All add the release note in px-backup as we are not claiming the generic backup from stork.

**Does this change need to be cherry-picked to a release branch?**:
No

