### PR TITLE
pb-2360: Using GetStorkPodNamespace api for cmdexecutor  image extraction as well.

### DIFF
--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -338,10 +338,15 @@ func executeCommandAction(
 	// The order of priority for image location value is Job annotation, environmental variable
 	// and then if both of them are missing, default to stork image repo
 	if len(os.Getenv(cmdExecutorImageRegistryEnvVar)) == 0 {
+		storkPodNs, err := k8sutils.GetStorkPodNamespace()
+		if err != nil {
+			logrus.Errorf("error in getting stork pod namespace: %v", err)
+			return err
+		}
 		// If env is not set get the values from stork deployment spec.
 		registry, registrySecret, err := k8sutils.GetImageRegistryFromDeployment(
 			k8sutils.StorkDeploymentName,
-			k8sutils.DefaultAdminNamespace,
+			storkPodNs,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
pb-2360

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
More details regarding the custom image require for air-gapped env is getting document in px-backup documentation.

**Does this change need to be cherry-picked to a release branch?**:
2.10

