### PR TITLE
pb-2330: remove the portworx repo name from default defaultCmdExecutorImage to support custom repo

### DIFF
--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -40,7 +40,7 @@ const (
 	// environment variable for command executor image registry and image registry secret.
 	cmdExecutorImageRegistryEnvVar       = "CMD-EXECUTOR-IMAGE-REGISTRY"
 	cmdExecutorImageRegistrySecretEnvVar = "CMD-EXECUTOR-IMAGE-REGISTRY-SECRET"
-	defaultCmdExecutorImage              = "openstorage/cmdexecutor:0.1"
+	defaultCmdExecutorImage              = "cmdexecutor:0.1"
 	// annotation key value for command executor image registry and image registry secret.
 	cmdExecutorImageOverrideKey          = "stork.libopenstorage.org/cmdexecutor-image"
 	cmdExecutorImageOverrideSecretKey    = "stork.libopenstorage.org/cmdexecutor-image-secret"


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
 pb-2330: remove the portworx repo name from default defaultCmdExecutorImage to support custom repo
 ```

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
no. Planning to added separate section in px-backup documentation.

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.10
