### PR TITLE
pb-3005: Added fix to include the CRDs even if CR is are present.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1025,9 +1025,21 @@ func (a *ApplicationBackupController) uploadCRDResources(backup *stork_api.Appli
 	}
 	if v1CrdApiReqrd {
 		var crds []*apiextensionsv1.CustomResourceDefinition
+		crdsGroups := make(map[string]bool)
+		// First collect the group detail for the CRDs, which has CR
 		for _, crd := range crdList.Items {
 			for _, v := range crd.Resources {
 				if _, ok := resKinds[v.Kind]; !ok {
+					continue
+				}
+				crdsGroups[v.Group] = true
+			}
+
+		}
+		// pick up all the CRDs that belongs to the group in the crdsGroups map
+		for _, crd := range crdList.Items {
+			for _, v := range crd.Resources {
+				if _, ok := crdsGroups[v.Group]; !ok {
 					continue
 				}
 				crdName := ruleset.Pluralize(strings.ToLower(v.Kind)) + "." + v.Group
@@ -1053,9 +1065,20 @@ func (a *ApplicationBackupController) uploadCRDResources(backup *stork_api.Appli
 		return nil
 	}
 	var crds []*apiextensionsv1beta1.CustomResourceDefinition
+	crdsGroups := make(map[string]bool)
+	// First collect the group detail for the CRDs, which has CR
 	for _, crd := range crdList.Items {
 		for _, v := range crd.Resources {
 			if _, ok := resKinds[v.Kind]; !ok {
+				continue
+			}
+			crdsGroups[v.Group] = true
+		}
+	}
+	// pick up all the CRDs that belongs to the group in the crdsGroups map
+	for _, crd := range crdList.Items {
+		for _, v := range crd.Resources {
+			if _, ok := crdsGroups[v.Group]; !ok {
 				continue
 			}
 			crdName := ruleset.Pluralize(strings.ToLower(v.Kind)) + "." + v.Group


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
```
pb-3005: Added fix to include the CRDs even if CR is are present.

            - With fix, we will include all the CRDs of a group, if one CRDs
              of a particular group had a CR in the given namespace.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
Yes
```
release-note
Issue: Currently we do not backup all the  CRDs of app. We backup a CRD only if there is a corresponding CR for that CRD
User Impact: Some application operator deployment expects all the CRDs to be present, even if there is no CR.
Resolution: With fix, we will include all the CRDs of a group, if one CRDs of a particular group had a CR in the given namespace.

```

**Does this change need to be cherry-picked to a release branch?**:
Yes 2.11.3

Testing:
Source Cluster:
There are five CRDs created for keycloak:
```
[root@siva3-juniper-thumb-2 ~]# kubectl  get crds | grep key
keycloakbackups.keycloak.org                                 2022-08-28T07:13:02Z
keycloakclients.keycloak.org                                 2022-08-28T07:13:02Z
keycloakrealms.keycloak.org                                  2022-08-28T07:13:02Z
keycloaks.keycloak.org                                       2022-08-28T07:13:02Z
keycloakusers.keycloak.org                                   2022-08-28T07:13:02Z
[root@siva3-juniper-thumb-2 ~]#
```
Only the keycloaks.keycloak.org had the CR:
```
[root@siva3-juniper-thumb-2 ~]# kubectl  get keycloaks.keycloak.org -A
NAMESPACE   NAME               AGE
keycloak    example-keycloak   3d7h
[root@siva3-juniper-thumb-2 ~]# kubectl get keycloakbackups.keycloak.org -A
No resources found
[root@siva3-juniper-thumb-2 ~]#
```
While taking backup, it include all the CRDs that belong to the group keycloak.org, even if CR is not present.
Verified that CRDs are restored properly
Also verified that crds.json was having all the required CR
![Screenshot 2022-08-31 at 8 05 34 PM](https://user-images.githubusercontent.com/52188641/187707391-12f0f9c6-35f2-45c9-bf8f-bcc62aa85404.png)
![Screenshot 2022-08-31 at 7 57 55 PM](https://user-images.githubusercontent.com/52188641/187707422-8cf3afc3-59c5-4809-87f7-577011fa5ba2.png)
![Screenshot 2022-08-31 at 7 57 31 PM](https://user-images.githubusercontent.com/52188641/187707435-2ef78f65-d572-45e5-93bc-d2d69cb8c294.png)
![Screenshot 2022-08-31 at 7 53 19 PM](https://user-images.githubusercontent.com/52188641/187707448-f6e80e07-4671-4477-94dc-9b087cf23b30.png)
![Screenshot 2022-08-31 at 7 53 16 PM](https://user-images.githubusercontent.com/52188641/187707452-843b4c1d-783b-4135-b17a-ae8b401d64c9.png)
Ds from the group.



