### PR TITLE
PWX-23579 : Allow setting QPS & Burst rate for storkctl command

### DIFF
--- a/pkg/appregistration/appregistration.go
+++ b/pkg/appregistration/appregistration.go
@@ -427,5 +427,11 @@ func GetSupportedGVR() map[schema.GroupVersionResource]string {
 			Group:    "mongodbcommunity.mongodb.com",
 			Version:  "v1",
 		}: "MongoDBCommunityList",
+		// VirtualMachine crds
+		{
+			Resource: "virtualmachines",
+			Group:    "kubevirt.io",
+			Version:  "v1",
+		}: "VirtualMachinesList",
 	}
 }

--- a/pkg/storkctl/factory.go
+++ b/pkg/storkctl/factory.go
@@ -29,6 +29,8 @@ type factory struct {
 	context       string
 	outputFormat  string
 	watch         bool
+	qps           int
+	burst         int
 }
 
 // Factory to be used for command line
@@ -58,6 +60,10 @@ type Factory interface {
 	setNamespace(string)
 	// IsWatchSet return true if -w/watch is passed
 	IsWatchSet() bool
+	// GetQPS return qps number for k8s api request
+	GetQPS() int
+	// GetBurst return qps number for k8s api request
+	GetBurst() int
 }
 
 // NewFactory Return a new factory interface that can be used by commands
@@ -71,6 +77,8 @@ func (f *factory) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&f.context, "context", "", "The name of the kubeconfig context to use")
 	flags.StringVarP(&f.outputFormat, "output", "o", outputFormatTable, "Output format. One of: table|json|yaml")
 	flags.BoolVarP(&f.watch, "watch", "w", false, "watch stork resourrces")
+	flags.IntVarP(&f.qps, "qps", "", 100, "Restrict number of k8s api requests from stork")
+	flags.IntVarP(&f.burst, "burst", "", 100, "Restrict number of k8s api requests from stork")
 }
 
 func (f *factory) BindGetFlags(flags *pflag.FlagSet) {
@@ -82,6 +90,13 @@ func (f *factory) AllNamespaces() bool {
 	return f.allNamespaces
 }
 
+func (f *factory) GetQPS() int {
+	return f.qps
+
+}
+func (f *factory) GetBurst() int {
+	return f.burst
+}
 func (f *factory) GetNamespace() string {
 	return f.namespace
 }

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -158,8 +158,8 @@ func newActivateMigrationsCommand(cmdFactory Factory, ioStreams genericclioption
 			if qps := cmdFactory.GetQPS(); qps > 1 {
 				config.QPS = float32(qps)
 			}
-			if burst := cmdFactory.GetQPS(); burst > 1 {
-				config.QPS = float32(burst)
+			if burst := cmdFactory.GetBurst(); burst > 1 {
+				config.Burst = burst
 			}
 			if allNamespaces {
 				namespaces, err := core.Instance().ListNamespaces(nil)
@@ -198,6 +198,7 @@ func newActivateMigrationsCommand(cmdFactory Factory, ioStreams genericclioption
 				updateIBPObjects("IBPCA", ns, true, ioStreams)
 				updateIBPObjects("IBPOrderer", ns, true, ioStreams)
 				updateIBPObjects("IBPConsole", ns, true, ioStreams)
+				updateVMObjects("VirtualMachine", ns, true, ioStreams)
 				updateCRDObjects(ns, true, ioStreams, config)
 				updateCronJobObjects(ns, true, ioStreams)
 			}
@@ -245,6 +246,7 @@ func newDeactivateMigrationsCommand(cmdFactory Factory, ioStreams genericcliopti
 				updateIBPObjects("IBPCA", ns, false, ioStreams)
 				updateIBPObjects("IBPOrderer", ns, false, ioStreams)
 				updateIBPObjects("IBPConsole", ns, false, ioStreams)
+				updateVMObjects("VirtualMachine", ns, true, ioStreams)
 				updateCRDObjects(ns, false, ioStreams, config)
 				updateCronJobObjects(ns, false, ioStreams)
 			}
@@ -454,6 +456,26 @@ func updateIBPObjects(kind string, namespace string, activate bool, ioStreams ge
 			}
 			printMsg(fmt.Sprintf("Updated replicas for %v %v/%v to %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), replicas), ioStreams.Out)
 		}
+	}
+}
+func updateVMObjects(kind string, namespace string, activate bool, ioStreams genericclioptions.IOStreams) {
+	objects, err := dynamic.Instance().ListObjects(
+		&metav1.ListOptions{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       kind,
+				APIVersion: "kubevirt.io/v1"},
+		},
+		namespace)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			util.CheckErr(err)
+		}
+		return
+	}
+	for _, o := range objects.Items {
+		path := []string{"spec", "running"}
+		unstructured.RemoveNestedField(o.Object, path...)
+		printMsg(fmt.Sprintf("Removed field for %v %v/%v", strings.ToLower(kind), o.GetNamespace(), o.GetName()), ioStreams.Out)
 	}
 }
 

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -155,6 +155,12 @@ func newActivateMigrationsCommand(cmdFactory Factory, ioStreams genericclioption
 				util.CheckErr(err)
 				return
 			}
+			if qps := cmdFactory.GetQPS(); qps > 1 {
+				config.QPS = float32(qps)
+			}
+			if burst := cmdFactory.GetQPS(); burst > 1 {
+				config.QPS = float32(burst)
+			}
 			if allNamespaces {
 				namespaces, err := core.Instance().ListNamespaces(nil)
 				if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
This PR add support to set  QPS & Burst rate for storkctl command.

**Does this PR change a user-facing CRD or CLI?**:
yes
```
# time ./bin/linux/storkctl activate migration -nopenshift4-debug --qps 500 --burst 100

real	0m0.844s
user	0m0.176s
sys	0m0.046s
```

**Is a release note needed?**:
yes
```release-note
Issue: storkctl activate takes too much time 
User Impact:  Activate/Deactivate migrated apps takes too much time
Resolution: storkctl now accept qps and burst rate for limiting k8s api queries 

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.11
