### PR TITLE
Pb 2279: Added fixes to take care new EncryptionV2Key variable in     backuplocation.

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -551,9 +551,11 @@ func (c *csi) uploadObject(
 	if err != nil {
 		return err
 	}
-
 	if backupLocation.Location.EncryptionKey != "" {
-		if data, err = crypto.Encrypt(data, backupLocation.Location.EncryptionKey); err != nil {
+		return fmt.Errorf("EncryptionKey is deprecated, use EncryptionKeyV2 instead")
+	}
+	if backupLocation.Location.EncryptionV2Key != "" {
+		if data, err = crypto.Encrypt(data, backupLocation.Location.EncryptionV2Key); err != nil {
 			return err
 		}
 	}
@@ -1235,9 +1237,15 @@ func (c *csi) downloadObject(
 		return nil, err
 	}
 	if restoreLocation.Location.EncryptionKey != "" {
-		if data, err = crypto.Decrypt(data, restoreLocation.Location.EncryptionKey); err != nil {
-			return nil, err
+		return nil, fmt.Errorf("EncryptionKey is deprecated, use EncryptionKeyV2 instead")
+	}
+	if restoreLocation.Location.EncryptionV2Key != "" {
+		var decryptData []byte
+		if decryptData, err = crypto.Decrypt(data, restoreLocation.Location.EncryptionV2Key); err != nil {
+			logrus.Debugf("decrypt failed with: %v and returning the data as it is", err)
+			return data, nil
 		}
+		return decryptData, nil
 	}
 
 	return data, nil

--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -43,6 +43,7 @@ type BackupLocationItem struct {
 	SecretConfig       string        `json:"secretConfig"`
 	Sync               bool          `json:"sync"`
 	RepositoryPassword string        `json:"repositoryPassword"`
+	EncryptionV2Key    string        `json:"encryptionV2Key"`
 }
 
 // ClusterItem is the spec used to store a the credentials associated with the cluster
@@ -138,7 +139,7 @@ func (bl *BackupLocation) UpdateFromSecret(client kubernetes.Interface) error {
 			return fmt.Errorf("error getting secretConfig for backupLocation: %v", err)
 		}
 		if val, ok := secretConfig.Data["encryptionKey"]; ok && val != nil {
-			bl.Location.EncryptionKey = strings.TrimSuffix(string(val), "\n")
+			bl.Location.EncryptionV2Key = strings.TrimSuffix(string(val), "\n")
 		}
 		if val, ok := secretConfig.Data["path"]; ok && val != nil {
 			bl.Location.Path = strings.TrimSuffix(string(val), "\n")

--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -35,7 +35,8 @@ type BackupLocation struct {
 type BackupLocationItem struct {
 	Type BackupLocationType `json:"type"`
 	// Path is either the bucket or any other path for the backup location
-	Path               string        `json:"path"`
+	Path string `json:"path"`
+	// EncryptionKey is deprecated. Instead use EncryptionV2Key field to pass the encryption key.
 	EncryptionKey      string        `json:"encryptionKey"`
 	S3Config           *S3Config     `json:"s3Config,omitempty"`
 	AzureConfig        *AzureConfig  `json:"azureConfig,omitempty"`
@@ -43,7 +44,8 @@ type BackupLocationItem struct {
 	SecretConfig       string        `json:"secretConfig"`
 	Sync               bool          `json:"sync"`
 	RepositoryPassword string        `json:"repositoryPassword"`
-	EncryptionV2Key    string        `json:"encryptionV2Key"`
+	// EncryptionV2Key will be used to pass encryption key.
+	EncryptionV2Key string `json:"encryptionV2Key"`
 }
 
 // ClusterItem is the spec used to store a the credentials associated with the cluster

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -934,9 +934,11 @@ func (a *ApplicationBackupController) uploadObject(
 	if err != nil {
 		return err
 	}
-
 	if backupLocation.Location.EncryptionKey != "" {
-		if data, err = crypto.Encrypt(data, backupLocation.Location.EncryptionKey); err != nil {
+		return fmt.Errorf("EncryptionKey is deprecated, use EncryptionKeyV2 instead")
+	}
+	if backupLocation.Location.EncryptionV2Key != "" {
+		if data, err = crypto.Encrypt(data, backupLocation.Location.EncryptionV2Key); err != nil {
 			return err
 		}
 	}

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -722,9 +722,15 @@ func (a *ApplicationRestoreController) downloadObject(
 		return nil, err
 	}
 	if restoreLocation.Location.EncryptionKey != "" {
-		if data, err = crypto.Decrypt(data, restoreLocation.Location.EncryptionKey); err != nil {
-			return nil, err
+		return nil, fmt.Errorf("EncryptionKey is deprecated, use EncryptionKeyV2 instead")
+	}
+	if restoreLocation.Location.EncryptionV2Key != "" {
+		var decryptData []byte
+		if decryptData, err = crypto.Decrypt(data, restoreLocation.Location.EncryptionV2Key); err != nil {
+			logrus.Errorf("ApplicationRestoreController/downloadObject: decrypt failed :%v, returing data direclty", err)
+			return data, nil
 		}
+		return decryptData, nil
 	}
 
 	return data, nil

--- a/pkg/applicationmanager/controllers/backupsync.go
+++ b/pkg/applicationmanager/controllers/backupsync.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -102,9 +103,13 @@ func (b *BackupSyncController) syncBackupsFromLocation(location *storkv1.BackupL
 					continue
 				}
 				if location.Location.EncryptionKey != "" {
-					if data, err = crypto.Decrypt(data, location.Location.EncryptionKey); err != nil {
+					return fmt.Errorf("EncryptionKey is deprecated, use EncryptionKeyV2 instead")
+				}
+				if location.Location.EncryptionV2Key != "" {
+					if decryptData, err := crypto.Decrypt(data, location.Location.EncryptionV2Key); err != nil {
 						log.BackupLocationLog(location).Errorf("Error decrypting backup %v during sync: %v", backupName, err)
-						continue
+					} else {
+						data = decryptData
 					}
 				}
 				backupInfo := storkv1.ApplicationBackup{}

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -29,6 +29,11 @@ func Decrypt(data []byte, passphrase string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Sometime, if we pass unencrypted data, which does not have header,
+	// We end up in data being less gcm.NonceSize. So added this check.
+	if len(data) < gcm.NonceSize() {
+		return nil, fmt.Errorf("unencrypted data crypto header is missing")
+	}
 	nonce, encryptedData := data[:gcm.NonceSize()], data[gcm.NonceSize():]
 	return gcm.Open(nil, nonce, encryptedData, nil)
 }

--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -1031,9 +1031,11 @@ func (c *csiDriver) UploadSnapshotObjects(
 	if err != nil {
 		return err
 	}
-
 	if backupLocation.Location.EncryptionKey != "" {
-		if data, err = crypto.Encrypt(data, backupLocation.Location.EncryptionKey); err != nil {
+		return fmt.Errorf("EncryptionKey is deprecated, use EncryptionKeyV2 instead")
+	}
+	if backupLocation.Location.EncryptionV2Key != "" {
+		if data, err = crypto.Encrypt(data, backupLocation.Location.EncryptionV2Key); err != nil {
 			return err
 		}
 	}
@@ -1077,9 +1079,10 @@ func (c *csiDriver) DownloadSnapshotObjects(
 	if err != nil {
 		return snapshotInfoList, err
 	}
-	if backupLocation.Location.EncryptionKey != "" {
-		if data, err = crypto.Decrypt(data, backupLocation.Location.EncryptionKey); err != nil {
-			return snapshotInfoList, err
+	if backupLocation.Location.EncryptionV2Key != "" {
+		if decryptData, err := crypto.Decrypt(data, backupLocation.Location.EncryptionV2Key); err != nil {
+		} else {
+			data = decryptData
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
pb-2279

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Issue: Backups were not encrypted even though the encryption was pass in the backuplocation CR.
User Impact: Users were not able to take encrypted backup.
Resolution: Fixed to take the encryption key passed in the backuplocation CR and encrypt the backup.

```

**Does this change need to be cherry-picked to a release branch?**:
2.11 branch

