### PR TITLE
pb2328: Support both v1beta1 and v1 for CSI volume snapshot APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.0
-	github.com/portworx/kdmp v0.4.1-0.20220426034740-53f16b1cdbb8
+	github.com/portworx/kdmp v0.4.1-0.20220612094815-855f9e2fd62e
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20220401024625-dbc61a336f65
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -1366,6 +1366,8 @@ github.com/portworx/kdmp v0.4.1-0.20220424063235-a4aa78cfd821 h1:q9vCva3CmgNYSUX
 github.com/portworx/kdmp v0.4.1-0.20220424063235-a4aa78cfd821/go.mod h1:nb5AupP/63ByyqAYfZ+E32LDEnP0PjgH6w+yKXxWIgE=
 github.com/portworx/kdmp v0.4.1-0.20220426034740-53f16b1cdbb8 h1:aUKrX2mg5mXtwdK/sBP9RiSQ2FRjm9pmL1DRdKWuqQY=
 github.com/portworx/kdmp v0.4.1-0.20220426034740-53f16b1cdbb8/go.mod h1:nb5AupP/63ByyqAYfZ+E32LDEnP0PjgH6w+yKXxWIgE=
+github.com/portworx/kdmp v0.4.1-0.20220612094815-855f9e2fd62e h1:ctpGIuLeUzrk33LFhor4cWETzu+UshhkIDqjTOsTMMU=
+github.com/portworx/kdmp v0.4.1-0.20220612094815-855f9e2fd62e/go.mod h1:nb5AupP/63ByyqAYfZ+E32LDEnP0PjgH6w+yKXxWIgE=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194 h1:lBVk1jEP5WGUk9uYTSwZaS9PZimj+uk61IYY8ewOmvA=
 github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,11 +1,17 @@
 package version
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
 	version "github.com/hashicorp/go-version"
+	kSnapshotClient "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	coreops "github.com/portworx/sched-ops/k8s/core"
+	"github.com/sirupsen/logrus"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 // Version will be overridden with the current version at build time using the -X linker flag
@@ -16,7 +22,8 @@ var (
 )
 
 const (
-	k8sMinVersionCSIDriverV1 = "1.22"
+	k8sMinVersionCSIDriverV1      = "1.22"
+	k8sMinVersionVolumeSnapshotV1 = "1.20"
 )
 
 // RequiresV1Registration returns true if crd needs to be registered as apiVersion V1
@@ -51,6 +58,39 @@ func RequiresV1CSIdriver() (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+// RequiresV1VolumeSnapshot returns true if V1 version of VolumeSnapshot APIs need to be called
+func RequiresV1VolumeSnapshot() (bool, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return false, err
+	}
+	cs, err := kSnapshotClient.NewForConfig(config)
+	if err != nil {
+		return false, err
+	}
+	_, err = cs.SnapshotV1().VolumeSnapshots("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil && !k8s_errors.IsNotFound(err) {
+		logrus.Errorf("Failed to get VolumeSnapshot v1 version error: %s", err)
+		return false, err
+	} else if k8s_errors.IsNotFound(err) {
+		// Try for v1beta1
+		_, err := cs.SnapshotV1beta1().VolumeSnapshots("").List(context.TODO(), metav1.ListOptions{})
+		if err != nil && !k8s_errors.IsNotFound(err) {
+			logrus.Errorf("Failed to get VolumeSnapshot v1beta1 version CRD error: %s", err)
+			return false, err
+		} else if k8s_errors.IsNotFound(err) {
+			logrus.Warnf("VolumeSnapshot CRDs are not installed in the cluster, Please install appropriate version of volumesnapshot CRDs: %s", err)
+			// Not attempting for v1alpha1 CRD search, it is too old to adopt
+			// Returning error as nil to keep the previous behavior unchanged, which doesn't bail out in the absence of CRDs
+			return false, nil
+		}
+		//Found v1beta1 CRD
+		return false, nil
+	}
+	//Found the v1 CRD
+	return true, nil
 }
 
 // GetFullVersion returns the full kubernetes server version

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
@@ -44,6 +44,7 @@ type JobOpts struct {
 	JobConfigMapNs             string
 	KopiaImageExecutorSource   string
 	KopiaImageExecutorSourceNs string
+	NodeAffinity               map[string]string
 }
 
 // WithKopiaImageExecutorSource is job parameter.
@@ -370,6 +371,14 @@ func WithJobConfigMap(jobConfigMap string) JobOption {
 func WithJobConfigMapNs(jobConfigMapNs string) JobOption {
 	return func(opts *JobOpts) error {
 		opts.JobConfigMapNs = jobConfigMapNs
+		return nil
+	}
+}
+
+// WithNodeAffinity is job parameter.
+func WithNodeAffinity(l map[string]string) JobOption {
+	return func(opts *JobOpts) error {
+		opts.NodeAffinity = l
 		return nil
 	}
 }

--- a/vendor/github.com/portworx/kdmp/pkg/version/version.go
+++ b/vendor/github.com/portworx/kdmp/pkg/version/version.go
@@ -1,16 +1,23 @@
 package version
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"runtime"
 
 	version "github.com/hashicorp/go-version"
+	kSnapshotClient "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	coreops "github.com/portworx/sched-ops/k8s/core"
+	"github.com/sirupsen/logrus"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 const (
-	k8sMinVersionCronJobV1 = "1.21"
+	k8sMinVersionCronJobV1        = "1.21"
+	k8sMinVersionVolumeSnapshotV1 = "1.20"
 )
 
 // Base version information.
@@ -48,6 +55,39 @@ func Get() Info {
 		Compiler:   runtime.Compiler,
 		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
+}
+
+// RequiresV1VolumeSnapshot returns true if V1 version of VolumeSnapshot APIs need to be called
+func RequiresV1VolumeSnapshot() (bool, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return false, err
+	}
+	cs, err := kSnapshotClient.NewForConfig(config)
+	if err != nil {
+		return false, err
+	}
+	_, err = cs.SnapshotV1().VolumeSnapshots("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil && !k8s_errors.IsNotFound(err) {
+		logrus.Errorf("Failed to get VolumeSnapshot v1 version error: %s", err)
+		return false, err
+	} else if k8s_errors.IsNotFound(err) {
+		// Try for v1beta1
+		_, err := cs.SnapshotV1beta1().VolumeSnapshots("").List(context.TODO(), metav1.ListOptions{})
+		if err != nil && !k8s_errors.IsNotFound(err) {
+			logrus.Errorf("Failed to get VolumeSnapshot v1beta1 version CRD error: %s", err)
+			return false, err
+		} else if k8s_errors.IsNotFound(err) {
+			logrus.Warnf("VolumeSnapshot CRDs are not installed in the cluster, Please install appropriate version of volumesnapshot CRDs: %s", err)
+			// Not attempting for v1alpha1 CRD search, it is too old to adopt
+			// Returning error as nil to keep the previous behavior unchanged, which doesn't bail out in the absence of CRDs
+			return false, nil
+		}
+		//Found v1beta1 CRD
+		return false, nil
+	}
+	//Found the v1 CRD
+	return true, nil
 }
 
 // RequiresV1Registration returns true if crd nees to be registered as apiVersion V1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -615,7 +615,7 @@ github.com/pierrec/lz4/internal/xxh32
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20220426034740-53f16b1cdbb8
+# github.com/portworx/kdmp v0.4.1-0.20220612094815-855f9e2fd62e
 ## explicit
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1


### PR DESCRIPTION
pb-2328: Support both v1 & v1beta1 version of volumeSnapshot feature
- Added support for V1 VolumeSnapshot APIs which is GA from
  kubernetes 1.20 version.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>

**What type of PR is this?** BUG
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: From k8s 1.20 onwards the volumesnapshot feature is promoted to GA, hence we need to support corresponding APIs at the same time maintain backward compatibility with v1beta1 till it is removed in future version. 


**Does this PR change a user-facing CRD or CLI?**: It doesn't change any existing CRDs rather expects user to installs new CRDs with respect to volumesnapshots, volumesnapshotClass, volumesnapshotContent & necessary controllers. Additionally  enable adequate support in code to use them
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: Yes
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: The stork code will fails to take backup in systems having only v1 based volumesnapshot CRDs & it will expect user to install v1beta1 CRDs as a workaround for k8s beyond 1.20. Additionally in future version of k8s wherein v1beta1 support will be removed this work around will also not work.
User Impact: Backup/restore will fail if Application cluster has only v1 based volumesnapshot CRDs and user reluctant to install v1beta1
Resolution: The code enables support for v1 volumesnapshot CRDs & controllers via this PR. Hence stork need to be upgraded to reflect this change in customer's application cluster for a gracefull backup/restore operation via px-backup 

```

**Does this change need to be cherry-picked to a release branch?**: 2.10
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

Detailed unit test related screenshots are attached in the bug report **pb-2328** (https://portworx.atlassian.net/browse/PB-2328)