### PR TITLE
PWX-26330: (Cherry-pick) Disable px-object-controller by default.

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -143,7 +143,7 @@ func main() {
 			Name:  "application-controller",
 			Usage: "Start the controllers for managing applications (default: true)",
 		},
-		cli.BoolTFlag{
+		cli.BoolFlag{
 			Name:  "px-object-controller",
 			Usage: "Start the px object controller.",
 		},


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>


Which issue(s) this PR fixes 
Cherry-pick to 2.12
Closes #PWX-26307 [https://portworx.atlassian.net/browse/PWX-26307]

Special notes for your reviewer:
https://github.com/portworx/porx/pull/9762 has already been created to add support for disk encryption using customer managed key.

Customer should be able to provide Encrypt/Decrypt on their default gce account for disk encryption so that if device level kms account is not provided then

if an account.json file has been updated in the pod via GOOGLE_APPLICATION_CREDENTIALS, that service account should be used as disk encryption kms account.
If deployement is using instance gce account, that service account should be used as disk encryption kms account.
