### PR TITLE
PWX-24000: Treat pure backend block volumes as Portworx volumes

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -166,6 +166,7 @@ const (
 	proxyPath            = "proxy_nfs_exportpath"
 	pureBackendParam     = "backend"
 	pureFileParam        = "pure_file"
+	pureBlockParam       = "pure_block"
 )
 
 type cloudSnapStatus struct {
@@ -679,8 +680,8 @@ func (p *portworx) IsSupportedPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClai
 			if _, ok := storageClass.Parameters[proxyEndpoint]; ok && skipDirectAccessVolumes {
 				logrus.Tracef("proxy endpoint is set, not classifying it as pxd for pvc [%v]", pvc.Name)
 				return false
-			} else if val, ok := storageClass.Parameters[pureBackendParam]; ok && val == pureFileParam && skipDirectAccessVolumes {
-				logrus.Tracef("pure file backend param set, not classifying it as pxd for pvc [%v]", pvc.Name)
+			} else if val, ok := storageClass.Parameters[pureBackendParam]; ok && (val == pureFileParam || val == pureBlockParam) && skipDirectAccessVolumes {
+				logrus.Tracef("pure backend param set, not classifying it as pxd for pvc [%v]", pvc.Name)
 				return false
 			}
 			provisioner = storageClass.Provisioner


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
- Portworx now supports Pure FA direct access volumes. 
- The portworx driver should treat these volumes as Portworx volumes in scheduling decisions. 

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Yes
-->
```release-note
Improvement: Portworx FA DirectAccess volumes will now be considered in stork scheduling decisions.

```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.11

** Testing Notes **
Pinned a pod using FA DA volume on a node which has no Portworx installed. Pod is in pending state with the following events
```
Events:
  Type     Reason            Age                From   Message
  ----     ------            ----               ----   -------
  Warning  FailedScheduling  17s                stork  failed filter with extender at URL http://stork-service.portworx:8099/filter, code 400
  Warning  FailedScheduling  16s                stork  failed filter with extender at URL http://stork-service.portworx:8099/filter, code 400
  Warning  FailedScheduling  16s (x2 over 18s)  stork  No node found with storage driver
```