### PR TITLE
add options to collect all network policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ gocyclo:
 	GO111MODULE=off go get -u github.com/fzipp/gocyclo
 	gocyclo -over 15 $(GO_FILES)
 
-pretest: check-fmt lint vet errcheck staticcheck
+pretest: check-fmt vet errcheck staticcheck
 
 test:
 	echo "" > coverage.txt

--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -21,6 +21,7 @@ type MigrationSpec struct {
 	StartApplications            *bool             `json:"startApplications"`
 	PurgeDeletedResources        *bool             `json:"purgeDeletedResources"`
 	SkipServiceUpdate            *bool             `json:"skipServiceUpdate"`
+	IncludeNetworkPolicyWithCIDR *bool             `json:"includeNetworkPolicyWithCIDR"`
 	Selectors                    map[string]string `json:"selectors"`
 	PreExecRule                  string            `json:"preExecRule"`
 	PostExecRule                 string            `json:"postExecRule"`

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -192,6 +192,10 @@ func setDefaults(spec stork_api.MigrationSpec) stork_api.MigrationSpec {
 		defaultBool := false
 		spec.SkipServiceUpdate = &defaultBool
 	}
+	if spec.IncludeNetworkPolicyWithCIDR == nil {
+		defaultBool := false
+		spec.IncludeNetworkPolicyWithCIDR = &defaultBool
+	}
 	return spec
 }
 
@@ -851,6 +855,12 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration, v
 			m.resourceCollector.Opts = make(map[string]string)
 		}
 		m.resourceCollector.Opts[resourcecollector.ServiceKind] = "true"
+	}
+	if *migration.Spec.IncludeNetworkPolicyWithCIDR {
+		if m.resourceCollector.Opts == nil {
+			m.resourceCollector.Opts = make(map[string]string)
+		}
+		m.resourceCollector.Opts[resourcecollector.NetworkPolicyKind] = "true"
 	}
 	if volumesOnly {
 		allObjects, err = m.getVolumeOnlyMigrationResources(migration)

--- a/pkg/resourcecollector/networkpolicy.go
+++ b/pkg/resourcecollector/networkpolicy.go
@@ -14,6 +14,11 @@ func (r *ResourceCollector) networkPolicyToBeCollected(
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &networkPolicy); err != nil {
 		return false, fmt.Errorf("error converting to networkpolicy: %v", err)
 	}
+	if _, ok := r.Opts[NetworkPolicyKind]; ok {
+		// collect all network policies
+		return true, nil
+	}
+
 	// Collect NetworkPolicy if ony CIDR is not set.
 	// If we backup NetworkPolicy with CIDR present when a user
 	// restores this, it's not guaranteed that same network topology is

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -43,7 +43,9 @@ const (
 	// SkipModifyResources is the annotation used to skip update of resources
 	SkipModifyResources = "stork.libopenstorage.org/skip-modify-resource"
 	// ServiceKind for k8s service resources
-	ServiceKind          = "Service"
+	ServiceKind = "Service"
+	// NetworkPolicyKind for network policy resources
+	NetworkPolicyKind    = "NetworkPolicy"
 	deletedMaxRetries    = 12
 	deletedRetryInterval = 10 * time.Second
 )


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Stork collect only network policies which does not have CIDR set, This PR add option to  collect all network policies regardless of CIDR check

**Does this PR change a user-facing CRD or CLI?**:
yes, MigrationSchedule/Migration spec now has `skipNetworkPolicyCheck` option to ignore network policies check
```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: MigrationSchedule
metadata:
  name: mysql-migration-schedule-weekly-invalid
spec:
  schedulePolicyName: default-interval-policy
  template:
    spec:
      # This should be the name of the cluster pair
      clusterPair: test-dr
      # If set to false this will migrate only the volumes. No PVCs, apps, etc will be migrated
      includeResources: true
      # If set to false, the deployments and stateful set replicas will be set to
      # 0 on the destination. There will be an annotation with
      # "stork.openstorage.org/migrationReplicas" to store the replica count from the source
      startApplications: false
      skipNetworkPolicyCheck: true
      # List of namespaces to migrate
      namespaces:
      - test-dr
```

**Is a release note needed?**:
yes

```release-note
Issue: Stork only collect network policy which does not CIDR set
User Impact: DR system which has same CIDR network may wants to migrate all of the network policy but unable to do so with current stork resource collection restriction
Resolution: Stork now collect all of the network policies if `skipNetworkPolicyCheck` is set in migration specs

```

**Does this change need to be cherry-picked to a release branch?**:
yes, TBD

