### PR TITLE
DS-2051: Add `selector` and `namespace` args.

### DIFF
--- a/cmd/cmdexecutor/cmdexecutor.go
+++ b/cmd/cmdexecutor/cmdexecutor.go
@@ -45,6 +45,7 @@ func parsePodNameAndNamespace(podString string) (string, string, error) {
 	return "default", podString, nil
 }
 
+// Parses label selector (e.g. "label1=value1,label2=value2") into a map of strings.
 func parseLabelSelector(labelSelectorString string) (map[string]string, error) {
 	labelSelector, err := metav1.ParseToLabelSelector(labelSelectorString)
 	if err != nil {
@@ -66,17 +67,17 @@ func main() {
 	flag.Parse()
 
 	podListSpecified := len(podList) > 0
-	selectorWithNamespaceSpecified := labelSelector != "" && namespace != ""
+	selectorAndNamespaceSpecified := labelSelector != "" && namespace != ""
 
 	if labelSelector != "" && namespace == "" {
 		logrus.Fatalf("-namespace must be specified when using -selector")
 	}
 
-	if podListSpecified && selectorWithNamespaceSpecified {
+	if podListSpecified && selectorAndNamespaceSpecified {
 		logrus.Fatalf("-pod args cannot be used in combination with -selector arg")
 	}
 
-	if !podListSpecified && !selectorWithNamespaceSpecified {
+	if !podListSpecified && !selectorAndNamespaceSpecified {
 		logrus.Fatalf("no pods specified to the command executor")
 	}
 
@@ -117,7 +118,7 @@ func main() {
 	}
 
 	// Fetch list of pods using label selector.
-	if selectorWithNamespaceSpecified {
+	if selectorAndNamespaceSpecified {
 		selectorsMap, err := parseLabelSelector(labelSelector)
 		if err != nil {
 			logrus.Fatalf(err.Error())


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
This PR adds `-selector` and `-namespace` flags. These flags provide user with another way to specify the list of pods where to run the command. 

The `-selector` and `-namespace` args cannot be combined with the `-pod` args as this flag already requires the namespace to be included (`-pod my-namespace/my-pod`).

The behavior of the `selector` is intended to be similar [to the one in `kubectl` itself](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering).

**Example usage**: 

```shell
cmdexecutor -cmd <cmd> -taskid <taskid> -namespace my-namespace -selector label1=value1,label2=value2
```


**Does this PR change a user-facing CRD or CLI?**:
Yes, without breaking changes. The behavior of `-pod` args remains unchanged.

**Is a release note needed?**:
Improvement: cmd-executor can now select pods to run custom commands using namespace name and label selectors. 

**Does this change need to be cherry-picked to a release branch?**:
No.

