### PR TITLE
pb-2375: Fixed issue in handling the return value of GetObjectLockConfiguration call from FB and Dell ECS objectstore, when bucket is not enabled with lock

### DIFF
--- a/pkg/objectstore/s3/s3.go
+++ b/pkg/objectstore/s3/s3.go
@@ -109,6 +109,10 @@ func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockIn
 	if (out != nil) && (out.ObjectLockConfiguration != nil) {
 		if aws.StringValue(out.ObjectLockConfiguration.ObjectLockEnabled) == "Enabled" {
 			objLockInfo.LockEnabled = true
+		} else {
+			// For some of the objectstore like FB and dell ECS, GetObjectLockConfiguration
+			// will return empty objectlockconfiguration instead of nil or error
+			return objLockInfo, nil
 		}
 		if out.ObjectLockConfiguration.Rule != nil &&
 			out.ObjectLockConfiguration.Rule.DefaultRetention != nil {


### PR DESCRIPTION

**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
pb-2375: Fixed issue in handling the return value of GetObjectLockConfiguration call from FB and Dell ECS objecstore, when bucket is not enabled with lock
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
Yes
```release-note
Issue: Addition of non lock bucket with FB and Dell ECS objectstore fails.
User Impact: Not able to add backuplocation with FB and Dell ECS objectstore without lock.
Resolution: Fixed the error handling of GetObjectConfiguration for objectstore that return empty config struct instead of error.
```

**Does this change need to be cherry-picked to a release branch?**:
2.10

