### PR TITLE
pb2939: enable NFS type backuplocation

### DIFF
--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -41,6 +41,7 @@ type BackupLocationItem struct {
 	S3Config           *S3Config     `json:"s3Config,omitempty"`
 	AzureConfig        *AzureConfig  `json:"azureConfig,omitempty"`
 	GoogleConfig       *GoogleConfig `json:"googleConfig,omitempty"`
+	NfsConfig          *NfsConfig    `json:"NfsConfig,omitempty"`
 	SecretConfig       string        `json:"secretConfig"`
 	Sync               bool          `json:"sync"`
 	RepositoryPassword string        `json:"repositoryPassword"`
@@ -73,6 +74,8 @@ const (
 	BackupLocationAzure BackupLocationType = "azure"
 	// BackupLocationGoogle stores the backup in Google Cloud Storage
 	BackupLocationGoogle BackupLocationType = "google"
+	// BackupLocationNFS stores the backup in NFS backed Storage
+	BackupLocationNFS BackupLocationType = "nfs"
 )
 
 // ClusterType is the type of the cluster
@@ -123,6 +126,11 @@ type GoogleConfig struct {
 	AccountKey string `json:"accountKey"`
 }
 
+type NfsConfig struct {
+	NfsServerAddr string `json:"nfsServerAddr"`
+	NfsExportPath string `json:"nfsExportPath"`
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // BackupLocationList is a list of ApplicationBackups
@@ -154,6 +162,8 @@ func (bl *BackupLocation) UpdateFromSecret(client kubernetes.Interface) error {
 		return bl.getMergedAzureConfig(client)
 	case BackupLocationGoogle:
 		return bl.getMergedGoogleConfig(client)
+	case BackupLocationNFS:
+		return bl.getMergedNfsCred(client)
 	default:
 		return fmt.Errorf("Invalid BackupLocation type %v", bl.Location.Type)
 	}
@@ -171,6 +181,25 @@ func (bl *BackupLocation) UpdateFromClusterSecret(client kubernetes.Interface) e
 		case AzureCluster:
 			return bl.getMergedAzureClusterCred(client)
 		default:
+		}
+	}
+	return nil
+}
+
+func (bl *BackupLocation) getMergedNfsCred(client kubernetes.Interface) error {
+	if bl.Location.NfsConfig == nil {
+		bl.Location.NfsConfig = &NfsConfig{}
+	}
+	if bl.Location.SecretConfig != "" {
+		secretConfig, err := client.CoreV1().Secrets(bl.Namespace).Get(context.TODO(), bl.Location.SecretConfig, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error getting secretConfig for backupLocation: %v", err)
+		}
+		if val, ok := secretConfig.Data["serverAddr"]; ok && val != nil {
+			bl.Location.NfsConfig.NfsServerAddr = strings.TrimSuffix(string(val), "\n")
+		}
+		if val, ok := secretConfig.Data["exportPath"]; ok && val != nil {
+			bl.Location.NfsConfig.NfsExportPath = strings.TrimSuffix(string(val), "\n")
 		}
 	}
 	return nil

--- a/pkg/objectstore/nfs/nfs.go
+++ b/pkg/objectstore/nfs/nfs.go
@@ -1,0 +1,13 @@
+package nfs
+
+import (
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/objectstore/common"
+	"github.com/sirupsen/logrus"
+)
+
+// GetObjLockInfo fetches the object lock configuration of a bucket
+func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockInfo, error) {
+	logrus.Infof("object lock is not supported for nfs server")
+	return &common.ObjLockInfo{}, nil
+}

--- a/pkg/objectstore/objectstore.go
+++ b/pkg/objectstore/objectstore.go
@@ -7,6 +7,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/objectstore/azure"
 	"github.com/libopenstorage/stork/pkg/objectstore/common"
 	"github.com/libopenstorage/stork/pkg/objectstore/google"
+	"github.com/libopenstorage/stork/pkg/objectstore/nfs"
 	"github.com/libopenstorage/stork/pkg/objectstore/s3"
 	"gocloud.dev/blob"
 )
@@ -59,6 +60,8 @@ func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockIn
 		return azure.GetObjLockInfo(backupLocation)
 	case stork_api.BackupLocationS3:
 		return s3.GetObjLockInfo(backupLocation)
+	case stork_api.BackupLocationNFS:
+		return nfs.GetObjLockInfo(backupLocation)
 	default:
 		return nil, fmt.Errorf("invalid backupLocation type: %v", backupLocation.Location.Type)
 	}


### PR DESCRIPTION
- added NFS type to stork v1alpha1 APIs
- added objectlock specific for for NFS
- in Application controller skipped path check

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: This enable the px-backup backuplocation to use NFS server as a backend


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

