### PR TITLE
PWX-26151: Skip collection of endpoints for headless service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ replace (
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7 => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20220804223926-812cb10d08c4
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220714042759-8f183fe386ca
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220824221759-f21d3c3b4496
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20220815024644-ca99a26a617c
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.6.0

--- a/go.sum
+++ b/go.sum
@@ -1436,6 +1436,8 @@ github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987/go.m
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20220714042759-8f183fe386ca h1:jrjwiQdqgDRsQZuiRDaWsbvx/z5t1icQPf7dgJOQUKE=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20220714042759-8f183fe386ca/go.mod h1:0IQvado0rnmbRMORaCqCDrrzjBrX5sU+Sz2+vQwEsjM=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220824221759-f21d3c3b4496 h1:4VuOzgXy6EU6zrVTEP4wlAaBUwdGA2jY1ckyjthTvb8=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20220824221759-f21d3c3b4496/go.mod h1:/xDBMzUV30kbdQYaPdAFcAYqEada6ZnWi4zt4KzFzAI=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.0.0-20220815024644-ca99a26a617c h1:vTjozKeb8DcF7qRqJWCMBxuUDpht5/TGMHkntwBBohA=
 github.com/portworx/torpedo v0.0.0-20220815024644-ca99a26a617c/go.mod h1:MggFBtnLHdUpaP9HKxZhVCinOYl5sMDNtrJb6YyrPyQ=

--- a/pkg/resourcecollector/endpoint.go
+++ b/pkg/resourcecollector/endpoint.go
@@ -7,6 +7,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	headlessService = "service.kubernetes.io/headless"
+)
+
 func (r *ResourceCollector) endpointsToBeCollected(
 	object runtime.Unstructured,
 ) (bool, error) {
@@ -32,6 +36,13 @@ func (r *ResourceCollector) endpointsToBeCollected(
 	if endpoint.Annotations != nil {
 		// collect manually created endpoint resources
 		if _, ok := endpoint.Annotations[v1.LastAppliedConfigAnnotation]; !ok {
+			return false, nil
+		}
+	}
+	if endpoint.Labels != nil {
+		// skip collecting endpointfs for headless service
+		// https://kubernetes.io/docs/reference/labels-annotations-taints/#servicekubernetesioheadless
+		if _, ok := endpoint.Labels[headlessService]; ok {
 			return false, nil
 		}
 

--- a/vendor/github.com/portworx/sched-ops/k8s/core/core.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/core.go
@@ -23,6 +23,7 @@ import (
 const (
 	masterLabelKey           = "node-role.kubernetes.io/master"
 	controlplaneLabelKey     = "node-role.kubernetes.io/controlplane"
+	controlDashPlaneLabelKey = "node-role.kubernetes.io/control-plane"
 	pvcStorageProvisionerKey = "volume.beta.kubernetes.io/storage-provisioner"
 	labelUpdateMaxRetries    = 5
 )

--- a/vendor/github.com/portworx/sched-ops/k8s/core/nodes.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/nodes.go
@@ -138,7 +138,8 @@ func (c *Client) IsNodeMaster(node corev1.Node) bool {
 	// for newer k8s these fields exist but they are empty
 	_, hasMasterLabel := node.Labels[masterLabelKey]
 	_, hasControlPlaneLabel := node.Labels[controlplaneLabelKey]
-	if hasMasterLabel || hasControlPlaneLabel {
+	_, hasControlDashPlaneLabel := node.Labels[controlDashPlaneLabelKey]
+	if hasMasterLabel || hasControlPlaneLabel || hasControlDashPlaneLabel {
 		return true
 	}
 	return false

--- a/vendor/github.com/portworx/sched-ops/k8s/stork/resourcetransformation.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/stork/resourcetransformation.go
@@ -27,7 +27,7 @@ type ResourceTransformOps interface {
 	ValidateResourceTransformation(string, string, time.Duration, time.Duration) error
 }
 
-// CreateResourceTransformation creates the ResourceTransformation
+// CreateResourceTransformation creates the ResourceTransformation CR
 func (c *Client) CreateResourceTransformation(ResourceTransformation *storkv1alpha1.ResourceTransformation) (*storkv1alpha1.ResourceTransformation, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func (c *Client) CreateResourceTransformation(ResourceTransformation *storkv1alp
 	return c.stork.StorkV1alpha1().ResourceTransformations(ResourceTransformation.Namespace).Create(context.TODO(), ResourceTransformation, metav1.CreateOptions{})
 }
 
-// GetResourceTransformation gets the ResourceTransformation
+// GetResourceTransformation gets the ResourceTransformation CR
 func (c *Client) GetResourceTransformation(name string, namespace string) (*storkv1alpha1.ResourceTransformation, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func (c *Client) GetResourceTransformation(name string, namespace string) (*stor
 	return ResourceTransformation, nil
 }
 
-// ListResourceTransformations lists all the ResourceTransformations
+// ListResourceTransformations lists all the ResourceTransformations CR
 func (c *Client) ListResourceTransformations(namespace string, filterOptions metav1.ListOptions) (*storkv1alpha1.ResourceTransformationList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (c *Client) ListResourceTransformations(namespace string, filterOptions met
 	return ResourceTransformations, nil
 }
 
-// UpdateResourceTransformation updates the ResourceTransformation
+// UpdateResourceTransformation updates the ResourceTransformation CR
 func (c *Client) UpdateResourceTransformation(ResourceTransformation *storkv1alpha1.ResourceTransformation) (*storkv1alpha1.ResourceTransformation, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func (c *Client) UpdateResourceTransformation(ResourceTransformation *storkv1alp
 	return c.stork.StorkV1alpha1().ResourceTransformations(ResourceTransformation.Namespace).Update(context.TODO(), ResourceTransformation, metav1.UpdateOptions{})
 }
 
-// DeleteResourceTransformation deletes the ResourceTransformation
+// DeleteResourceTransformation deletes the ResourceTransformation CR
 func (c *Client) DeleteResourceTransformation(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -731,7 +731,7 @@ github.com/portworx/px-object-controller/client/listers/objectservice/v1alpha1
 github.com/portworx/px-object-controller/pkg/client
 github.com/portworx/px-object-controller/pkg/controller
 github.com/portworx/px-object-controller/pkg/utils
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20220401024625-dbc61a336f65 => github.com/portworx/sched-ops v1.20.4-rc1.0.20220714042759-8f183fe386ca
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20220401024625-dbc61a336f65 => github.com/portworx/sched-ops v1.20.4-rc1.0.20220824221759-f21d3c3b4496
 ## explicit
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -1907,7 +1907,7 @@ sigs.k8s.io/yaml
 # github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20220804223926-812cb10d08c4
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220714042759-8f183fe386ca
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220824221759-f21d3c3b4496
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20220815024644-ca99a26a617c
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.6.0


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
Add fix for `PWX-26151: PWX-26151: Skip collection of endpoints for headless service`

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no


**Does this change need to be cherry-picked to a release branch?**:
2.12

```
=== RUN   TestMigration/testMigrationFailoverFailback
--- PASS: TestMigration (564.12s)
    --- PASS: TestMigration/testMigration (561.05s)
        --- PASS: TestMigration/testMigration/intervalScheduleCleanupTest (558.04s)
    --- PASS: TestMigration/testMigrationFailoverFailback (0.06s)
PASS

DONE 6 tests in 587.369s
```

