### PR TITLE
pb-2288: ebsVolume.Size is size in GiB, So converting it to bytes.

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -556,7 +556,8 @@ func (a *aws) GetRestoreStatus(restore *storkapi.ApplicationRestore) ([]*storkap
 		case "available", "in-use":
 			vInfo.Status = storkapi.ApplicationRestoreStatusSuccessful
 			vInfo.Reason = "Restore successful for volume"
-			vInfo.TotalSize = uint64(*ebsVolume.Size)
+			// converting to bytes
+			vInfo.TotalSize = uint64(*ebsVolume.Size) * units.GiB
 		}
 		volumeInfos = append(volumeInfos, vInfo)
 	}


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
 pb-2288: ebsVolume.Size is size in GiB, So converting it to bytes.

**Does this PR change a user-facing CRD or CLI?**:
No
**Is a release note needed?**:
```release-note
Issue: The restore size for EBS volumes was displaying incorrectly
User Impact: It will be confusing for user as the restore is less than the backup size for EBS volume.
Resolution: Fixed to correct restore size for EBS volume
```

**Does this change need to be cherry-picked to a release branch?**:
yes, to 2.10 branch

Testing:
![Screenshot 2022-04-12 at 3 17 17 AM](https://user-images.githubusercontent.com/52188641/162838968-57a7d33d-4a7e-4c74-ac0c-e7d81fc155cf.png)


