### PR TITLE
Add missing rancher labels to Service spec in rancher

### DIFF
--- a/test/integration_test/specs/mysql-enc-pvc-rancher/mysql.yaml
+++ b/test/integration_test/specs/mysql-enc-pvc-rancher/mysql.yaml
@@ -63,6 +63,7 @@ metadata:
   annotations:
     field.cattle.io/projectId: "project-A"
   labels:
+    field.cattle.io/projectId: "project-A"
     app: mysql
 spec:
   selector:


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
The mysql service used by Rancher migration failoverFailback test did not have the rancher label, but the test was checking if the label exists.

**Does this PR change a user-facing CRD or CLI?**:
 No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.11
