### PR TITLE
ProjectMappings for Rancher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ vendor:
 lint:
 	GO111MODULE=off go get -u golang.org/x/lint/golint
 	for file in $(GO_FILES); do \
+		echo "running lint on ${file}" \
 		golint $${file}; \
 		if [ -n "$$(golint $${file})" ]; then \
 			exit 1; \

--- a/pkg/apis/stork/v1alpha1/clusterpair.go
+++ b/pkg/apis/stork/v1alpha1/clusterpair.go
@@ -26,7 +26,10 @@ type ClusterPair struct {
 // ClusterPairSpec is the spec to create the cluster pair
 type ClusterPairSpec struct {
 	Config  api.Config        `json:"config"`
-	Options map[string]string `json:"options"`
+	Options map[string]string `json:"options",yaml:"options"`
+	// PlatformOptions are kubernetes platform provider related
+	// options.
+	PlatformOptions PlatformSpec `json:"platformOptions",yaml:"platformOptions"`
 }
 
 // ClusterPairStatusType is the status of the pair
@@ -61,6 +64,43 @@ type ClusterPairStatus struct {
 	// ID of the remote storage which is paired
 	// +optional
 	RemoteStorageID string `json:"remoteStorageId"`
+}
+
+// RancherSecret holds the reference to the api keys used to interact
+// with a rancher cluster
+type RancherSecret struct {
+	// APIKeySecretName is the name of the kubernetes secret
+	// that hosts the API key
+	APIKeySecretName string `json:"apiKeySecretName"`
+	// APIKeySecretNamespace is the namespace of the kubernetes secret
+	// that hosts the API key
+	APIKeySecretNamespace string `json:"apiKeySecretNamespace"`
+}
+
+// RancherSpec provides options for interacting with Rancher
+type RancherSpec struct {
+	// ProjectMappings allows a cluster pair to migrate namespaces between different
+	// Rancher projects. The key in the map is the source project while the value
+	// is the destination project. Specify this only if you have not provided
+	// API key to stork for creating the project on the target cluster.
+	ProjectMappings map[string]string `json:"projectMappings,omitempty"`
+
+	// --- FUTURE Rancher Specs ---
+	// SourceRancherSecret is the rancher secrets for source cluster
+	// SourceRancherSecret RancherSecret `json:"sourceRancherSecret"`
+	// DestinationRancherSecret is the rancher secrets for source cluster
+	// DestinationRancherSecret RancherSecret `json:"destRancherSecret"`
+	// SourceURL is the rancher source URL endpoint
+	// SourceURL string `json: sourceURL`
+	// Destination is the destination URL endpoint
+	// Destination string `json: destinationURL`
+}
+
+// PlatformSpec provide options for interacting with kubernetes platform
+// provider like: EKS / AKS / GKE / Rancher / Openshift
+type PlatformSpec struct {
+	// Rancher configuration
+	Rancher *RancherSpec `json:"rancher,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1073,11 +1073,9 @@ func (a *ApplicationBackupController) backupResources(
 	}
 
 	// Don't modify resources if mentioned explicitly in specs
+	resourceCollectorOpts := resourcecollector.Options{}
 	if backup.Spec.SkipServiceUpdate {
-		if a.resourceCollector.Opts == nil {
-			a.resourceCollector.Opts = make(map[string]string)
-		}
-		a.resourceCollector.Opts[resourcecollector.ServiceKind] = "true"
+		resourceCollectorOpts.SkipServices = true
 	}
 
 	// Always backup optional resources. When restorting they need to be
@@ -1112,7 +1110,9 @@ func (a *ApplicationBackupController) backupResources(
 				backup.Spec.Selectors,
 				objectMap,
 				optionalBackupResources,
-				true)
+				true,
+				resourceCollectorOpts,
+			)
 			if err != nil {
 				log.ApplicationBackupLog(backup).Errorf("Error getting resources: %v", err)
 				return err
@@ -1125,7 +1125,7 @@ func (a *ApplicationBackupController) backupResources(
 				for _, resource := range resourceTypes {
 					if resource.Kind == backupResourceType || (backupResourceType == "PersistentVolumeClaim" && resource.Kind == "PersistentVolume") {
 						log.ApplicationBackupLog(backup).Tracef("GetResourcesType for : %v", resource.Kind)
-						objects, err := a.resourceCollector.GetResourcesForType(resource, nil, resourceTypeNsBatch, backup.Spec.Selectors, nil, true)
+						objects, err := a.resourceCollector.GetResourcesForType(resource, nil, resourceTypeNsBatch, backup.Spec.Selectors, nil, true, resourceCollectorOpts)
 						if err != nil {
 							log.ApplicationBackupLog(backup).Errorf("Error getting resources: %v", err)
 							return err

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -758,7 +758,9 @@ func (a *ApplicationCloneController) cloneResources(
 		clone.Spec.Selectors,
 		nil,
 		clone.Spec.IncludeOptionalResourceTypes,
-		false)
+		false,
+		resourcecollector.Options{},
+	)
 	if err != nil {
 		log.ApplicationCloneLog(clone).Errorf("Error getting resources: %v", err)
 		return err

--- a/pkg/resourcecollector/networkpolicy.go
+++ b/pkg/resourcecollector/networkpolicy.go
@@ -2,19 +2,76 @@ package resourcecollector
 
 import (
 	"fmt"
+	"github.com/libopenstorage/stork/pkg/utils"
+	"strings"
 
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+func (r *ResourceCollector) prepareNetworkPolicyForCollection(
+	object runtime.Unstructured,
+	opts Options,
+) error {
+	var (
+		networkPolicy v1.NetworkPolicy
+		err           error
+	)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &networkPolicy); err != nil {
+		return fmt.Errorf("error converting to networkpolicy: %v", err)
+	}
+
+	// Handle namespace selectors for Rancher Network Policies
+	if len(opts.RancherProjectMappings) > 0 {
+
+		ingressRule := networkPolicy.Spec.Ingress
+		for ingressIndex, ingress := range ingressRule {
+			for fromIndex, fromPolicyPeer := range ingress.From {
+				if fromPolicyPeer.NamespaceSelector != nil {
+					for key, val := range fromPolicyPeer.NamespaceSelector.MatchLabels {
+						if strings.Contains(key, utils.CattleProjectPrefix) {
+							if newProjectID, ok := opts.RancherProjectMappings[val]; ok {
+								networkPolicy.Spec.Ingress[ingressIndex].From[fromIndex].NamespaceSelector.MatchLabels[key] = newProjectID
+							}
+						}
+					}
+				}
+			}
+		}
+		egressRule := networkPolicy.Spec.Egress
+		for egressIndex, egress := range egressRule {
+			for toIndex, toPolicyPeer := range egress.To {
+				if toPolicyPeer.NamespaceSelector != nil {
+					for key, val := range toPolicyPeer.NamespaceSelector.MatchLabels {
+						if strings.Contains(key, utils.CattleProjectPrefix) {
+							if newProjectID, ok := opts.RancherProjectMappings[val]; ok {
+								networkPolicy.Spec.Egress[egressIndex].To[toIndex].NamespaceSelector.MatchLabels[key] = newProjectID
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&networkPolicy)
+	if err != nil {
+		return err
+	}
+	object.SetUnstructuredContent(o)
+	return nil
+}
+
 func (r *ResourceCollector) networkPolicyToBeCollected(
 	object runtime.Unstructured,
+	opts Options,
 ) (bool, error) {
 	var networkPolicy v1.NetworkPolicy
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &networkPolicy); err != nil {
 		return false, fmt.Errorf("error converting to networkpolicy: %v", err)
 	}
-	if _, ok := r.Opts[NetworkPolicyKind]; ok {
+
+	if opts.IncludeAllNetworkPolicies {
 		// collect all network policies
 		return true, nil
 	}
@@ -34,8 +91,8 @@ func (r *ResourceCollector) networkPolicyToBeCollected(
 	}
 	egreeRule := networkPolicy.Spec.Egress
 	for _, egress := range egreeRule {
-		for _, networkPolicyPeer := range egress.To {
-			ipBlock := networkPolicyPeer.IPBlock
+		for _, toPolicyPeer := range egress.To {
+			ipBlock := toPolicyPeer.IPBlock
 			if ipBlock != nil && len(ipBlock.CIDR) != 0 {
 				return false, nil
 			}

--- a/pkg/resourcecollector/pod.go
+++ b/pkg/resourcecollector/pod.go
@@ -1,0 +1,87 @@
+package resourcecollector
+
+import (
+	"github.com/libopenstorage/stork/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+	"strings"
+)
+
+// PreparePodSpecNamespaceSelector will update the Namespace Selectors
+// with the provided project mappings for Rancher
+func PreparePodSpecNamespaceSelector(
+	podSpec *v1.PodSpec,
+	projectMappings map[string]string,
+) *v1.PodSpec {
+	if podSpec.Affinity == nil || len(projectMappings) == 0 {
+		return podSpec
+	}
+
+	// Anti Affinity
+	// - handle PreferredDuringSchedulingIgnoredDuringExecution
+	if podSpec.Affinity.PodAntiAffinity != nil {
+		for affinityIndex, affinityTerm := range podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+			if affinityTerm.PodAffinityTerm.NamespaceSelector != nil {
+				for key, val := range affinityTerm.PodAffinityTerm.NamespaceSelector.MatchLabels {
+					if strings.Contains(key, utils.CattleProjectPrefix) {
+						if newProjectID, ok := projectMappings[val]; ok {
+							affinityTerm.PodAffinityTerm.NamespaceSelector.MatchLabels[key] = newProjectID
+							// reset the affinity term at the affinityIndex
+							podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[affinityIndex] = affinityTerm
+						}
+					}
+				}
+			}
+		}
+
+		// Affinity
+		// - handle RequiredDuringSchedulingIgnoredDuringExecution
+		for affinityIndex, affinityTerm := range podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+			if affinityTerm.NamespaceSelector != nil {
+				for key, val := range affinityTerm.NamespaceSelector.MatchLabels {
+					if strings.Contains(key, utils.CattleProjectPrefix) {
+						if newProjectID, ok := projectMappings[val]; ok {
+							affinityTerm.NamespaceSelector.MatchLabels[key] = newProjectID
+							// reset the affinity term at the affinityIndex
+							podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[affinityIndex] = affinityTerm
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Affinity
+	// - handle PreferredDuringSchedulingIgnoredDuringExecution
+	if podSpec.Affinity.PodAntiAffinity != nil {
+		for affinityIndex, affinityTerm := range podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+			if affinityTerm.PodAffinityTerm.NamespaceSelector != nil {
+				for key, val := range affinityTerm.PodAffinityTerm.NamespaceSelector.MatchLabels {
+					if strings.Contains(key, utils.CattleProjectPrefix) {
+						if newProjectID, ok := projectMappings[val]; ok {
+							affinityTerm.PodAffinityTerm.NamespaceSelector.MatchLabels[key] = newProjectID
+							// reset the affinity term at the affinityIndex
+							podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution[affinityIndex] = affinityTerm
+						}
+					}
+				}
+			}
+		}
+
+		// Affinity
+		// - handle RequiredDuringSchedulingIgnoredDuringExecution
+		for affinityIndex, affinityTerm := range podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+			if affinityTerm.NamespaceSelector != nil {
+				for key, val := range affinityTerm.NamespaceSelector.MatchLabels {
+					if strings.Contains(key, utils.CattleProjectPrefix) {
+						if newProjectID, ok := projectMappings[val]; ok {
+							affinityTerm.NamespaceSelector.MatchLabels[key] = newProjectID
+							// reset the affinity term at the affinityIndex
+							podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[affinityIndex] = affinityTerm
+						}
+					}
+				}
+			}
+		}
+	}
+	return podSpec
+}

--- a/pkg/storkctl/groupsnapshot.go
+++ b/pkg/storkctl/groupsnapshot.go
@@ -2,9 +2,8 @@ package storkctl
 
 import (
 	"fmt"
-	"strings"
-
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/utils"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/spf13/cobra"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +41,7 @@ func newCreateGroupSnapshotCommand(cmdFactory Factory, ioStreams genericclioptio
 				return
 			}
 
-			labelSelector, err := parseKeyValueList(pvcSelectors)
+			labelSelector, err := utils.ParseKeyValueList(pvcSelectors)
 			if err != nil {
 				util.CheckErr(err)
 				return
@@ -56,7 +55,7 @@ func newCreateGroupSnapshotCommand(cmdFactory Factory, ioStreams genericclioptio
 
 			var optsMap map[string]string
 			if len(opts) > 0 {
-				optsMap, err = parseKeyValueList(opts)
+				optsMap, err = utils.ParseKeyValueList(opts)
 				if err != nil {
 					util.CheckErr(err)
 					return
@@ -217,20 +216,4 @@ func groupSnapshotPrinter(
 		rows = append(rows, row)
 	}
 	return rows, nil
-}
-
-// parseKeyValueList parses a list of key values into a map
-func parseKeyValueList(expressions []string) (map[string]string, error) {
-	matchLabels := make(map[string]string)
-	for _, e := range expressions {
-		entry := strings.SplitN(e, "=", 2)
-		if len(entry) != 2 {
-			return nil, fmt.Errorf("invalid key value: %s provided. "+
-				"Example format: app=mysql", e)
-		}
-
-		matchLabels[entry[0]] = entry[1]
-	}
-
-	return matchLabels, nil
 }

--- a/pkg/storkctl/groupsnapshot_test.go
+++ b/pkg/storkctl/groupsnapshot_test.go
@@ -5,6 +5,7 @@ package storkctl
 
 import (
 	"fmt"
+	"github.com/libopenstorage/stork/pkg/utils"
 	"strings"
 	"testing"
 
@@ -91,7 +92,7 @@ func TestDuplicateGroupSnapshots(t *testing.T) {
 
 	name := "test-group-snap-duplicate"
 	namespace := "default"
-	selectors, err := parseKeyValueList([]string{"app=mysql"})
+	selectors, err := utils.ParseKeyValueList([]string{"app=mysql"})
 	require.NoError(t, err, "failed to parse selectors")
 
 	createGroupSnapshotAndVerify(t, name, namespace, selectors, "", "", nil, nil, 0)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// CattlePrefix is the prefix to all Rancher related annotations and labels
+	CattlePrefix = "cattle.io"
+	// CattleProjectPrefix is the prefix used in all Rancher project related annotations and labels
+	CattleProjectPrefix = "cattle.io/projectId"
+)
+
+// ParseKeyValueList parses a list of key=values string into a map
+func ParseKeyValueList(expressions []string) (map[string]string, error) {
+	matchLabels := make(map[string]string)
+	for _, e := range expressions {
+		entry := strings.SplitN(e, "=", 2)
+		if len(entry) != 2 {
+			return nil, fmt.Errorf("invalid key value: %s provided. "+
+				"Example format: app=mysql", e)
+		}
+
+		matchLabels[entry[0]] = entry[1]
+	}
+
+	return matchLabels, nil
+}

--- a/test/integration_test/clusterdomain_test.go
+++ b/test/integration_test/clusterdomain_test.go
@@ -110,6 +110,8 @@ func failoverAndFailbackClusterDomainTest(t *testing.T) {
 		true,
 		false,
 		false,
+		"",
+		nil,
 	)
 
 	// validate the following

--- a/test/integration_test/migration_backup_test.go
+++ b/test/integration_test/migration_backup_test.go
@@ -46,6 +46,8 @@ func deploymentMigrationBackupTest(t *testing.T) {
 			false,
 			true,
 			false,
+			"",
+			nil,
 		)
 
 		// Cleanup up source

--- a/test/integration_test/migration_failover_failback_test.go
+++ b/test/integration_test/migration_failover_failback_test.go
@@ -17,6 +17,12 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	rancherLabelKey          = "field.cattle.io/projectId"
+	projectIDMappings        = "project-A=project-B,project-C=project-D"
+	projectIDMappingsReverse = "project-B=project-A,project-D=project-C"
+)
+
 func testMigrationFailoverFailback(t *testing.T) {
 	// Create secrets on source and destination
 	// Since the secrets need to be created on the destination before migration
@@ -46,22 +52,32 @@ func testMigrationFailoverFailback(t *testing.T) {
 		require.NoError(t, err, "failed to create secret for volumes")
 	}
 
-	t.Run("failoverAndFailbackMigrationTest", failoverAndFailbackMigrationTest)
+	t.Run("vanillaFailoverAndFailbackMigrationTest", vanillaFailoverAndFailbackMigrationTest)
+	t.Run("rancherFailoverAndFailbackMigrationTest", rancherFailoverAndFailbackMigrationTest)
 }
 
-func failoverAndFailbackMigrationTest(t *testing.T) {
+func vanillaFailoverAndFailbackMigrationTest(t *testing.T) {
+	failoverAndFailbackMigrationTest(t)
+}
 
+func rancherFailoverAndFailbackMigrationTest(t *testing.T) {
 	// Migrate the resources
+	instanceID := "mysql-migration-failover-failback-rancher"
+	appKey := "mysql-enc-pvc-rancher"
 	ctxs, preMigrationCtx := triggerMigration(
 		t,
-		"mysql-migration-failover-failback",
-		"mysql-enc-pvc",
+		instanceID,
+		appKey,
 		nil,
-		[]string{"mysql-migration-failover-failback"},
+		[]string{instanceID},
 		true,
 		false,
 		false,
 		false,
+		projectIDMappings,
+		map[string]string{
+			rancherLabelKey: "project-A",
+		},
 	)
 
 	// validate the following
@@ -87,15 +103,64 @@ func failoverAndFailbackMigrationTest(t *testing.T) {
 	// validate the migration summary based on the application specs that were deployed by the test
 	validateMigrationSummary(t, preMigrationCtx, expectedResources, expectedVolumes, migrationObj.Name, migrationObj.Namespace)
 
-	scaleFactor := testMigrationFailover(t, preMigrationCtx, ctxs)
+	scaleFactor := testMigrationFailover(t, preMigrationCtx, ctxs, "", appKey, instanceID)
 
-	testMigrationFailback(t, preMigrationCtx, ctxs, scaleFactor)
+	testMigrationFailback(t, preMigrationCtx, ctxs, scaleFactor, projectIDMappingsReverse, appKey, instanceID)
+}
+
+func failoverAndFailbackMigrationTest(t *testing.T) {
+
+	appKey := "mysql-enc-pvc"
+	instanceID := "mysql-migration-failover-failback"
+	// Migrate the resources
+	ctxs, preMigrationCtx := triggerMigration(
+		t,
+		instanceID,
+		appKey,
+		nil,
+		[]string{instanceID},
+		true,
+		false,
+		false,
+		false,
+		"",
+		nil,
+	)
+
+	// validate the following
+	// - migration is successful
+	// - app starts on cluster 1
+	validateAndDestroyMigration(t, ctxs, preMigrationCtx, true, false, true, true, true)
+
+	var migrationObj *v1alpha1.Migration
+	var ok bool
+	for _, specObj := range ctxs[0].App.SpecList {
+		if migrationObj, ok = specObj.(*v1alpha1.Migration); ok {
+			break
+		}
+	}
+
+	err := setSourceKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+
+	// 1 sts, 1 service, 1 pvc, 1 pv
+	expectedResources := uint64(4)
+	// 1 volume
+	expectedVolumes := uint64(1)
+	// validate the migration summary based on the application specs that were deployed by the test
+	validateMigrationSummary(t, preMigrationCtx, expectedResources, expectedVolumes, migrationObj.Name, migrationObj.Namespace)
+
+	scaleFactor := testMigrationFailover(t, preMigrationCtx, ctxs, "", appKey, instanceID)
+
+	testMigrationFailback(t, preMigrationCtx, ctxs, scaleFactor, "", appKey, instanceID)
 }
 
 func testMigrationFailover(
 	t *testing.T,
 	preMigrationCtx *scheduler.Context,
 	ctxs []*scheduler.Context,
+	projectIDMappings string,
+	appKey, instanceID string,
 ) map[string]int32 {
 	// Failover the application
 
@@ -139,13 +204,34 @@ func testMigrationFailover(
 	err = setDestinationKubeConfig()
 	require.NoError(t, err, "Error setting remote config")
 
-	// Set scale factor to it's orignal values on cluster 2
+	// Set scale factor to it's original values on cluster 2
 	err = schedulerDriver.ScaleApplication(preMigrationCtx, oldScaleFactor)
 	require.NoError(t, err, "Unexpected error on ScaleApplication")
 
 	err = schedulerDriver.WaitForRunning(preMigrationCtx, defaultWaitTimeout, defaultWaitInterval)
 	require.NoError(t, err, "Error waiting for pod to get to running state on remote cluster after migration")
 
+	if len(projectIDMappings) > 0 {
+		namespace := appKey + "-" + instanceID
+		ns, err := core.Instance().GetNamespace(namespace)
+		require.NoError(t, err, "failed to get namespace")
+		projectValue, ok := ns.Labels[rancherLabelKey]
+		require.True(t, ok, "expected rancher label")
+		require.Equal(t, projectValue, "project-B")
+
+		serviceList, err := core.Instance().ListServices(namespace, meta_v1.ListOptions{})
+		require.NoError(t, err, "failed to get services")
+		require.GreaterOrEqual(t, len(serviceList.Items), 1, "unexpected number of services")
+		for _, service := range serviceList.Items {
+			projectValue, ok := service.Labels[rancherLabelKey]
+			require.True(t, ok, "expected rancher label")
+			require.Equal(t, projectValue, "project-B")
+
+			projectValue, ok = service.Annotations[rancherLabelKey]
+			require.True(t, ok, "expected rancher label")
+			require.Equal(t, projectValue, "project-B")
+		}
+	}
 	return oldScaleFactor
 }
 
@@ -154,12 +240,14 @@ func testMigrationFailback(
 	preMigrationCtx *scheduler.Context,
 	ctxs []*scheduler.Context,
 	scaleFactor map[string]int32,
+	projectIDMappings string,
+	appKey, instanceID string,
 ) {
 	// Failback the application
 	// Trigger a reverse migration
 
-	ctxsReverse, err := schedulerDriver.Schedule("mysql-migration-failover-failback",
-		scheduler.ScheduleOptions{AppKeys: []string{"mysql-enc-pvc"}})
+	ctxsReverse, err := schedulerDriver.Schedule(instanceID,
+		scheduler.ScheduleOptions{AppKeys: []string{appKey}})
 	require.NoError(t, err, "Error scheduling task")
 	require.Equal(t, 1, len(ctxsReverse), "Only one task should have started")
 
@@ -169,12 +257,12 @@ func testMigrationFailback(
 	postMigrationCtx := ctxsReverse[0].DeepCopy()
 
 	// create, apply and validate cluster pair specs
-	err = scheduleClusterPair(ctxsReverse[0], false, false, "cluster-pair-reverse", true)
+	err = scheduleClusterPair(ctxsReverse[0], false, false, "cluster-pair-reverse", projectIDMappings, true)
 	require.NoError(t, err, "Error scheduling cluster pair")
 
 	// apply migration specs
 	err = schedulerDriver.AddTasks(ctxsReverse[0],
-		scheduler.ScheduleOptions{AppKeys: []string{"mysql-migration-failover-failback"}})
+		scheduler.ScheduleOptions{AppKeys: []string{instanceID}})
 	require.NoError(t, err, "Error scheduling migration specs")
 
 	err = schedulerDriver.WaitForRunning(ctxsReverse[0], defaultWaitTimeout, defaultWaitInterval)
@@ -212,5 +300,154 @@ func testMigrationFailback(
 	err = schedulerDriver.WaitForRunning(postMigrationCtx, defaultWaitTimeout, defaultWaitInterval)
 	require.NoError(t, err, "Error waiting for pod to get to running state on source cluster after failback")
 
+	// Check the namespace labels are transformed
+	if len(projectIDMappings) > 0 {
+		namespace := appKey + "-" + instanceID
+		ns, err := core.Instance().GetNamespace(namespace)
+		require.NoError(t, err, "failed to get namespace")
+		projectValue, ok := ns.Labels[rancherLabelKey]
+		require.True(t, ok, "expected rancher label")
+		require.Equal(t, projectValue, "project-A")
+
+		serviceList, err := core.Instance().ListServices(namespace, meta_v1.ListOptions{})
+		require.NoError(t, err, "failed to get services")
+		require.GreaterOrEqual(t, len(serviceList.Items), 1, "unexpected number of services")
+		for _, service := range serviceList.Items {
+			projectValue, ok := service.Labels[rancherLabelKey]
+			require.True(t, ok, "expected rancher label")
+			require.Equal(t, projectValue, "project-A")
+
+			projectValue, ok = service.Annotations[rancherLabelKey]
+			require.True(t, ok, "expected rancher label")
+			require.Equal(t, projectValue, "project-A")
+		}
+	}
+
 	destroyAndWait(t, []*scheduler.Context{postMigrationCtx})
 }
+
+// The below two functions are currently not invoked during the tests since the namespaceSelector
+// is still Alpha in kubernetes v1.21.0 . We can add these extra checks once we move our integration tests
+// to k8s v1.24.0 where this field is GA
+
+/*
+func validateFailbackAffinityNamespaceSelector(
+	t *testing.T,
+	postMigrationCtx *scheduler.Context,
+) {
+	found := false
+	for _, specObj := range postMigrationCtx.App.SpecList {
+		if statefulSetSpec, ok := specObj.(*appsapi.StatefulSet); ok {
+			found = true
+			sts, err := apps.Instance().GetStatefulSet(statefulSetSpec.Name, statefulSetSpec.Namespace)
+			require.NoError(t, err, "failed to get stateful set on remote cluster")
+			require.NotNil(t, sts.Spec.Template.Spec.Affinity, "affinity is nil")
+
+			// Pod Affinity
+			affinity := sts.Spec.Template.Spec.Affinity.PodAffinity
+			require.NotNil(t, affinity, "pod affinity is nil")
+
+			// RequiredDuringSchedulingIgnoredDuringExecution
+			require.NotEmpty(t, affinity.RequiredDuringSchedulingIgnoredDuringExecution, "affinity is empty")
+			selector := affinity.RequiredDuringSchedulingIgnoredDuringExecution[0].NamespaceSelector
+			require.NotNil(t, selector, "namespace selector is nil")
+			require.Equal(t, len(selector.MatchLabels), 1, "incorrect match labels")
+			projectValue, ok := selector.MatchLabels[rancherLabelKey]
+			require.True(t, ok, "missing label key in namespace selector")
+			require.Equal(t, projectValue, "projectA", "incorrect namespace selector value")
+
+			// PreferredDuringSchedulingIgnoredDuringExecution
+			require.NotEmpty(t, affinity.PreferredDuringSchedulingIgnoredDuringExecution, "affinity is empty")
+			selector = affinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.NamespaceSelector
+			require.NotNil(t, selector, "namespace selector is nil")
+			require.Equal(t, len(selector.MatchLabels), 1, "incorrect match labels")
+			projectValue, ok = selector.MatchLabels[rancherLabelKey]
+			require.True(t, ok, "missing label key in namespace selector")
+			require.Equal(t, projectValue, "projectA", "incorrect namespace selector value")
+
+			// Pod Anti Affinity
+			antiAffinity := sts.Spec.Template.Spec.Affinity.PodAntiAffinity
+			require.NotNil(t, antiAffinity, "pod antiAffinity is nil")
+
+			// RequiredDuringSchedulingIgnoredDuringExecution
+			require.NotEmpty(t, antiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, "affinity is empty")
+			selector = antiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].NamespaceSelector
+			require.NotNil(t, selector, "namespace selector is nil")
+			require.Equal(t, len(selector.MatchLabels), 1, "incorrect match labels")
+			projectValue, ok = selector.MatchLabels[rancherLabelKey]
+			require.True(t, ok, "missing label key in namespace selector")
+			require.Equal(t, projectValue, "projectC", "incorrect namespace selector value")
+
+			// PreferredDuringSchedulingIgnoredDuringExecution
+			require.NotEmpty(t, antiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, "affinity is empty")
+			selector = antiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.NamespaceSelector
+			require.NotNil(t, selector, "namespace selector is nil")
+			require.Equal(t, len(selector.MatchLabels), 1, "incorrect match labels")
+			projectValue, ok = selector.MatchLabels[rancherLabelKey]
+			require.True(t, ok, "missing label key in namespace selector")
+			require.Equal(t, projectValue, "projectC", "incorrect namespace selector value")
+		}
+	}
+	require.True(t, found, "Expected StatefulSet to be found on remote cluster")
+}
+
+func validateFailoverAffinityNamespaceSelector(
+	t *testing.T,
+	preMigrationCtx *scheduler.Context,
+) {
+	found := false
+	for _, specObj := range preMigrationCtx.App.SpecList {
+		if statefulSetSpec, ok := specObj.(*appsapi.StatefulSet); ok {
+			found = true
+			sts, err := apps.Instance().GetStatefulSet(statefulSetSpec.Name, statefulSetSpec.Namespace)
+			require.NoError(t, err, "failed to get stateful set on remote cluster")
+			require.NotNil(t, sts.Spec.Template.Spec.Affinity, "affinity is nil")
+
+			// Pod Affinity
+			affinity := sts.Spec.Template.Spec.Affinity.PodAffinity
+			require.NotNil(t, affinity, "pod affinity is nil")
+
+			// RequiredDuringSchedulingIgnoredDuringExecution
+			require.NotEmpty(t, affinity.RequiredDuringSchedulingIgnoredDuringExecution, "affinity is empty")
+			selector := affinity.RequiredDuringSchedulingIgnoredDuringExecution[0].NamespaceSelector
+			require.NotNil(t, selector, "namespace selector is nil")
+			require.Equal(t, len(selector.MatchLabels), 1, "incorrect match labels")
+			projectValue, ok := selector.MatchLabels[rancherLabelKey]
+			require.True(t, ok, "missing label key in namespace selector")
+			require.Equal(t, projectValue, "projectB", "incorrect namespace selector value")
+
+			// PreferredDuringSchedulingIgnoredDuringExecution
+			require.NotEmpty(t, affinity.PreferredDuringSchedulingIgnoredDuringExecution, "affinity is empty")
+			selector = affinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.NamespaceSelector
+			require.NotNil(t, selector, "namespace selector is nil")
+			require.Equal(t, len(selector.MatchLabels), 1, "incorrect match labels")
+			projectValue, ok = selector.MatchLabels[rancherLabelKey]
+			require.True(t, ok, "missing label key in namespace selector")
+			require.Equal(t, projectValue, "projectB", "incorrect namespace selector value")
+
+			// Pod Anti Affinity
+			antiAffinity := sts.Spec.Template.Spec.Affinity.PodAntiAffinity
+			require.NotNil(t, antiAffinity, "pod antiAffinity is nil")
+
+			// RequiredDuringSchedulingIgnoredDuringExecution
+			require.NotEmpty(t, antiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, "affinity is empty")
+			selector = antiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].NamespaceSelector
+			require.NotNil(t, selector, "namespace selector is nil")
+			require.Equal(t, len(selector.MatchLabels), 1, "incorrect match labels")
+			projectValue, ok = selector.MatchLabels[rancherLabelKey]
+			require.True(t, ok, "missing label key in namespace selector")
+			require.Equal(t, projectValue, "projectD", "incorrect namespace selector value")
+
+			// PreferredDuringSchedulingIgnoredDuringExecution
+			require.NotEmpty(t, antiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, "affinity is empty")
+			selector = antiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.NamespaceSelector
+			require.NotNil(t, selector, "namespace selector is nil")
+			require.Equal(t, len(selector.MatchLabels), 1, "incorrect match labels")
+			projectValue, ok = selector.MatchLabels[rancherLabelKey]
+			require.True(t, ok, "missing label key in namespace selector")
+			require.Equal(t, projectValue, "projectD", "incorrect namespace selector value")
+		}
+	}
+	require.True(t, found, "Expected StatefulSet to be found on remote cluster")
+}
+*/

--- a/test/integration_test/migration_stork_failures_test.go
+++ b/test/integration_test/migration_stork_failures_test.go
@@ -61,7 +61,7 @@ func deleteStorkPodsDuringMigrationTest(t *testing.T, clusterKey string, delStor
 	require.NoError(t, err, "Error waiting for app to get to running state")
 
 	// create, apply and validate cluster pair specs
-	err = scheduleClusterPair(ctxs[0], false, true, defaultClusterPairDir, false)
+	err = scheduleClusterPair(ctxs[0], false, true, defaultClusterPairDir, "", false)
 	require.NoError(t, err, "Error scheduling cluster pair")
 
 	// apply migration specs

--- a/test/integration_test/specs/mysql-enc-pvc-rancher/mysql.yaml
+++ b/test/integration_test/specs/mysql-enc-pvc-rancher/mysql.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  serviceName: mysql-service
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+      version: "1"
+  template:
+    metadata:
+      labels:
+        app: mysql
+        version: "1"
+    spec:
+      schedulerName: stork
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: password
+        ports:
+        - containerPort: 3306
+        livenessProbe:
+          exec:
+            command: ["sh", "-c", "mysqladmin -u root -p$MYSQL_ROOT_PASSWORD ping"]
+          initialDelaySeconds: 70
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "mysql -u root -p$MYSQL_ROOT_PASSWORD -e \"select 1\""]
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: mysql-data
+          mountPath: /var/lib/mysql
+  volumeClaimTemplates:
+  - metadata:
+      name: mysql-data
+      annotations:
+        volume.beta.kubernetes.io/storage-class: mysql-sc
+        px/secret-name: volume-secrets
+        px/secret-namespace: kube-system
+        px/secret-key: mysql-secret
+        field.cattle.io/projectId: "project-A"
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 8Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+  annotations:
+    field.cattle.io/projectId: "project-A"
+  labels:
+    app: mysql
+spec:
+  selector:
+    app: mysql
+  ports:
+    - name: transport
+      port: 3306

--- a/test/integration_test/specs/mysql-enc-pvc-rancher/portworx/px-sc.yaml
+++ b/test/integration_test/specs/mysql-enc-pvc-rancher/portworx/px-sc.yaml
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: mysql-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+   repl: "2"
+   secure: "true"

--- a/test/integration_test/specs/mysql-migration-failover-failback-rancher/migration.yaml
+++ b/test/integration_test/specs/mysql-migration-failover-failback-rancher/migration.yaml
@@ -1,0 +1,14 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: Migration
+metadata:
+  name: mysql-migration
+spec:
+  # This should be the name of the cluster pair
+  clusterPair: remoteclusterpair
+  # If set to false this will migrate only the volumes. No PVCs, apps, etc will be migrated
+  includeResources: true
+  # If set to false, the deployments and stateful set replicas will be set to 0 on the destination. There will be an annotation with "stork.openstorage.org/migrationReplicas" to store the replica count from the source
+  startApplications: false
+  # List of namespaces to migrate
+  namespaces:
+  - mysql-enc-pvc-rancher-mysql-migration-failover-failback-rancher


### PR DESCRIPTION
**What type of PR is this?**
>feature


**What this PR does / why we need it**:
PlatformOptions in ClusterPair allow users to specify any configurations required for
kubernetes platform providers like Rancher / EKS / AKS etc

Currently the PlatformOptions are only being used for Rancher. Each platform can define their
own spec within this PlatformOptions.

RancherSpec:
- ProjectMappings: Allows users to configure source and target cluster projectID mappings
so that stork can apply the correct annotations on the destination project where it
is migrating the k8s resources.
- RancherSecret (FUTURE): Proposal for specifying a kubernetes secret to specify rancher api keys that would
be used to send REST APIs to Rancher endpoint for creating/deleting/getting project details

NetworkPolicy / All Affinity referencing objects - Deployment/StatefulSet etc
- Parse a pod spec and if NamespaceSelectors are set, check if there are any rancher project labels
and replace them with the target project ID mapping.

**Does this PR change a user-facing CRD or CLI?**:
Yes

**Is a release note needed?**:

```release-note
Rancher Project Mapping Support: You can now specify project mappings between the source and destination cluster in the ClusterPair object. Stork will migrate resources between the clusters while translating the project related information by using the project mappings. Currently annotations, labels and namespace selectors on NetworkPolicy and any pod spec are handled by Stork while transforming the resources across projects between two clusters.

```

**Does this change need to be cherry-picked to a release branch?**:
2.11
