### PR TITLE
PWX-24431 : Support manually created endpoint resources for migration and backup

### DIFF
--- a/pkg/resourcecollector/endpoint.go
+++ b/pkg/resourcecollector/endpoint.go
@@ -1,0 +1,28 @@
+package resourcecollector
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) endpointsToBeCollected(
+	object runtime.Unstructured,
+) (bool, error) {
+	var endpoint v1.Endpoints
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &endpoint); err != nil {
+		return false, fmt.Errorf("error converting to endpoint: %v", err)
+	}
+
+	if endpoint.Annotations != nil {
+		if _, ok := endpoint.Annotations["last_applied_annotation"]; ok {
+			return true, nil
+		}
+		if _, ok := endpoint.Annotations["collect_resource"]; ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -42,6 +42,9 @@ const (
 	StorkResourceHash = "stork.libopenstorage.org/resource-hash"
 	// SkipModifyResources is the annotation used to skip update of resources
 	SkipModifyResources = "stork.libopenstorage.org/skip-modify-resource"
+	// IncludeResources to not skip resources of specific type
+	IncludeResources = "stork.libopenstorage.org/include-resource"
+
 	// ServiceKind for k8s service resources
 	ServiceKind          = "Service"
 	deletedMaxRetries    = 12
@@ -153,7 +156,7 @@ func resourceToBeCollected(resource metav1.APIResource, grp schema.GroupVersion,
 		"LimitRange",
 		"NetworkPolicy",
 		"PodDisruptionBudget",
-		"Endpoint":
+		"Endpoints":
 		return true
 	case "Job":
 		return slice.ContainsString(optionalResourceTypes, "job", strings.ToLower) ||
@@ -523,7 +526,7 @@ func (r *ResourceCollector) objectToBeCollected(
 		return r.dataVolumesToBeCollected(object)
 	case "VirtualMachineInstance":
 		return r.virtualMachineInstanceToBeCollected(object)
-	case "Endpoint":
+	case "Endpoints":
 		return r.endpointsToBeCollected(object)
 	}
 

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -152,7 +152,8 @@ func resourceToBeCollected(resource metav1.APIResource, grp schema.GroupVersion,
 		"ReplicaSet",
 		"LimitRange",
 		"NetworkPolicy",
-		"PodDisruptionBudget":
+		"PodDisruptionBudget",
+		"Endpoint":
 		return true
 	case "Job":
 		return slice.ContainsString(optionalResourceTypes, "job", strings.ToLower) ||
@@ -522,6 +523,8 @@ func (r *ResourceCollector) objectToBeCollected(
 		return r.dataVolumesToBeCollected(object)
 	case "VirtualMachineInstance":
 		return r.virtualMachineInstanceToBeCollected(object)
+	case "Endpoint":
+		return r.endpointsToBeCollected(object)
 	}
 
 	return true, nil


### PR DESCRIPTION
**What type of PR is this?**
>enhancement

**What this PR does / why we need it**:
Support manually created endpoint resources for migration and backup

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes

```release-note
Issue: Endpoint resources are not migrated by stork
Resolution: stork will now migrate manually created endpoint resources, user can also set annotation `"stork.libopenstorage.org/include-resource"` to collect auto-created endpoint

```

**Does this change need to be cherry-picked to a release branch?**:
2.11.2
