### PR TITLE
pb-2298: minimum retention period added to error msg of failed backup

### DIFF
--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -227,19 +227,20 @@ func GetConfigValue(cm, ns, key string) (string, error) {
 
 // IsValidBucketRetentionPeriod - returns the sanity of retention period
 // for a object locked bucket this function returns true if retention
-// period set on the bucket is more than the minimum retention period
-func IsValidBucketRetentionPeriod(bucketRetentionPeriod int64) (bool, error) {
+// period set on the bucket is more than the minimum retention period and
+// minimum required retention period.
+func IsValidBucketRetentionPeriod(bucketRetentionPeriod int64) (bool, int64, error) {
 	var incrBkpCnt int64
 	var i string
 	var err error
 	ns := DefaultAdminNamespace
 	if i, err = GetConfigValue(StorkConfigMapName, ns, ObjectLockIncrBackupCountKey); err != nil {
-		return false, fmt.Errorf("failed to get %s key from px-backup-configmap: %v", ObjectLockIncrBackupCountKey, err)
+		return false, 0, fmt.Errorf("failed to get %s key from px-backup-configmap: %v", ObjectLockIncrBackupCountKey, err)
 	}
 	if i != "" {
 		incrBkpCnt, err = strconv.ParseInt(i, 10, 64)
 		if err != nil {
-			return false, fmt.Errorf("failed to convert backup incremental count: %v", err)
+			return false, 0, fmt.Errorf("failed to convert backup incremental count: %v", err)
 		}
 	} else {
 		incrBkpCnt = ObjectLockDefaultIncrementalCount
@@ -248,5 +249,5 @@ func IsValidBucketRetentionPeriod(bucketRetentionPeriod int64) (bool, error) {
 	// and a full backup following it makes up the minimum number of retention period
 	// user should set.
 	minRetentionDays := minProtectionPeriod + incrBkpCnt + 1
-	return (bucketRetentionPeriod >= minRetentionDays), nil
+	return (bucketRetentionPeriod >= minRetentionDays), minRetentionDays, nil
 }


### PR DESCRIPTION
When a scheduled backup failed due to insufficient retention period then
user need to be aware of minimum retention period to be set via error
message.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?**Bug
> Uncomment only one and also add the corresponding label in the PR:
bug


**What this PR does / why we need it**: User need to know about the minimum retention period required when a scheduled backup fails due to insufficient retention period set on the S3 bucket. 


**Does this PR change a user-facing CRD or CLI?**:No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
**Unit test**
Below screen shot shows the same
![backup_info](https://user-images.githubusercontent.com/15273500/164375624-2872c9fb-eb0f-48c8-8ab1-6c82741fba20.png)

