### PR TITLE
Update object to be migrated as per resource transformation specs

### DIFF
--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -27,6 +27,7 @@ type MigrationSpec struct {
 	PostExecRule                 string            `json:"postExecRule"`
 	IncludeOptionalResourceTypes []string          `json:"includeOptionalResourceTypes"`
 	SkipDeletedNamespaces        *bool             `json:"skipDeletedNamespaces"`
+	UpdateResourceSpecs          string            `json:"updateResourceSpecs"`
 }
 
 // MigrationStatus is the status of a migration operation

--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -27,7 +27,7 @@ type MigrationSpec struct {
 	PostExecRule                 string            `json:"postExecRule"`
 	IncludeOptionalResourceTypes []string          `json:"includeOptionalResourceTypes"`
 	SkipDeletedNamespaces        *bool             `json:"skipDeletedNamespaces"`
-	UpdateResourceSpecs          string            `json:"updateResourceSpecs"`
+	TransformSpecs               []string          `json:"transformSpecs"`
 }
 
 // MigrationStatus is the status of a migration operation

--- a/pkg/apis/stork/v1alpha1/resourcetransformation.go
+++ b/pkg/apis/stork/v1alpha1/resourcetransformation.go
@@ -35,6 +35,8 @@ const (
 // path in resource specs
 type ResourceTransformationValueType string
 
+type KindResourceTransform map[string][]TransformResourceInfo
+
 const (
 	// IntResourceType is to update integer value to specified resource path
 	IntResourceType ResourceTransformationValueType = "int"
@@ -90,6 +92,7 @@ type TransformResourceInfo struct {
 	meta.GroupVersionKind `json:",inline"`
 	Status                ResourceTransformationStatusType `json:"status"`
 	Reason                string                           `json:"reason"`
+	Specs                 TransformSpecs                   `json:"specs"`
 }
 
 // ResourceTransformationSpec is used to update k8s resources
@@ -109,6 +112,14 @@ type TransformSpecs struct {
 	Selectors map[string]string `json:"selectors"`
 	// Paths collection of resource path to update
 	Paths []ResourcePaths `json:"paths"`
+}
+
+type TransformSpecPatch struct {
+	GVK map[string]PatchStruct
+}
+type PatchStruct struct {
+	// namespace - resource in namespace
+	Resources map[string]TransformResourceInfo
 }
 
 // ResourcePaths specifies the patch to modify resource

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1028,7 +1028,7 @@ func (m *MigrationController) prepareResources(
 	resPatch, err := resourcecollector.GetResourcePatch(migration.Spec.UpdateResourceSpecs, migration.Spec.Namespaces)
 	if err != nil {
 		log.MigrationLog(migration).
-			Warnf("Unable to get transformation spec from :%s, skipping transformation for this migration, err: %v", err)
+			Warnf("Unable to get transformation spec from :%s, skipping transformation for this migration, err: %v", migration.Spec.UpdateResourceSpecs, err)
 	}
 	for _, o := range objects {
 		metadata, err := meta.Accessor(o)

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1043,7 +1043,7 @@ func (m *MigrationController) prepareResources(
 				return fmt.Errorf("error preparing PV resource %v: %v", metadata.GetName(), err)
 			}
 		case "Deployment", "StatefulSet", "DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer", "ReplicaSet":
-			err := m.prepareApplicationResource(migration, clusterPair, o, resPatch[metadata.GetNamespace()][resource.Kind])
+			err := m.prepareApplicationResource(migration, clusterPair, o)
 			if err != nil {
 				return fmt.Errorf("error preparing %v resource %v: %v", o.GetObjectKind().GroupVersionKind().Kind, metadata.GetName(), err)
 			}
@@ -1287,7 +1287,6 @@ func (m *MigrationController) prepareApplicationResource(
 	migration *stork_api.Migration,
 	clusterPair *stork_api.ClusterPair,
 	object runtime.Unstructured,
-	resPatch []stork_api.TransformResourceInfo,
 ) error {
 	content := object.UnstructuredContent()
 	if clusterPair.Spec.PlatformOptions.Rancher != nil &&

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -372,10 +372,9 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 				}
 			}
 			// Make sure if transformation CR is in ready state
-			if migration.Spec.UpdateResourceSpecs != "" {
-				resp, err := storkops.Instance().GetResourceTransformation(migration.Spec.UpdateResourceSpecs, ns)
-				if err != nil && !errors.IsNotFound(err) {
-					errMsg := fmt.Sprintf("unable to retrive transformation %s, err: %v", migration.Spec.UpdateResourceSpecs, err)
+			if len(migration.Spec.TransformSpecs) != 0 {
+				if len(migration.Spec.TransformSpecs) > 1 {
+					errMsg := fmt.Sprintf("providing multiple transformation specs is not supported in this release %v, err: %v", migration.Spec.TransformSpecs, err)
 					log.MigrationLog(migration).Errorf(errMsg)
 					m.recorder.Event(migration,
 						v1.EventTypeWarning,
@@ -387,8 +386,9 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 					}
 					return nil
 				}
-				if resp != nil && resp.Status.Status != stork_api.ResourceTransformationStatusReady {
-					errMsg := fmt.Sprintf("transformation %s is not in ready state: %s", migration.Spec.UpdateResourceSpecs, resp.Status.Status)
+				resp, err := storkops.Instance().GetResourceTransformation(migration.Spec.TransformSpecs[0], ns)
+				if err != nil && !errors.IsNotFound(err) {
+					errMsg := fmt.Sprintf("unable to retrive transformation %s, err: %v", migration.Spec.TransformSpecs, err)
 					log.MigrationLog(migration).Errorf(errMsg)
 					m.recorder.Event(migration,
 						v1.EventTypeWarning,
@@ -399,6 +399,44 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 						log.MigrationLog(migration).Errorf("Error updating CR, err: %v", err)
 					}
 					return nil
+				}
+				if resp != nil {
+					// ensure to re-run dry-run for newly introduced object before
+					// starting migration
+					resp.Status.Resources = []*stork_api.TransformResourceInfo{}
+					resp.Status.Status = stork_api.ResourceTransformationStatusInitial
+					resp.ResourceVersion = ""
+					transform, err := storkops.Instance().UpdateResourceTransformation(resp)
+					if err != nil && !errors.IsNotFound(err) {
+						errMsg := fmt.Sprintf("Error updating transformation CR: %v", err)
+						log.MigrationLog(migration).Errorf(errMsg)
+						m.recorder.Event(migration,
+							v1.EventTypeWarning,
+							string(stork_api.MigrationStatusFailed),
+							err.Error())
+						err = m.updateMigrationCR(context.Background(), migration)
+						if err != nil {
+							if err != nil {
+								log.MigrationLog(migration).Errorf("Error updating CR, err: %v", err)
+							}
+						}
+						return nil
+					}
+					if err := storkops.Instance().ValidateResourceTransformation(transform.Name, ns, 1*time.Minute, 5*time.Second); err != nil {
+						errMsg := fmt.Sprintf("transformation %s is not in ready state: %s", migration.Spec.TransformSpecs, resp.Status.Status)
+						log.MigrationLog(migration).Errorf(errMsg)
+						m.recorder.Event(migration,
+							v1.EventTypeWarning,
+							string(stork_api.MigrationStatusFailed),
+							err.Error())
+						err = m.updateMigrationCR(context.Background(), migration)
+						if err != nil {
+							if err != nil {
+								log.MigrationLog(migration).Errorf("Error updating CR, err: %v", err)
+							}
+						}
+						return nil
+					}
 				}
 			}
 		}
@@ -1025,10 +1063,16 @@ func (m *MigrationController) prepareResources(
 	if err != nil {
 		return err
 	}
-	resPatch, err := resourcecollector.GetResourcePatch(migration.Spec.UpdateResourceSpecs, migration.Spec.Namespaces)
+	transformName := ""
+	// this is already handled in pre-checks, we dont support multiple resource transformation
+	// rules specified in migration specs
+	if len(migration.Spec.TransformSpecs) != 0 && len(migration.Spec.TransformSpecs) == 1 {
+		transformName = migration.Spec.TransformSpecs[0]
+	}
+	resPatch, err := resourcecollector.GetResourcePatch(transformName, migration.Spec.Namespaces)
 	if err != nil {
 		log.MigrationLog(migration).
-			Warnf("Unable to get transformation spec from :%s, skipping transformation for this migration, err: %v", migration.Spec.UpdateResourceSpecs, err)
+			Warnf("Unable to get transformation spec from :%s, skipping transformation for this migration, err: %v", transformName, err)
 	}
 	for _, o := range objects {
 		metadata, err := meta.Accessor(o)

--- a/pkg/migration/controllers/resourcetransformation.go
+++ b/pkg/migration/controllers/resourcetransformation.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	resourceTransformationController = "resource-transformation-controller"
+	// ResourceTransformationControllerName of resource transformation CR handler
+	ResourceTransformationControllerName = "resource-transformation-controller"
 )
 
 // NewResourceTransformation creates a new instance of ResourceTransformation Manager
@@ -59,7 +60,7 @@ func (r *ResourceTransformationController) Init(mgr manager.Manager) error {
 		return err
 	}
 
-	return controllers.RegisterTo(mgr, resourceTransformationController, r, &stork_api.ResourceTransformation{})
+	return controllers.RegisterTo(mgr, ResourceTransformationControllerName, r, &stork_api.ResourceTransformation{})
 }
 
 // Reconcile manages ResourceTransformation resources.

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -39,6 +39,5 @@ func (m *Migration) Init(mgr manager.Manager, migrationAdminNamespace string, mi
 	if err != nil {
 		return fmt.Errorf("error initializing migration schedule controller: %v", err)
 	}
-	rt := controllers.NewResourceTransformation(mgr, m.Driver, m.Recorder, m.ResourceCollector)
-	return rt.Init(mgr)
+	return nil
 }

--- a/pkg/resourcecollector/resourcetransformation.go
+++ b/pkg/resourcecollector/resourcetransformation.go
@@ -24,8 +24,13 @@ func GetResourcePatch(transformName string, namespaces []string) (map[string]sto
 	}
 	for _, namespace := range namespaces {
 		resp, err := storkops.Instance().GetResourceTransformation(transformName, namespace)
-		if err != nil && !errors.IsNotFound(err) {
-			logrus.Infof("not found in namespace: %v", transformName)
+		if err != nil {
+			// current namespace does not have any transform CR
+			// skip it from map
+			if errors.IsNotFound(err) {
+				continue
+			}
+			logrus.Errorf("Unable to get resource transfomration specs %s/%s, err: %v", namespace, transformName, err)
 			return nil, err
 		}
 		resMap := make(map[string][]stork_api.TransformResourceInfo)
@@ -66,7 +71,7 @@ func TransformResources(
 					} else {
 						err := unstructured.SetNestedField(content, value, strings.Split(path.Path, ".")...)
 						if err != nil {
-							logrus.Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, patch.Kind, patch.Namespace, patch.Name, err)
+							logrus.Errorf("Unable to perform operation %s on path %s on resource kind: %s/,%s/%s,  err: %v", path.Operation, path, patch.Kind, patch.Namespace, patch.Name, err)
 							return err
 						}
 					}
@@ -103,13 +108,13 @@ func TransformResources(
 					}
 					err := unstructured.SetNestedField(content, value, strings.Split(path.Path, ".")...)
 					if err != nil {
-						logrus.Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, patch.Kind, patch.Namespace, patch.Name, err)
+						logrus.Errorf("Unable to perform operation %s on path %s on resource kind: %s/,%s/%s,  err: %v", path.Operation, path, patch.Kind, patch.Namespace, patch.Name, err)
 						return err
 					}
 				}
 			}
 			object.SetUnstructuredContent(content)
-			logrus.Infof("updated resource of kind %v with patch , resource: %v", patch.Kind, object)
+			logrus.Infof("Updated resource of kind %v with patch , resource: %v", patch.Kind, object)
 		}
 	}
 	return nil

--- a/pkg/resourcecollector/resourcetransformation.go
+++ b/pkg/resourcecollector/resourcetransformation.go
@@ -1,0 +1,140 @@
+package resourcecollector
+
+import (
+	"fmt"
+	"strings"
+
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Since we collect all resources from required migration namespace at once
+// getResourcePatch creates map of namespace: {kind: []resourceinfo{}}
+// to get transform spec for matching resources
+func GetResourcePatch(transformName string, namespaces []string) (map[string]stork_api.KindResourceTransform, error) {
+	// namespace- Kind:TransformSpec map for faster lookup
+	patch := make(map[string]stork_api.KindResourceTransform)
+	if transformName == "" {
+		logrus.Infof("empty name ")
+		return patch, nil
+	}
+	for _, namespace := range namespaces {
+		resp, err := storkops.Instance().GetResourceTransformation(transformName, namespace)
+		if err != nil && !errors.IsNotFound(err) {
+			logrus.Infof("not found in namespace: %v", transformName)
+			return nil, err
+		}
+		resMap := make(map[string][]stork_api.TransformResourceInfo)
+		for _, resource := range resp.Status.Resources {
+			resMap[resource.Kind] = append(resMap[resource.Group], *resource)
+		}
+		patch[namespace] = resMap
+	}
+	logrus.Infof("resource patch : %v", patch)
+	return patch, nil
+}
+
+// this method transform object as per resource transformation specified in each namespaces
+func TransformResources(
+	object runtime.Unstructured,
+	resPatch []stork_api.TransformResourceInfo,
+	name, namespace string,
+) error {
+	for _, patch := range resPatch {
+		if patch.Name == name && patch.Namespace == namespace {
+			content := object.UnstructuredContent()
+			for _, path := range patch.Specs.Paths {
+				switch path.Operation {
+				case stork_api.AddResourcePath:
+					value := getNewValueForPath(path.Value, string(path.Type))
+					if path.Type == stork_api.KeyPairResourceType {
+						updateMap := value.(map[string]string)
+						err := unstructured.SetNestedStringMap(content, updateMap, strings.Split(path.Path, ".")...)
+						if err != nil {
+							logrus.Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, patch.Kind, patch.Namespace, patch.Name, err)
+							return err
+						}
+					} else if path.Type == stork_api.SliceResourceType {
+						err := unstructured.SetNestedField(content, value, strings.Split(path.Path, ".")...)
+						if err != nil {
+							logrus.Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, patch.Kind, patch.Namespace, patch.Name, err)
+							return err
+						}
+					} else {
+						err := unstructured.SetNestedField(content, value, strings.Split(path.Path, ".")...)
+						if err != nil {
+							logrus.Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, patch.Kind, patch.Namespace, patch.Name, err)
+							return err
+						}
+					}
+
+				case stork_api.DeleteResourcePath:
+					unstructured.RemoveNestedField(content, strings.Split(path.Path, ".")...)
+					logrus.Debugf("Removed patch path %s on resource kind: %s/,%s/%s", path, patch.Kind, patch.Namespace, patch.Name)
+
+				case stork_api.ModifyResourcePathValue:
+					var value interface{}
+					if path.Type == stork_api.KeyPairResourceType {
+						currMap, _, err := unstructured.NestedMap(content, strings.Split(path.Path, ".")...)
+						if err != nil {
+							return fmt.Errorf("unable to find suspend path, err: %v", err)
+						}
+						mapList := strings.Split(path.Value, ",")
+						for _, val := range mapList {
+							keyPair := strings.Split(val, ":")
+							currMap[keyPair[0]] = keyPair[1]
+						}
+						value = currMap
+					} else if path.Type == stork_api.SliceResourceType {
+						currList, _, err := unstructured.NestedSlice(content, strings.Split(path.Path, ".")...)
+						if err != nil {
+							return fmt.Errorf("unable to find suspend path, err: %v", err)
+						}
+						arrList := strings.Split(path.Value, ",")
+						for _, val := range arrList {
+							currList = append(currList, val)
+						}
+						value = currList
+					} else {
+						value = path.Value
+					}
+					err := unstructured.SetNestedField(content, value, strings.Split(path.Path, ".")...)
+					if err != nil {
+						logrus.Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, patch.Kind, patch.Namespace, patch.Name, err)
+						return err
+					}
+				}
+			}
+			object.SetUnstructuredContent(content)
+			logrus.Infof("updated resource of kind %v with patch , resource: %v", patch.Kind, object)
+		}
+	}
+	return nil
+}
+
+func getNewValueForPath(oldVal, valType string) interface{} {
+	var updatedValue interface{}
+	if valType == string(stork_api.KeyPairResourceType) {
+		newVal := make(map[string]string)
+		mapList := strings.Split(oldVal, ",")
+		for _, val := range mapList {
+			keyPair := strings.Split(val, ":")
+			newVal[keyPair[0]] = keyPair[1]
+		}
+		updatedValue = newVal
+		logrus.Infof("map updated : %v", updatedValue, mapList)
+	} else if valType == string(stork_api.SliceResourceType) {
+		newVal := []string{}
+		arrList := strings.Split(oldVal, ",")
+		newVal = append(newVal, arrList...)
+		updatedValue = newVal
+		logrus.Infof("map updated : %v", updatedValue, arrList)
+	} else {
+		updatedValue = oldVal
+	}
+	return updatedValue
+}

--- a/pkg/resourcecollector/resourcetransformation.go
+++ b/pkg/resourcecollector/resourcetransformation.go
@@ -126,13 +126,11 @@ func getNewValueForPath(oldVal, valType string) interface{} {
 			newVal[keyPair[0]] = keyPair[1]
 		}
 		updatedValue = newVal
-		logrus.Infof("map updated : %v", updatedValue, mapList)
 	} else if valType == string(stork_api.SliceResourceType) {
 		newVal := []string{}
 		arrList := strings.Split(oldVal, ",")
 		newVal = append(newVal, arrList...)
 		updatedValue = newVal
-		logrus.Infof("map updated : %v", updatedValue, arrList)
 	} else {
 		updatedValue = oldVal
 	}

--- a/pkg/resourcecollector/resourcetransformation.go
+++ b/pkg/resourcecollector/resourcetransformation.go
@@ -19,7 +19,7 @@ func GetResourcePatch(transformName string, namespaces []string) (map[string]sto
 	// namespace- Kind:TransformSpec map for faster lookup
 	patch := make(map[string]stork_api.KindResourceTransform)
 	if transformName == "" {
-		logrus.Infof("empty name ")
+		logrus.Error("Empty name received for resource transformation")
 		return patch, nil
 	}
 	for _, namespace := range namespaces {
@@ -30,11 +30,10 @@ func GetResourcePatch(transformName string, namespaces []string) (map[string]sto
 		}
 		resMap := make(map[string][]stork_api.TransformResourceInfo)
 		for _, resource := range resp.Status.Resources {
-			resMap[resource.Kind] = append(resMap[resource.Group], *resource)
+			resMap[resource.Kind] = append(resMap[resource.Kind], *resource)
 		}
 		patch[namespace] = resMap
 	}
-	logrus.Infof("resource patch : %v", patch)
 	return patch, nil
 }
 
@@ -42,10 +41,10 @@ func GetResourcePatch(transformName string, namespaces []string) (map[string]sto
 func TransformResources(
 	object runtime.Unstructured,
 	resPatch []stork_api.TransformResourceInfo,
-	name, namespace string,
+	objName, objNamespace string,
 ) error {
 	for _, patch := range resPatch {
-		if patch.Name == name && patch.Namespace == namespace {
+		if patch.Name == objName && patch.Namespace == objNamespace {
 			content := object.UnstructuredContent()
 			for _, path := range patch.Specs.Paths {
 				switch path.Operation {

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/resourcetransformation.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/resourcetransformation.go
@@ -1,0 +1,72 @@
+package stork
+
+import (
+	"context"
+
+	storkv1alpha1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ResourceTransformOps is an interface to perform k8s ResourceTransformOps operations
+type ResourceTransformOps interface {
+	// CreateResourceTransformation creates the ResourceTransformation
+	CreateResourceTransformation(*storkv1alpha1.ResourceTransformation) (*storkv1alpha1.ResourceTransformation, error)
+	// GetResourceTransformation gets the ResourceTransformation
+	GetResourceTransformation(string, string) (*storkv1alpha1.ResourceTransformation, error)
+	// ListResourceTransformations lists all the ResourceTransformations
+	ListResourceTransformations(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ResourceTransformationList, error)
+	// UpdateResourceTransformation updates the ResourceTransformation
+	UpdateResourceTransformation(*storkv1alpha1.ResourceTransformation) (*storkv1alpha1.ResourceTransformation, error)
+	// DeleteResourceTransformation deletes the ResourceTransformation
+	DeleteResourceTransformation(string, string) error
+}
+
+// CreateResourceTransformation creates the ResourceTransformation
+func (c *Client) CreateResourceTransformation(ResourceTransformation *storkv1alpha1.ResourceTransformation) (*storkv1alpha1.ResourceTransformation, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.stork.StorkV1alpha1().ResourceTransformations(ResourceTransformation.Namespace).Create(context.TODO(), ResourceTransformation, metav1.CreateOptions{})
+}
+
+// GetResourceTransformation gets the ResourceTransformation
+func (c *Client) GetResourceTransformation(name string, namespace string) (*storkv1alpha1.ResourceTransformation, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	ResourceTransformation, err := c.stork.StorkV1alpha1().ResourceTransformations(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return ResourceTransformation, nil
+}
+
+// ListResourceTransformations lists all the ResourceTransformations
+func (c *Client) ListResourceTransformations(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ResourceTransformationList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	ResourceTransformations, err := c.stork.StorkV1alpha1().ResourceTransformations(namespace).List(context.TODO(), filterOptions)
+	if err != nil {
+		return nil, err
+	}
+	return ResourceTransformations, nil
+}
+
+// UpdateResourceTransformation updates the ResourceTransformation
+func (c *Client) UpdateResourceTransformation(ResourceTransformation *storkv1alpha1.ResourceTransformation) (*storkv1alpha1.ResourceTransformation, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.stork.StorkV1alpha1().ResourceTransformations(ResourceTransformation.Namespace).Update(context.TODO(), ResourceTransformation, metav1.UpdateOptions{})
+}
+
+// DeleteResourceTransformation deletes the ResourceTransformation
+func (c *Client) DeleteResourceTransformation(name string, namespace string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+	return c.stork.StorkV1alpha1().ResourceTransformations(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
+		PropagationPolicy: &deleteForegroundPolicy,
+	})
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/stork.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/stork.go
@@ -42,6 +42,7 @@ type Ops interface {
 	ApplicationCloneOps
 	VolumeSnapshotRestoreOps
 	ApplicationRegistrationOps
+	ResourceTransformOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)


### PR DESCRIPTION
**What type of PR is this?**
>feature

**What this PR does / why we need it**:
Add updating resource as per transformation specs

**Does this PR change a user-facing CRD or CLI?**:
yes 
Migration spec now accept `updateResourceSpecs` param to update resource as per transformation rule before migrating 
resources.
```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: MigrationSchedule
metadata:
  name: mysql-migration-transform-interval
spec:
  schedulePolicyName: migrate-every-5m
  template:
    spec:
      # This should be the name of the cluster pair
      clusterPair: remoteclusterpair
      # If set to false this will migrate only the volumes. No PVCs, apps, etc will be migrated
      includeResources: true
      # If set to false, the deployments and stateful set replicas will be set to
      # 0 on the destination. There will be an annotation with
      # "stork.openstorage.org/migrationReplicas" to store the replica count from the source
      startApplications: false
      # Update service resource as per transformation specs
      transformSpecs:
      - mysql-service-transform
      namespaces:
      - mysql-1-pvc-mysql-migration-transform-interval

  ```
Transformation CR :
```
apiVersion: stork.libopenstorage.org/v1alpha1
kind : ResourceTransformation
metadata:
   name: test
specs:
  transformSpecs:
  - paths:
      - path: "spec.type"
        value: "LoadBalancer"
        type: "string"
        operation: "add"
      - path: "metadata.labels"
        value: "handler: project1,app:mysql-2"
        type: "keypair"
        operation: "modify"
    resource: "/v1/Service"
```
**Is a release note needed?**:
yes
```release-note
Migration can now accept resource transformation rules by which customer can modify resources before applying it on DR cluster. This transformation rules has to be created as part of `ResourceTransformation` CR and passed in to migration specification using `updateResourceSpecs` option.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

Note: 

Jenkins for regression : https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%202.12-dev%20%20C7/job/2.12-px-2.11-migration-csi/135/consoleFull

```
time="2022-08-26T15:49:44Z" level=info msg="[mysql-1-pvc] Destroyed PVC: mysql-data"
=== RUN   TestMigration/testMigrationFailoverFailback
--- PASS: TestMigration (340.97s)
    --- PASS: TestMigration/testMigration (337.92s)
        --- PASS: TestMigration/testMigration/transformResourceTest (334.91s)
    --- PASS: TestMigration/testMigrationFailoverFailback (0.04s)
PASS

DONE 6 tests in 363.544s
```
