### PR TITLE
PWX-24637: mutate the virt-launcher container to intercept statfs()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,3 +36,4 @@ COPY ./bin/darwin/storkctl /storkctl/darwin/
 COPY ./bin/windows/storkctl.exe /storkctl/windows/
 COPY ./LICENSE /licenses
 COPY ./bin/stork /
+COPY ./bin/px_statfs.so /

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
+DOCKER_HUB_REPO ?= openstorage
+
+DOCKER_HUB_STORK_IMAGE ?= stork
+DOCKER_HUB_STORK_TAG ?= dev
+
+DOCKER_HUB_CMD_EXECUTOR_IMAGE ?= cmdexecutor
+DOCKER_HUB_CMD_EXECUTOR_TAG ?= dev
+
+DOCKER_HUB_STORK_TEST_IMAGE ?= stork_test
+DOCKER_HUB_STORK_TEST_TAG ?= dev
+
 STORK_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_IMAGE):$(DOCKER_HUB_STORK_TAG)
 CMD_EXECUTOR_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_CMD_EXECUTOR_IMAGE):$(DOCKER_HUB_CMD_EXECUTOR_TAG)
 STORK_TEST_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_TEST_IMAGE):$(DOCKER_HUB_STORK_TEST_TAG)
@@ -29,9 +40,9 @@ LDFLAGS += "-s -w -X github.com/libopenstorage/stork/pkg/version.Version=$(VERSI
 BUILD_OPTIONS := -ldflags=$(LDFLAGS)
 
 .DEFAULT_GOAL=all
-.PHONY: test clean vendor vendor-update
+.PHONY: test clean vendor vendor-update px-statfs
 
-all: stork storkctl cmdexecutor pretest
+all: stork storkctl cmdexecutor pretest px-statfs
 
 vendor-tidy:
 	go mod tidy
@@ -119,6 +130,10 @@ storkctl:
 	@cd cmd/storkctl && CGO_ENABLED=0 GOOS=linux go build $(BUILD_OPTIONS) -o $(BIN)/linux/storkctl
 	@cd cmd/storkctl && CGO_ENABLED=0 GOOS=darwin go build $(BUILD_OPTIONS) -o $(BIN)/darwin/storkctl
 	@cd cmd/storkctl && CGO_ENABLED=0 GOOS=windows go build $(BUILD_OPTIONS) -o $(BIN)/windows/storkctl.exe
+
+px-statfs:
+	@echo "Building px_statfs.so"
+	@cd drivers/volume/portworx/px-statfs && gcc -g -shared -fPIC -o $(BIN)/px_statfs.so px_statfs.c -ldl -D__USE_LARGEFILE64
 
 container: help
 	@echo "Building container: docker build --build-arg VERSION=$(DOCKER_HUB_STORK_TAG) --build-arg RELEASE=$(DOCKER_HUB_STORK_TAG) --tag $(STORK_IMG) -f Dockerfile . "

--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -18,6 +18,7 @@ import (
 	storkvolume "github.com/libopenstorage/stork/drivers/volume"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/errors"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/storage"
@@ -648,6 +649,11 @@ func (a *aws) getAWSClient(backupLocationName, ns string) (*ec2.EC2, error) {
 		client = a.client
 	}
 	return client, nil
+}
+
+// GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
+func (a *aws) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {
+	return nil, nil
 }
 
 func init() {

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -18,6 +18,7 @@ import (
 	storkvolume "github.com/libopenstorage/stork/drivers/volume"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/errors"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/storage"
@@ -670,6 +671,11 @@ func (a *azure) getAzureSession(backupLocationName, ns string) (*azureSession, e
 		azureSession.diskClient = a.diskClient
 	}
 	return azureSession, nil
+}
+
+// GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
+func (a *azure) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {
+	return nil, nil
 }
 
 func init() {

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -17,6 +17,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/applicationmanager/controllers"
 	"github.com/libopenstorage/stork/pkg/crypto"
 	"github.com/libopenstorage/stork/pkg/errors"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/objectstore"
 	"github.com/libopenstorage/stork/pkg/snapshotter"
@@ -1891,6 +1892,11 @@ func (c *csi) CleanupRestoreResources(restore *storkapi.ApplicationRestore) erro
 		logrus.Tracef("failed to clean CSI snapshots: %v", err)
 	}
 	return nil
+}
+
+// GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
+func (c *csi) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {
+	return nil, nil
 }
 
 func init() {

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -12,6 +12,7 @@ import (
 	storkvolume "github.com/libopenstorage/stork/drivers/volume"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/errors"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/storage"
@@ -645,6 +646,11 @@ func (g *gcp) getGCPSession(backupLocationName, ns string) (*gcpSession, error) 
 		gcpSession.projectID = g.projectID
 	}
 	return gcpSession, nil
+}
+
+// GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
+func (g *gcp) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {
+	return nil, nil
 }
 
 func init() {

--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -1007,6 +1007,11 @@ func (k *kdmp) getSnapshotClassName(backup *storkapi.ApplicationBackup) string {
 	return ""
 }
 
+// GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
+func (k *kdmp) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {
+	return nil, nil
+}
+
 func init() {
 	a := &kdmp{}
 

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -13,6 +13,7 @@ import (
 	storkvolume "github.com/libopenstorage/stork/drivers/volume"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/errors"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/storage"
 	"github.com/sirupsen/logrus"
@@ -440,6 +441,11 @@ func (l *linstor) GetClusterID() (string, error) {
 		}
 	}
 	return id, nil
+}
+
+// GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
+func (l *linstor) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {
+	return nil, nil
 }
 
 func init() {

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -10,6 +10,7 @@ import (
 	storkvolume "github.com/libopenstorage/stork/drivers/volume"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/errors"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/pborman/uuid"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
@@ -312,6 +313,11 @@ func (m *Driver) UpdateMigratedPersistentVolumeSpec(
 
 	return pv, nil
 
+}
+
+// GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
+func (m *Driver) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {
+	return nil, nil
 }
 
 func init() {

--- a/drivers/volume/portworx/px-statfs/px_statfs.c
+++ b/drivers/volume/portworx/px-statfs/px_statfs.c
@@ -1,0 +1,180 @@
+#define _GNU_SOURCE
+
+#include <unistd.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/vfs.h> /* or <sys/statfs.h> */
+#include <sys/statvfs.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+/*
+ * To compile:
+ *  gcc -g -shared -fPIC -o px_statfs.so px_statfs.c -ldl -D__USE_LARGEFILE64
+ */
+
+typedef int (*real_statfs_t)(const char *path, struct statfs *buf);
+extern int lstat(const char *pathname, struct stat *statbuf);
+
+ssize_t real_statfs(const char *path, struct statfs *buf)
+{
+    return ((real_statfs_t)dlsym(RTLD_NEXT, "statfs"))(path, buf);
+}
+
+void read_to_str(char *filename, char *buf, int read_cnt)
+{
+    int fd = -1;
+    fd = open(filename, O_RDONLY);
+    if (fd <= 0)
+    {
+        return;
+    }
+    read(fd, buf, read_cnt);
+    close(fd);
+    return;
+}
+
+/*
+ * For regular pxd devices
+ * check /sys/devices/pxd/1/major
+ */
+int is_pxd_reg_device(int major, int minor)
+{
+    char filename[256] = {0};
+    char major_nr_str[10] = {0};
+    sprintf(filename, "/sys/devices/pxd/%d/major", minor);
+    read_to_str(filename, major_nr_str, 9);
+    if (strlen(major_nr_str) > 0)
+    {
+        int pxd_major = atoi(major_nr_str);
+        if (pxd_major == major)
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/*
+ * For encrypted device
+ * # cat /sys/dev/block/253:0/dm/uuid
+ *    CRYPT-LUKS1-41d2686ad84f43d2a64f20502c2f9db0-pxd-enc706349485201319665
+ * # cat /sys/dev/block/253:0/dm/name
+ *    pxd-enc706349485201319665
+ */
+int is_pxd_enc_device(int major, int minor)
+{
+    char filename[256] = {0};
+    char pxd_namestr[10] = {0};
+    char *pattern = "pxd-enc\0";
+    sprintf(filename, "/sys/dev/block/%d:%d/dm/name", major, minor);
+    read_to_str(filename, pxd_namestr, 9);
+    if (strlen(pxd_namestr) > 0)
+    {
+        if (strncmp(pxd_namestr, pattern, strlen(pattern)) == 0)
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/*
+ * For loopback devices
+ * # cat /sys/dev/block/7:0/loop/backing_file
+ *    /dev/pxd/pxd7871666956677911
+ */
+int is_pxd_passthrough_device(int major, int minor)
+{
+    char filename[256] = {0};
+    char pxd_namestr[20] = {0};
+    char *pattern = "/dev/pxd/pxd\0";
+    sprintf(filename, "/sys/dev/block/%d:%d/loop/backing_file", major, minor);
+    read_to_str(filename, pxd_namestr, 19);
+    if (strlen(pxd_namestr) > 0)
+    {
+        if (strncmp(pxd_namestr, pattern, strlen(pattern)) == 0)
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int is_px_device(int major, int minor)
+{
+    int is_true;
+
+    is_true = is_pxd_reg_device(major, minor);
+    if (is_true)
+        return 1;
+
+    is_true = is_pxd_enc_device(major, minor);
+    if (is_true)
+        return 1;
+
+    is_true = is_pxd_passthrough_device(major, minor);
+    if (is_true)
+        return 1;
+
+    return 0;
+}
+
+int get_major_minor_nr(const char *path, int *major, int *minor)
+{
+    struct stat statbuf = {0};
+    int rc = 0;
+    rc = lstat(path, &statbuf);
+    if (rc != 0)
+    {
+        *major = 0;
+        *minor = 0;
+        return -1;
+    }
+    unsigned int maj = (unsigned int)((statbuf.st_dev & 0x000000000000ff00) >> 8);
+    unsigned int min = (unsigned int)((statbuf.st_dev & 0x00000000000000ff));
+    *major = maj;
+    *minor = min;
+    return 0;
+}
+
+int statfs(const char *path, struct statfs *buf)
+{
+    int rc = -1;
+
+    // Perform the actual system call
+    rc = real_statfs(path, buf);
+
+    if (rc == 0)
+    {
+        // TODO: do we need to check buf->f_type in (ext4 | XFS) ?
+        int major = 0;
+        int minor = 0;
+        int rc2 = get_major_minor_nr(path, &major, &minor);
+        if (rc2 != 0)
+        {
+            return rc;
+        }
+
+        int is_pxd = is_px_device(major, minor);
+        if (is_pxd == 1)
+        {
+            buf->f_type = 0x6969; // NFS_SUPER_MAGIC
+        }
+    }
+
+    // Behave just like the regular syscall would
+    return rc;
+}
+
+int __statfs(const char *path, struct statfs *buf)
+{
+    return statfs(path, buf);
+}
+
+int statfs64(const char *path, struct statfs64 *buf)
+{
+    return statfs(path, (struct statfs *)buf);
+}

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -18,6 +18,7 @@ import (
 	"github.com/libopenstorage/stork/drivers"
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/errors"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -136,6 +137,9 @@ type Driver interface {
 
 	// GetClusterID returns the clusterID for the driver
 	GetClusterID() (string, error)
+
+	// GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
+	GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error)
 
 	// GroupSnapshotPluginInterface Interface for group snapshots
 	GroupSnapshotPluginInterface

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -2,6 +2,7 @@ package k8sutils
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -37,6 +38,18 @@ const (
 	//minProtectionPeriod defines minimum number of days, the backup are protected via object-lock feature
 	minProtectionPeriod = 1
 )
+
+// JSONPatchOp is a single json mutation done by a k8s mutating webhook
+type JSONPatchOp struct {
+	// Operation e.g. add, replace
+	Operation string `json:"op"`
+
+	// Path to mutate
+	Path string `json:"path"`
+
+	// Value for the path
+	Value json.RawMessage `json:"value,omitempty"`
+}
 
 // GetPVCsForGroupSnapshot returns all PVCs in given namespace that match the given matchLabels. All PVCs need to be bound.
 func GetPVCsForGroupSnapshot(namespace string, matchLabels map[string]string) ([]v1.PersistentVolumeClaim, error) {

--- a/pkg/webhookadmission/webhook.go
+++ b/pkg/webhookadmission/webhook.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/libopenstorage/stork/drivers/volume"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/portworx/sched-ops/k8s/admissionregistration"
 	"github.com/portworx/sched-ops/k8s/core"
 	log "github.com/sirupsen/logrus"
@@ -64,6 +65,7 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 	var admissionResponse *v1beta1.AdmissionResponse
 	var err error
 	var schedPath string
+	var patches []k8sutils.JSONPatchOp
 	admissionReview := v1beta1.AdmissionReview{}
 	isStorkResource := false
 	skipHookAnnotation := defaultSkipAnnotation
@@ -90,7 +92,8 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 	}
 
 	arReq := admissionReview.Request
-	resourceName := ""
+	resourceName := arReq.Name
+
 	switch arReq.Kind.Kind {
 	case "StatefulSet":
 		var ss appv1.StatefulSet
@@ -100,7 +103,9 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 			http.Error(w, "Decode error", http.StatusBadRequest)
 			return
 		}
-		resourceName = ss.GetName()
+		if resourceName == "" {
+			resourceName = ss.GenerateName
+		}
 		log.Debugf("Received admission review request for sts %s,%s", resourceName, arReq.Namespace)
 		if !skipSchedulerUpdate(skipHookAnnotation, ss.ObjectMeta.Annotations) {
 			isStorkResource, err = c.checkVolumeOwner(ss.Spec.Template.Spec.Volumes, arReq.Namespace)
@@ -119,7 +124,9 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 			http.Error(w, "Decode error", http.StatusBadRequest)
 			return
 		}
-		resourceName = deployment.GetName()
+		if resourceName == "" {
+			resourceName = deployment.GenerateName
+		}
 		log.Debugf("Received admission review request for deployment %s,%s", resourceName, arReq.Namespace)
 		if !skipSchedulerUpdate(skipHookAnnotation, deployment.ObjectMeta.Annotations) {
 			isStorkResource, err = c.checkVolumeOwner(deployment.Spec.Template.Spec.Volumes, arReq.Namespace)
@@ -138,7 +145,9 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 			http.Error(w, "Decode error", http.StatusBadRequest)
 			return
 		}
-		resourceName = pod.GetName()
+		if resourceName == "" {
+			resourceName = pod.GenerateName
+		}
 		log.Debugf("Received admission review request for pod %s,%s", resourceName, arReq.Namespace)
 		if !skipSchedulerUpdate(skipHookAnnotation, pod.ObjectMeta.Annotations) {
 			isStorkResource, err = c.checkVolumeOwner(pod.Spec.Volumes, arReq.Namespace)
@@ -148,11 +157,23 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 				return
 			}
 			schedPath = podSpecSchedPath
+
+			// get extra patches for pods
+			if isStorkResource {
+				// pod object does not have name and namespace populated, so we pass them separately. Also,
+				// if the pod is using generateName, arReq.Name is empty.
+				patches, err = c.Driver.GetPodPatches(arReq.Namespace, &pod)
+				if err != nil {
+					log.Errorf("Failed to get pod patches for pod %s/%s: %v", arReq.Namespace, resourceName, err)
+					c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "could not get pod patches", err.Error())
+					http.Error(w, "Could not get pod patches", http.StatusInternalServerError)
+					return
+				}
+			}
 		}
 	}
 
 	if !isStorkResource {
-		// ignore for non driver application + resources other than depoy/ss
 		admissionResponse = &v1beta1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: "Ignoring backends which are not supported by stork ",
@@ -161,13 +182,22 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 		}
 	} else {
 		// create patch
-		log.Debugf("Updating scheduler to stork for Resource:%s, Name: %s, Namespace:%s", arReq.Kind.Kind, resourceName, arReq.Namespace)
-		patch := createPatch(schedPath)
+		log.Debugf("Updating scheduler to stork for Resource:%s, Name: %s, Namespace:%s",
+			arReq.Kind.Kind, resourceName, arReq.Namespace)
+
+		patchBytes, err := createPatch(patches, schedPath)
+		if err != nil {
+			log.Errorf("Could not create patch: %v", err)
+			c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "could not create patch", err.Error())
+			http.Error(w, "Could not create patch", http.StatusInternalServerError)
+			return
+		}
+
 		admissionResponse = &v1beta1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: "Successful",
 			},
-			Patch:   patch,
+			Patch:   patchBytes,
 			Allowed: true,
 			PatchType: func() *v1beta1.PatchType {
 				pt := v1beta1.PatchTypeJSONPatch
@@ -298,20 +328,18 @@ func (c *Controller) Stop() error {
 	return nil
 }
 
-// createJson patch to update container spec scheduler path
-func createPatch(schedpath string) []byte {
-	p := []map[string]string{}
-	patch := map[string]string{
-		"op":    "replace",
-		"path":  schedpath,
-		"value": storkScheduler,
-	}
-	p = append(p, patch)
-	b, err := json.Marshal(p)
+// createPatch creates a Json patch to update container spec scheduler path in addition to the other patches provided
+func createPatch(patches []k8sutils.JSONPatchOp, schedPath string) ([]byte, error) {
+	allPatches := append(patches, k8sutils.JSONPatchOp{
+		Operation: "replace",
+		Path:      schedPath,
+		Value:     []byte(strconv.Quote(storkScheduler)),
+	})
+	patchBytes, err := json.Marshal(&allPatches)
 	if err != nil {
-		log.Errorf("could not marshal patch: %v", err)
+		return nil, fmt.Errorf("failed to marshal the patch object: %w", err)
 	}
-	return b
+	return patchBytes, nil
 }
 
 func skipSchedulerUpdate(skipHookAnnotation string, annotations map[string]string) bool {


### PR DESCRIPTION
**What type of PR is this?**
>feature

**What this PR does / why we need it**:
Live migration of KubeVirt VM fails if the VM is using
a bind-mounted sharedv4 volume. The root cause is that libvirt
uses a statfs() call to check the file system type and
incorrectly concludes that the volume is not shared.

This patch addresses this problem as described below.

We use a shared library px_statfs.so that intercepts libvirt's statfs call.
If the input path is backed by a PX volume, we change the file system
type returned by the real statfs call. This shared library is bundled with
the stork container.

If a virt-launcher pod is being created and is using a PX volume, stork's
mutating webhook creates a ConfigMap in the pod's namespace.

This configMap has 2 keys that represent the 2 files that we want to inject
into the virt-launcher container's /etc directory:

  - ld.so.preload
  - px_statfs.so

The stork webhook then mutates the virt-launcher pod's spec to mount
the configMap as a volume and inject the 2 files above in /etc dir on the
container's file system. This makes linux load px_statfs.so in the libvirt
process that is running inside the virt-launcher container and intercept
libvirts' statfs() call.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: Kubevirt live migration fails if VM is using Portworx volume.
User Impact: Can't use live migration feature of Kubevirt.
Resolution: The problem was fixed by intercepting libvirt's statfs() call.
```

**Does this change need to be cherry-picked to a release branch?**:
Yes. 2.12.0.
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

