### PR TITLE
Do not list all k8s resources for volumeonly migration

### DIFF
--- a/pkg/appregistration/appregistration.go
+++ b/pkg/appregistration/appregistration.go
@@ -29,6 +29,8 @@ const (
 	PostgressApp = "postgress"
 	// MongoDBCommunityApp registration name
 	MongoDBCommunityApp = "mongodbcommunity"
+	// VirtualMachineApp registration name
+	VirtualMachineApp = "virtualmachine"
 )
 
 // GetSupportedCRD returns the list of supported CRDs.
@@ -319,7 +321,21 @@ func GetSupportedCRD() map[string][]stork_api.ApplicationResource {
 			},
 		},
 	}
-
+	defCRD[VirtualMachineApp] = []stork_api.ApplicationResource{
+		{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Kind:    "VirtualMachine",
+				Group:   "kubevirt.io",
+				Version: "v1",
+			},
+			KeepStatus: false,
+			SuspendOptions: stork_api.SuspendOptions{
+				Path:  "spec.runStrategy",
+				Type:  "string",
+				Value: "Halted",
+			},
+		},
+	}
 	return defCRD
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> bug

**What this PR does / why we need it**:
Stork Migration controller list all of k8s resources for migrating volume only resources, with this PR migration controller will only collect resources resources required for volume only migration

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes

```release-note
Issue: Stork Migration controller list all k8s resources for `volumeOnly` Migration
User Impact: Resource Migration taking too much time for `volumeOnly` Migration
Resolution: Stork now only list pvc and pv required for driver volume migration

```

**Does this change need to be cherry-picked to a release branch?**:
2.11


Integration job: https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%202.11-dev%20%20C7/job/stork-2.11-px-2.11-dev-migr/113/console 
