### PR TITLE
pb-2836: Fixing some typecasting error related to v1beta1 volumesnapshot

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -782,7 +782,7 @@ func (c *csi) cleanupSnapshots(
 		}
 	}
 
-	logrus.Debugf("started clean up of %v snapshots and %v snapshotcontents", len(vsMap.(map[string]*kSnapshotv1.VolumeSnapshot)), len(vsContentMap.(map[string]*kSnapshotv1.VolumeSnapshotContent)))
+	logrus.Debugf("started clean up of %v snapshots and %v snapshotcontents", len(vsMap.(map[string]*kSnapshotv1beta1.VolumeSnapshot)), len(vsContentMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)))
 	return nil
 }
 

--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -1194,7 +1194,7 @@ func (c *csiDriver) restoreVolumeSnapshot(
 	} else {
 		vs.(*kSnapshotv1beta1.VolumeSnapshot).ResourceVersion = ""
 		vs.(*kSnapshotv1beta1.VolumeSnapshot).Spec.Source.PersistentVolumeClaimName = nil
-		vs.(*kSnapshotv1beta1.VolumeSnapshot).Spec.Source.VolumeSnapshotContentName = &vsc.(*kSnapshotv1beta1.VolumeSnapshot).Name
+		vs.(*kSnapshotv1beta1.VolumeSnapshot).Spec.Source.VolumeSnapshotContentName = &vsc.(*kSnapshotv1beta1.VolumeSnapshotContent).Name
 		vs.(*kSnapshotv1beta1.VolumeSnapshot).Namespace = namespace
 		newVS, err = c.snapshotClient.SnapshotV1beta1().VolumeSnapshots(namespace).Create(context.TODO(), vs.(*kSnapshotv1beta1.VolumeSnapshot), metav1.CreateOptions{})
 		if err != nil {
@@ -1416,7 +1416,7 @@ func (c *csiDriver) RetainLocalSnapshots(
 			} else {
 				vs = snapshotInfo.SnapshotRequest.(*kSnapshotv1beta1.VolumeSnapshot)
 				snapName = vs.(*kSnapshotv1beta1.VolumeSnapshot).Name
-				vs.(*kSnapshotv1.VolumeSnapshot).Annotations[snapDeleteAnnotation] = "true"
+				vs.(*kSnapshotv1beta1.VolumeSnapshot).Annotations[snapDeleteAnnotation] = "true"
 			}
 			snapshotInfo.SnapshotRequest = vs
 			newSnapInfo, err := c.RecreateSnapshotResources(snapshotInfo, snapshotDriverName, namespace, retain)
@@ -1799,7 +1799,7 @@ func (c *csiDriver) waitForVolumeSnapshotBound(vs interface{}, namespace string)
 		if err != nil {
 			return nil, true, fmt.Errorf("failed to get volumesnapshot object %v/%v: %v", namespace, vs.(*kSnapshotv1beta1.VolumeSnapshot).Name, err)
 		}
-		if curVS.(*kSnapshotv1beta1.VolumeSnapshot).Status == nil || curVS.(*kSnapshotv1.VolumeSnapshot).Status.BoundVolumeSnapshotContentName == nil {
+		if curVS.(*kSnapshotv1beta1.VolumeSnapshot).Status == nil || curVS.(*kSnapshotv1beta1.VolumeSnapshot).Status.BoundVolumeSnapshotContentName == nil {
 			return nil, true, fmt.Errorf("failed to find get status for snapshot: %s/%s, status: %+v", namespace, vs.(*kSnapshotv1beta1.VolumeSnapshot).Name, vs.(*kSnapshotv1beta1.VolumeSnapshot).Status)
 		}
 		return nil, false, nil


### PR DESCRIPTION
Wrong typecasting causes crash while duplicating backup and executing
other backup operations. Fixed by changing to correct typecasting.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?**BUG
> Uncomment only one and also add the corresponding label in the PR:
bug

**What this PR does / why we need it**:It fixes some stork crash while performing backup duplicate operation and other backup operations. This is side effect of change in pb-2328 and found in functional test.


**Does this PR change a user-facing CRD or CLI?**: no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: no
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:no
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

