### PR TITLE
Integration-test for networkpolicies and endpoints resource migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,8 +73,8 @@ replace (
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7 => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20220426191846-06ff1e09348f
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220401024625-dbc61a336f65
-	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20220708194938-51851a4a76a7
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220714042759-8f183fe386ca
+	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20220714042817-25f6ab6dc5d1
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.6.0
 

--- a/go.sum
+++ b/go.sum
@@ -1368,9 +1368,13 @@ github.com/portworx/px-backup-api v1.2.2-0.20210917042806-f2b0725444af/go.mod h1
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20220401024625-dbc61a336f65 h1:BJoyW5YUZmxSpOfbmqWxBKmAtsJFyDOM0P09jvLYYoY=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20220401024625-dbc61a336f65/go.mod h1:0IQvado0rnmbRMORaCqCDrrzjBrX5sU+Sz2+vQwEsjM=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220714042759-8f183fe386ca h1:jrjwiQdqgDRsQZuiRDaWsbvx/z5t1icQPf7dgJOQUKE=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220714042759-8f183fe386ca/go.mod h1:0IQvado0rnmbRMORaCqCDrrzjBrX5sU+Sz2+vQwEsjM=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.0.0-20220708194938-51851a4a76a7 h1:lDvFNvXnGModzVAMwo5yypYwEFpfTN+IGyUpuXKpbpI=
 github.com/portworx/torpedo v0.0.0-20220708194938-51851a4a76a7/go.mod h1:qhBrOHe4PKNcZULBSnL7YEOZDulSe0SwAPuZAxrghvg=
+github.com/portworx/torpedo v0.0.0-20220714042817-25f6ab6dc5d1 h1:P4Lo6jDUUKglz7rkqlK8Hg4gLXqIIrgQaEeWxcXrV8U=
+github.com/portworx/torpedo v0.0.0-20220714042817-25f6ab6dc5d1/go.mod h1:I2wJjwLvCub+L1eNHWyHIIe6SrCreMVgwym4dCsR1WE=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=

--- a/test/integration_test/specs/endpoint-migration-schedule-interval/migrationschedule.yaml
+++ b/test/integration_test/specs/endpoint-migration-schedule-interval/migrationschedule.yaml
@@ -1,0 +1,22 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: MigrationSchedule
+metadata:
+  name: endpoint-migration-schedule-interval
+spec:
+  schedulePolicyName: migrate-every-5m
+  template:
+    spec:
+      # This should be the name of the cluster pair
+      clusterPair: remoteclusterpair
+      # If set to false this will migrate only the volumes. No PVCs, apps, etc will be migrated
+      includeResources: true
+      # If set to false, the deployments and stateful set replicas will be set to
+      # 0 on the destination. There will be an annotation with
+      # "stork.openstorage.org/migrationReplicas" to store the replica count from the source
+      startApplications: false
+      # If set to true, migration will also delete resources which are no longer
+      # present on source cluster. Only resource which are earlier migrated by stork will be cleaned up
+      purgeDeletedResources: true
+      # List of namespaces to migrate
+      namespaces:
+      - endpoint-endpoint-migration-schedule-interval

--- a/test/integration_test/specs/endpoint-migration-schedule-interval/schedulepolicy.yaml
+++ b/test/integration_test/specs/endpoint-migration-schedule-interval/schedulepolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: SchedulePolicy
+metadata:
+  name: migrate-every-5m
+policy:
+  interval:
+    intervalMinutes: 5

--- a/test/integration_test/specs/endpoint/aws/aws-sc.yaml
+++ b/test/integration_test/specs/endpoint/aws/aws-sc.yaml
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: mysql-sc 
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+reclaimPolicy: Delete

--- a/test/integration_test/specs/endpoint/azure/azure-sc.yaml
+++ b/test/integration_test/specs/endpoint/azure/azure-sc.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: mysql-sc
+provisioner: kubernetes.io/azure-disk
+parameters:
+  skuName: Standard_LRS

--- a/test/integration_test/specs/endpoint/endpoints.yaml
+++ b/test/integration_test/specs/endpoint/endpoints.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: custom-endpoint
+subsets:
+  - addresses:
+    - ip: 5.6.7.8
+    ports:
+    - port: 8080
+      protocol: TCP

--- a/test/integration_test/specs/endpoint/gce/gke-sc.yaml
+++ b/test/integration_test/specs/endpoint/gce/gke-sc.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: mysql-sc
+parameters:
+  type: pd-standard
+provisioner: kubernetes.io/gce-pd
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/test/integration_test/specs/endpoint/linstor/linstor-sc.yaml
+++ b/test/integration_test/specs/endpoint/linstor/linstor-sc.yaml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: mysql-sc
+provisioner: linstor.csi.linbit.com
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+parameters:
+  autoPlace: "2"
+  storagePool: sda

--- a/test/integration_test/specs/endpoint/mysql.yaml
+++ b/test/integration_test/specs/endpoint/mysql.yaml
@@ -1,0 +1,79 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+   name: mysql-data
+   labels:
+     app: mysql 
+   annotations:
+     volume.beta.kubernetes.io/storage-class: mysql-sc
+spec:
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    app: mysql 
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+      version: "1"
+  template:
+    metadata:
+      labels:
+        app: mysql
+        version: "1"
+    spec:
+      schedulerName: stork
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: password
+        ports:
+        - containerPort: 3306
+        livenessProbe:
+          exec:
+            command: ["sh", "-c", "mysqladmin -u root -p$MYSQL_ROOT_PASSWORD ping"]
+          initialDelaySeconds: 70
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "mysql -u root -p$MYSQL_ROOT_PASSWORD -e \"select 1\""]
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+  labels:
+    app: mysql
+spec:
+  selector:
+    app: mysql
+  ports:
+    - name: transport
+      port: 3306

--- a/test/integration_test/specs/endpoint/portworx/px-sc.yaml
+++ b/test/integration_test/specs/endpoint/portworx/px-sc.yaml
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: mysql-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+   repl: "2"
+allowVolumeExpansion: true

--- a/test/integration_test/specs/networkpolicy-all-migration-schedule-interval/migrationschedule.yaml
+++ b/test/integration_test/specs/networkpolicy-all-migration-schedule-interval/migrationschedule.yaml
@@ -1,0 +1,24 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: MigrationSchedule
+metadata:
+  name: networkpolicy-all-migration-schedule-interval
+spec:
+  schedulePolicyName: migrate-every-5m
+  template:
+    spec:
+      # This should be the name of the cluster pair
+      clusterPair: remoteclusterpair
+      # If set to false this will migrate only the volumes. No PVCs, apps, etc will be migrated
+      includeResources: true
+      # If set to false, the deployments and stateful set replicas will be set to
+      # 0 on the destination. There will be an annotation with
+      # "stork.openstorage.org/migrationReplicas" to store the replica count from the source
+      startApplications: false
+      # If set to true, migration will also delete resources which are no longer
+      # present on source cluster. Only resource which are earlier migrated by stork will be cleaned up
+      purgeDeletedResources: true
+      # IncludeNetworkPolicyWithCIDR collect network policy resource with cidr set
+      includeNetworkPolicyWithCIDR: true
+      # List of namespaces to migrate
+      namespaces:
+      - networkpolicy-networkpolicy-all-migration-schedule-interval

--- a/test/integration_test/specs/networkpolicy-all-migration-schedule-interval/schedulepolicy.yaml
+++ b/test/integration_test/specs/networkpolicy-all-migration-schedule-interval/schedulepolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: SchedulePolicy
+metadata:
+  name: migrate-every-5m
+policy:
+  interval:
+    intervalMinutes: 5

--- a/test/integration_test/specs/networkpolicy-migration-schedule-interval/migrationschedule.yaml
+++ b/test/integration_test/specs/networkpolicy-migration-schedule-interval/migrationschedule.yaml
@@ -1,0 +1,22 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: MigrationSchedule
+metadata:
+  name: networkpolicy-migration-schedule-interval
+spec:
+  schedulePolicyName: migrate-every-5m
+  template:
+    spec:
+      # This should be the name of the cluster pair
+      clusterPair: remoteclusterpair
+      # If set to false this will migrate only the volumes. No PVCs, apps, etc will be migrated
+      includeResources: true
+      # If set to false, the deployments and stateful set replicas will be set to
+      # 0 on the destination. There will be an annotation with
+      # "stork.openstorage.org/migrationReplicas" to store the replica count from the source
+      startApplications: false
+      # If set to true, migration will also delete resources which are no longer
+      # present on source cluster. Only resource which are earlier migrated by stork will be cleaned up
+      purgeDeletedResources: true
+      # List of namespaces to migrate
+      namespaces:
+      - networkpolicy-networkpolicy-migration-schedule-interval

--- a/test/integration_test/specs/networkpolicy-migration-schedule-interval/schedulepolicy.yaml
+++ b/test/integration_test/specs/networkpolicy-migration-schedule-interval/schedulepolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: SchedulePolicy
+metadata:
+  name: migrate-every-5m
+policy:
+  interval:
+    intervalMinutes: 5

--- a/test/integration_test/specs/networkpolicy/cidr-policy.yaml
+++ b/test/integration_test/specs/networkpolicy/cidr-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    labels:
+      app.kubernetes.io/instance: cidr-policy-test
+    name: cidr-policy-test
+spec:
+    egress:
+    - to:
+      - ipBlock:
+          cidr: 10.65.1.0/25
+      - ipBlock:
+          cidr: 172.16.0.0/25
+    policyTypes:
+    - Egress

--- a/test/integration_test/specs/networkpolicy/mysql.yaml
+++ b/test/integration_test/specs/networkpolicy/mysql.yaml
@@ -1,0 +1,79 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+   name: mysql-data
+   labels:
+     app: mysql 
+   annotations:
+     volume.beta.kubernetes.io/storage-class: mysql-sc
+spec:
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    app: mysql 
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+      version: "1"
+  template:
+    metadata:
+      labels:
+        app: mysql
+        version: "1"
+    spec:
+      schedulerName: stork
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: password
+        ports:
+        - containerPort: 3306
+        livenessProbe:
+          exec:
+            command: ["sh", "-c", "mysqladmin -u root -p$MYSQL_ROOT_PASSWORD ping"]
+          initialDelaySeconds: 70
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "mysql -u root -p$MYSQL_ROOT_PASSWORD -e \"select 1\""]
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+  labels:
+    app: mysql
+spec:
+  selector:
+    app: mysql
+  ports:
+    - name: transport
+      port: 3306

--- a/test/integration_test/specs/networkpolicy/networkpolicy-1.yaml
+++ b/test/integration_test/specs/networkpolicy/networkpolicy-1.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: policy-with-cidr-test
+spec:
+    ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app: incident-registration
+    podSelector:
+      matchLabels:
+        name: oracle
+    policyTypes:
+    - Ingress

--- a/test/integration_test/specs/networkpolicy/networkpolicy-2.yaml
+++ b/test/integration_test/specs/networkpolicy/networkpolicy-2.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: policy-with-cidr-test-2
+spec:
+    ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app: incident-registration
+    podSelector:
+      matchLabels:
+        name: oracle
+    policyTypes:
+    - Ingress

--- a/test/integration_test/specs/networkpolicy/portworx/px-sc.yaml
+++ b/test/integration_test/specs/networkpolicy/portworx/px-sc.yaml
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: mysql-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+   repl: "2"
+allowVolumeExpansion: true

--- a/vendor/github.com/portworx/sched-ops/k8s/core/core.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/core.go
@@ -48,6 +48,7 @@ type Ops interface {
 	ServiceOps
 	ServiceAccountOps
 	LimitRangeOps
+	NetworkPolicyOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)

--- a/vendor/github.com/portworx/sched-ops/k8s/core/endpoints.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/endpoints.go
@@ -14,6 +14,8 @@ type EndpointsOps interface {
 	CreateEndpoints(endpoints *corev1.Endpoints) (*corev1.Endpoints, error)
 	// GetEndpoints retrieves endpoints for a given namespace/name.
 	GetEndpoints(name, namespace string) (*corev1.Endpoints, error)
+	// ListEndpoints retrieves endpoints for a given namespace
+	ListEndpoints(string, metav1.ListOptions) (*corev1.EndpointsList, error)
 	// PatchEndpoints applies a patch for a given endpoints.
 	PatchEndpoints(name, namespace string, pt types.PatchType, jsonPatch []byte, subresources ...string) (*corev1.Endpoints, error)
 	// DeleteEndpoints removes endpoints for a given namespace/name.
@@ -36,6 +38,14 @@ func (c *Client) GetEndpoints(name, ns string) (*corev1.Endpoints, error) {
 		return nil, err
 	}
 	return c.kubernetes.CoreV1().Endpoints(ns).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// ListEndpoints retrieves endpoints for a given namespace
+func (c *Client) ListEndpoints(ns string, opts metav1.ListOptions) (*corev1.EndpointsList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kubernetes.CoreV1().Endpoints(ns).List(context.TODO(), opts)
 }
 
 // PatchEndpoints applies a patch for a given endpoints.

--- a/vendor/github.com/portworx/sched-ops/k8s/core/networkpolicy.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/networkpolicy.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"context"
+
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// NetworkPolicyOps is an interface to deal with kubernetes NetworkPolicy.
+type NetworkPolicyOps interface {
+	// CreateNetworkPolicy creates a given network policy.
+	CreateNetworkPolicy(NetworkPolicy *v1.NetworkPolicy) (*v1.NetworkPolicy, error)
+	// GetNetworkPolicy retrieves NetworkPolicy for a given namespace/name.
+	GetNetworkPolicy(name, namespace string) (*v1.NetworkPolicy, error)
+	// ListNetworkPolicy retrieves NetworkPolicy for a given namespace/name.
+	ListNetworkPolicy(namespace string, listOptions metav1.ListOptions) (*v1.NetworkPolicyList, error)
+	// PatchNetworkPolicy applies a patch for a given NetworkPolicy.
+	PatchNetworkPolicy(name, namespace string, pt types.PatchType, jsonPatch []byte, subresources ...string) (*v1.NetworkPolicy, error)
+	// DeleteNetworkPolicy removes NetworkPolicy for a given namespace/name.
+	DeleteNetworkPolicy(name, namespace string) error
+	// UpdateNetworkPolicy updates the given networkpolicy
+	UpdateNetworkPolicy(NetworkPolicy *v1.NetworkPolicy) (*v1.NetworkPolicy, error)
+}
+
+// CreateNetworkPolicy creates a given NetworkPolicy.
+func (c *Client) CreateNetworkPolicy(NetworkPolicy *v1.NetworkPolicy) (*v1.NetworkPolicy, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kubernetes.NetworkingV1().NetworkPolicies(NetworkPolicy.Namespace).Create(context.TODO(), NetworkPolicy, metav1.CreateOptions{})
+}
+
+// GetNetworkPolicy retrieves NetworkPolicy for a given namespace/name.
+func (c *Client) GetNetworkPolicy(name, ns string) (*v1.NetworkPolicy, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kubernetes.NetworkingV1().NetworkPolicies(ns).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// ListNetworkPolicy retrieves NetworkPolicies for a given namespace.
+func (c *Client) ListNetworkPolicy(ns string, opts metav1.ListOptions) (*v1.NetworkPolicyList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kubernetes.NetworkingV1().NetworkPolicies(ns).List(context.TODO(), opts)
+}
+
+// PatchNetworkPolicy applies a patch for a given NetworkPolicy.
+func (c *Client) PatchNetworkPolicy(name, ns string, pt types.PatchType, jsonPatch []byte, subresources ...string) (*v1.NetworkPolicy, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kubernetes.NetworkingV1().NetworkPolicies(ns).Patch(context.TODO(), name, pt, jsonPatch, metav1.PatchOptions{}, subresources...)
+}
+
+// DeleteNetworkPolicy retrieves NetworkPolicy for a given namespace/name.
+func (c *Client) DeleteNetworkPolicy(name, ns string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+	return c.kubernetes.NetworkingV1().NetworkPolicies(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
+// UpdateNetworkPolicy updates the given network policy.
+func (c *Client) UpdateNetworkPolicy(NetworkPolicy *v1.NetworkPolicy) (*v1.NetworkPolicy, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.kubernetes.NetworkingV1().NetworkPolicies(NetworkPolicy.Namespace).Update(context.TODO(), NetworkPolicy, metav1.UpdateOptions{})
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/core/pods.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/pods.go
@@ -346,12 +346,8 @@ func (c *Client) IsPodReady(pod corev1.Pod) bool {
 
 // IsPodBeingManaged returns true if the pod is being managed by a controller
 func (c *Client) IsPodBeingManaged(pod corev1.Pod) bool {
-	if len(pod.OwnerReferences) == 0 {
-		return false
-	}
-
 	for _, owner := range pod.OwnerReferences {
-		if *owner.Controller {
+		if owner.Controller != nil && *owner.Controller {
 			// We are assuming that if a pod has a owner who has set itself as
 			// a controller, the pod is managed. We are not checking for specific
 			// contollers like ReplicaSet, StatefulSet as that is
@@ -361,7 +357,6 @@ func (c *Client) IsPodBeingManaged(pod corev1.Pod) bool {
 			return true
 		}
 	}
-
 	return false
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -624,7 +624,7 @@ github.com/portworx/kdmp/pkg/version
 github.com/portworx/kvdb
 github.com/portworx/kvdb/common
 github.com/portworx/kvdb/mem
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20220401024625-dbc61a336f65 => github.com/portworx/sched-ops v1.20.4-rc1.0.20220401024625-dbc61a336f65
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20220401024625-dbc61a336f65 => github.com/portworx/sched-ops v1.20.4-rc1.0.20220714042759-8f183fe386ca
 ## explicit
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -647,7 +647,7 @@ github.com/portworx/sched-ops/k8s/rbac
 github.com/portworx/sched-ops/k8s/storage
 github.com/portworx/sched-ops/k8s/stork
 github.com/portworx/sched-ops/task
-# github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145 => github.com/portworx/torpedo v0.0.0-20220708194938-51851a4a76a7
+# github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145 => github.com/portworx/torpedo v0.0.0-20220714042817-25f6ab6dc5d1
 ## explicit
 github.com/portworx/torpedo/drivers/api
 github.com/portworx/torpedo/drivers/node
@@ -1771,8 +1771,8 @@ sigs.k8s.io/yaml
 # github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20220426191846-06ff1e09348f
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220401024625-dbc61a336f65
-# github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20220708194938-51851a4a76a7
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220714042759-8f183fe386ca
+# github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20220714042817-25f6ab6dc5d1
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.6.0
 # k8s.io/api => k8s.io/api v0.21.4


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
Add integration test to cover migration of endpoints and network policy resource

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

**Note:** 
This PR is on top of #1108 and #1115, please review integration test commits only. Will rebase once vendor pr gets merged in
- Dependent feature pr needs to be merged first #1108 , #1115 
- vendor pr needs to be merge 
https://github.com/portworx/torpedo/pull/818
https://github.com/portworx/sched-ops/pull/282

```
ime="2022-07-05T16:41:36Z" level=info msg="[endpoint] Destroyed SchedulePolicy: migrate-every-5m"
2022/07/05 16:41:36 app mysql is not terminated yet. Cause: pods: [mysql-5fc69d79b7-x76ks (node=stork-stork-2-11-px-2-11-dev-migr-123-1)] are still present Next retry in: 10s
time="2022-07-05T16:41:46Z" level=info msg="[endpoint] Validated destroy of Deployment: mysql"
time="2022-07-05T16:41:46Z" level=info msg="[endpoint] Validated destroy of Service: mysql-service"
time="2022-07-05T16:41:46Z" level=info msg="[endpoint] Destroyed PVC: mysql-data"
--- PASS: TestMigration (1001.07s)
    --- PASS: TestMigration/testMigration (998.06s)
        --- PASS: TestMigration/testMigration/networkpolicyTest (680.37s)
        --- PASS: TestMigration/testMigration/endpointTest (314.67s)
PASS

DONE 6 tests in 1055.747s
```