### PR TITLE
pb-2330: Made fix to support image name to have custom repo as well for cmdexecutor image

### DIFF
--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -180,10 +180,10 @@ func GetImageRegistryFromDeployment(name, namespace string) (string, string, err
 	}
 	imageFields := strings.Split(deploy.Spec.Template.Spec.Containers[0].Image, "/")
 	// Here the assumption is that the image format will be <registry-name>/<extra-dir-name>/<repo-name>/image:tag
-	// or <repo-name>/image:tag. If repo name contains any path (<registry-name>/<repo-name>/<extra-dir-name>/image:tag), below logic will not work.
+	// or <repo-name>/image:tag or <registry-name>/<repo-name>/<extra-dir-name>/image:tag).
 	// Customer might have extra dirs before the repo-name as mentioned above
-	// here minus 2 is for image name and repo name exclusion
-	registryFields := imageFields[0 : len(imageFields)-2]
+	// here minus 1 is for image name
+	registryFields := imageFields[0 : len(imageFields)-1]
 	registry := strings.Join(registryFields, "/")
 	imageSecret := deploy.Spec.Template.Spec.ImagePullSecrets
 	if imageSecret != nil {


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
pb-2330: Made fix to support image name to have custom repo as well for cmdexecutor image
```
**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
Planning to add seperate documentation for the custom image in air-gapped environment.
**Does this change need to be cherry-picked to a release branch?**:
2.10

