### PR TITLE
PWX-24190 Fix elapsed volume migration time when completed

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1940,11 +1940,11 @@ func (m *MigrationController) getMigrationSummary(migration *stork_api.Migration
 		}
 		elapsedTimeVolume := "NA"
 		if !migration.CreationTimestamp.IsZero() {
-			if migration.Status.Stage == stork_api.MigrationStageApplications {
+			if migration.Status.Stage == stork_api.MigrationStageApplications || migration.Status.Stage == stork_api.MigrationStageFinal {
 				if !migration.Status.VolumeMigrationFinishTimestamp.IsZero() {
 					elapsedTimeVolume = migration.Status.VolumeMigrationFinishTimestamp.Sub(migration.CreationTimestamp.Time).String()
 				}
-			} else {
+			} else { // Volume migration hasn't finished, use current total time
 				elapsedTimeVolume = time.Since(migration.CreationTimestamp.Time).String()
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug

**What this PR does / why we need it**:
https://portworx.atlassian.net/browse/PWX-24190
Volume migration elapsed time is incorrectly showing total time, want to match start/volume migration finish timestamps

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.11

