### PR TITLE
pb-2037: Making snapshot timeout configurable

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -35,6 +35,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/rule"
 	"github.com/libopenstorage/stork/pkg/schedule"
 	"github.com/libopenstorage/stork/pkg/snapshot"
+	"github.com/libopenstorage/stork/pkg/snapshotter"
 	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/libopenstorage/stork/pkg/webhookadmission"
 	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
@@ -232,6 +233,7 @@ func run(c *cli.Context) {
 	kdmpConfig.Data[drivers.KopiaExecutorLimitCPU] = drivers.DefaultKopiaExecutorLimitCPU
 	kdmpConfig.Data[drivers.KopiaExecutorLimitMemory] = drivers.DefaultKopiaExecutorLimitMemory
 	kdmpConfig.Data[drivers.KopiaExecutorImageSecretKey] = ""
+	kdmpConfig.Data[snapshotter.SnapshotTimeoutKey] = ""
 	if marketPlace == awsMarketPlace {
 		kdmpConfig.Data[drivers.KopiaExecutorImageKey] = strings.Join([]string{awsKopiaExecutorImage, awsKopiaExecutorImageTag}, ":")
 	} else {


### PR DESCRIPTION
Added a configMap which can alter the snapshot timeout period this helps
in addressing OCS cluster issues wherein it takes genuinely more time.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?**Bug
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: In certain OCP version the local snapshot takes a lot of time to complete it hence we need to keep the timeout configurable. So that user can experiment with it based on the OCP version and types of Node config it is running the OCP setup. 

**Does this PR change a user-facing CRD or CLI?**: No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: NO
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->

**Does this change need to be cherry-picked to a release branch?**: 2.10
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
** UnitTesting**
The configMap feild in kdmp-config looks as below with name SNAPSHOT_TIMEOUT
![rror xcurs](https://user-images.githubusercontent.com/15273500/164152894-3e0d89d2-c349-41db-8cae-4f9f1cca98df.png)
Currently set it as 3second to simulate the timeout scenario, because on OCP 4.9 and with a PVC of 100GB and data worth of 50GB in it takes 14 seconds. When this bug was raised in OCP 4.8.0 it took more than 17 minutes.
![image](https://user-images.githubusercontent.com/15273500/164153215-f8466b29-6c70-481e-9a75-e5ab9834a66e.png)

OCP backup taken as below 
![Create Backup](https://user-images.githubusercontent.com/15273500/164153271-ea9163c1-be82-4998-8a42-f1c65ba37e10.png)

Backup failed with a configured timeout 
![Pasted Graphic 4](https://user-images.githubusercontent.com/15273500/164153324-2cc2c41a-ca70-4da2-9689-7cbeedb0ed08.png)

![IN CLUSTER](https://user-images.githubusercontent.com/15273500/164153339-5b3b5f3f-f5f2-4bf2-9afd-73797a84494a.png)



