### PR TITLE
pb-2371: Handle non-existent bucket scenario for object-lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: go
 go:
-  - 1.16.x
+  - 1.17.3
 before_install:
   - sudo apt-get update -yq
   - sudo apt-get install go-md2man -y

--- a/pkg/objectstore/s3/s3.go
+++ b/pkg/objectstore/s3/s3.go
@@ -78,10 +78,15 @@ func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockIn
 	out, err := s3.New(sess).GetObjectLockConfiguration(input)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			// When a minio server doesn't have object-lock implemented
-			// then Minio backed backuplocation throws this error for
-			// normal buckets too hence we need to ignore this for now.
-			if awsErr.Code() == "ObjectLockConfigurationNotFoundError" || awsErr.Code() == "MethodNotAllowed" {
+			// When a Minio server doesn't have object-lock implemented then above API
+			// throws following error codes depending on version it runs for normal buckets
+			//	1. "ObjectLockConfigurationNotFoundError"
+			//  2. "MethodNotAllowed"
+			// Similarly in case of AWS, we need to ignore "NoSuchBucket" so that
+			// px-backup/stork can create the bucket on behalf user when validation flag is not set.
+			if awsErr.Code() == "ObjectLockConfigurationNotFoundError" ||
+				awsErr.Code() == "MethodNotAllowed" ||
+				awsErr.Code() == "NoSuchBucket" {
 				// for a non-objectlocked bucket we needn't throw error
 				return objLockInfo, nil
 			}


### PR DESCRIPTION
Handle error code "NoSuchBucket" while fetching object lock info for a
AWS S3 based bucket.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?**Bug
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: When a user creates a backuplocation object without validation flag set then code fails to fetch the object lock info for the bucket as the bucket wouldn't have created during validation process. Hence "NoSuchBucket" error is discounted in the object lock info fetch logic. It enables stork to create the bucket in later point in time. This is found in integration test for AWS S3 bucket. This issue never occurs when experimented via UI as UI always sets validation flag for the bucket in px-backup.


**Does this PR change a user-facing CRD or CLI?**:No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

