### PR TITLE
PWX-23693 Allow scheduling of pods with pending pvcs due to WaitForFi…

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -581,8 +581,8 @@ func (a *aws) InspectNode(id string) (*storkvolume.NodeInfo, error) {
 	return nil, &errors.ErrNotSupported{}
 }
 
-func (a *aws) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*storkvolume.Info, error) {
-	return nil, &errors.ErrNotSupported{}
+func (a *aws) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePendingWFFC bool) ([]*storkvolume.Info, []*storkvolume.Info, error) {
+	return nil, nil, &errors.ErrNotSupported{}
 }
 
 func (a *aws) GetSnapshotPlugin() snapshotVolume.Plugin {

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -602,8 +602,8 @@ func (a *azure) InspectNode(id string) (*storkvolume.NodeInfo, error) {
 	return nil, &errors.ErrNotSupported{}
 }
 
-func (a *azure) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*storkvolume.Info, error) {
-	return nil, &errors.ErrNotSupported{}
+func (a *azure) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePendingWFFC bool) ([]*storkvolume.Info, []*storkvolume.Info, error) {
+	return nil, nil, &errors.ErrNotSupported{}
 }
 
 func (a *azure) GetSnapshotPlugin() snapshotVolume.Plugin {

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -1356,8 +1356,8 @@ func (c *csi) InspectNode(id string) (*storkvolume.NodeInfo, error) {
 	return nil, &errors.ErrNotSupported{}
 }
 
-func (c *csi) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*storkvolume.Info, error) {
-	return nil, &errors.ErrNotSupported{}
+func (c *csi) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePendingWFFC bool) ([]*storkvolume.Info, []*storkvolume.Info, error) {
+	return nil, nil, &errors.ErrNotSupported{}
 }
 
 func (c *csi) GetSnapshotPlugin() snapshotVolume.Plugin {

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -584,8 +584,8 @@ func (g *gcp) InspectNode(id string) (*storkvolume.NodeInfo, error) {
 	return nil, &errors.ErrNotSupported{}
 }
 
-func (g *gcp) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*storkvolume.Info, error) {
-	return nil, &errors.ErrNotSupported{}
+func (g *gcp) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePendingWFFC bool) ([]*storkvolume.Info, []*storkvolume.Info, error) {
+	return nil, nil, &errors.ErrNotSupported{}
 }
 
 func (g *gcp) GetSnapshotPlugin() snapshotVolume.Plugin {

--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -907,8 +907,8 @@ func (k *kdmp) InspectNode(id string) (*storkvolume.NodeInfo, error) {
 	return nil, &errors.ErrNotSupported{}
 }
 
-func (k *kdmp) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*storkvolume.Info, error) {
-	return nil, &errors.ErrNotSupported{}
+func (k *kdmp) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePendingWFFC bool) ([]*storkvolume.Info, []*storkvolume.Info, error) {
+	return nil, nil, &errors.ErrNotSupported{}
 }
 
 func (k *kdmp) GetSnapshotPlugin() snapshotVolume.Plugin {

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -252,10 +252,6 @@ func (l *linstor) GetNodes() ([]*storkvolume.NodeInfo, error) {
 }
 
 func (l *linstor) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePendingWFFC bool) ([]*storkvolume.Info, []*storkvolume.Info, error) {
-	// TODO how to handle includePendingWFFC
-	if includePendingWFFC {
-		return nil, nil, &errors.ErrNotSupported{}
-	}
 	var empty []*storkvolume.Info
 	var volumes []*storkvolume.Info
 	for _, volume := range podSpec.Volumes {

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/storage"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -252,10 +253,12 @@ func (l *linstor) GetNodes() ([]*storkvolume.NodeInfo, error) {
 }
 
 func (l *linstor) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePendingWFFC bool) ([]*storkvolume.Info, []*storkvolume.Info, error) {
-	var empty []*storkvolume.Info
+	// includePendingWFFC - Includes pending volumes in the second return value if they are using WaitForFirstConsumer binding mode
 	var volumes []*storkvolume.Info
+	var pendingWFFCVolumes []*storkvolume.Info
 	for _, volume := range podSpec.Volumes {
 		volumeName := ""
+		isPendingWFFC := false
 		if volume.PersistentVolumeClaim != nil {
 			pvc, err := core.Instance().GetPersistentVolumeClaim(
 				volume.PersistentVolumeClaim.ClaimName,
@@ -269,8 +272,13 @@ func (l *linstor) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePe
 			}
 
 			if pvc.Status.Phase == v1.ClaimPending {
-				return nil, nil, &storkvolume.ErrPVCPending{
-					Name: volume.PersistentVolumeClaim.ClaimName,
+				// Only include pending volume if requested and storage class has WFFC
+				if includePendingWFFC && isWaitingForFirstConsumer(pvc) {
+					isPendingWFFC = true
+				} else {
+					return nil, nil, &storkvolume.ErrPVCPending{
+						Name: volume.PersistentVolumeClaim.ClaimName,
+					}
 				}
 			}
 			volumeName = pvc.Spec.VolumeName
@@ -284,10 +292,29 @@ func (l *linstor) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePe
 					VolumeName: volumeName,
 				}
 			}
-			volumes = append(volumes, volumeInfo)
+			if isPendingWFFC {
+				pendingWFFCVolumes = append(pendingWFFCVolumes, volumeInfo)
+			} else {
+				volumes = append(volumes, volumeInfo)
+			}
 		}
 	}
-	return volumes, empty, nil
+	return volumes, pendingWFFCVolumes, nil
+}
+
+func isWaitingForFirstConsumer(pvc *v1.PersistentVolumeClaim) bool {
+	var sc *storagev1.StorageClass
+	var err error
+	storageClassName := k8shelper.GetPersistentVolumeClaimClass(pvc)
+	if storageClassName != "" {
+		sc, err = storage.Instance().GetStorageClass(storageClassName)
+		if err != nil {
+			logrus.Warnf("Did not get the storageclass %s for pvc %s/%s, err: %v", storageClassName, pvc.Namespace, pvc.Name, err)
+			return false
+		}
+		return *sc.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer
+	}
+	return false
 }
 
 func (l *linstor) GetVolumeClaimTemplates(templates []v1.PersistentVolumeClaim) ([]v1.PersistentVolumeClaim, error) {

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -131,6 +131,11 @@ func (m *Driver) NewPVC(volumeName string) *v1.PersistentVolumeClaim {
 	return pvc
 }
 
+// AddPVC adds an already created PVC
+func (m *Driver) AddPVC(pvc *v1.PersistentVolumeClaim) {
+	m.pvcs[pvc.Name] = pvc
+}
+
 // ProvisionVolume Provision a volume in the mock driver
 func (m *Driver) ProvisionVolume(
 	volumeName string,
@@ -248,15 +253,16 @@ func (m Driver) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePend
 			if storageClassName != mockStorageClassName {
 				if storageClassName == MockStorageClassNameWFFC {
 					isWFFC = true
+				} else {
+					continue
 				}
-				continue
 			}
 
 			volumeInfo, err := m.InspectVolume(pvc.Spec.VolumeName)
 			if err != nil {
 				return nil, nil, err
 			}
-			if isWFFC {
+			if includePendingWFFC && isWFFC {
 				pendingWFFC = append(pendingWFFC, volumeInfo)
 			} else {
 				volumes = append(volumes, volumeInfo)

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -49,6 +49,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -732,10 +733,13 @@ func (p *portworx) OwnsPV(pv *v1.PersistentVolume) bool {
 	return true
 }
 
-func (p *portworx) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*storkvolume.Info, error) {
+func (p *portworx) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePendingWFFC bool) ([]*storkvolume.Info, []*storkvolume.Info, error) {
+	// includePendingWFFC - Includes pending volumes in the second return value if they are using WaitForFirstConsumer binding mode
 	var volumes []*storkvolume.Info
+	var pendingWFFCVolumes []*storkvolume.Info
 	for _, volume := range podSpec.Volumes {
 		volumeName := ""
+		isPendingWFFC := false
 		var (
 			pvc *v1.PersistentVolumeClaim
 			err error
@@ -745,7 +749,7 @@ func (p *portworx) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*stor
 				volume.PersistentVolumeClaim.ClaimName,
 				namespace)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
 			if !p.OwnsPVC(core.Instance(), pvc) {
@@ -753,8 +757,13 @@ func (p *portworx) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*stor
 			}
 
 			if pvc.Status.Phase == v1.ClaimPending {
-				return nil, &storkvolume.ErrPVCPending{
-					Name: volume.PersistentVolumeClaim.ClaimName,
+				// Only include pending volume if requested and storage class has WFFC
+				if includePendingWFFC && isWaitingForFirstConsumer(pvc) {
+					isPendingWFFC = true
+				} else {
+					return nil, nil, &storkvolume.ErrPVCPending{
+						Name: volume.PersistentVolumeClaim.ClaimName,
+					}
 				}
 			}
 			volumeName = pvc.Spec.VolumeName
@@ -782,10 +791,29 @@ func (p *portworx) GetPodVolumes(podSpec *v1.PodSpec, namespace string) ([]*stor
 				}
 			}
 
-			volumes = append(volumes, volumeInfo)
+			if isPendingWFFC {
+				pendingWFFCVolumes = append(pendingWFFCVolumes, volumeInfo)
+			} else {
+				volumes = append(volumes, volumeInfo)
+			}
 		}
 	}
-	return volumes, nil
+	return volumes, pendingWFFCVolumes, nil
+}
+
+func isWaitingForFirstConsumer(pvc *v1.PersistentVolumeClaim) bool {
+	var sc *storagev1.StorageClass
+	var err error
+	storageClassName := k8shelper.GetPersistentVolumeClaimClass(pvc)
+	if storageClassName != "" {
+		sc, err = storage.Instance().GetStorageClass(storageClassName)
+		if err != nil {
+			logrus.Warnf("Did not get the storageclass %s for pvc %s/%s, err: %v", storageClassName, pvc.Namespace, pvc.Name, err)
+			return false
+		}
+		return *sc.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer
+	}
+	return false
 }
 
 func (p *portworx) GetVolumeClaimTemplates(templates []v1.PersistentVolumeClaim) (

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -106,8 +106,9 @@ type Driver interface {
 	// InspectNode using ID
 	InspectNode(id string) (*NodeInfo, error)
 
-	// GetPodVolumes Get all the volumes used by a pod backed by the driver
-	GetPodVolumes(*v1.PodSpec, string) ([]*Info, error)
+	// GetPodVolumes Gets the volumes used by a pod backed by the driver
+	// Optionally returns volumes that are pending due to WaitForFirstConsumer binding
+	GetPodVolumes(*v1.PodSpec, string, bool) ([]*Info, []*Info, error)
 
 	// GetVolumeClaimTemplates Get all the volume templates from the list backed by
 	// the driver

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -107,8 +107,8 @@ type Driver interface {
 	InspectNode(id string) (*NodeInfo, error)
 
 	// GetPodVolumes Gets the volumes used by a pod backed by the driver
-	// Optionally returns volumes that are pending due to WaitForFirstConsumer binding
-	GetPodVolumes(*v1.PodSpec, string, bool) ([]*Info, []*Info, error)
+	// If includePendingWFFC is set, also returns volumes that are pending due to WaitForFirstConsumer binding
+	GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePendingWFFC bool) ([]*Info, []*Info, error)
 
 	// GetVolumeClaimTemplates Get all the volume templates from the list backed by
 	// the driver

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -268,7 +268,7 @@ func (m *Monitor) cleanupDriverNodePods(node *volume.NodeInfo) {
 }
 
 func (m *Monitor) doesDriverOwnPodVolumes(pod *v1.Pod) (bool, error) {
-	volumes, err := m.Driver.GetPodVolumes(&pod.Spec, pod.Namespace)
+	volumes, _, err := m.Driver.GetPodVolumes(&pod.Spec, pod.Namespace, false)
 	if err != nil {
 		storklog.PodLog(pod).Errorf("Error getting volumes for pod: %v", err)
 		return false, err

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -190,7 +190,7 @@ func testLostPod(
 	require.NoError(t, err, "failed to get pod from fake API")
 	require.NotNil(t, pod, "got nil pod back from get pod")
 
-	info, err := driver.GetPodVolumes(&pod.Spec, "")
+	info, _, err := driver.GetPodVolumes(&pod.Spec, "", false)
 	if driverPod {
 		require.NoError(t, err, "failed to get pod from fake API")
 		require.NotNil(t, info, "got nil pod volumes from driver")

--- a/specs/stork-scheduler.yaml
+++ b/specs/stork-scheduler.yaml
@@ -51,7 +51,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims", "persistentvolumes"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses", "csinodes","csidrivers", "csistoragecapacities"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
…rstConsumer


**What type of PR is this?**
bug


**What this PR does / why we need it**:
PWX-23693 - when using stork scheduler with WaitForFirstConsumer, stork refuses to schedule without a bound PVC, which is waiting for the pod to be scheduled, causing deadlock. This allows stork scheduling to continue, ignoring pending pvc error if it is the above scenario.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.11

**Notes**
Had to give stork-scheduler update permissions for pvc's
_The pod and volume did not end up on the same node, why?_

```
Events:
  Type    Reason     Age   From     Message
  ----    ------     ----  ----     -------
  Normal  Scheduled  15s   stork    Successfully assigned default/mysql-6bf645d794-4lmmk to lpitstick-k8s1-node0
  Normal  Pulled     11s   kubelet  Container image "mysql:5.6" already present on machine
  Normal  Created    11s   kubelet  Created container mysql
  Normal  Started    11s   kubelet  Started container mysql
/home/lpitstick/kubeup> k describe pvc/mysql-data-wait
Name:          mysql-data-wait
Namespace:     default
StorageClass:  px-mysql-sc-wait
Status:        Bound
Volume:        pvc-1c791b0a-31c6-4ea2-8d37-d117e12ea98b
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-class: px-mysql-sc-wait
               volume.beta.kubernetes.io/storage-provisioner: pxd.portworx.com
               volume.kubernetes.io/selected-node: lpitstick-k8s1-node0
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      2Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       mysql-6bf645d794-4lmmk
Events:
  Type    Reason                 Age                From                                                                               Message
  ----    ------                 ----               ----                                                                               -------
  Normal  WaitForFirstConsumer   39s (x5 over 93s)  persistentvolume-controller                                                        waiting for first consumer to be created before binding
  Normal  ExternalProvisioning   29s (x2 over 29s)  persistentvolume-controller                                                        waiting for a volume to be created, either by external provisioner "pxd.portworx.com" or manually created by system administrator
  Normal  Provisioning           29s                pxd.portworx.com_px-csi-ext-5fb4cc4bff-9wb26_8acb2ecf-7978-4459-9886-438b85f710f5  External provisioner is provisioning volume for claim "default/mysql-data-wait"
  Normal  VolumeCreateSuccess    27s                portworx                                                                           Volume (Name: pvc-1c791b0a-31c6-4ea2-8d37-d117e12ea98b Id: 586059265191846179) created successfully
  Normal  ProvisioningSucceeded  26s                pxd.portworx.com_px-csi-ext-5fb4cc4bff-9wb26_8acb2ecf-7978-4459-9886-438b85f710f5  Successfully provisioned volume pvc-1c791b0a-31c6-4ea2-8d37-d117e12ea98b
```

```
time="2022-05-11T22:19:20Z" level=warning msg="Failed to inspect volume pvc-675c7fc1-1bc6-43ff-8780-364daa0dda68: Failed to inspect volume: pvc-675c7fc1-1bc6-43ff-8780-364daa0dda68 due to err: Volume inspect returned err: Get \"http://10.100.251.66:9001/v1/osd-volumes?VolumeID=pvc-675c7fc1-1bc6-43ff-8780-364daa0dda68\": dial tcp 10.100.251.66:9001: i/o timeout"
time="2022-05-11T22:22:39Z" level=debug msg="Nodes in filter request:" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="lpitstick-k8s1-node0 [{Type:InternalIP Address:192.168.121.53} {Type:Hostname Address:lpitstick-k8s1-node0}]" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="lpitstick-k8s1-node2 [{Type:InternalIP Address:192.168.121.112} {Type:Hostname Address:lpitstick-k8s1-node2}]" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="lpitstick-k8s1-node1 [{Type:InternalIP Address:192.168.121.232} {Type:Hostname Address:lpitstick-k8s1-node1}]" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="Nodes in filter response:" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="lpitstick-k8s1-node0 [{Type:InternalIP Address:192.168.121.53} {Type:Hostname Address:lpitstick-k8s1-node0}]"
time="2022-05-11T22:22:39Z" level=debug msg="lpitstick-k8s1-node2 [{Type:InternalIP Address:192.168.121.112} {Type:Hostname Address:lpitstick-k8s1-node2}]"
time="2022-05-11T22:22:39Z" level=debug msg="lpitstick-k8s1-node1 [{Type:InternalIP Address:192.168.121.232} {Type:Hostname Address:lpitstick-k8s1-node1}]"

time="2022-05-11T22:22:39Z" level=debug msg="Nodes in prioritize request:" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="[{Type:InternalIP Address:192.168.121.53} {Type:Hostname Address:lpitstick-k8s1-node0}]" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="[{Type:InternalIP Address:192.168.121.112} {Type:Hostname Address:lpitstick-k8s1-node2}]" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="[{Type:InternalIP Address:192.168.121.232} {Type:Hostname Address:lpitstick-k8s1-node1}]" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="Nodes in response:" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="{Host:lpitstick-k8s1-node0 Score:5}" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="{Host:lpitstick-k8s1-node2 Score:5}" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
time="2022-05-11T22:22:39Z" level=debug msg="{Host:lpitstick-k8s1-node1 Score:5}" Namespace=default Owner=ReplicaSet/mysql-6bf645d794 PodName=mysql-6bf645d794-4lmmk
```