### PR TITLE
Force full backup on specified day in daily schedule

### DIFF
--- a/pkg/apis/stork/v1alpha1/schedulepolicy.go
+++ b/pkg/apis/stork/v1alpha1/schedulepolicy.go
@@ -124,6 +124,8 @@ type DailyPolicy struct {
 	// Options to be passed in to the driver. These will be passed in
 	// to the object being triggered
 	Options map[string]string `json:"options"`
+	// ForceFullSnapshotDay specifies day of the week for full snapshot to take place
+	ForceFullSnapshotDay string `json:"forceFullSnapshotDay"`
 }
 
 // GetHourMinute parses and return the hour and minute specified in the policy

--- a/pkg/applicationmanager/controllers/applicationbackupschedule.go
+++ b/pkg/applicationmanager/controllers/applicationbackupschedule.go
@@ -14,6 +14,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/objectstore"
 	"github.com/libopenstorage/stork/pkg/schedule"
+	"github.com/libopenstorage/stork/pkg/utils"
 	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
@@ -41,7 +42,6 @@ const (
 	// ApplicationBackupObjectLockRetentionAnnotation - object lock retention period annotation
 	// Since this annotation is used in the px-backup, creating with portworx.io annotation prefix.
 	ApplicationBackupObjectLockRetentionAnnotation = "portworx.io/" + "object-lock-retention-period"
-	incrementalCountAnnotation                     = "portworx.io/cloudsnap-incremental-count"
 	dayInSec                                       = 86400
 	//ObjectLockDefaultIncrementalCount default incremental backup count
 	ObjectLockDefaultIncrementalCount = 5
@@ -453,8 +453,8 @@ func (s *ApplicationBackupScheduleController) startApplicationBackup(backupSched
 				backupscheduleCreationTime, diff, elaspedDays, elaspedDaysInSecs, currentDayStartTime)
 
 			if lastSuccessfulBackupCreateTime < currentDayStartTime {
-				// forcing it to be full backup, by setting the incrementalCountAnnotation to zero
-				backup.Spec.Options[incrementalCountAnnotation] = fmt.Sprintf("%v", 0)
+				// forcing it to be full backup, by setting the PXIncrementalCountAnnotation to zero
+				backup.Spec.Options[utils.PXIncrementalCountAnnotation] = fmt.Sprintf("%v", 0)
 			}
 		}
 	}

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -8,6 +8,7 @@ import (
 
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/k8sutils"
+	"github.com/libopenstorage/stork/pkg/utils"
 	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/core"
@@ -229,7 +230,17 @@ func GetOptions(policyName string, namespace string, policyType stork_api.Schedu
 	case stork_api.SchedulePolicyTypeInterval:
 		return schedulePolicy.Policy.Interval.Options, nil
 	case stork_api.SchedulePolicyTypeDaily:
-		return schedulePolicy.Policy.Daily.Options, nil
+		options := schedulePolicy.Policy.Daily.Options
+		scheduledDay, ok := stork_api.Days[schedulePolicy.Policy.Daily.ForceFullSnapshotDay]
+		if ok {
+			currentDay := GetCurrentTime().Weekday()
+			// force full backup on specified day
+			if currentDay == scheduledDay {
+				options[utils.PXIncrementalCountAnnotation] = "0"
+			}
+			logrus.Debugf("Forcing full-snapshot for daily snapshotschedule policy on the day %s", schedulePolicy.Policy.Daily.ForceFullSnapshotDay)
+		}
+		return options, nil
 	case stork_api.SchedulePolicyTypeWeekly:
 		return schedulePolicy.Policy.Weekly.Options, nil
 	case stork_api.SchedulePolicyTypeMonthly:

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -238,7 +238,7 @@ func GetOptions(policyName string, namespace string, policyType stork_api.Schedu
 			if currentDay == scheduledDay {
 				options[utils.PXIncrementalCountAnnotation] = "0"
 			}
-			logrus.Debugf("Forcing full-snapshot for daily snapshotschedule policy on the day %s", schedulePolicy.Policy.Daily.ForceFullSnapshotDay)
+			logrus.Infof("Forcing full-snapshot for daily snapshotschedule policy on the day %s", schedulePolicy.Policy.Daily.ForceFullSnapshotDay)
 		}
 		return options, nil
 	case stork_api.SchedulePolicyTypeWeekly:

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -10,6 +10,9 @@ const (
 	CattlePrefix = "cattle.io"
 	// CattleProjectPrefix is the prefix used in all Rancher project related annotations and labels
 	CattleProjectPrefix = "cattle.io/projectId"
+	// PXIncrementalCountAnnotation is the annotation used to set cloud backup incremental count
+	// for volume
+	PXIncrementalCountAnnotation = "portworx.io/cloudsnap-incremental-count"
 )
 
 // ParseKeyValueList parses a list of key=values string into a map


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Daily schedule policy now accept `forceFullSnapshotDay` day which will result in force full backup of volume 

**Does this PR change a user-facing CRD or CLI?**:
yes

```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: VolumeSnapshotSchedule
metadata:
  name: mysql-snapshot-schedule
  namespace: test
  annotations:
    portworx/snapshot-type: cloud
spec:
  schedulePolicyName: daily
  suspend: false
  reclaimPolicy: Delete
  template:
    spec:
      persistentVolumeClaimName: mysql-data
```

Schedule Policy : 
```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: SchedulePolicy
metadata:
  name: daily
policy:
  daily:
    time: "12:04PM"
    forceFullSnapshotDay: "Monday"
```

**Is a release note needed?**:
yes

```release-note
User can specify `forceFullSnapshotDay`  in daily snapshot schedule policy to ensure full volume backup on specified day of the week
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.12.0

