### PR TITLE
Nw policy failover failback

### DIFF
--- a/test/integration_test/migration_failover_failback_test.go
+++ b/test/integration_test/migration_failover_failback_test.go
@@ -96,8 +96,8 @@ func rancherFailoverAndFailbackMigrationTest(t *testing.T) {
 	err := setSourceKubeConfig()
 	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
 
-	// 1 sts, 1 service, 1 pvc, 1 pv
-	expectedResources := uint64(4)
+	// 1 sts, 1 service, 1 pvc, 1 pv, 1 nw policy
+	expectedResources := uint64(5)
 	// 1 volume
 	expectedVolumes := uint64(1)
 	// validate the migration summary based on the application specs that were deployed by the test
@@ -143,8 +143,8 @@ func failoverAndFailbackMigrationTest(t *testing.T) {
 	err := setSourceKubeConfig()
 	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
 
-	// 1 sts, 1 service, 1 pvc, 1 pv
-	expectedResources := uint64(4)
+	// 1 sts, 1 service, 1 pvc, 1 pv, 1 nw policy
+	expectedResources := uint64(5)
 	// 1 volume
 	expectedVolumes := uint64(1)
 	// validate the migration summary based on the application specs that were deployed by the test
@@ -231,6 +231,38 @@ func testMigrationFailover(
 			require.True(t, ok, "expected rancher label")
 			require.Equal(t, projectValue, "project-B")
 		}
+
+		nwPolicyList, err := core.Instance().ListNetworkPolicy(namespace, meta_v1.ListOptions{})
+		require.NoError(t, err, "failed to get network policies")
+		require.GreaterOrEqual(t, len(nwPolicyList.Items), 1, "unexpected number of network policies")
+		for _, nwPolicy := range nwPolicyList.Items {
+			projectValue, ok := nwPolicy.Labels[rancherLabelKey]
+			require.True(t, ok, "expected rancher label")
+			require.Equal(t, projectValue, "project-B")
+
+			projectValue, ok = nwPolicy.Annotations[rancherLabelKey]
+			require.True(t, ok, "expected rancher label")
+			require.Equal(t, projectValue, "project-B")
+
+			require.GreaterOrEqual(t, nwPolicy.Spec.Egress, 1, "unexpected egress")
+			require.GreaterOrEqual(t, nwPolicy.Spec.Egress[0].To, 1, "unexpected egress network policy peer")
+			require.NotNil(t, nwPolicy.Spec.Egress[0].To[0].NamespaceSelector, "expected non nil namespace selector")
+			for k, v := range nwPolicy.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels {
+				if k == rancherLabelKey {
+					require.Equal(t, v, "project-B", "Unexpected match label in namespace selector of nw policy")
+				}
+			}
+
+			require.GreaterOrEqual(t, nwPolicy.Spec.Ingress, 1, "unexpected ingress")
+			require.GreaterOrEqual(t, nwPolicy.Spec.Ingress[0].From, 1, "unexpected ingress network policy peer")
+			require.NotNil(t, nwPolicy.Spec.Ingress[0].From[0].NamespaceSelector, "expected non nil namespace selector")
+			for k, v := range nwPolicy.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels {
+				if k == rancherLabelKey {
+					require.Equal(t, v, "project-B", "Unexpected match label in namespace selector of nw policy")
+				}
+			}
+		}
+
 	}
 	return oldScaleFactor
 }
@@ -276,8 +308,9 @@ func testMigrationFailback(
 		}
 	}
 
-	// 1 sts, 1 service, 1 pvc, 1 pv
-	expectedResources := uint64(4)
+	// 1 sts, 1 service, 1 pvc, 1 pv, 1 network policy
+	expectedResources := uint64(5)
+
 	// 1 volume
 	expectedVolumes := uint64(1)
 	// validate the migration summary
@@ -318,8 +351,39 @@ func testMigrationFailback(
 			require.Equal(t, projectValue, "project-A")
 
 			projectValue, ok = service.Annotations[rancherLabelKey]
+			require.True(t, ok, "expected rancher annotation")
+			require.Equal(t, projectValue, "project-A")
+		}
+
+		nwPolicyList, err := core.Instance().ListNetworkPolicy(namespace, meta_v1.ListOptions{})
+		require.NoError(t, err, "failed to get network policies")
+		require.GreaterOrEqual(t, len(nwPolicyList.Items), 1, "unexpected number of network policies")
+		for _, nwPolicy := range nwPolicyList.Items {
+			projectValue, ok := nwPolicy.Labels[rancherLabelKey]
 			require.True(t, ok, "expected rancher label")
 			require.Equal(t, projectValue, "project-A")
+
+			projectValue, ok = nwPolicy.Annotations[rancherLabelKey]
+			require.True(t, ok, "expected rancher label")
+			require.Equal(t, projectValue, "project-A")
+
+			require.GreaterOrEqual(t, nwPolicy.Spec.Egress, 1, "unexpected egress")
+			require.GreaterOrEqual(t, nwPolicy.Spec.Egress[0].To, 1, "unexpected egress network policy peer")
+			require.NotNil(t, nwPolicy.Spec.Egress[0].To[0].NamespaceSelector, "expected non nil namespace selector")
+			for k, v := range nwPolicy.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels {
+				if k == rancherLabelKey {
+					require.Equal(t, v, "project-A", "Unexpected match label in namespace selector of nw policy")
+				}
+			}
+
+			require.GreaterOrEqual(t, nwPolicy.Spec.Ingress, 1, "unexpected ingress")
+			require.GreaterOrEqual(t, nwPolicy.Spec.Ingress[0].From, 1, "unexpected ingress network policy peer")
+			require.NotNil(t, nwPolicy.Spec.Ingress[0].From[0].NamespaceSelector, "expected non nil namespace selector")
+			for k, v := range nwPolicy.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels {
+				if k == rancherLabelKey {
+					require.Equal(t, v, "project-A", "Unexpected match label in namespace selector of nw policy")
+				}
+			}
 		}
 	}
 

--- a/test/integration_test/specs/mysql-enc-pvc-rancher/networkpolicy.yaml
+++ b/test/integration_test/specs/mysql-enc-pvc-rancher/networkpolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    field.cattle.io/projectId: "project-A"
+  labels:
+    field.cattle.io/projectId: "project-A"
+  name: default-allow-all
+spec:
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              field.cattle.io/projectId: "project-A"
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              field.cattle.io/projectId: "project-A"
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/test/integration_test/specs/mysql-enc-pvc/networkpolicy.yaml
+++ b/test/integration_test/specs/mysql-enc-pvc/networkpolicy.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    field.cattle.io/projectId: "project-A"
+  labels:
+    field.cattle.io/projectId: "project-A"
+    objectset.rio.cattle.io/hash: aba71c7b292b839a3c8b07cb60663855ca5e632d
+  name: default-allow-all
+spec:
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              field.cattle.io/projectId: "project-A"
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              field.cattle.io/projectId: "project-A"
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
- Add network policy to FailoverFailback migration tests
- In the test, check if the project labels are corrected migrated in NetworkPolicy namespace selector fields.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.11

