### PR TITLE
PWX-23582: VM object migration support

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1277,8 +1277,8 @@ func (m *MigrationController) prepareCRDClusterResource(
 				disableVersion = int64(0)
 				currVal = fmt.Sprintf("%v", curr)
 			} else if suspend.Type == "string" {
-				curr, found, err := unstructured.NestedString(content, fields...)
-				if err != nil || !found {
+				curr, _, err := unstructured.NestedString(content, fields...)
+				if err != nil {
 					return fmt.Errorf("unable to find suspend path, err: %v", err)
 				}
 				disableVersion = suspend.Value

--- a/pkg/resourcecollector/datavolume.go
+++ b/pkg/resourcecollector/datavolume.go
@@ -1,0 +1,9 @@
+package resourcecollector
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+func (r *ResourceCollector) dataVolumesToBeCollected(
+	object runtime.Unstructured,
+) (bool, error) {
+	return false, nil
+}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -518,6 +518,10 @@ func (r *ResourceCollector) objectToBeCollected(
 		return r.resourceQuotaToBeCollected(object)
 	case "NetworkPolicy":
 		return r.networkPolicyToBeCollected(object)
+	case "DataVolume":
+		return r.dataVolumesToBeCollected(object)
+	case "VirtualMachineInstance":
+		return r.virtualMachineInstanceToBeCollected(object)
 	}
 
 	return true, nil
@@ -618,7 +622,12 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 		case "Job":
 			err := r.prepareJobForCollection(o, namespaces)
 			if err != nil {
-				return fmt.Errorf("error preparing ClusterRoleBindings resource %v: %v", metadata.GetName(), err)
+				return fmt.Errorf("error preparing job resource %v: %v", metadata.GetName(), err)
+			}
+		case "VirtualMachine":
+			err := r.prepareVirtualMachineForCollection(o, namespaces)
+			if err != nil {
+				return fmt.Errorf("error preparing VirtualMachine resource %v: %v", metadata.GetName(), err)
 			}
 		}
 

--- a/pkg/resourcecollector/virtualmachine.go
+++ b/pkg/resourcecollector/virtualmachine.go
@@ -1,0 +1,27 @@
+package resourcecollector
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) prepareVirtualMachineForCollection(
+	object runtime.Unstructured,
+	namespaces []string,
+) error {
+	// VM object has mutually exclusive field to start/stop VM's
+	// lets remove spec.running to avoid gettting blocked by
+	// webhook controller
+	content := object.UnstructuredContent()
+	path := []string{"spec", "running"}
+	unstructured.RemoveNestedField(content, path...)
+	path = []string{"spec", "runStrategy"}
+	if err := unstructured.SetNestedField(content, "Always", path...); err != nil {
+		return err
+	}
+	// since dr handles volume migration datavolumetemplates
+	// is not necessary
+	path = []string{"spec", "dataVolumeTemplates"}
+	unstructured.RemoveNestedField(content, path...)
+	return nil
+}

--- a/pkg/resourcecollector/virtualmachineinstance.go
+++ b/pkg/resourcecollector/virtualmachineinstance.go
@@ -1,0 +1,9 @@
+package resourcecollector
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+func (r *ResourceCollector) virtualMachineInstanceToBeCollected(
+	object runtime.Unstructured,
+) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Support VM object migration. Ensure all of child CR and volumes migrated properly

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes

```release-note
Issue: kube-virt VM object migration is partial successful
User Impact: Users has to do manual intervention to successfully start VM on DR site
Resolution:  stork can migrate and manage kube-virt VM resources activation/deactivation

```

**Does this change need to be cherry-picked to a release branch?**:
2.11

