### PR TITLE
pb-2293: add logic to extract registry that container extra directories with in it for rule cmd executor.

### DIFF
--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -179,14 +179,12 @@ func GetImageRegistryFromDeployment(name, namespace string) (string, string, err
 		return "", "", err
 	}
 	imageFields := strings.Split(deploy.Spec.Template.Spec.Containers[0].Image, "/")
-	var registry string
-	// Here the assumtption is that the image format will be <registry-name>/<repo-name>/image:tag
+	// Here the assumption is that the image format will be <registry-name>/<extra-dir-name>/<repo-name>/image:tag
 	// or <repo-name>/image:tag. If repo name contains any path (<registry-name>/<repo-name>/<extra-dir-name>/image:tag), below logic will not work.
-	if len(imageFields) == 3 {
-		registry = imageFields[0]
-	} else {
-		registry = ""
-	}
+	// Customer might have extra dirs before the repo-name as mentioned above
+	// here minus 2 is for image name and repo name exclusion
+	registryFields := imageFields[0 : len(imageFields)-2]
+	registry := strings.Join(registryFields, "/")
 	imageSecret := deploy.Spec.Template.Spec.ImagePullSecrets
 	if imageSecret != nil {
 		return registry, imageSecret[0].Name, nil


### PR DESCRIPTION



**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
 pb-2293: add logic to extract registry that container extra directories
    with in it for rule cmd executor.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
No, planning to add a seperate section in the air-gapped documentation.

**Does this change need to be cherry-picked to a release branch?**:
2.10 branch.

