### PR TITLE
pb-2939: enable NFS type backuplocation

### DIFF
--- a/how ed4bac3825565902733b151138c32367231e48b3
+++ b/how ed4bac3825565902733b151138c32367231e48b3
@@ -1,0 +1,11072 @@
+[33mcommit ed4bac3825565902733b151138c32367231e48b3[m[33m ([m[1;36mHEAD -> [m[1;32mpb-2939[m[33m, [m[1;31morigin/pb-2939[m[33m)[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Wed Jul 27 06:48:28 2022 +0000
+
+    pb-2939: enable NFS type backuplocation
+    
+    - added NFS type to stork v1alpha1 APIs
+    - added objectlock specific API for for NFS
+    - skipped bucket exist check in Application backup
+      controller specifically for NFS scenario
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 207a503c45ae3f373f558b32a27b2a20e2199930[m[33m ([m[1;31morigin/nfs-ea[m[33m, [m[1;31morigin/master[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mnfs-ea[m[33m, [m[1;32mmaster[m[33m)[m
+Author: sivakumar subraani <sivakumar subramani>
+Date:   Wed Aug 31 14:36:10 2022 +0000
+
+    pb-3005: Added fix to include the CRDs even if CR is are present.
+    
+            - With fix, we will include all the CRDs of a group, if one CRDs
+              of a parrticular group had a CR in the given namespace.
+
+[33mcommit fae173e9c7cecf9de0db8f1032a894b6a2b88084[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Aug 30 09:36:57 2022 -0700
+
+    Log when stork takes a forceful snapshot
+
+[33mcommit 72bd1fe2809fa757332807c204eb7aee5b02e1cd[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Aug 29 18:21:28 2022 +0530
+
+    Force full backup on specified day in daily schedule
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 25b400055100500a8b4bcf8fc2e21c533ee1487f[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Sat Aug 27 14:57:33 2022 +0530
+
+    vendor update - sched-ops master
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 0b54138f41d94eef252454d7f9ebd052a5ab4f59[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Sat Aug 27 14:57:05 2022 +0530
+
+    pwx-26151: skip collecting endpoints for headless service
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 9782bc0f44250054346ac0d5089ce21da68d7fc8[m
+Author: Rohit-PX <rkulkarni@purestorage.com>
+Date:   Mon Aug 15 22:26:01 2022 +0000
+
+    vendor updates
+    
+    Signed-off-by: Rohit-PX <rkulkarni@purestorage.com>
+
+[33mcommit d630f1478d0ed353bb97b72990ba8f7e44d31b0b[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Fri Aug 26 12:46:06 2022 +0530
+
+    Ensure to re-run transformation validation before each migration run
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit d3d4c9dd3d51f0e0b24f30f66739aa980f1eb49e[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Aug 24 20:27:59 2022 +0530
+
+    vendor update sched-ops
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 5c6a98c625fba875466959c0c9f2b5899cf8fde0[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Aug 24 20:27:04 2022 +0530
+
+    Dry-run resource transformation validation during migration prechecks
+    
+      - validate transform CR
+      - dry-run on newly detected object before starting migration
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 338ee5d16d70740c1a65d6c667dc01789f2ed9a7[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Aug 24 19:32:48 2022 +0530
+
+    Allow enable/disable resource transformation controller
+    
+       - addressed review comments
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 0e2f00364d25c4d50908018cffa151782577c62b[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Thu Aug 18 19:57:28 2022 +0530
+
+    vendor updates stork sched ops
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 4307eea88180b29a575ebaa981e65e17e65f76ff[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Thu Aug 18 19:56:24 2022 +0530
+
+    Add transformation rule handler in resourcecollector
+    
+     - allow dry run for keypair and slice value type
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 71a23be2d835d72dd7085cd7cd8e9ab388e13955[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Thu Aug 18 19:54:48 2022 +0530
+
+    pwx-24979: integrate transform resource api with migration path
+    
+      - accept resource transformation in migration spec
+      - update resource as per transformation rule
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 8e7b43a5ed1451e9bbf52ed7ded0c08c6066ae7c[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Aug 1 22:11:18 2022 +0530
+
+    PWx-24851: Enhance UX experience for setting up clusterpair for async-dr setups
+    
+      - query cluster pair token using px endpoint + port
+      - query port by looking at px-api service rest port
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit f7504fc6481ec72836f12b45cdba1f2d7200bf5e[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Tue Aug 9 18:20:24 2022 +0530
+
+    Register and handle Resource Transformation events via controller
+    
+      - validate specs for resource transformation cr
+      - apply patch on unstruct k8s objects
+      - run patched resources on dry run namespace with DryRun option set to
+    all
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit d88159e3c4fb7280d2dcb9366f48663e40863dd6[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Aug 1 15:14:30 2022 +0530
+
+    PWX-24976: Register ResourceTransformation CR api
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 33f1d74c6b17890b6ab028b28ca45cc2e5ad715a[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Aug 1 14:41:51 2022 +0530
+
+    codegen generated file for resource transformation CR
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 60d0c119d70efb14b7471869a8ec4073eb5bc1ab[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Aug 1 11:49:50 2022 +0530
+
+    PWX-26033: Dont include FA/FB device for migration
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit eeb4e468b4a5b30428615ab57dc0388f1c21a254[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Fri Aug 5 14:08:53 2022 -0600
+
+    hold off on clusterpair port changes
+    
+    Signed-off-by: Luke Pitstick <lpitstick@purestorage.com>
+
+[33mcommit e7f47e6ad9ba6887719c0eb75eb29427a8f22f10[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Thu Aug 4 16:56:37 2022 -0600
+
+    Vendor update openstorage
+    
+    Signed-off-by: Luke Pitstick <lpitstick@purestorage.com>
+
+[33mcommit 4f0688cc42c91656ae13c1648bc99d039c4d5305[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Tue Aug 2 19:31:51 2022 -0600
+
+    Deal with clusterpair ports later
+    
+    Signed-off-by: Luke Pitstick <lpitstick@purestorage.com>
+
+[33mcommit 3949621aec5bfbc197c9096d6f97a9c156fc5ea7[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Fri Jul 29 14:50:54 2022 -0600
+
+    vendor openstorage
+    
+    Signed-off-by: Luke Pitstick <lpitstick@purestorage.com>
+
+[33mcommit 393d44c93c5d34d4e53fde9a048bd3c423413c2c[m
+Author: Mudassir Latif <mudassir.latif@portworx.com>
+Date:   Tue Apr 20 02:09:28 2021 +0000
+
+    Stork should use the new secure port
+    
+    If tls is enabled, use tls.config generated by the openstorage
+      library helper
+    
+    Signed-off-by: Mudassir Latif <mudassir.latif@purestorage.com>
+
+[33mcommit c83f1e7b3f5c0e00f916fc018ce5f81bf52f140b[m
+Author: Priyanshu Pandey <ppandey@purestorage.com>
+Date:   Wed Aug 17 00:09:57 2022 -0600
+
+    PWX-26330: Disable px-object-controller by default.
+    
+    Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>
+
+[33mcommit 27c04a2ab7eee15bdd4f09dbee8c6eda66e4aad6[m
+Author: sivakumar subraani <sivakumar subramani>
+Date:   Sat Aug 6 13:02:05 2022 +0000
+
+    pb-3000: Added debug statement in GetObjLockInfo api
+
+[33mcommit 30cda4f7559413a7b355231291aa12de51c04ae9[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Wed Aug 10 07:38:04 2022 +0000
+
+    pb-3002: call v1 version CRD API for k8s 1.22 or more.
+    
+    Fixed a v1beta1 based getCRD call which will fail for k8s-1.22 or more
+    because these APIs are removed in k8s-1.22 onwards.
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 09d16ab442dc1074ae7fcb8fb349976355f2d25c[m
+Author: Priyanshu Pandey <ppandey@purestorage.com>
+Date:   Wed Aug 10 13:43:30 2022 -0600
+
+    PWX-26225: Error in starting px-object-controller should not throw fatal error.
+    
+    Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>
+
+[33mcommit 1fbe01b49d18a03b33708bd38260954fa1cf1a97[m
+Author: Priyanshu Pandey <ppandey@purestorage.com>
+Date:   Thu Aug 4 18:22:26 2022 -0600
+
+    PWX-26049: Vendor updated px-object-controller to fix cache initialization, delete error and multitenancy.
+    
+    Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>
+
+[33mcommit 914167074236981785d8877f228248bcaf8bdce3[m
+Author: Priyanshu Pandey <ppandey@purestorage.com>
+Date:   Thu Jul 28 19:34:28 2022 -0600
+
+    PWX-24682: Fixing static check issues.
+    
+    Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>
+
+[33mcommit 0961a8a9baf9e4db540022dea6dd92ecd5e03ac0[m
+Author: Priyanshu Pandey <ppandey@purestorage.com>
+Date:   Thu Jul 28 15:18:45 2022 -0600
+
+    PWX-24682: Vendor px-object-controller and start it to use px sdk server.
+    
+    Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>
+
+[33mcommit c55ae997e904d27186195ffc9aabb27621c89321[m[33m ([m[1;32mnfs-feature-master-branch[m[33m)[m
+Author: sivakumar subraani <sivakumar subramani>
+Date:   Thu Jul 21 08:05:49 2022 +0000
+
+    pb-2279: Added fixes to take care new EncryptionV2Key variable in
+    backuplocation.
+    
+            - Replace reference to EncryptionKey to EncryptionV2Key
+            - If decrypt function, assume it to be uncrypted and try using
+              data directly.
+
+[33mcommit 114ffbf85f353c2e5ffac0e576ce9ebfd1e9352b[m
+Author: sivakumar subraani <sivakumar subramani>
+Date:   Tue Jul 12 05:46:26 2022 +0000
+
+    pb-2279: Added new variable for encryption key in backuplocation CR definition
+
+[33mcommit a35d4636f8aa5c7fe5bf335eb339a77887f994a6[m
+Author: Rohit-PX <rkulkarni@purestorage.com>
+Date:   Wed Jul 20 23:05:16 2022 +0000
+
+    Rename webhook tests to be picked as part of extender tests
+    
+    Signed-off-by: Rohit-PX <rkulkarni@purestorage.com>
+
+[33mcommit 221afd7223485afd9ab6db39dad999a0efd50de3[m
+Author: Neelesh Thakur <neelesh.thakur@purestorage.com>
+Date:   Fri Jul 15 19:06:12 2022 -0600
+
+    PTX-10293: added tests for the webhook changes for virt-launcher pod
+    
+    Tests to verify that the virt-launcher pod will return "nfs" as
+    the file system type for regular and encrypted PX volumes.
+    
+    We use "kubevirt.io: virt-launcher" label to simulate the virt-launcher pod.
+    
+    Also, verify that the pods without the virt-launcher label will return
+    the correct FS type depending on it is a bind-mount or an nfs-mount.
+    
+    Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>
+
+[33mcommit 5c3c9b63fa1d89a41c212aef032447a9e435f910[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Jul 15 16:27:08 2022 -0700
+
+    Add missing rancher labels to Service spec in rancher
+
+[33mcommit dd549f812cdb5bc38627ac24c18468684e480215[m[33m ([m[1;31morigin/master_nfs_upload[m[33m)[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Tue Jul 5 21:06:49 2022 +0530
+
+    vendor updates for torpedo,schedops libs
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 5d079db193a9592e1d838d557adc4cf133ca2688[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Tue Jul 5 21:05:04 2022 +0530
+
+    integration test for migration of endpoints, networkpolicy resource
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit ef512411ebc0467cb3f2ae9b3f33ca81c3eef4c4[m
+Author: Rohit-PX <rkulkarni@purestorage.com>
+Date:   Tue Jul 12 23:40:08 2022 +0000
+
+    Vendor updates
+    
+    Signed-off-by: Rohit-PX <rkulkarni@purestorage.com>
+
+[33mcommit c4447251aa35ac43c3db09eadb504fa2fb3a3ff9[m
+Author: Rohit-PX <rkulkarni@purestorage.com>
+Date:   Fri Jul 8 18:12:37 2022 +0000
+
+    Add CBT suite to be run for every check-in to stork
+    
+    Signed-off-by: Rohit-PX <rkulkarni@purestorage.com>
+
+[33mcommit 3e79dc8074385c0c40973549f6eb666fb8f950f6[m
+Author: Neelesh Thakur <neelesh.thakur@purestorage.com>
+Date:   Wed Jun 29 13:07:11 2022 -0600
+
+    PWX-24637: mutate the virt-launcher container to intercept statfs()
+    
+    Live migration of KubeVirt VM fails if the VM is using
+    a bind-mounted sharedv4 volume. The root cause is that libvirt
+    uses a statfs() call to check the file system type and
+    incorrectly concludes that the volume is not shared.
+    
+    This patch addresses this problem as described below.
+    
+    We use a shared library px_statfs.so that intercepts libvirt's statfs call.
+    If the input path is backed by a PX volume, we change the file system
+    type returned by the real statfs call. This shared library is bundled with
+    the stork container.
+    
+    If a virt-launcher pod is being created and is using a PX volume, stork's
+    mutating webhook creates a ConfigMap in the pod's namespace.
+    
+    This configMap has 2 keys that represent the 2 files that we want to inject
+    into the virt-launcher container's /etc directory:
+    
+      - ld.so.preload
+      - px_statfs.so
+    
+    The stork webhook then mutates the virt-launcher pod's spec to mount
+    the configMap as a volume and inject the 2 files above in /etc dir on the
+    container's file system. This makes linux load px_statfs.so in the libvirt
+    process that is running inside the virt-launcher container and intercept
+    libvirts' statfs() call.
+    
+    Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>
+
+[33mcommit a0abc0790f8c47a61c7d985e6050ae5402eb4b74[m
+Author: sivakumar subraani <sivakumar subramani>
+Date:   Mon Jul 11 09:45:20 2022 +0000
+
+    pb-2904: vendored latest kdmp repo changes.
+
+[33mcommit 7cb8bb703e541c973d34dd9dec744b3cafac38b2[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Jul 4 13:32:25 2022 +0530
+
+    Collect manually created endpoint resources for backup and migration
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 02e473c7ac2d8735d3946db626811e92aef16bce[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Fri Jul 1 09:46:49 2022 +0530
+
+    add support for endpoint object collection
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 7bc6cb9cd0b1a5b3f619541ae6fe99d2f0a9b6e7[m
+Author: sivakumar subraani <sivakumar subramani>
+Date:   Sat Jul 9 03:48:16 2022 +0000
+
+    pb-2903: Added error handling for  GetObjLockInfo api for cloudian
+    objectstore.
+    
+            - In the case of cloudian objectore, GetObjectLockConfiguration
+              api was returning ObjectLockConfigurationNotFound as error.
+            - So added the error check to handle ObjectLockConfigurationNotFound error as well
+
+[33mcommit 0dc4b5c3f9e51882f4aaa6422ed22c61db97db0e[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Jun 7 09:47:29 2022 -0700
+
+    PWX-24046: Add PlatformOptions to ClusterPair spec.
+    
+    PlatformOptions allow users to specify any configurations required for
+    kubernetes platform providers like Rancher / EKS / AKS etc
+    
+    Currently the PlatformOptions are only being used for Rancher. Each platform can define their
+    own spec within this PlatformOptions.
+    
+    RancherSpec:
+    - ProjectMappings: Allows users to configure source and target cluster projectID mappings
+    so that stork can apply the correct annotations on the destination project where it
+    is migrating the k8s resources.
+    - RancherSecret (FUTURE): Proposal for specifying a kubernetes secret to specify rancher api keys that would
+    be used to send REST APIs to Rancher endpoint for creating/deleting/getting project details
+    
+    NetworkPolicy / All Affinity referencing objects - Deployment/StatefulSet etc
+    - Parse a pod spec and if NamespaceSelectors are set, check if there are any rancher project labels
+    and replace them with the target project ID mapping.
+    
+    Pass resource collector options in every resource collector API
+    
+    - The resource collector instance is a common instance used in backup
+    and migration controllers. A common instance cannot dictate the options
+    used for different migration or backup objects.
+    
+    - Instead of a global map on the resource collector options use an actual
+    Options object and pass it as an argument to every API.
+    
+    PWX-24046: Integration test fixes to support Rancher Project Mappings
+    
+    - Currently the tests will run on vanilla k8s clusters but the
+    specs are simulated as if they were created for Rancher cluster by applying
+    project labels to them`
+
+[33mcommit f2ecc587a5498c509539dd7a017a649d53af74df[m[33m ([m[1;31morigin/pb-2279-new[m[33m)[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Thu Jul 7 19:24:59 2022 +0530
+
+    Remove deprecated go lint check
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 6f3d4011761594a84e3f807aff737b9631cca195[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Tue Jun 14 18:55:20 2022 +0530
+
+    add options to collect all network policy
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit fc773c955dd296224b1c91a6c4d0193a36fc6131[m
+Author: Rohit-PX <rkulkarni@purestorage.com>
+Date:   Wed Jun 29 00:23:44 2022 +0000
+
+    Add namespace to context so that restore gets created in the right namespace
+    
+    Signed-off-by: Rohit-PX <rkulkarni@purestorage.com>
+
+[33mcommit 2b41fb3302fac2987e1033aba84d13ddba25086d[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Mon Jun 27 16:42:02 2022 +0000
+
+    pb-2867: fix restore path issue for CSI backups
+    
+    - fix the variable scope related issue in the restore logic of CSI backup.
+    - changed the switch case to have right type assertion check
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 567bac837623c1cf6d4c2384b68a909519e8f382[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Fri Apr 8 16:01:50 2022 +0000
+
+    pb-2037: Making snapshot timeout configurable
+    
+    Added a configMap to change the local-snapshot timeout period.
+    This helps in addressing certain version of OCS cluster issues
+    wherein it takes genuinely more time
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 7c76e059bbd14a00086fcafa5d7f0a0e3ef64a72[m
+Author: Ozgur Gul <gul.ozgur@yahoo.com>
+Date:   Mon Jun 20 12:24:55 2022 +0100
+
+    Removed apos
+
+[33mcommit 03127f2704d19dbeb8cfaf71159054f54c97a282[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Wed Jun 15 16:23:06 2022 +0000
+
+    pb-2836: Fixing some typecasting error related to v1beta1 volumesnapshot
+    
+    Wrong typecasting causes crash while duplicating backup and executing
+    other backup operations. Fixed by changing to correct typecasting.
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit e1af2420fa3c94c43df760073ee4870b1fadbb7b[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Mon Jun 13 04:11:02 2022 +0000
+
+    pb-2328: vendored kdmp changes
+    
+    Vendored latest kdmp for supporting v1 & v1beta1 volumesnapshot CRD
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 78361560475e6722100b36d1c319f28154c00a0b[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Mon Jun 6 10:30:07 2022 +0000
+
+    pb-2328: Support both v1 & v1beta1 version of volumeSnapshot
+    
+    - Added support for V1 VolumeSnapshot APIs which is GA from
+      kubernetes 1.20 version.
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 7c9d3c0c2d63b57e606841ea0d3a2b86be227a7e[m[33m ([m[1;31morigin/master_sched_restore[m[33m)[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Jun 7 19:16:00 2022 +0000
+
+    PWX-24000: Treat pure backend block volumes as Portworx volumes.
+
+[33mcommit 2836033676a1a6a205e495abffa0cf146342e37d[m
+Author: Jindrich Zak <jindra.zak@gmail.com>
+Date:   Wed May 25 13:38:09 2022 +0200
+
+    Extract populating podNames.
+
+[33mcommit 879e0d32d1302a72c177cb859826eaefe74e2aff[m
+Author: Jindrich Zak <jindra.zak@gmail.com>
+Date:   Wed May 25 13:06:37 2022 +0200
+
+    Improve variable names and comments.
+
+[33mcommit b83100db2f7204d12aee27c7830cfb8a959f4692[m
+Author: Jindrich Zak <jindra.zak@gmail.com>
+Date:   Mon May 23 17:05:14 2022 +0200
+
+    DS-2051: Add selector and namespace args.
+
+[33mcommit d38953726d0051f71e25af910357b9279e3b3dd3[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Tue Jun 7 21:46:08 2022 +0530
+
+    PWX-24245: Register VM object with suspendOption
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 17183ee239b22f49faa79e67f076f66e7780bec1[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Jun 6 22:57:06 2022 +0530
+
+    Do not list all k8s resources for volumeonly migration
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit dbe85f5ebd61b81ea9e7525590d5696afb619966[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Fri Jun 3 10:26:32 2022 -0600
+
+    PWX-24190 Fix elapsed volume migration time when completed
+
+[33mcommit 19a108754d893579aa5fbadc8cabf23fef3a8532[m[33m ([m[1;31morigin/siva-hack[m[33m)[m
+Author: ram-infrac <35250819+ram-infrac@users.noreply.github.com>
+Date:   Wed May 25 09:48:53 2022 +0530
+
+    Revert "support for k8s 1.22 kube-scheduler"
+    
+    This reverts commit e894216546860d5045d61a9de6e6bbcc7f1907c8.
+
+[33mcommit be647da3bb6dd51030be83ffcc6fa01f67254013[m
+Author: ram-infrac <35250819+ram-infrac@users.noreply.github.com>
+Date:   Wed May 25 09:48:53 2022 +0530
+
+    Revert "add namespace resource permission for stork-scheduler clusterrole"
+    
+    This reverts commit 506827a08711999512d473702116884e93a00a94.
+
+[33mcommit 2ee1892bf48a8d67324799fe58d68dc0c66507ac[m
+Author: sivakumar subraani <sivakumar subramani>
+Date:   Mon May 23 10:03:24 2022 +0000
+
+    pb-2375: Fixed issue in handling the return value of GetObjectLockConfiguration call from FB and Dell ECS objecstore, when bucket is not enabled with lock
+
+[33mcommit 909dd2bfec71148ec982a3900a19682bc1d6f8e0[m[33m ([m[1;31morigin/pb-2377[m[33m)[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon May 9 18:51:20 2022 +0530
+
+    PWX-23656 Support for removing field during activate/deactivate migration
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 9f9672e04a290190cc499ee618740dbb4bb2a845[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon May 9 18:49:27 2022 +0530
+
+    PWX-23579: parallelize application activation/deactivation
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 59d86634e3ede548e63a15d4f1118c6f3a6000c5[m
+Author: Serhii Aheienko <serhii.aheienko@gmail.com>
+Date:   Fri May 13 10:02:31 2022 +0300
+
+    cmdexecutor: use a unique wait.sh script name per a command
+
+[33mcommit 6dfb6c8797454cb24b38ccfa00c05e3813c5e579[m
+Author: root <root@ip-10-13-107-197.pwx.purestorage.com>
+Date:   Thu May 12 05:20:15 2022 +0000
+
+    Update vendor
+
+[33mcommit 930954abd922ef4927bf18f2f0d9a670358dc313[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Wed May 11 22:11:43 2022 -0700
+
+    PWX-22627: Add support for IAM role in BackupLocation
+
+[33mcommit ff41727c85c3b116cfa8c771c534694c2242318b[m
+Author: Andrei Kvapil <kvapss@gmail.com>
+Date:   Thu May 12 22:15:57 2022 +0200
+
+    linstor: support for WaitingForFirstConsumer
+
+[33mcommit b0d15e0142aaf54801914df04545c67ef61994fb[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Thu May 12 11:11:33 2022 -0600
+
+    PR feedback and testing
+
+[33mcommit 5cfeb4a07ad890495393e55eba8171ee2e796095[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Wed May 11 15:40:01 2022 -0600
+
+    PWX-23693 Allow scheduling of pods with pending pvcs due to WaitForFirstConsumer
+
+[33mcommit c5f1df8c0627b8d145811d3d625ca38183320691[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed May 11 17:23:59 2022 +0530
+
+    pwx-23582: VM object migration support
+    
+     pwx-23657: link datavolume and pvc object during migration
+     pwx-23658: avoid ownerref resources for vm object
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 5e8179bd1548d4ff7309270b98fe36c51ba4cc0d[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Wed May 11 11:34:59 2022 -0700
+
+    PWX-23703: Explicitly pass migration taskID to get the CloudMigrateStatus for Portworx driver
+
+[33mcommit 506827a08711999512d473702116884e93a00a94[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Mon Nov 29 14:22:37 2021 +0000
+
+    add namespace resource permission for stork-scheduler clusterrole
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit e894216546860d5045d61a9de6e6bbcc7f1907c8[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Fri Nov 26 10:53:23 2021 +0000
+
+    support for k8s 1.22 kube-scheduler
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 3fce175ced10464c5bea9336ad0b258322cfd7c5[m
+Author: Rohit-PX <rkulkarni@purestorage.com>
+Date:   Tue May 3 07:43:25 2022 +0000
+
+    Skip deleted namespaces from a migration schedule
+    
+    Signed-off-by: Rohit-PX <rkulkarni@purestorage.com>
+
+[33mcommit 3cce9702fa805ef6d3f0f910d91fd2cc20ba8a8c[m
+Author: sivakumar subraani <sivakumar subramani>
+Date:   Wed May 4 08:00:39 2022 +0000
+
+    pb-2081: Added retry logic to wait for the volumesnapshot status update, before accessing restoreSize.
+
+[33mcommit fdce2656c89e85bbc99bd7228fa65bc1bc270fb6[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Tue May 3 10:15:49 2022 +0000
+
+    pb-2371: Handle non-existent bucket scenario for object-lock
+    
+    - Handle error code "NoSuchBucket" while fetching object lock info for a
+      AWS S3 based bucket.
+    - Fixed go version to eliminate travis build failure.
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 80663f52424749aeb42d8511bbabd2ff95263bcc[m
+Author: sivakumar subraani <sivakumar subramani>
+Date:   Mon May 2 10:42:07 2022 +0000
+
+    pb-2081: In kdmp case, resetting the Datasource field of pvc for restore.
+
+[33mcommit fc9a311052adbb9f0b4c003cd53113fd04725835[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Apr 27 19:02:05 2022 +0530
+
+    PWX-23581: print stork leader deatails in logs
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 4fc84928a3670580addc5286a0d9014ca53bacdc[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Apr 27 21:59:38 2022 +0530
+
+    [portworx] update delete api calls with context
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 37724f3f4b33c6a97dd7e9c71e5c4d982c03d9d7[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Apr 27 21:58:50 2022 +0530
+
+    openstorage vendor updates
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 46e4721a492f3a1a452d3debf9ed1c8927272d74[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Thu Apr 28 17:14:55 2022 +0530
+
+    PB-2365: Use pvcUID instead of name while creating dataexport CR during generic backup cleanup.
+
+[33mcommit 4a7ba30a06ef04bde1cf7fe7b1e72b8b358d2cac[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Tue Apr 26 04:48:40 2022 -0400
+
+    pb-2360: Using GetStorkPodNamespace api for cmdexecutor  image extraction as well.
+    
+            - This take care of the usecase even if stork is deployed on non kube-systen namespace
+
+[33mcommit e9c353b483189926a742b1b44a1021512522b7c1[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Tue Apr 26 01:10:22 2022 -0400
+
+    vendoring latest kdmp changes from master branch
+
+[33mcommit 74d55834aed7dc76e43572351fa3da3059e0c778[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sun Apr 24 04:50:48 2022 -0400
+
+    pb-2330: vendoring latest kdmp repo from master branch
+
+[33mcommit d535c7ad80183298d903720b4c1d36f4881b65cd[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sat Apr 23 17:48:03 2022 -0400
+
+    pb-2330: remove the portworx repo name from default defaultCmdExecutorImage to support custom repo
+
+[33mcommit 67a73e91b0b4ae888a75c379bd1f4e9951b7413b[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sat Apr 23 01:17:49 2022 -0400
+
+    pb-2330: Made fix to support image name to have custom repo as well for cmdexecutor image
+
+[33mcommit da41de4d9b056272fc0e45d64708c7435ae31493[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Thu Apr 21 13:45:57 2022 +0000
+
+    pb-2324: CSIDriver V1 version API needed for k8s 1.22 and beyond
+    
+    CSIDriver V1beta1 API support is removed from k8s1.22 verson.
+    This caused certain DS to initiliazed nil and caused crash for CSI based
+    backup. Added adequet check and called appropriate APIs of CSI driver.
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 5b345b98e8eee3aebde6e8c3050a5d726f81c93b[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Apr 15 13:18:16 2022 -0700
+
+    Explicitly pass token to generate cluster pair method
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit bb2f19719160564e8d44114cad8d4b10027dd106[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Thu Apr 21 04:56:29 2022 +0000
+
+    pb-2298: minimum retention period added to error msg of failed backup
+    
+    When a scheduled backup failed due to insufficient retention period then
+    user need to be aware of minimum retention period to be set via error
+    message.
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 192d0a46a62a52b0c1b9b71efe507bc48f57c0a9[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Wed Apr 20 17:11:56 2022 +0000
+
+    pb-2325: Set retention period for object-locked Failed backup
+    
+    The scheduled failed backup which is created for object-locked bucket
+    need to set retention period appropriately. This helps px-backup to
+    delete them when auto-delete flag enabled in px-backup.
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 4e0ceaba2bc7b0404a18203f51247a802ad4f0c7[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Wed Apr 20 04:13:05 2022 -0400
+
+    pb-2323: vendoring latest kdmp repo from master branch.
+
+[33mcommit 7f25dd83e0ff21878cc6af64d921c92256e8fd1d[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sun Apr 17 04:35:06 2022 -0400
+
+    pb-2292: vendor kdmp repo from master branch
+
+[33mcommit 22745ed2d3f0e64f91cc75b98b693ca57cead250[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Fri Apr 15 13:21:46 2022 -0400
+
+    pb-2293: add logic to extract registry that container extra directories
+    with in it for rule cmd executor.
+
+[33mcommit 3c18fd21ed95d6fac6840459b45c64bc799fadbe[m
+Author: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>
+Date:   Thu Apr 14 13:52:51 2022 +0530
+
+    Modify to use helper method from component helpers package
+    
+    Signed-off-by: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>
+
+[33mcommit 94aaa8e65871f3dd01d6098797522f61da796ab0[m
+Author: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>
+Date:   Thu Apr 14 13:52:11 2022 +0530
+
+    Fix tests due to change in GetClusterPairingInfo parameters
+    
+    Signed-off-by: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>
+
+[33mcommit b74d6b851d331c4b4c3d5694fe887bc8a41ee30b[m
+Author: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>
+Date:   Thu Apr 14 12:53:22 2022 +0530
+
+    Update vendor files
+    
+    Signed-off-by: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>
+
+[33mcommit a10cbd1a3b0eb50e9c3f5427e5f7cf9a07374439[m
+Author: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>
+Date:   Thu Apr 14 10:36:37 2022 +0530
+
+    Update go.mod to support kdmp vendoring changes
+    
+    Signed-off-by: Kesavan Thiruvenkadasamy <kthiruvenkadasamy@purestorage.com>
+
+[33mcommit 20b65fd654eb7e9292ca7b901948a8b2053a8161[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Tue Apr 12 14:48:51 2022 -0600
+
+    PWX-22676 wait for extender to be ready
+
+[33mcommit 314500a3005a8ee8049b1a41e9cd252ac72d4c72[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Mon Apr 11 17:47:33 2022 -0400
+
+    pb-2288: ebsVolume.Size is size in GiB, So converting it to bytes.
+
+[33mcommit e37c9a9167c803d8ab58516a3beb11f8711c8b9d[m
+Author: diptiranjanpx <dipti@portworx.com>
+Date:   Thu Mar 31 10:13:16 2022 +0000
+
+    [PB-2270]: Initializing cred values from backuplocation only if cluster secret is provided.
+
+[33mcommit 7cc7d37aee9ff9ab8ecf41dd738382e60246c8d4[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Thu Mar 31 16:43:53 2022 -0400
+
+    pb-2266: Adding backupType in the applicationbackup CR created by
+    schedule backups.
+    
+            - Added fix in Makefile to address the staticcheck failure.
+
+[33mcommit 239ea6d7b67b7639c79068f8081827798f219ef1[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Tue Mar 29 11:16:53 2022 +0000
+
+    pb-2267: fixed issue in object lock configmap name
+    
+    Changed the name of object lock configMap from stork-objLock-config to
+    stork-objlock-config. This is to avoid any capital letter in it.
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 856c442b010aa198927172c5b1db598d93945722[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Tue Mar 29 06:54:05 2022 +0000
+
+    Upgrade openssl libs
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 55772e1191e22bfdaf786e8df3119b7d2c06b32b[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Wed Mar 16 23:04:40 2022 +0530
+
+    [PB-2194]: backuplocation object to have crdential info associated with the cluster.
+
+[33mcommit f2a6dae7ef2862ebe1a12aa9ba50bc0baf134a31[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Sun Mar 27 20:35:09 2022 +0000
+
+    pb-2259: Fail the schedule-backup for an invalid retention period
+    
+    - Created a configMap related to object lock which can be used for altering
+      the incremental count of schedule backups.
+    - Implemented the following logic, if the retention period is altered in
+      between two scheduled backup, then backup will fail for an invalid
+      retention period
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 6f84565113d2f75bb868e6b13a250d15a2774972[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Wed Mar 23 15:43:16 2022 -0400
+
+    pb-2260: Return default objLockInfo struct instead of error for gke and azure bucket in GetObjLockInfo
+
+[33mcommit 6d25cd654c5f4e4308e885fb87b343418146fbf5[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Mar 21 19:59:50 2022 +0530
+
+    Check empty RemotepairID before deleting clusterpair
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 8b23fb4c6900f6d5a8ea7ee0974ecae1a634efa3[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Mar 16 22:42:56 2022 +0530
+
+    PWX-23244: Allow pods using FA/FB pvcs in scheduling decisions
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 4dc0126f48f84b0b06267bf2b25e6769eca26650[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sun Mar 20 13:55:22 2022 -0400
+
+    pb-2236: Added logic to force full backup for locked period backup from schedulebackup
+    
+            - Starting of every day time slot, forcing to have first backup of schedulebackup to
+              full backup always.
+            - This is to take care, if the incremental backup was overlapping between two day's
+              time slot and avoid having incremental backup as first backup in starting of day.
+
+[33mcommit 035c2a6f1f1c212e8d5b849d73fc8c7eae42aaa8[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Thu Mar 17 14:02:28 2022 -0400
+
+    pb-2241: fixed a nil pointer access in GetObjLockInfo function.
+
+[33mcommit 12a3debbfa7fdaa597e2f41959e8d6f81e854118[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Tue Mar 15 02:04:11 2022 -0600
+
+    PWX-23212 Treat StorageDown nodes as degraded instead of Online
+
+[33mcommit 0f598651a156e0cc45d0e42ea045af73d7f377ac[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Feb 16 22:36:25 2022 +0530
+
+    Upgrade torpedo scheduler calls
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit aa8760e4ab2bebe5dd4f6dd05e7731259deb42a7[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Feb 16 22:34:42 2022 +0530
+
+    Update px vendor libs
+    
+      - torpedo - master
+      - openstorage - master
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit a9c84cc30c0026ce126ce478858c2f2e2190431f[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Tue Mar 15 12:29:12 2022 +0530
+
+    PWX-23231: Ignore completed migration while checking inactive cluster domain
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 0413d4fc78d4c2a0469c6cc15cbef5b481ec3dc5[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Fri Mar 11 00:12:16 2022 +0530
+
+    PWX-23026: Check if underlying storage pair is used by another clusterpair
+    
+       Hold deletion of clusterpair if another clusterpair exists which is using
+    same storagepair
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 64e7ec07c1c7444155f40291d8634c500fd215b4[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sun Mar 13 01:41:38 2022 -0500
+
+    pb-2179: Added changes required for the supporting object lock for backupschedule deletion.
+    
+            - Adding the "object-lock-retention-period" annotation to the
+              applicationbackup CR created by applicationbackupschedule in stork
+            - This retention period annotation value will be used in the backupscync
+              logic to update the retention period of the synced backup object.
+            - Added GetObjLockInfo in stork objectstore as it needs to be called in
+              stork as well as px-backup
+
+[33mcommit 7cb7774a5b7eb3d10b2f9ad64528465a660ad222[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sat Mar 12 02:20:28 2022 -0800
+
+    PWX-23215: Set the elapsed time in MigrationSummary only when required.
+    
+    - Only if a resources or volumes are getting migrated then set their
+      respective elapsed times.
+
+[33mcommit a2172901c210d8fce60381b485b256788f72a173[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sat Mar 12 02:05:46 2022 -0800
+
+    PWX-23317: Raise an event if clusterpair not found in Migration
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit b9e921fcf993b440b61034019a86ad79b661f27b[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Thu Mar 10 00:25:33 2022 -0500
+
+    pb-2219: Add changes to use the registry name and image secret for kopia
+    executor from stork deployment spec.
+    
+            - Add GetStorkPodNamespace to get the stork pod namespace, even
+              if it is not installed in the kube-system.
+
+[33mcommit 880ec6d853bc095265ade4391e1bdcc5369f14d2[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Wed Mar 9 23:23:49 2022 -0500
+
+    pb-2219: vendor changes for latest sched-ops
+
+[33mcommit 7c320e7123d4b7540b96ac0311756666f0acc315[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Wed Mar 9 10:01:08 2022 -0500
+
+    pb-2219: vendoring latest kdmp changes
+
+[33mcommit 3dc2fcb4f165e2c03917d76099aef979219ad88d[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Fri Mar 4 16:48:21 2022 +0530
+
+    allow to run complete integration suite
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 5670d51b3f82a8c9f2de0af8a3acce2be6f41cef[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Wed Mar 2 10:28:19 2022 -0700
+
+    PD-1108 update app spec example
+
+[33mcommit 36fbc08b8080b8394cf42d6d6350a5e8bf18dd14[m[33m ([m[1;31morigin/pb-2196[m[33m)[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sun Feb 27 10:17:31 2022 -0500
+
+    pb-2172: Added fixes related to handling of rule command executor image.
+    
+            - Added CMD-EXECUTOR-IMAGE-REGISTRY and CMD-EXECUTOR-IMAGE-REGISTRY-SECRET environment variable
+              to get the custom regitry name and secret for rule command executor pod image.
+            - Added the annotation to get the image registry secret value,
+              if some one pass the custom image registry value as annotation in the rule CR.
+            - Added logic to take the image registry name and secret value
+              from the stork deployment if the both the env and rule annotation is missing.
+            - Also, add a fix to fail the backup and delete the rule command
+              executor pod, if the rule command executor pod is struck in Pending phase for more
+              than five minutes. Some times, it gets struck in pending state,
+              if there is any issue with the image registry or secret value.
+            - Minor fix in printing a err in handle function.
+
+[33mcommit 7ad5271f34accb5fd7e06c5a3232cd2d84296a0c[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Feb 21 22:35:17 2022 +0530
+
+    [integration-test] increase nodeoffline timeout to avoid race
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 5651b078a3bb7d6d76461d2d4bf5306cc6ac2839[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Feb 21 22:34:26 2022 +0530
+
+    PWX-22971: application clone failing at resource stage
+    
+      - get volume driverName by looking at pv object
+    in case of non backup/restore prepareresource calls
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 021fc3c60b10c3600d39ee2401d616e246741deb[m
+Author: Lalatendu Das <ldas@purestorage.com>
+Date:   Thu Feb 24 03:03:33 2022 +0000
+
+    pb-2178: Obtain object-lock info for S3 bucket
+    
+    Added a function to objectstore package to extract object lock info from
+    a S3 bucket.
+    
+    Signed-off-by: Lalatendu Das <ldas@purestorage.com>
+
+[33mcommit 950cc24775fd742ea5decc2952d87868103b74da[m
+Author: Andrei Kvapil <kvapss@gmail.com>
+Date:   Tue Feb 8 00:54:39 2022 +0100
+
+    Format log for linstor driver
+    
+    Signed-off-by: Andrei Kvapil <kvapss@gmail.com>
+
+[33mcommit 6479dc4086383dea472f00532ec2574db38d11f1[m
+Author: Andrei Kvapil <kvapss@gmail.com>
+Date:   Wed Feb 2 00:44:05 2022 +0100
+
+    Update golinstor module
+    
+    Signed-off-by: Andrei Kvapil <kvapss@gmail.com>
+
+[33mcommit ecb55920e63ede800b4af9492e3e7b76e7921a08[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Thu Feb 17 11:29:29 2022 +0530
+
+    pwx-22958: fix failing integration tests
+    
+      pvcResizeTest - wait for next migration schedule to trigger
+      driverNodeTest - Adjust pods reschdule time with updated health monitor timeout
+      pvcOwnershipTest - use correct storage-provisioner annotation
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit b9773cd69de90aa418a6d1666ce43ca3285ab92c[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Sun Feb 13 09:35:54 2022 -0800
+
+    Add RabbitMQ operator migration test
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit e3077b75414649fbd329988a205599bc4b48a96a[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Feb 7 18:18:03 2022 +0530
+
+    Support for activate/deactivate nested server with CR
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 97078febb7be8bf2975223af55c0f782f98d0e0b[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Feb 7 18:17:38 2022 +0530
+
+    Allow multiple disable path options for appreg
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit f6567f866498e703b4b3f77c9528c0383e1f8b6b[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon Feb 14 10:17:10 2022 -0800
+
+    STOR-479: Add separate elapsed times for Volumes and Resources.
+
+[33mcommit ecbf6806f8495a73f6e570f666996318c565dac5[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Jan 28 16:04:52 2022 -0800
+
+    STOR-479: Add MigrationSummary to Migration CR.
+    
+    Stork
+    - MigrationSummary provides a short summary on what objects got migrated as a part
+    of a migration cycle. It includes the following:
+      - total number of k8s resources expected to be migrated
+      - actual number of k8s resources successfully migrated
+      - total number of volumes expected to be migrated
+      - actual number of volumes successfully migrated
+      - total number of bytes transferred
+    - Portworx driver will report the total number of bytes transfered for each volume.
+    - The Migration summary will provide a sum of the total bytes transferred.
+    
+    Storkctl
+    - Add total bytes transferred column to get migrations output
+    - Modify UTs
+    
+    Integration Tests
+    - Validate Migration summary is updated in the TestMigrationFailoverFailback test.
+
+[33mcommit 93d78dd8cce75f056d1731d1060f160664daea56[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Feb 11 15:30:38 2022 -0800
+
+    PWX-22606: Give low scores to nodes which are in Degraded state.
+    
+    - A node if in Degraded state will return half of the score they would
+    originally return based on the node/zone/rack/region priority.
+    - If a volume has a replica on a node but the node is in Degraded state
+    stork will give it a score of rackPriority / 2. This is done since
+    a pod running on that node is not really hyperconverged and should be
+    score similar to any another node in the same rack.
+    - Added UTs for scenarios where a node needs to be scored based on
+    zone/region/node/rack but is in Degraded state.
+
+[33mcommit c96b617b194f8b39ef53c78d7d4a0d2844de84bb[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Feb 14 13:32:13 2022 +0530
+
+    Update sched-op apis update changes
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 25f03b2f96683c02ea3cd7e8e089fc21d77d7d81[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Feb 14 13:31:46 2022 +0530
+
+    Update sched-ops vendor to master
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 7565de60dc1fbd5b538520f52b7ed83fa55d49eb[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Feb 9 20:52:54 2022 +0530
+
+    Add autosuspend option to migrationschedule object
+    
+    -   auto-suspend will allow to stop migration on src cluster
+    if remote cluster has activated migrated application
+    -   fix review comments
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit b513b6b7e34cfde918dc5ae445cc0d4c38644def[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Wed Feb 2 22:33:45 2022 +0530
+
+    integration test for auto-suspend migrationschedule
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit b26bf18c95b489ae40676b4e63c2ffca8cc191f3[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Thu Nov 11 22:32:02 2021 +0530
+
+    add migrationschedule name annotation to migration objects
+    
+     - Dont scale down apps automatically on primary cluster
+     - Check and create namespace on DR cluster for migrationschedule
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit b8161121037cfa530e049bec847b05634c742310[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Feb 18 10:52:59 2021 +0530
+
+    Disable migration if dr site apps are active
+    
+    - stor340: Redo cluster-pairing automatically
+    - storkctl deactivate will also set migrationschedule appactivate field
+    - vendor update sched-ops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 1b6fbe92dbdb86af46d4f29a1913122647db586a[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Feb 11 03:16:53 2022 -0800
+
+    Torpedo vendor changes for CRD support
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 44fe3c71f1c9cd6fdd2d0e54e8921c6dccdffe5f[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Jan 25 17:00:15 2022 -0800
+
+    STOR-484: Increase the health monitor offline node timeout to ~4 minutes.
+    
+    - The health monitor in STORK currently waits only for a minute after it detects
+     storage driver node as offline. Changing this timeout to ~2 minutes. Stork will
+     continue to poll for offline nodes every 2 minutes. So the max time a pod
+     running on an offline node to get deleted will be 4 minutes.
+    - A storage driver if restarting due to an upgrade can take upto 3 minutes and
+    STORK could cause an unnecessary restart to the application pods.
+
+[33mcommit 32685418fb8895c0fdfd930f3a7b22c7bc08cac0[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Wed Feb 9 08:38:57 2022 -0700
+
+    PWX-22607 Add annotation to disable hyperconvergence prioritizing
+    
+    PWX-22609 Change webhook controller default to true
+
+[33mcommit c87fbac8704ba86c2b0b4b3a66ca72bdb1ce60b0[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Feb 9 08:17:24 2022 -0800
+
+    Replace sysbench with fio
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 27f15651b86df1fae49b7d38c255d372d36c3658[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Thu Feb 10 10:55:38 2022 +0530
+
+    Don't upload storkctl binaries to s3 bucket
+    
+      - Users can copy storkctl binary from stork pod itself
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit a91c1d9f36773830f0e5b5ec4ee4e36ece2fa633[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Feb 7 18:52:53 2022 +0530
+
+    Update PerconaXtraDBCluster suspend option to gracefully shutdown cluster
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 610beced0c6f61bb2621b63bf4172156b593c961[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Tue Feb 8 12:35:11 2022 +0530
+
+    Mark snapshot status as failed if manually deleted by user
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit be77c700bab9910edefe9f3495d65f7a99374df0[m
+Author: Ram <rsuradkar@purestorage.com>
+Date:   Mon Feb 7 23:23:00 2022 +0530
+
+    Always sync volumesnapshotschedule and volumesnapshot status
+    
+    Signed-off-by: Ram <rsuradkar@purestorage.com>
+
+[33mcommit 5911c1dfd7d2726701cd87f0cad3fda9c4ca91da[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Jan 21 11:19:53 2022 -0800
+
+    STOR-577: Portworx Driver: Do an explicit not found check in DeletePair
+    
+    - Change the error condition to do a string check on "not found".
+
+[33mcommit 58e441bdcdb6bef965754ea09e8e6c786c8594a2[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Feb 1 05:52:17 2022 -0800
+
+    Separate out migration and snapshot tests and run all tests
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit aa43b560025eddd304b7451b83b6f92edafa81b5[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Feb 1 06:56:02 2022 -0800
+
+    Migration test for mongo operator
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 765e8957c86b475590e59dfa5e1f3fed8171d2df[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Fri Jan 28 17:08:20 2022 +0530
+
+    integration test to validate pvc resize after  migration
+    
+    Signed-off-by: Ram Suradkar<rsuradkar@purestorage.com>
+
+[33mcommit cd44606a7ae9ffd35f09fd35e705849237b2f9e0[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Jan 25 17:19:33 2022 +0530
+
+    keep storage class in pvc spec for migrated pvcs
+    
+    Signed-off-by: Ram Suradkar<rsuradkar@purestorage.com>
+
+[33mcommit daf8f93a88ba71fbf05f65bc1273fff604124220[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Tue Feb 1 15:59:11 2022 -0700
+
+    PR Feedback
+
+[33mcommit 1f7daadb5770bcab336d6531216b3417c14724f9[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Fri Jan 28 09:59:31 2022 -0700
+
+    Refactor
+
+[33mcommit e2f0a0626cfa75eebc60691186bd013e0f77a74a[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Wed Jan 26 10:36:53 2022 -0700
+
+    Scramble object order
+
+[33mcommit 8fc1f3b8777a3da4f999ad42af635e2a2e757fa8[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Wed Jan 12 11:27:22 2022 -0700
+
+    STOR-573 apply updatedObjects in parallel during migration
+
+[33mcommit 0928646b2c4cc578af379e7c307cce7180a600a8[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Jan 25 17:49:39 2022 +0530
+
+    Fix CVEs reported by dependabot
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 998683f66f18eba1281ad99a9e370d5dc2f163c3[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Jan 21 03:49:54 2022 -0800
+
+    Add support for openstorage.portworx.io as jwt issuer
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 46d20f921bfed040ec1a77395b80f8dc6de4deac[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Mon Jan 17 03:02:15 2022 -0500
+
+    pb-2162: vendor changes for the kdmp master branch
+
+[33mcommit 0fb31b7231a46cfafaf3b0e274b6b2cdd2278f5b[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Mon Jan 17 00:11:35 2022 -0500
+
+    pb-2162: Added fixes for backup/restore on ocp environment.
+            - Including system:openshift:scc rolebinding in the backup
+            - Added privileged scc for job role.
+
+[33mcommit 532949ca566da7252178d1d64a157e9990cc6513[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Mon Jan 17 09:29:40 2022 +0530
+
+    Vendoring in from latest kdmp.
+
+[33mcommit af871c01650a1346f6fad5e5a709581513e6069b[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Sat Jan 15 09:36:27 2022 +0530
+
+    Addressed the review comments.
+
+[33mcommit 97b8e4a58046075759f4894ad5853e2d5fd133f0[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Wed Jan 12 12:38:25 2022 +0530
+
+    [PB-2148]: Implementing job framework to make pvc bound in case of waitforfirstconsumer case.
+
+[33mcommit 6a8c69b4c08ffc2607715a955ecbddadcbf74e08[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Jan 4 07:31:23 2022 -0800
+
+    Integration test to delete stork pods on destination during migration.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 8ac87e611313c709628b9b84581b50302874e624[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Thu Jan 13 00:46:52 2022 -0500
+
+    Skipping zone checks for EFS provisioner for  generic backup/restore paths
+
+[33mcommit a9f23af1c447c143dd2deeb09f291e3bd1cdf58f[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Wed Jan 12 14:29:27 2022 -0500
+
+    pb-2157: retaining the rolebinding subjects if the namespace is not set during restore.
+
+[33mcommit 40a08b489d40baa6c205f91af32ce3dc8932ee28[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Mon Jan 10 02:30:20 2022 -0500
+
+    pb-2113: vendor change for kdmp from master branch.
+
+[33mcommit 6f415f0c02cf5264d7f643b28eb191219a5ad7f9[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Thu Jan 6 00:40:13 2022 -0500
+
+    Multi zone support for aws/gke
+    - As part of kdmp restore, it is made sure that kdmp job pod
+      and the restore PV's are created in the same zone
+
+[33mcommit 26cf2a3f08e89f27af4aebe3d9371a2638aaf305[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sat Jan 8 05:20:32 2022 -0500
+
+    pb-2156: Added logic to default to KDMP for OCP rdb and cephfs provisioner.
+
+[33mcommit 25a9fe73f69bf48e434754984719c3ea4109973c[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Fri Jan 7 02:22:37 2022 -0500
+
+    pb-2149: vendor changes for kdmp from master branch
+
+[33mcommit a872471fa9c3e1f3975bdebee27f3449239c36d1[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon Jan 3 13:39:27 2022 -0800
+
+    Raise an event if cluster pair delete fails.
+    
+    - Do not remove the finalizer if cluster pair delete fails from the driver's perspective.
+    - Retry the operation in the next reconcile loop.
+
+[33mcommit a89660147f853ce6903276fc23603725e085cfde[m[33m ([m[1;31morigin/pb-2011[m[33m)[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Tue Jan 4 14:20:49 2022 -0500
+
+    pb-2151: Added check to make sure zone array is not empty in preparePVCResourceForApply
+
+[33mcommit 553ab59745655eef724d93394b2cdbe8c1d006c8[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Fri Dec 24 09:42:27 2021 +0530
+
+    [PB-2143]: Making pvc size same as csi snapshot size to avoid the clone failure.
+
+[33mcommit 40510a2cf18ea1350235a4c0e52c9600830fddba[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Tue Dec 28 23:01:39 2021 -0500
+
+    pb-2118: Added changes to support cross-region backup in native GKE
+    driver.
+    
+            - Update the logic take the destination zone and region in the
+              StartRestor function.
+            - Updating the PVC resource with nodeselected annotation form
+              the destination cluster based on the region/zone selected for
+              restore.
+
+[33mcommit d92c49f0fce3cf7cc767185858a3455f0b7bdfde[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Fri Dec 24 10:41:11 2021 -0500
+
+    vendor changes for kubernetes pkg
+
+[33mcommit 35c1a8a55fe67e0a260ccce178158bf618f7e234[m[33m ([m[1;31morigin/siva-zone-map[m[33m, [m[1;31morigin/siva-tz[m[33m, [m[1;31morigin/siva-reconcile-dec19[m[33m, [m[1;31morigin/siva-gke-cross-reg[m[33m, [m[1;31morigin/master_aws_cross_region[m[33m)[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Fri Dec 17 09:07:27 2021 -0500
+
+    pb-2131: vendor latest kdmp from the master branch.
+
+[33mcommit 87099e7fa665325ea1f210177a2691c3fbce3478[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Mon Dec 13 17:28:23 2021 +0530
+
+    PB-1079: Don't list the related clusterrole and clusterrolebinding of a serivce account
+             if user does not have permission for that namespace.
+
+[33mcommit bf7971a45ad320fda421caf8233af4abacf70812[m
+Author: Luke Pitstick <lpitstick@purestorage.com>
+Date:   Wed Dec 15 17:41:10 2021 -0700
+
+    STOR-516 only try to create a clusterpair if a token is provided
+
+[33mcommit 52d82cd78bbc2a53b0e4d9840153b908794f923e[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Thu Dec 16 00:18:18 2021 -0500
+
+    Passing kdmp-config map name for kdmp job delete
+
+[33mcommit 97686573a69cf4ba783f1ba5a6a876274ce7ed8e[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Thu Dec 16 00:18:59 2021 -0500
+
+    vendor update for kdmp
+
+[33mcommit b7e24a0a132d74859b615477cbe4fb37fab832ad[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Thu Dec 16 00:22:11 2021 +0530
+
+    [PB-2133]: Checking for waitforfirstConsumer if pvc's storage class has that set as volumebindingmode.
+
+[33mcommit 43d8125b338591ad7d467b4f528396425e4be80e[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Tue Dec 14 08:12:45 2021 -0500
+
+     As part of restore if a user selects few PVC's to be restored, filter the
+     non-selected PVC's from includeResource map. This is applicable for
+     the case where Retain is selected.
+
+[33mcommit fc184ff7afb8a367663ac65beb4614d91370a4e6[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon Dec 13 14:21:15 2021 -0800
+
+    Set the new storage class on the PVC during ApplicationRestore
+    
+    - If the storage class mapping is set on ApplicationRestore on the PVC's
+    source storage class is found in this mapping, then on the destination cluster where
+    the PVC is being recreated set the new storage class obtained from this mapping.
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit b928b4459c336c0b55f869a42a0a5d1841abd090[m[33m ([m[1;31morigin/pb-2126[m[33m)[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Tue Dec 14 01:15:14 2021 -0500
+
+    vendor update for kdmp
+
+[33mcommit 7fc6acdc30fa79b0fdd6e50ac80e5028722a0df9[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Mon Dec 13 06:37:57 2021 -0500
+
+    pb-2125: Added check for nil SC in getRestorePVCs
+
+[33mcommit b7e52e497c1cc39402b7cae9962c05843830c784[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sat Dec 11 11:35:09 2021 -0500
+
+    pb-2113: Setting storageclass to nil in pvc, if it is empty.
+    
+            - The default storageclass configured on the setup, will be
+              picked up, only when the storageclass is not set.
+            - Emptystring as pvc storageclass will not select
+              the default storageclass configured on the cluster.
+
+[33mcommit 3e09549170c56aa5ca4bb55ea631a1b9fd65ef98[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sat Dec 11 05:48:52 2021 -0500
+
+    pb-2113: vendor changes for kdmp from master branch.
+
+[33mcommit a8542eec3af49ed816f69080c3db05e9a71db340[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Fri Dec 10 11:38:11 2021 -0500
+
+    pb-2116: Added kubernetes.io/azure-file provison in
+    csiDriverWithoutSnapshotSupport
+    
+            - moved the check to pv.Spec.CSI secion in CreateSnapshot up,
+              immediately after getting the pv content.
+            - Added a note to mention that filestore.csi.storage.gke.io gke
+              filestore support snapshot.
+
+[33mcommit 2d6758d5b2a104066450d69bbf8f40cb0c308daf[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Fri Dec 10 11:06:59 2021 +0530
+
+    vendoring in latest kdmp.
+
+[33mcommit 4ab3a2976f98dba9a69aa313d392ea20232d35f9[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Wed Dec 8 09:03:56 2021 -0500
+
+    pb-2110: Fixed the issue in return value of IsCSIDriverWithoutSnapshotSupport api for non-csi case
+
+[33mcommit 76e500ff1027b5cb781050d5e0f87752f28ee5ec[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Tue Dec 7 13:24:43 2021 -0500
+
+    pb-2101: vendor latest from master kdmp branch.
+
+[33mcommit 455059e68e28fd8bbc76fd59b789d4855dd116c9[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sat Dec 4 12:56:45 2021 -0500
+
+    pb-2098: Added google file and azure file check to default to KDMP
+    driver.
+    
+            - Removed IsDriverWithoutSnapshotSupport and
+              isCSISnapshotClassRequired.
+            - Added a IsCSIDriverWithoutSnapshotSupport common API in volume pkg
+              and adding it in kdmp and csi driver.
+            - Also added csiDriverWithOutSnapshotKey configmap field to get user
+              input for driver that does not support snapshot.
+
+[33mcommit 253823493dfc8193627994edd4a4fd1ab1ae4ba9[m[33m ([m[1;33mtag: v2.8.1[m[33m)[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Mon Dec 6 21:14:43 2021 +0530
+
+    [PB-2104]: Using , as the delimiter for the composite string of volumesnapshot.
+
+[33mcommit 798dedbbc8fd13ff15ddaa3c18c7ef12733a3703[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Thu Dec 2 16:55:32 2021 +0530
+
+    [PB-2094]: Preventing readding of volumesnapshotname in the applicationrestore CR.
+
+[33mcommit e18d7ab585343b8f9f4d9670872e0f620dc62f42[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Fri Dec 3 07:26:25 2021 -0500
+
+    Fixing kdmp restore across Azure regions
+    - As part of the  restore, fetch the driver from the vol info instead of calling GetPVDriver()
+    - Removed volume.kubernetes.io/selected-node annotation from the PVC spec or else Azure PVC
+      always tries to get bounded to the same node which might not be present
+
+[33mcommit ed6344395196bf16ea7ec98b326b9e745d611df2[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Fri Dec 3 08:25:53 2021 -0500
+
+    pb-2101: Fixed the issue in isCSISnapshotClassRequired function such
+    that for non CSI volumes, it will directly go the kdmp backup
+    
+            - Added hostaccess scc in the backup job for ocp platform.
+
+[33mcommit b3ef06d0ac77aa2fcb27525c813faf7377a116ec[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Mon Nov 29 20:22:45 2021 +0530
+
+    Vendoring in latest kdmp changes.
+
+[33mcommit 4971dde10020b335b378ab69fe3ef5f4201d7cfb[m[33m ([m[1;31morigin/pb-2065-fix[m[33m)[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Wed Nov 24 05:14:13 2021 +0000
+
+    revert clsuterolebinding collection based on user access to SA
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit b0a612a2c0c1562db1bf6148dabd6af8d5f790ac[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Tue Nov 23 18:41:36 2021 +0000
+
+    PB-2079: collect clusterrolebinding subjects if sa is not found
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 2844ee938a69e354583d10ec73b649042dbfd424[m[33m ([m[1;31morigin/pb-2075[m[33m)[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Mon Nov 22 09:07:14 2021 -0500
+
+    vendor update from kdmp master
+
+[33mcommit 911f9b4d7a0103f24e7b296581698511aaa90778[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Sun Nov 21 14:28:31 2021 -0500
+
+    Skipping namespaces which are not part of restore ns mapping
+
+[33mcommit d5f1968e0c6ccd80472e968d3e35f904464c4ee0[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Fri Nov 19 12:59:55 2021 -0500
+
+    Adding env variable to specify market place deployment
+     - user can set env MARKET_PLACE=aws to specify the stork being deployed on
+       AWS marketplace so that appropriate kopia executor image is picked from
+       market place repository
+
+[33mcommit 996b135ce10ee46602d1d6b3ed64259c0afa7659[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Thu Nov 11 03:51:58 2021 -0800
+
+    STOR-528: CSI VolumeSnapshotClass fixes
+    
+    - If the SnapshotClassName is set as "default" or "Default"
+    let Kubernetes handle the snapshot class selection. It wil use
+    the default snapshot class set by the admin for that CSI provider.
+    
+    - Do not create stork-* volume snapshot class on startup if a snapshot
+    class for the CSI driver already exists.
+
+[33mcommit 3b570e260980728db57a736cfb38ad880c25c929[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Sat Nov 20 08:54:20 2021 -0500
+
+    vendor kmdp master changes
+
+[33mcommit 102cb76fa35c17c3814ea8397651361b9425f6b8[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Fri Nov 19 13:20:30 2021 -0500
+
+    pb-2061: removed the incorrect error handling while calling
+    runtimeclient.ObjectKeyFromObject function.
+
+[33mcommit f26546d3c2e02365ed290cf918c5b67ed7c0daae[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Sun Nov 14 23:30:03 2021 +0530
+
+    [PB-2010]: support for replace policy in generic restore.
+    Volume status to become RETAINED if replace policy is set to retain.
+
+[33mcommit 621a7a06d7f89eac70c91069c0faff2b594dbc9f[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Wed Nov 17 07:49:54 2021 -0500
+
+    pb-2036 Resetting restore PVC's PV to nil irrespective of storageclass map presence.
+
+[33mcommit c80e6a289a46f35565a93a5f3d2af31790c5ee5c[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Tue Nov 16 13:29:10 2021 -0500
+
+    vendor changes for kdmp repo from master branch
+
+[33mcommit 57ffbba72a69f1ae55c735492da092ee6d636b3a[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Wed Nov 17 17:07:22 2021 +0530
+
+    Change the pull request template
+
+[33mcommit f34c13b723e3182564f383a7f2c4585a20ed05c4[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Mon Nov 15 21:55:59 2021 +0530
+
+    [PB-2030]: pv/pvc should be included as resources in kdmp restore list.
+
+[33mcommit 99e44c8183308007b8093395b9207fcabcf9cc5f[m[33m ([m[1;31morigin/pb-2016[m[33m)[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Thu Nov 11 02:54:13 2021 -0800
+
+    STOR-556: OCP Migration improvements.
+    
+    - Do not collect DeploymentConfigs owned by operators.
+    - Do not collect openshift-service-ca.crt config map created by
+      Openshift in every namespace.
+
+[33mcommit 738d7529eb9fb0531fae14ea7973276e1f8e2f05[m[33m ([m[1;31morigin/pb-2023[m[33m)[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Sun Nov 14 15:56:02 2021 -0500
+
+    pb-2020: Added check in assigning SnapshotStorageClass in dataexport CR
+    
+            - Assigng the SnapshotStorageClass in DE CR only when
+              LocalSnapshotRestore is true, in which case, we will try the
+              local snapshot restore.
+
+[33mcommit 6421f416e268a3e57c6eaed86a304f644deb2666[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Sat Nov 13 23:49:36 2021 +0530
+
+    Vendoring in latest kdmp changes.
+
+[33mcommit e02f28e240e975461486adac2fa2e982db5152ef[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Sat Nov 6 00:07:47 2021 +0530
+
+    [STOR-513]: support for local restore for csi volumes.
+
+[33mcommit dd2092c53a724c1253220130ff37a97949549cd8[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Fri Nov 12 16:47:05 2021 -0500
+
+    pb-2015: remove the storage-class and storage-provisioner annotation
+    from pvc while restore it.
+    
+            - Even though we updated the spec.storageclass of the pvc to the
+              new storage class from the storage class, while restoring
+              ,it was not getting bound. The k8s was referring to the old
+              storage class from the annotation and pvc was struck in
+              pending state.
+
+[33mcommit 9718d1ff9852f17595374d77b74296cbb3ae6118[m
+Author: sivakumar subramani <ssubramani@purestorage.com>
+Date:   Fri Nov 12 21:24:17 2021 -0500
+
+    pb-2003: added ordered way of classifying the driver in GetPVDriver api
+    
+            GetPVDriver is used in the resource restore path and we try to
+            avoid CSI pvc applied again. Since ordered list is not used in
+            this function, some it ended up in kdmp driver and ended in
+            partial success.
+
+[33mcommit 347ffbf96bb9d52708bc6a37afdaaaf8bc1198ab[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Thu Nov 11 23:07:41 2021 +0530
+
+    Fixing volumesnapshot name and handling already exists for volumesnapshot and content.
+
+[33mcommit 0775ca36730abf3a638a2e493fa00c917e817962[m[33m ([m[1;31morigin/pb-2009[m[33m)[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Wed Nov 10 11:11:27 2021 +0530
+
+    Putting the volumesnapshot class and backupUID in volume info as these are required in restore.
+
+[33mcommit 3b1295efc88bfd9abffd4ea800af36f7a253e732[m[33m ([m[1;31morigin/stor-514[m[33m)[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Mon Nov 8 18:06:12 2021 +0530
+
+    vendoring in latest kdmp changes.
+
+[33mcommit c7d81c69e91f69634a531dfc431c86acf4edaacb[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Sat Nov 6 07:30:43 2021 -0400
+
+    stor-547: Fixing crash when taking a backup of CSI and PXD vols
+    - If backupType is Generic in kdmp-config, use this for all drivers
+      except pxd to take generic backup
+
+[33mcommit 496fcd87ccdd3dc9b6bef491c1c476b0d9093d09[m[33m ([m[1;31morigin/stor-2003[m[33m)[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Wed Nov 3 19:20:26 2021 +0530
+
+    [STOR-551]: pvc creation for kdmp restore should happen in kdmp controller.
+
+[33mcommit f865cb5dc48b400fd6b15d4a506ff1d0d261944f[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Fri Nov 5 05:24:20 2021 -0400
+
+    vendor kdmp chnages from master branch
+
+[33mcommit f496102140c3ee3172bdd769d1efa8f4e8e1a3a5[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Thu Nov 4 23:20:44 2021 -0400
+
+    vendor changes for openstorage repo from release-9.1 branch.
+
+[33mcommit 34afda6d8f143e7aafbac71fc175ddd8a7591b32[m[33m ([m[1;31morigin/stor-545-vendor-issue[m[33m)[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Tue Nov 2 05:23:36 2021 -0400
+
+    pb-1997: Added check not to intialize the snapshot class in the DE, if
+    CSI does not support snapshot or cases where we want to skip CSI and
+    take generic backup (proxy-volume)
+
+[33mcommit 88ec148875262be67266d259a228dff0bebc7023[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Fri Oct 29 06:10:58 2021 -0400
+
+    stor-514: Added checks such that pure FB and vsphere PVC will be
+    defaulted to kdmp driver for snapshot.
+
+[33mcommit 088d8fdeaa377052ced2b24b40c7de60009c9040[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Wed Nov 3 01:42:31 2021 -0400
+
+    vendor changes of kdmp from master branch
+
+[33mcommit c5afc04d779bdd4316f13c759de19809c27c1d49[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Mon Nov 1 07:39:57 2021 -0400
+
+    pb-1988: Added alreadyExists check for creation of volumeSnapshot and
+    PVC creation
+    
+            - While deleting the snapshot CRs, setting the proper retain
+              value. For latest snapshot, retain will be set true, so that local
+              snapshot will be retained. For other snapshots, it will be set
+              false, so that both the CR and local snapshot files are also
+              will be deleted
+
+[33mcommit 3eba3cbbe1ebd31a077be0787c977552c2f29203[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Tue Nov 2 13:59:23 2021 -0400
+
+    stor-545: Added provisioner and volumesnapshot fields in applicationbackup CR.
+
+[33mcommit de495f217e7c9a7b646ac8cc385e7bdd926548f6[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Tue Nov 2 13:57:50 2021 -0400
+
+    stor:545 vendor for kdmp from master branch
+
+[33mcommit ffa64d33f81da4e239a05a59dbb33f58b95377cf[m[33m ([m[1;31morigin/pb-1988[m[33m)[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Thu Oct 28 07:02:09 2021 -0400
+
+    vendor latest kdmp from master branch
+
+[33mcommit 6b1ee47a38b7a0f79b3204e0dfa3a6826f7fc814[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Tue Oct 26 14:07:45 2021 -0400
+
+    Changed "generic type string to "Generic"
+
+[33mcommit 477a879b25d5220680b8bce278ca617cfd1bd188[m[33m ([m[1;31morigin/pb-1982-fix[m[33m, [m[1;31morigin/pb-1982-1[m[33m)[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Mon Oct 25 16:49:17 2021 +0530
+
+    Vendoring latest kdmp changes.
+
+[33mcommit 964e1d8300eb989d9b0045b1b2407cb5313550e7[m
+Author: diptianjan <dipti@portworx.com>
+Date:   Mon Oct 4 20:03:04 2021 +0530
+
+    [STOR-481]: Uploading CRs in csi generic backup.
+    Made the required changes as part of snapshotter package.
+
+[33mcommit 6883a2cd0a78dbdae38110a91a7e562593ed2011[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Sat Oct 23 01:12:02 2021 -0400
+
+    pb-1981: Adding kdmp CRs to skip during applicationregistration.
+
+[33mcommit 76dec1e5d808b0537e5e7fe39971128a9574a79b[m[33m ([m[1;31morigin/pb-1982[m[33m)[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Fri Oct 22 14:25:18 2021 +0530
+
+    STOR-537: Reverse Migration is failing for PX pv objects
+    
+     - improve volume bound time
+     - skip pv update if respective pvcs are skipped
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit c9b0d02b75a97e9f92d968e0c9bd0e8c03d6cc51[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Fri Oct 22 03:55:19 2021 -0400
+
+    pb-1978: Adding deletionTimestamp check before calling delete for dataexport CR.
+
+[33mcommit ec2e7d3eddf9b9879fa8c07509819030bddb02a9[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Thu Oct 21 07:31:49 2021 -0400
+
+    Reading backup type from config map
+    - User can set all backups to be generic by adding BACKUP_TYPE=generic in kdmp-config map
+    - This way all backups would be forced to be generic
+
+[33mcommit 89fefe24385bf17e853cf76cd075b01b587b99d2[m[33m ([m[1;31morigin/pb-1966[m[33m)[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Thu Oct 21 14:21:32 2021 -0700
+
+    Remove wget from Dockerfile and use curl instead
+    
+    - Reduces the vulnerabilities reported by DTR
+      from:
+    
+    15 critical
+    58 major
+    25 minor
+    
+      to:
+    
+    7 critical
+    27 major
+    22 minor
+
+[33mcommit a5fefcb5309db5da8558b465b40ef006b233a7e2[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Thu Oct 7 15:40:26 2021 -0700
+
+    Modified the decision making process for choosing a driver for a PVC.
+    
+    - Create an ordered list of drivers defined in STORK. For every PVC
+      stork will check these drivers can handle this PVC. If all the drivers
+      fail the last one in the list - KDMP will pick it up.
+    - The goal is KDMP should handle all kinds of PVCs for all the different
+      workflows that stork supports.
+    - This also means that for currently non-supported APIs by KDMP driver
+      the respective operation will fail if none of the other drivers support that PVC.
+
+[33mcommit da58d384827f250ee6c5fca50e52833253d236ae[m[33m ([m[1;31morigin/pb-1975[m[33m)[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Tue Oct 19 07:49:01 2021 -0400
+
+    stor-529: Calling cleanupResources as part of finalizer handlers in applicationbackup controller code
+
+[33mcommit 4504d85f717aeedaa895741c517517d2445ca643[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Wed Oct 20 00:30:27 2021 -0400
+
+    vendor update for kdmp
+
+[33mcommit 79a787fa7fac963177a7cf7c00b96a6fb19b7f2a[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Mon Oct 18 23:30:41 2021 +0530
+
+    Remove stork-scheduler version update from integration test script
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 09f413387529b9395bbc12eed41715610a2f2272[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Thu Oct 14 19:24:32 2021 +0530
+
+    update migration status for each pv
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit b34b23c22405e93bb9b8bbd3d34727c3a5db6c9f[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Thu Oct 14 14:22:18 2021 +0530
+
+    STOR-530: Unable to take backup on GKE 1.21 cluster
+    
+      fix deprecated zone label for pv
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit c73c5b896fece5123977158b54a9b0bf0133205f[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Mon Oct 18 09:59:32 2021 -0400
+
+    vendor update for kdmp
+
+[33mcommit 8dfb41df7cd9df0b30a558b6feeb4cba821e56f1[m[33m ([m[1;31morigin/pb-1962[m[33m)[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Tue Oct 12 15:41:54 2021 -0400
+
+    vendor changes for kdmp from master branch
+
+[33mcommit 55ebe4dca9bce5543d636e459315cfe9d8c5c220[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Mon Oct 11 14:23:55 2021 -0400
+
+    pb-1802: Added steps to create the kdmp-config cm with default values.
+    
+            - Initially creating the kdmp-config config map with the default
+              values need for kdmp job rate limit values and container
+              resource limit values as well.
+            - Also added check to include Final stage in the failure check
+              of kdmp driver.
+
+[33mcommit 5f7672036ecea70c0f0c18236f846a6b68dda51b[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Oct 12 13:01:44 2021 -0700
+
+    STOR-526: Use python 3.9.2 in stork image.
+    
+    - Python 3.x until 3.9.1 have a security vulnerability - CVE-2021-3177
+    - Updated the python version in the container to 3.9.2
+
+[33mcommit dfae08b0e45a434756f2e90f52a7f741b7634b4a[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Oct 12 10:49:24 2021 -0700
+
+    STOR-527: Add nil check in GetPodVolumes portworx implementation.
+    
+    - A PVC object can be empty if the PersistentVolume is directly
+    provided in the pod spec.
+
+[33mcommit 2d69baba429571c28e4ce6a3fca6d51889726e27[m[33m ([m[1;31morigin/pb-1802-1[m[33m)[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Fri Oct 8 16:04:28 2021 -0400
+
+    stor-522 Fetch backup and restore size or data mover
+
+[33mcommit 943077c0288ba0aa44d6d933d43c97546c03fc34[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sun Oct 10 08:44:05 2021 -0700
+
+    STOR-398-v2: Add plural forms as short names for VolumeSnapshots and VolumeSnapshotDatas
+
+[33mcommit 09ff758c99ddf882f6877e6f80dbfac163a29dbe[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Oct 1 14:47:47 2021 -0700
+
+    vendor update from libopenstorage/openstorage
+
+[33mcommit 53e732e0cbc709cd06383824144fb35f09cb08aa[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Thu Sep 30 17:31:36 2021 -0700
+
+    Portworx: Parse the storage class mapping while restoring a volume.
+    
+    This change allows backing up a Portworx volume of a particular storage class
+    and properties, and restore that volume with a different storage class.
+    For ex. Backup a volume with HALevel=2 and restore it with HALevel=1
+    
+    - Parse the storage class mapping from restore spec and find if a mapping
+      for the current PVC's storage class is found.
+    - If found, fetch the actual contents of storage class and parse them into
+      a RestoreVolumeSpec.
+    - Invoke the CloudBackupRestore API with this RestoreVolumeSpec.
+
+[33mcommit ae7f793dcb5ced8f6c784fecf05271b8877d1a8a[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Oct 5 16:15:06 2021 +0530
+
+    ptx-1404: nit msg for storkctl activate migration on crds
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 32732ed798324413c228de8c2c88ac28a8bb4fcd[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Oct 5 16:14:43 2021 +0530
+
+    stor-520: handle nil entry for ns labels while restore
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 21f38b24e9b2391ec8bb19c52789dd31b1cc9801[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Wed Oct 6 22:14:40 2021 -0400
+
+    vendor update for kdmp - fixed job  pending issue
+
+[33mcommit 28160efc05cbcfbd6d97550ec14193a6886571f0[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Oct 5 15:53:56 2021 +0530
+
+    stor-509: Update pvc uid mapping while migrating pv objects
+    
+       CSI PVC does not go into bound state on DR cluster if pv claimref has
+    invalid pvc uid
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 95179147a087d3ce386e4fbd224de1df998d8c59[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Wed Oct 6 01:15:09 2021 -0400
+
+    vendor update for kdmp
+
+[33mcommit c670be7925d2c605a199c849695d86fae48cc77b[m[33m ([m[1;31morigin/pb-1856[m[33m)[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon Oct 4 14:26:18 2021 -0700
+
+    KDMP: Before starting a restore check if destination PVC is in Bound state.
+    
+    - Check for both pvc.Spec.VolumeName is not empty and the PVC status is in Bound state.
+
+[33mcommit bcf7e2bfd81f36fc9c8abdb403fe6c27bef1093a[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon Oct 4 09:25:16 2021 -0700
+
+    Portworx: Check for auth params in in-tree storage class definition as well.
+
+[33mcommit f7b00bd26bb32c6ede8b707b74e9499eebbe4a04[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Mon Oct 4 10:06:15 2021 -0400
+
+    pb-1941: remove the fix of changing the status to Inprogress for call cleanupResources.
+
+[33mcommit a59d39773a96e6a40f544f5db73d3be6f95be887[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Mon Oct 4 09:26:54 2021 -0400
+
+    vendor changes for kdmp repo master
+
+[33mcommit 264b68e6821ea71cb8ecb31a1e5491c07b56d51c[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Sat Oct 2 11:24:13 2021 -0400
+
+    pb-1941,pb-1944: modified the generic backup resource name to be match
+    new naming format as given below
+    
+            - name format <backup>-<shortUID of backup CR>-<shortID of
+              PVC>-<NS>
+            - Calling cleanup function in Final case is creating issue as
+              px-backup will delete the CR as soon the stork updates the CR
+              status to success or failure and stage as Final. Because of that
+              application backup CR is getting deleted before dataexport CR.
+            - Now calling cleanup before moving the status of final stage
+              and success.
+
+[33mcommit 7e90929602d8adf5b26bb6e09a1f1510134f0045[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Fri Oct 1 16:13:50 2021 -0400
+
+    vendor changes for kdmp repo.
+
+[33mcommit 2c7dd9dff943380dbf39e3ce990de513e711caa1[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Thu Sep 30 13:33:24 2021 -0400
+
+    pb-1941: added pvc UID to be part of volumeInfo in ApplicationBackup and ApplicationRestore CR definition
+
+[33mcommit 5251ee38dcae0eeddf25d9293cb4378f76435749[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sat Sep 25 08:25:19 2021 -0700
+
+    vendor updates from kdmp
+
+[33mcommit 67dbf03ec05d2c43aedff60f173cdf1a0b17daf6[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Sep 24 09:34:24 2021 -0700
+
+    Add support for handling snapshots in KDMP driver.
+    
+    - Pass the snapshot storage class in the DataExport CR when provided
+      in the ApplicationBackup CR.
+
+[33mcommit f67574376f8814491755a77fb48ea0ab10dbd223[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon Sep 27 17:04:00 2021 -0700
+
+    STOR-398: Add short names for VolumeSnapshot and VolumeSnapshotData CRs.
+    
+    - vendor update from libopenstorage/external-storage
+
+[33mcommit 7803c7adc1c39c1e4434b2500a945c9cce816cea[m[33m ([m[1;31morigin/pb-1916-1[m[33m)[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Wed Sep 29 10:55:24 2021 +0530
+
+    [kdmp] remove postfix special chars while labelling crs
+    
+       - address review comments
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit fca8c6636db9db23345c1148fcdb24638c914e64[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Sep 28 20:52:32 2021 +0530
+
+    Fix issue of multi-ns backup and restore for kdmp driver
+    
+      stor-512: restore completed as partialsuccess for generic backup
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 41bbb1103ccaf60ddc249f91c6ce6cee9f35dc2b[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Sep 28 12:57:37 2021 +0530
+
+    Add CleanupResource api for backup/restore
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit e59eac2d59151994889f5d1ce9cb6442035fcbd4[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Mon Sep 27 10:56:24 2021 +0530
+
+    Cleanup DataExport CR after backup/restore
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 4ae2c86c8db63740114b972862dac0fc7fa2f653[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Tue Sep 28 03:16:13 2021 -0400
+
+    vendor update for kdmp for ssl enable/disable
+
+[33mcommit 326cd5363a2a2da9bf83c36de0527849e15b3fb4[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Tue Sep 28 01:58:06 2021 -0400
+
+    stor-510: Not classifying proxy-volume as pxd, even if protworx provisioner annotation is set
+
+[33mcommit 8aba1590582a3f9695602e7b67eacb4a333bea2b[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Fri Sep 24 22:51:25 2021 +0530
+
+    Vendor updates sched-ops
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit df8c2cf49691750255fd2528b613dd143df1d5d6[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Fri Sep 24 22:50:58 2021 +0530
+
+    Update webhook configuration for v1.22+ k8s
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 5649d7905f279dbb6de84f3d4c874abe62cbaec8[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Mon Sep 27 13:11:03 2021 -0400
+
+    stor-506: Added worked around to delete the dataexport CR at the end, when all the snapshots are completed.
+
+[33mcommit 004803657a35ef8784279b7a60be061e9aff11c1[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Sat Sep 25 17:09:57 2021 -0400
+
+    pb-1908: truncating the CR name and pvc names BY 63 char, while adding it as label in the dataExport CR
+
+[33mcommit 81341fbebede49e2c87ab114a2eba1df81a1267a[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Sat Sep 25 16:33:58 2021 -0400
+
+    vendor changes for truncate pkg
+
+[33mcommit 68d023ca0411fcf1430dfed3cd6c568d3f57fd0c[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Fri Sep 24 14:14:26 2021 -0400
+
+    pb-1908: Added backup and restore CR name and pvc name in the dataexport
+    CR.
+
+[33mcommit 11a01171d12169d7c4b9473fe9c2a70c3fcb91d1[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Mon Sep 20 13:44:40 2021 -0400
+
+    Handling kdmp in-progress job cancellation and deletion based on RetentionPolicy
+
+[33mcommit ba2e13b85471aa80b965d70d774cbb93a6dd1007[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Sun Sep 19 21:47:36 2021 -0400
+
+    vendor udpate for kdmp
+
+[33mcommit 97089f8df6351ee79232d83580492f7c11b28572[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Sep 7 17:26:42 2021 -0700
+
+    Add a Snapshotter interface.
+    
+    - The snapshotter interface provides APIs for snapshots and restores.
+    - Extracted out the snapshotting functionality from the CSI driver and added it
+      to the snapshotter interface
+    
+    The goal is to separate out the snapshot functionality from the actual drivers so
+    that different components in stork can use it.
+
+[33mcommit 3d3c55483ac9eac974fd51d53cec64911c0b6682[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Sep 21 17:48:16 2021 -0700
+
+    STOR-425: Do not silently fail cluster domain update commands for invalid domain.
+    
+    - Check if the input domain is part of the existing cluster domains. If it is not
+      fail the activate/deactivate command.
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit 324b5fbca9199057acf1ac88e6b5647b1f1ed12d[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Sep 21 16:45:59 2021 -0700
+
+    STOR-483: Skip filtering for volumes which do not have DataNodes populated.
+    
+    - Certain storage providers like Portworx proxy volumes or Portworx direct access volumes
+      do not have the volumeInfo.DataNodes populated. Do not filter out the request for
+      such volumes.
+
+[33mcommit d6c398ec818b224cf2872be82cf684c0ec94ff25[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon Sep 13 15:58:05 2021 -0700
+
+    [Portworx Driver] Add support for PX-Security enabled clusters.
+    
+    - Add support for backing and restoring PVCs which are provisioned
+      on a PX-Security enabled cluster.
+    
+    Backup:
+      - CSI Volumes: Use the token secret name/namespace specified
+        as a part of NodePublish secrets
+      - In-tree Volumes: Use the token secret name/namespace provided as annotations
+      - Save the secret name and namespaces as a part of backup.VolumeInfo.Options
+        so that they can be used while restoring.
+      - If a templatized namespace is provided, then store ${pvc.namespace} as a part
+        of backup.VolumeInfo.Options so that on restore the token secret in the namespace where
+        restore is being done is used.
+    
+    Restore:
+      - Use the token secret name and namespace provided as a part of backup options.
+      - If a templatized namespace is found use the secret in the namespace where the
+        PVC is being restored.
+
+[33mcommit 416cc7f6bb67e6dfbc7d798e2e6edc150dd22db0[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Mon Sep 20 17:03:24 2021 +0530
+
+    STOR-444: Update FinishTimestamp for failed applicationbackup
+    
+      stor-448: update labels & annot of namespace based on replace policy
+      stor-443: update activate/deactivate message for crds
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 2f877c0c4f539d892e0ad6809ba38a0d4c0a5f79[m[33m ([m[1;31morigin/master-siva-kdmp[m[33m)[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Wed Sep 22 16:29:08 2021 +0530
+
+    csidriverfix: handle completed backups
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit be7a00a6e6a32853c2d20e581ffb41f46deed480[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Sep 21 17:58:55 2021 -0700
+
+    Add auth annotations to migrations triggered by migrationschedules
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 46d39c7ba17439ac098c8c2140e74c89ffb1f90f[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Sep 21 18:04:13 2021 -0700
+
+    STOR-499: ApplicationRestores fail if there is a mix of CSI PVCs and other storage providers.
+    
+    - Skip the volumes which are not CSI PVCs in CSI driver restore path.
+
+[33mcommit 95b5446437ef4264a4c4761961b4263eac1d1d6a[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Sep 17 12:44:30 2021 -0700
+
+    STOR-459: CSI: Skip restore of PVCs if driver is not CSI
+
+[33mcommit 238047cfa43fc2bbb9523daa14c9b3acc86ed834[m[33m ([m[1;31morigin/master-temp-siva[m[33m)[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Wed Sep 15 22:54:48 2021 +0530
+
+    vendor updates- kdmp
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 0bba70b9c361c9c0537e391489b9bf761084d8bc[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Wed Sep 15 22:55:23 2021 +0530
+
+    stor-455: Generic restore support
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 40e5288a9f38f5433a86789e577c310b0c8eb91c[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Thu Sep 16 19:32:23 2021 +0530
+
+    stor-485: add completed backup volume to backup list
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 15fea41a173d59d1a0046288e2f910a1ada74471[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Wed Sep 8 19:25:29 2021 +0530
+
+    Set KDMP custom images to latest tag
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 57f38c06d0be33c6eddc6db6668362d4aa916537[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Wed Sep 8 11:16:01 2021 +0530
+
+    vendor updates
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit b3519171190bae929abc05cbacab8c46e3a3ce22[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Sep 7 23:43:44 2021 +0530
+
+    start kdmp controller from stork
+    
+      - implemented GetBackupStatus() for kdmp
+      - implemented DeleteBackup() for kdmp
+      - support generic backup type
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit f3d706348018e98171982e167d09f250a2893280[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Sep 7 23:41:22 2021 +0530
+
+    vendor update schedops,kdmp
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 2eb4df7710e38e4539a80b3e63a0850b69ecf611[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Mon Sep 6 22:06:14 2021 +0530
+
+    stor-462: detect pvcs to be collected for kdmp driver
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 1cc475a3d99eb80bd33cc6241b7dca60ccd534b8[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Mon Sep 6 22:05:19 2021 +0530
+
+    stor-463: vendor updates KDMP
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 62cec2a70e06d26382aa36378bf39525cb98fc68[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Wed Sep 8 15:41:43 2021 +0530
+
+    allow list of crd via v1beta1 apis
+    
+       - stork tries to list crds via v1 apis which is not supported
+    for older k8s versions
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 5a1f8a4142bf301efe146d065684e72c6f07a019[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Sep 2 10:50:12 2021 -0700
+
+    Add new parameter for kube-scheduler version
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit a33dbd5084a7288e991946006c7c3082df2ba8c4[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Thu Sep 2 10:11:18 2021 -0400
+
+    stor:468 Changed the field name GenericBackupRepoKey to RepositoryPassword in backuplocation CR
+
+[33mcommit e3ed875d73038e495dc45c2de1882bfbf8b9f068[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Wed Sep 1 04:32:47 2021 -0400
+
+    stor-467: Added genericBackupRepoKey field in backuplocation CR for
+    storing generic backup repo password.
+
+[33mcommit c2b5a3de3b0e25bb393079323d9aef0f92e00f05[m[33m ([m[1;33mtag: v1.4.0[m[33m)[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Aug 26 15:11:21 2021 -0700
+
+    Make version check optional in integration tests
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit dbf03a3e170f6888124d71d9c43bbc984ec0527d[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Aug 25 11:42:59 2021 -0700
+
+    New test for volume snapshot restore with vdbench data
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 4ffc964e861ca7c1fba432d2e65e8d48ad448813[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Mon Aug 23 23:56:48 2021 +0530
+
+    PB-1363: Unable to take csi + px volume backups
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 2a2a656c01729580f2a0666072898d750c103189[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Aug 24 22:30:37 2021 -0700
+
+    Added migration failover and failback tests.
+    
+    - The existing migration tests setup one way cluster pairs between two clusters
+      however the migrations also happen only in one direction. Once the migration
+      is complete the resources are deleted and a reverse migration is triggered.
+    - This does not execute the scenario of failover and failback of the same
+      application and volume between the two clusters.
+    - Currently the test is only added for  portworx driver. Using portworx encryted volumes with mysql statefulsets.
+
+[33mcommit 044b271694cafee5501da227a19bb4457f6e354b[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Wed Aug 25 11:03:39 2021 +0530
+
+    check destination svc annoatation before assigning keys
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 24078363cc2475142226d76c989f91ae6ff41e9c[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Mon Aug 23 23:20:11 2021 +0530
+
+    Correct applicationbackup schema spec for BackupType
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit fa823b8b7139e0aff62c4675ab9fe5e1c1f2176b[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Mon Aug 16 20:18:56 2021 +0530
+
+    vendor updates
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit f5abbcfc2627d89615649df9e427d0a45cb4a440[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Mon Aug 16 20:18:36 2021 +0530
+
+    support v1 crd based on k8s version
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit 670dcdf1439f167e0e61922dccb3d5b8e9139b8f[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Wed Jul 28 14:38:18 2021 -0700
+
+    Fix the ClusterRoleBinding in prometheus specs.
+
+[33mcommit 4da3fdd765809e43ba29f2d39821aa46f97e6fbb[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Thu Aug 19 04:08:35 2021 -0400
+
+    stor-458: Added following changes in stork CRD for data mover feature.
+    
+      - Added backupType in ApplicationBackup and ApplicationBackupSchedule
+        CR definitions.
+      - Added storageClass in ApplicationBackupVolumeInfo definition.
+
+[33mcommit 748124ffafcbcbb67b87cae27cf0f3c8bb311e43[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon Aug 16 14:08:49 2021 -0700
+
+    Do not force delete pods in VolumeSnapshotRestore.
+    
+    - Force deleting the pods immediately deletes the pod objects from k8s etcd,
+    which gives a false indication to stork that the pods have been deleted. The
+    subsequent restore call fails since the underlying PVC is not yet detached by k8s.
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit e0416ca19d6f2e05f050389cc643378e67468eb0[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Tue Aug 10 17:14:44 2021 +0000
+
+    move skipservicemodify check
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 7511262ac7ed7a5ffc7372c8659f9be71ab698fc[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Tue Aug 10 14:55:01 2021 +0000
+
+    [portworx] wait for driver to come online in case of in-place restore
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 6c1007168818a47db2f2a6ccd9ff9fbc1a2542f0[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Aug 3 16:41:59 2021 +0530
+
+    vendor update hashstructure
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit b6ceadd67b1200f75dbb16c87d3bf7031c0953df[m
+Author: Ram <rsuradakar@purestorage.com>
+Date:   Tue Aug 3 16:31:05 2021 +0530
+
+    [migration] only update svc if source svc has been changed
+    
+    Signed-off-by: Ram <rsuradakar@purestorage.com>
+
+[33mcommit f7458002924ff2ddd455d6f536459a30d142ffa8[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 29 18:58:47 2021 +0530
+
+    handle nil check for networkpolicy ipblock
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit b3358f1952fc1c3e5719ae66fd8f32cb65c4da51[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Jul 23 23:50:06 2021 -0700
+
+    STOR-441: Migrations are deleting the backing PX volume.
+    
+    With the recent changes for updating the PVC size as a part of Migrations we are now doing the following
+    
+    - Update the reclaim policy on the PV to Retain
+    
+    - Delete the PVC
+    
+    - Recreate the PVC and PV
+    
+    However due to a bug the Retain policy was not set and the volume was getting deleted.
+
+[33mcommit 2bdef2f941a58f96e29f6844c2ffbd699f2f41e0[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 22 22:58:43 2021 +0530
+
+    Fix integration tests intervalScheduleCleanupTest
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit f3707a86a1257bdc09f67ea08b6ecf25e2458260[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 21 23:14:19 2021 +0530
+
+    stor-415: remove svc ports while cloning services
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 3e15faa6803788dbe45894c16c801b3ae17a6974[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Jul 20 18:30:09 2021 +0530
+
+    stor-435: Migration failing, pvc already exists
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit d15d8f63d2e0a68ece8df1a9e7d2ddcf39e62156[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Wed Jul 21 14:28:10 2021 +0000
+
+    stor-439: Backup respenctive pv object for pvc resourcetypes
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 470afc7e3bf8bd698ea002c99bb4fa22e76d2b63[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Wed Jul 21 11:12:40 2021 -0400
+
+    Added extra check such we skip volume backup only ResourcType is not empty and does not contain PVC in it
+
+[33mcommit 708689004a4503ca602e5f596be2c58545f853b4[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Jul 16 23:44:32 2021 +0530
+
+    Omit checking sha for stork version checks
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 5a50585661c03ff438c56eed7b2db6c9e2179585[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 14 18:37:02 2021 +0530
+
+    stor-432: storkctl does not activate/deactivate mongodb CR's
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit fd83b8a6e053f2bbee101dfc7495a76d34224544[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 14 18:36:47 2021 +0530
+
+    use pluralizer rules to collect CRD
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 0922aafd843f0e8befbaa0257728e1eb67f4507e[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Sun Jul 11 06:46:23 2021 +0000
+
+    Removed incorrect return statement in the backupVolumes function
+
+[33mcommit d828f3b24c082ce3721d63a54abed3e2cfba393c[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Jul 9 11:02:13 2021 -0700
+
+    Add a nil check in volume snapshot schedule metrics reporting.
+
+[33mcommit adcbc5df0dea78b0621b1a9535910dfe3e836327[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Thu Jul 8 17:10:55 2021 -0700
+
+    STOR-393: Add a SAN to the webhook certificate created by stork.
+    
+    - Delete the old k8s secret which had the invalid cert and create a new one
+      on startup.
+
+[33mcommit 590fd09760ecbc3db988fffe86ba6d081539b055[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 8 18:44:21 2021 +0530
+
+    Update service account resource instead of delete/create
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit cfacfbf7ddcc8898aa426455d8cee68ff935e742[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 7 17:19:10 2021 +0530
+
+    integration-test to verify stork version
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit d044b4f0ca6a489280da3eebabc18524c542b4bf[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 7 17:12:16 2021 +0530
+
+    stor-423: add mongodb cr backup/migration support
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit b965cf79065ec2d4aa20c4ebc46aee55a144132a[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Wed Jul 7 11:00:13 2021 -0700
+
+    Fix the issues caused by git merge conflicts.
+
+[33mcommit cfc0a9c0dcd6a9dccea0f8593d8ad0c621211350[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Jun 25 08:39:04 2021 -0700
+
+    Handle exponential backoffs for ApplicationRestores.
+
+[33mcommit f50b1ef595dc556833a41a8982aa7278bde2236a[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Thu Jun 10 07:45:16 2021 -0700
+
+    Do not fail migration/backups when the storage provider returns ErrStorageProviderBusy
+    
+    - Handle AWS and Portworx providers.
+    - If the storage provider returns a known "BUSY" error the driver wraps it
+      and returns to the controller.
+    - If the controller sees this error, instead of marking the backup as failed it will retry
+      in the next reconcile loop.
+
+[33mcommit cc11e976bc0d0b43e969d08bb380a714c197bb7c[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Thu Jun 3 16:22:16 2021 -0700
+
+    Update openstorage vendor to release-9.1
+
+[33mcommit f9d222a92ec86869ef5e31240ff0ba5f56fe0927[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 1 18:28:23 2021 +0530
+
+    stor-419: store stork version in configmap
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit e3fd22331e6d980232ec7afeaf4502507a702e7f[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 1 16:21:43 2021 +0530
+
+    PB-1679: cluster-scope resource collection
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit dcac8089359ae81fc40c4e9293454f4b4b5e777b[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed May 26 01:25:54 2021 -0700
+
+    Integration test for creating reverse clusterpair using storkctl
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 3e2efa5ce47c5b7fd8817b3643cbeb3a989a2606[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Jun 25 18:37:53 2021 +0530
+
+    Allow setting k8s client api rate limiter
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 72271f246855c2421e84a75d8fdb3782cc2f3691[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Fri Jun 25 04:45:36 2021 -0400
+
+    Backing up selected resource and all resoucres of given namespace
+    - User can choose to backup all resources in one namespace and selected resources
+      in another namespace.
+    
+    Signed-off-by: Prashanth Kumar <prkumar@purestorage.com>
+
+[33mcommit d983afae5f3ddb731193b6648e156ce766ba94d1[m[33m ([m[1;31morigin/master_stor-409[m[33m)[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Thu May 27 08:44:29 2021 -0400
+
+    Reading rule CR from kube-system ns when multiple ns are selected for backup
+    
+    Signed-off-by: Prashanth Kumar <prkumar@purestorage.com>
+
+[33mcommit 2e5808966ce91feecfa5558d477ea05f6526469c[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Jun 8 22:15:00 2021 +0530
+
+    stor-397: merge annotation for SA during restore/migration
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 9833cbac3ed5bd431bed21a8c976a3dd2f97dc72[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Tue Jun 8 14:03:46 2021 +0000
+
+    codegen auto-generated files
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit ce2b1f3a82bdb95838c967e8c6bc196551aa7eed[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Tue Jun 8 14:02:57 2021 +0000
+
+    stor-262: add user option to skip service resource updates
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 4884d373602a85c5c92db097328ccdad95813f86[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jun 21 17:04:01 2021 +0530
+
+    stor-411: prevent invalid cr updates
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 68cd7af7b795f0e092129386d2f0b4d366add5a2[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jun 21 17:01:03 2021 +0530
+
+    Dont collect service accounts for user with no list permission in namespace
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit a57a188287caa8e4dcb6e4f7a2f3a49c4683ee94[m
+Author: Jim Ou <jqou@purestorage.com>
+Date:   Mon Jun 14 16:26:14 2021 -0600
+
+    [STOR-383] add metrics for volume snapshot schedule
+
+[33mcommit 75fcb2c975ff858d83b4102cd022f75cb8b298d5[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Fri Jun 4 07:56:41 2021 -0400
+
+    Backing up NetworkPolicy and PodDisruptionBudget objects
+    - NetworkPolicy with CIDR set are not backed up
+    
+    Signed-off-by: Prashanth Kumar <prkumar@purestorage.com>
+
+[33mcommit e04bd349f164fde6ca79eeb5f4d030e3168fe13a[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Jun 11 11:49:48 2021 -0700
+
+    Add a new annotation to skip PVCs from stork's scheduler scoring algorithm.
+    
+    - Use the stork.libopenstorage.org/skip-scheduler-scoring: true annotation on PVCs
+      which should not be considered while scoring nodes in scheduler's prioritize request.
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit d41e52c3055717fd90828b16af13c1eb72de309d[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Mon Jun 7 07:33:55 2021 -0400
+
+    Skipping backing up of gke-resource-quotas
+    - On GKE when a namespace is created by default this gets
+      created so no need of backing it up
+
+[33mcommit 41fd4bb8122fc9d9d2ffb730c9f34e6c158c5a51[m[33m ([m[1;31morigin/Jim[m[33m)[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jun 7 14:06:40 2021 +0530
+
+    fix namespaced schedule policy cache
+    
+      - use seperate cache watch listner for namespaced policy cache
+    store
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit cf4837a92f72ef00a1ca2f647b79802175b80b8e[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon May 24 20:12:36 2021 +0530
+
+    Update latest pvc specs while doing migration
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit f16f61ba373c03aa930232c37954a82ee410a915[m
+Author: Jose Rivera <jose@portworx.com>
+Date:   Fri May 28 19:24:15 2021 -0700
+
+    Yum has vulnerabilty issues, no need to install and use that.  Just use microdnf.
+    
+    Signed-off-by: Jose Rivera <jose@portworx.com>
+
+[33mcommit f93a58d5cb17e3ffe62cd13187cf39e2078c2018[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue May 25 18:52:15 2021 +0530
+
+    Return err check while updating cloned namespace
+    
+      - fix issue stor-391: application clone fails if dest namespace
+    already exists
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 6a04cfb8034630c87556664951a58910744f0335[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sun May 2 18:27:48 2021 -0700
+
+    Update schedule package to use namespaced schedule policy
+    
+    If the namespaced policy doesn't exist it looks for the cluster scoped
+    policy with the same name.
+    Also updated all controllers to pass in namespace
+    
+    Signed-off-by: Dinesh Israni <disrani@portworx.com>
+
+[33mcommit 49d22d604a33f6fbfac260bd7224433561515c28[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat May 1 13:15:33 2021 -0700
+
+    Add CRD for namespace scoped schedule policy
+    
+    Signed-off-by: Dinesh Israni <disrani@portworx.com>
+
+[33mcommit f4ae1e890236a3355a5d475722baa020bccd9baa[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat May 1 13:15:04 2021 -0700
+
+    Fix code gen for crds
+    
+    Signed-off-by: Dinesh Israni <disrani@portworx.com>
+
+[33mcommit c7e2ddb6c30e3439cfb0670524939ce958cb0198[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat May 1 13:13:15 2021 -0700
+
+    Vendor update
+    
+    Signed-off-by: Dinesh Israni <disrani@portworx.com>
+
+[33mcommit 5a5403beeb5483b24f1501a02d9902ab80e465a3[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri May 7 15:52:40 2021 +0530
+
+    Configure rsync time for application controllers
+    
+        - avoid sdk update if backup is already on final stage
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 23e047a46a877f3c4b02d87dce02e1ed24379eba[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Apr 28 17:34:44 2021 -0700
+
+    Add scaled cloudsnapshot test
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 6b98cc805c5fe13cb6363c75b9de9382bde49177[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Apr 15 11:52:28 2021 -0700
+
+    Update the ubuntu repo in travis yaml file
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 467fbbf7c0dfc19ba34e16c31ee83898ee32a7f2[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Apr 15 10:40:09 2021 -0700
+
+    Add permissions for stork-scheduler for k8s 1.21
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 362c554a2eed8df8599b65d7943264118fda0efc[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Apr 8 12:20:49 2021 +0530
+
+    Update grafana dashboard for changed metrics name
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit c9a91c3eb342a719d4e1f470259a016795f51727[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Apr 5 18:10:25 2021 -0700
+
+    Vendor updates for torp and schedops
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 4ea4aa09fac700aa5d3b0d532a752919e15d5323[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Apr 1 23:10:40 2021 +0530
+
+    Add pluralizer rules for prometheus crd
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 30fe03cc1e3360d2448782da6b5f8d5e62077dd5[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Mar 30 22:09:48 2021 +0530
+
+    rename stork prometheus metrics with standard prefix
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 241d285656f649e5efd5c1c9dd6ae53a4640e221[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Mar 25 21:59:46 2021 +0530
+
+    Vendor updates for torpedo,sched-ops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit ecb036fcdacd49de18ce4643c21085a9289b3d91[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Mar 25 21:59:11 2021 +0530
+
+    Integration test for webhook allow dryRun options
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 0e759fe18fdca84ae875bb37f01f7cc65ad7162f[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Mar 22 14:42:14 2021 -0700
+
+    Clusterpair failure tests
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 84fd96942e7e580aca453d5c881edb19e5a574d4[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Mar 22 09:49:06 2021 +0530
+
+    Add appreg suspend support for CR's
+    
+       - perconadb
+       - prometheus
+       - rabbitmq
+       - kafka (strimzi)
+       - postgress(acid.zalan.do)
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 34b4295cddfb3f50a4e90d2632d0e5d12bdc3870[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Mar 19 09:14:49 2021 +0530
+
+    prometheus alerts for stork metrics
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 309caf861575c27344a573a1199e8f4cd05ba437[m
+Author: Grant Griffiths <ggriffiths@purestorage.com>
+Date:   Tue Mar 2 20:21:56 2021 -0800
+
+    Fix API breaking changes and makefile
+    
+    Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>
+    
+    Modify the UTs to adhere to new k8s 1.20 client-go fake client.
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit 5e50c870b93868dcb8c0bdc8ff355bcc8f5d22cd[m
+Author: Grant Griffiths <ggriffiths@purestorage.com>
+Date:   Tue Mar 2 20:21:32 2021 -0800
+
+    Go modules and k8s 1.20 client upgrade
+    
+    Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>
+
+[33mcommit 6a6555e31aed9a8d57c24ce46cc62334b402dd90[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Feb 18 23:31:58 2021 +0530
+
+    Detect newly registered crd and create appreg entry in stork
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 625843e0adaaf0d862f2d17a542922ac6fcfd4f5[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Feb 1 11:32:22 2021 +0530
+
+    stor340: Redo cluster-pairing automatically
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 9161d8c105bf53a8320134e09706ee04c36de271[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Mar 18 12:38:06 2021 -0700
+
+    Add correct CLI option description for test-deploy
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 016d319198f857e6221bd6e3bd2131b726a86657[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Mar 15 16:54:19 2021 +0530
+
+    configure side-effect parameter for stork webhook
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit f4dec0e2027d9715022845068f3a67a4c757cc7a[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Jan 6 22:41:27 2021 -0800
+
+    Add separate CLI params for test, source and dest kubeconfig
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 24958a4afe4340577f729d5fdfcd898769ed27e1[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Wed Mar 10 13:04:48 2021 -0500
+
+    Added logic to exclude the controlled resources from GetResources API.
+    
+            - Define a list for excluding controlled resources being returned
+              as part of response of resourceCollector GetResources API.
+            - For now added configmap kube-root-ca.crt, which was getting created by
+              kube-controller-manager in every namespace.
+
+[33mcommit 23c03ff8b8e7093d8f786db933921c7cb3599908[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Wed Mar 10 03:17:22 2021 -0500
+
+    Adding support for fetching resources based on requested resource types
+    
+    Signed-off-by: Prashanth Kumar <prkumar@purestorage.com>
+
+[33mcommit 3f9d85b6a2bdc01c6571ffb16cf87c895b9e27c2[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Mar 15 12:31:31 2021 -0700
+
+    Add sec annotations to create mig method, check for auth in tests
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit a4a9149efb22a87292a9f268c5195004b6bf9234[m
+Author: siva-portworx <siva@portworx.com>
+Date:   Thu Mar 11 05:13:08 2021 -0500
+
+    Updating clusterIps field of service to nil in prepareServiceResourceForCollection.
+
+[33mcommit e30034fe41997cf2c67a87842c9db4ad0d0aa606[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jan 11 23:52:59 2021 +0530
+
+    vendor updates sched-ops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 5237b72f534ed106ff7cb652304398f186ffa776[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jan 11 23:52:34 2021 +0530
+
+    addeds UTs for migration/backup schedule metrics
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit dcd3673d9fd0d25b7c0ac8786722ad59c6a63815[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jan 7 13:29:23 2021 +0530
+
+    stor-331: add metrics support for backup/migration schedules
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit c6aa72f7275a855380b9cddc448fd038ab22eb34[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Mar 2 23:39:45 2021 +0530
+
+    Use python3 version to install libs for google-sdk
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 810667298b0bd7e4622563cf5eea11d733ecf8e5[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Dec 18 23:57:08 2020 +0530
+
+    add grafana dashboard for migration and application controllers
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit df631f75442a9bbbefb7808afee9b60f993eea1b[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Nov 30 23:27:57 2020 +0530
+
+    Add Readme for stork metrics setup instructions
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit a83d476388327abb6cc156111baf5ef4f32c9493[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 12 07:29:57 2021 -0800
+
+    Get ApplicationRegistrations only once when preparing resources
+
+[33mcommit a97d89752b7417f34fdebb444f2807bc408c25cf[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Wed Feb 3 02:58:10 2021 -0500
+
+    Reduce the backupVolumeBatchCount value to 3 from 10, to avoid timeout failures
+            Added BACKUP-VOLUME-BATCH-COUNT env and made default batch count to 3
+
+[33mcommit c378eb4f0f0ad7e7417787e98837dff3cb9d143f[m[33m ([m[1;31morigin/2.6.0[m[33m)[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 26 21:28:20 2021 -0800
+
+    storkctl: Check for error state of snapshot
+
+[33mcommit 771dbcf6355d16b2f0c515afdec96a892fb6df5c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 26 21:27:59 2021 -0800
+
+    Vendor update for snapshotter
+
+[33mcommit 999b4fe57514ffebbd509426d8a0b793ca07fb41[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Mon Jan 4 16:06:06 2021 +0000
+
+    add support for replicaset backup/migration
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit b59f19a4fd701fc4fa849e1563de2d6a2594cc64[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Fri Jan 22 10:35:59 2021 +0000
+
+    Create pvc objects if volumeOnly migration is enabled
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 7f434b6459066a997ba0ce112c782f4e8f058847[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Fri Jan 22 14:31:29 2021 -0500
+
+    Corrected the error handling, while calling CloudBackupCreate api.
+
+[33mcommit 62471255a1950f0e030d96dc3ab729202bb8ac79[m
+Author: Prashanth Kumar <prkumar@purestorage.com>
+Date:   Thu Jan 21 12:00:25 2021 -0500
+
+    [Portworx]: Setting backup size to zero on failure when fetching size
+
+[33mcommit e25223e916556a5d268a5f5fbe69e1f6c173ab3b[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Thu Jan 21 13:52:33 2021 -0500
+
+    Fixed the issue in updating volumeInfo, when all volumes are successful.
+
+[33mcommit 13500a25d0594facc6040b825d0b8b7033a78387[m
+Author: Rohit-PX <rohit.kulk@gmail.com>
+Date:   Tue Jan 19 18:19:37 2021 -0800
+
+    Explicitly add linux as the GOOS
+    
+    Signed-off-by: Rohit-PX <rohit.kulk@gmail.com>
+
+[33mcommit eab938d15257c9c8e2c0a063107ac393fcb56692[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Tue Jan 12 11:04:50 2021 -0500
+
+    Passing namespace list in batches to resourceCollector.GetResources()
+
+[33mcommit e8f89f1bdccc1c40b2da55520e148f697922bbb8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sun Dec 20 14:17:31 2020 -0600
+
+    Use path from updated backup when checking for deletion
+
+[33mcommit 1248b13b365b56c43cd7c204dc12315ee471e0e6[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Sun Dec 20 14:38:34 2020 +0530
+
+    vendor update apiextension fake client
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 44130387281274e46f0972dea9f313c05f3d626c[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Sun Dec 20 13:49:17 2020 +0530
+
+    wait for crds to register while starting metrics collection
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit e50f35b1d1d331969bfcc7e7c443e7fb66b3b3f0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Dec 18 20:14:24 2020 -0600
+
+    Don't check for namespace mapping again when finding objects to delete
+    
+    Namespace is already being mapped to the destination
+
+[33mcommit 26f1105e639f60d0cabf9d6a601df507215ef3ef[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Dec 18 19:06:11 2020 +0530
+
+    retry v1 crd registration while doing app restore
+    
+       - migration: err check crd reg before validating crds
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 9359272b8963f4011887d4e31935f7bbd6bc9cf6[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Dec 15 20:44:44 2020 +0530
+
+    vendor updates sched-ops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit e43523786e8d4eca46024fc974c5b4bf1687203c[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Dec 15 19:33:22 2020 +0530
+
+    Use apiextensionV1 api to register CRDs objects
+    
+      - store replica count for crd in annotation
+      - use replica count for crd to disable/enable CR resources
+      - apply crds as per apiversion for migration
+      -  for v1beta1 to v1 conversion set x-kubernetes-preserve-field to true
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 65ef486daaec48740c2c1808c791401d64f42977[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Thu Dec 17 07:37:05 2020 -0500
+
+    Added retry logic, while updating the ApplicationBackupStageApplications status to CR.
+    
+            If the CR update fails, we retry for 10 times with 10 sec delay.
+
+[33mcommit 86bb1aeffed41cc49eeb31290e96498c922c5947[m[33m ([m[1;31morigin/master-stork-pb1006[m[33m)[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Mon Dec 14 14:54:34 2020 -0800
+
+    [CSI] Add creation of default VolumeSnapshot classes
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 2abeb00f8fda83faa410b949aefe060d440bd0d0[m[33m ([m[1;31morigin/master-stor-319[m[33m)[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Dec 15 12:27:59 2020 +0530
+
+    Misc fix - avoid unnecessary export of metrics variables
+    
+       - addressed review comments
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit f9aa45605f36483075bd1de7a8e8e141dd564630[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Dec 15 12:13:53 2020 +0530
+
+    UT's for stork prometheus metrics
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit f5080570034c1cf10a622223ac050b8298e33602[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Dec 8 19:27:49 2020 +0530
+
+    vendor updates sched-ops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 9e6f90c25474e3e0b5bd9ed95475e09572dc4c9c[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Dec 8 19:26:59 2020 +0530
+
+    prometheus metrics for stork controllers
+    
+       - applicationbackup, restore and clone
+       - clusterpair, migrations
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 85fd554ba204a6122c287b1e6cf2e5e4ef0b7fe6[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Fri Nov 20 10:38:28 2020 -0500
+
+    Added retry logic for CloudBackupCreate failure.
+
+[33mcommit 057cf6eddca9f744e3cbe8d80c00aa7f860b1c0c[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Thu Dec 3 17:32:08 2020 -0800
+
+    [CSI] Remove cleanup checks for GetBackupStatus
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit fe97def95ced938b34f64b2335610ea263e13c04[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Thu Dec 3 23:11:40 2020 -0800
+
+    [CSI] Add CSI PV and PVCs back into restore resources
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 6cc44cc09147c696e92c0f80f6810f2c73d02bb0[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Tue Dec 1 13:31:15 2020 -0500
+
+    Applying IncludeResource filter before deleting resources for CSI driver
+
+[33mcommit 6ec732a6982020fa3463cae399b5b43d9369e0b0[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Mon Nov 30 08:39:58 2020 -0500
+
+    Avoid including non-csi volume ad part of csi's GetBackupStatus API.
+
+[33mcommit f4170587fb75644fd06a777efd8d48a3fb6ce40e[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Fri Nov 27 02:32:39 2020 -0500
+
+    Added retry logic, when CR updates fails for Inprogress status.
+    
+            - Also return VolumenInfo list in the case of failure in GetBackupStatus
+              implementation in csi driver.
+
+[33mcommit 17590efcd701adf12bc24ece11bf518143990859[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 24 22:34:41 2020 -0600
+
+    [CSI] Make the last part of the backup name unique
+
+[33mcommit 7ed4cb22e74b37ddcdf374fc5a36faf64bd9e349[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Thu Nov 19 22:53:20 2020 -0800
+
+    [CSI] Fix multi-namespace backups
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit ad3167ab2f03abd518d6b0462f485d0b1e74062c[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Tue Nov 17 10:26:29 2020 -0800
+
+    [CSI] Restore cleanup without backup obj and various fixes
+    
+    - Restore cleanup and cancel no longer depends on backup obj being
+      present.
+    - Use PVC size for backup/restore info sizes
+    - Fix VolumeSnapshot skip check to not look at group
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 2bfd876b181f530f3ff989089b16622e06ab4a09[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Fri Nov 13 21:26:15 2020 -0800
+
+    [CSI] Add support for Replace Policy
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit fa169aa4df8846006cad9ee3c6563fe41e3b1190[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Oct 26 12:04:15 2020 +0530
+
+    vendor updates - sched-ops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 184358e90a046cf81b0108adb5e4d97204befece[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Oct 26 12:02:40 2020 +0530
+
+    allow disabling cronjob support for migration
+    
+     - add storkctl option to activate/deactivate cronjobs
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit a8160b590191e06b3fa6d11f31055bc731719fd6[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Fri Nov 13 17:37:49 2020 -0800
+
+    [CSI] Namespace mapping, skip VS obj in includeObject, and UID fix
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 26fa22e1220f34fc3e1732cf6c18a14ef84ac15a[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Nov 12 18:28:47 2020 -0800
+
+    Vendor changes for torpedo
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 5be37c9e6b59c5b7d9f8412fbb10ad471adadd48[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Nov 3 12:51:03 2020 -0800
+
+    Add new param for config map name for generic csi drivers
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit e4cb462a5fffd36956c26bb8acb392aef2fe135c[m
+Author: Prashanth Kumar <prashanth.kumar@portworx.com>
+Date:   Tue Oct 27 18:25:58 2020 +0000
+
+    Reporting volume size in bytes for EKS
+
+[33mcommit d8a220614e1111679d4ee074d1922ffc9d7aff7c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 12 13:26:40 2020 -0800
+
+    Prune migrations even for PartialSuccess
+    
+    Some resources might always fail to be migrated, this causes the status for all
+    PartialSuccess migrations to be saved. Only need to keep the last one in this
+    case
+
+[33mcommit b798b8a785754906efb3cda7fce64d3633c047b2[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Thu Nov 12 13:30:03 2020 -0800
+
+    [CSI] Fix CSI Backup to correctly cleanup on failures
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 60fe6a774b34b146ced0c42a658c1a7d89105c0c[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Tue Nov 10 17:25:58 2020 -0800
+
+    [CSI] Make VolumeSnapshot objects unique per backup request
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 7f5bc87677c668cb7906d5492e7252ff92ef9d92[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 11 13:46:25 2020 -0800
+
+    Use client from resource collector when checking for PVC ownership
+    
+    Without this, if the resource collector is called for a remote cluster it tries
+    to fetch objects from the local cluster
+
+[33mcommit 38d537860e07ba14bf1c033ad250a2f0c1cc46d7[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Tue Nov 10 03:05:30 2020 -0800
+
+    [CSI] Add check to make sure VolumeSnapshot and VSC are cleaned up
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 52f8f1ff2bce1fec83e3701b21dd2ef062ea1248[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Tue Nov 10 01:49:57 2020 -0800
+
+    [CSI] Only remove bind-completed and bound-by-controller annotations
+    
+    - On CSI restore, we used to remove all kubernetes.io annotations
+    - We must only remove bind-completed and bound-by-controller as there
+    are other valid kubernetes.io annotations
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 302d84567bc648555cb65d148effe35ed27b49a0[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Wed Oct 28 23:22:57 2020 -0400
+
+    Added log level change step in SIGUSR1 singal handler of dbg pkg.
+
+[33mcommit 263a748f2e2020410cea6875f43c276bff29fe7b[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Wed Oct 28 17:19:34 2020 -0700
+
+    Don't skip VolumeName update on CSI driver check failure
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 45b8e5bb284ba103c7d02e3276a47f50d899b07d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 27 10:24:56 2020 -0700
+
+    Don't collect cluster scoped resources from ApplicationRegistration
+
+[33mcommit ad607f0fe8d64def47ba3e284cca45fd99c9e387[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 27 10:14:39 2020 -0700
+
+    Fetch ApplicationRegistration only once when preparing resources
+
+[33mcommit 4df3ef56e90025b567e911d22989487a28dcb7e5[m[33m ([m[1;31morigin/stor-292[m[33m)[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Sep 10 18:53:31 2020 -0700
+
+    Add security annotations to CRDs for auth-runs
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit acbcc4d6f412159be248d8dbc3d0d7a36f98743a[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Thu Oct 15 13:03:25 2020 -0700
+
+    [CSI] Add restoreInfo for initial restore and during status check
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 82b35eade174bac1ef6d9f9e5e814bab519bb35e[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Sep 24 23:24:39 2020 +0530
+
+    add UT's for stork extender and health monitor metrics
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 96c79ea053c8011fd24b352c865133caa7e6da9d[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Sep 24 23:22:44 2020 +0530
+
+    re-org metrics constant to respective pkgs
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 947a6d8f23c106585647f253014345bb3583a0c9[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Sep 24 23:21:36 2020 +0530
+
+    vendor updates prom testutil pkg
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit ec5afdb15404076e3a146dfd53157ae4c6f8a054[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Sep 2 23:39:40 2020 +0530
+
+    Specs to enable promethous metrics for stork
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 453be91054eff710cb29af4fb1ee42fc0e3262ed[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Sep 2 23:37:47 2020 +0530
+
+    Prometheus metrics for stork extender and monitor
+    
+     - added prometheus metrics for stork extenders which
+       covers hyper,non and semi-hyperconverged pod counter
+     - added stork monitor metrics for no of pod rescheduled
+       by stork monitor
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 7428dcbdbde0aae8fdc94f671a9f32ad6c14648c[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Tue Oct 13 10:18:47 2020 -0700
+
+    Fix for non-CSI PVC restore not erroring out
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 9b16a998e32b64c72efdf40cf7d8c9b8411894c8[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Sat Aug 29 11:39:56 2020 -0400
+
+    Submiiting the volume StartBackup in a batch count of ten.
+    
+            - This way, we will update the volume backup status
+              frequently to the CR content.
+
+[33mcommit 6254ad1390988ae2f183ec8f1e85d8cb071c3761[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Mon Jul 20 22:13:20 2020 -0700
+
+    Add CSI driver snapshot implementation
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit aa955bb559b2befc6bbbe17881bcdad09545c1cc[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Mon Jul 20 22:12:25 2020 -0700
+
+    Add external-snapshotter to vendor for snapshotter client
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit eb6c180439ad1136182e9b3f1477a63ca6bc9e0e[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Sep 10 21:53:37 2020 +0530
+
+    vendor updates for openstorage-7.0
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 717c7e9e2deaa2ecdad7d57b2428fe5521ba3497[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Sep 10 21:51:59 2020 +0530
+
+    [portworx] Allow passing delete local snapshot flag to CloudSnapCreate api
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 372aaa37b267008f09f08dd605bed192de5d20cd[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Sep 3 12:56:30 2020 +0530
+
+    Check for clusterdomains status only if sync-dr is configured
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 84e4083dc39bf40b6c99f786240725bdfc908cdb[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Sep 16 10:46:38 2020 +0530
+
+    Update go version to 1.13.1 for integration test container
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 7ac0941b63a97e00c4be777f7b0e0b116975e00c[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Thu Sep 10 05:56:34 2020 -0400
+
+    Applying label selector for clusterRole, clusterRoleBinding and ServiceAccount resources.
+
+[33mcommit 1c2360c11cfe5029d00884c4cded3483b432e2d6[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Sep 14 23:09:53 2020 +0530
+
+    UT's to test suspend/resume of multiple migrSchedules
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 17295a28a23695781b028b88b2db21459d295001[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Sep 14 22:51:35 2020 +0530
+
+    Fix multiple suspend/resume migrSchedule issue
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 26af754f4f441db6582f143757d5a89386a1c83c[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Sep 11 22:16:52 2020 +0530
+
+    Wait for resource deletion before re-creating during migration
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 76504464515e9c9f95c59d8d4897e9baeaf9ad5c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Sep 11 00:12:21 2020 -0500
+
+    Check for permission error when processing objects in resource collector
+
+[33mcommit a168522973f7d76fdb6b84b66ab86350e4b660a1[m[33m ([m[1;31morigin/master-stork810[m[33m)[m
+Author: Luis Pabón <lpabon@users.noreply.github.com>
+Date:   Wed Sep 9 16:09:40 2020 -0400
+
+    Revert "Add authentication labels to volume"
+    
+    This reverts commit ab2ab4a00d358f1302ea9ba548f1b4866c6d86c9.
+
+[33mcommit ab2ab4a00d358f1302ea9ba548f1b4866c6d86c9[m
+Author: Luis Pabón <luis@portworx.com>
+Date:   Tue Sep 8 21:00:39 2020 -0700
+
+    Add authentication labels to volume
+    
+    If a request is authenticated, then the resulting volumes must have
+    the labels pointing to the authentication information
+    
+    Signed-off-by: Luis Pabón <luis@portworx.com>
+
+[33mcommit 84fb515ef5275afc9a9453065c4a1405558a2a7a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Sep 8 12:18:15 2020 -0500
+
+    Skip types in resource collector for forbidden errors
+
+[33mcommit 849b951f6a1ea3efee12193d6f2f2ebdc26f0374[m
+Author: sivakumar subramani <siva@portworx.com>
+Date:   Wed Sep 2 09:08:07 2020 -0400
+
+    Continuing with next namespace creation, if current ns already exists.
+
+[33mcommit 8b66f7b32f20e7c102ac0e7a6487d2d8f4b3d331[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Aug 31 20:05:54 2020 -0700
+
+    Vendor updates for torpedo/auto-pilot/apimachinery
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit cb114b6b67e5c75ac70e5fd9ad4758a44fdf707e[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Jul 21 22:49:48 2020 -0700
+
+    Use objectstore drivers to validate deletion of app backups
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit c0553effb7673a45073005fa6c5e3e9e485479f0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Sep 1 10:05:13 2020 -0700
+
+    Set Group to core fif empty when creating object map
+
+[33mcommit 373647b437fb7d9d6f10134ca598b1bd3f044233[m[33m ([m[1;31morigin/master-stork-263[m[33m)[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Aug 25 16:36:20 2020 -0700
+
+    Add support to specify resources during application backup
+
+[33mcommit 915046a60cd113e02af7c8cf8236ceaa4d2928a4[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Aug 21 17:52:59 2020 +0530
+
+    vendor updates sched-ops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit ea687f06194a5cb8bb63f542fac4c681a4c40ce8[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Aug 24 22:59:21 2020 +0530
+
+    Add debug logs to webhook server
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit b773b813de577ab22cddf682ef44a90f9a063af7[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Aug 21 17:51:15 2020 +0530
+
+    Register all crds found at startup
+    
+       - create applicationregistration cr for all crds
+         present at k8s server
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 04eb8c25862aa40fb532b0c795d9b529cebfca2d[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Aug 21 10:43:31 2020 +0530
+
+    [Portworx] Restrict backuplocation for migration in px < 2.6
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit f1504ba8bf6771ed732ed3aee3c84540ad762763[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Aug 20 00:00:09 2020 +0530
+
+    create backuplocation on destination cluster if passed as pair option
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 931f76d1dd64c38ffa11a6fa6ed9ae2e31775f2c[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Aug 19 23:58:59 2020 +0530
+
+    [portworx] pass in backuplocation as credid to clusterpair create api
+       - use IoProfileBkupSrc for volume restore
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 267a2d45c45a8035284a0a32e1030da4a5ec23a3[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Aug 19 23:58:16 2020 +0530
+
+    vendor updates - libopenstorage/openstorage
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 6c183fbe824476cb552c9b617f1378036b35409f[m[33m ([m[1;33mtag: v2.5.0-rc1[m[33m)[m
+Author: Prashanth Kumar <prashanth.kumar@portworx.com>
+Date:   Mon Aug 17 07:48:49 2020 +0000
+
+    Adding actual backup size in backup volume info
+
+[33mcommit 026b75e319a6ce62a37f0c5e1a3a534ef771f5d0[m
+Author: Prashanth Kumar <prashanth.kumar@portworx.com>
+Date:   Sun Aug 16 03:57:16 2020 +0000
+
+    [Azure]: Fix to populate backup size for azure volumes
+
+[33mcommit 486be964eb459ef0f861705f38f512c092f1ed08[m
+Author: Prashanth Kumar <prashanth.kumar@portworx.com>
+Date:   Thu Aug 13 16:46:56 2020 +0000
+
+    Passing empty endpoint to AWS objectstore operations
+    
+    AWS SDK fetches correct endpoint based on provided region
+
+[33mcommit 9137cf544fca3fd772f9c13ee6361ae231dcac19[m
+Author: siva-portworx <siva@portworx>
+Date:   Mon Aug 10 12:29:00 2020 +0000
+
+    Added check for Notfound error in GetRestoreStatus of all driver.
+    
+            - In all driver module except portworx, add check in get volume
+              status during restore to mark the restore of the volume, if we
+              NotFound error, while querying volume status.
+
+[33mcommit 843d3b6f920cdbe545438b4e22fb5a7573d16d4e[m
+Author: Prashanth Kumar <prashanth.kumar@portworx.com>
+Date:   Mon Aug 17 18:21:02 2020 +0000
+
+    Computing total backup size before uploading metadata.json file
+
+[33mcommit 1dac4379fc8e18e09500b98f59368c7f0d93c786[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Aug 13 20:04:35 2020 -0700
+
+    Don't do namespace check in ApplicationBackup if it is completed
+
+[33mcommit db9a159795aaa698138d685c4dc27b92aeaa69ff[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Aug 13 20:04:16 2020 -0700
+
+    Only create namespaces that are being restored
+
+[33mcommit c1f4dba5f8ca2b034d56b9b235e11d7b0903277f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Aug 13 19:52:34 2020 -0700
+
+    Use core as group when checking for PVC to restore
+
+[33mcommit 55a355495cb2098d9961ad552246d51580b3ddb2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Aug 10 21:02:55 2020 -0700
+
+    ResourceCollector: When checking for resources set group name for core
+    
+    The group in the resource is empty, need to set it to core before comparing
+
+[33mcommit 890250ca53187c614635e6b9d0fb25605a3cf809[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Aug 6 16:30:32 2020 -0700
+
+    Update Rule spec to take in container name
+    
+    This is required since a pod could have multiple containers and we
+    need to know which one we should run the commands in
+
+[33mcommit ddc1313ace02d7bf3d273d8133af5211f9382af2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Aug 6 16:29:58 2020 -0700
+
+    Add support to pass in * to select all namespaces to backup
+
+[33mcommit 20d6600800dc043293219c82edf30a3a39c5f74f[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Sat Aug 8 15:32:26 2020 -0700
+
+    Update copyright to 2020
+
+[33mcommit 03645313f300e57d269d019aa9aef1ebd47090dd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Aug 6 22:25:51 2020 -0700
+
+    Add support to collect LimitRange for Migration/ApplicationBackup/Clone
+
+[33mcommit 38a3d0e88f11c1957056cd9266a745fedccd08b9[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Aug 4 20:56:43 2020 +0530
+
+    allow string type for appreg suspend option
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit c560870c6513cf0ae7c010785a3fbc3328929fd1[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 30 21:03:42 2020 +0530
+
+    vendor updates sched-ops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit c1f5b284fd6001cd2185b8eb1ff407d2e4fe698c[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jul 13 16:59:46 2020 +0530
+
+    storkctl ux enhancement
+      - accept storage option for clusterpair
+      - add option to allow validating migration spec
+      - add watch option to storkctl stork resources
+      - fix error checks
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 6bd079c2dbdfcfa6775cf14808a6dfe1b6626720[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Thu Jul 30 10:27:44 2020 -0700
+
+    [Portworx] Move jwtIssuer to be configurable env var
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit f8508819999ae828a7297efe5e39a9e738e41c4f[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Tue Jul 28 14:04:56 2020 -0700
+
+    [Portworx] Add check for PX version check for jwt issuer
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit c885fcc517746e19e09c2be216517a18532093a9[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Jul 22 17:40:18 2020 -0700
+
+    Create new bucket for stork integration tests
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit a13cf62cb58a033cae5451062f0070a046ea72bc[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jul 23 09:51:32 2020 -0700
+
+    Vendor update for sched-ops
+
+[33mcommit 2913e9a4dbbd11c86054f60c20f25e4fbdab38b5[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 23 22:09:56 2020 +0530
+
+    ignore if appregistration cr is not present on cluster
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 79beb7b368f2cbdde72f29a95b956b4794363824[m
+Author: siva-portworx <siva@portworx>
+Date:   Mon Jul 20 13:09:10 2020 +0000
+
+    Added fix to not to wait for the re-created resources in DeleteResources API.
+
+[33mcommit d71a72639040a642c645d35efea87af41d2b9f47[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 23 17:30:56 2020 +0530
+
+    use resourcecollector k8sclient instead of schedop client to list
+    crd resources
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit d0f437ecf0bc0ab34c81bf189c410e9807657912[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 23 12:58:51 2020 +0530
+
+    vendor updates torpedo,schedops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 9894cc3a0c74ff05b6e50f0a67facc86a21b55cf[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 16 21:55:05 2020 +0530
+
+    update sched-ops createNamespace api
+     - address review comments
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 156ab1456043087e55591a8ea23bab390a9cfeb9[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 8 23:43:17 2020 +0530
+
+    replace namespace metadata if namespace already exists
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 6e7c4ceea12ac211d7de9725f3927f9c1127b134[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 8 00:36:03 2020 +0530
+
+    keep namespace metadata for application backup,restore & clone
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit db41af12556938bb6801dba12618b2e7b6b9d131[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jul 21 17:11:42 2020 -0700
+
+    Add some missing storage classes in integration tests
+
+[33mcommit 8a3223c18abdc4ef69acead06180bb04e691b96c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jul 21 16:50:02 2020 -0700
+
+    Ignore empty pre and post exec rules
+
+[33mcommit b59a8963fb5722a45f6df5ca93653d768cec1655[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jul 20 19:54:33 2020 +0530
+
+    delete crd.json on applicationbackup delete retension
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 4f725e7283e1795b7f001dd339b2b511f7945859[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 8 00:36:58 2020 +0530
+
+    handle  pre/post exec rule for volumesnapshotschedules
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 61017a7f1e81ca5f64dee22fddbb54a3e2a6bae0[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Jul 16 14:40:08 2020 -0700
+
+    Fix expected backup count for scheduled interval backup tests
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 46e9a68ba9551362f28ced6692fdd0424a013c8a[m
+Author: Prashanth Kumar <prashanth.kumar@portworx.com>
+Date:   Fri Jul 17 13:55:40 2020 +0000
+
+    [Portworx]: Fix updating of volume info for backup size on unsupported porx version
+
+[33mcommit 71f3174023222e4f654f2758e821d9db338eaf49[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jul 13 19:35:37 2020 -0700
+
+    Collect ResourceQuota objects from ResourceCollector
+
+[33mcommit 014b4a24bd86461a775f9b4af7a91f893f5998cd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jul 13 19:34:55 2020 -0700
+
+    Update namespace in Role during apply in resource collector
+
+[33mcommit 3e71515998dc0aa678e02cd63fb3db0a08714132[m
+Author: Christoph Böhmwalder <christoph.boehmwalder@linbit.com>
+Date:   Fri Jul 3 10:19:15 2020 +0200
+
+    [LINSTOR] add volume driver for LINSTOR
+    
+    Add a new volume driver for LINSTOR, an SDS solution by LINBIT. Also
+    make some changes in order to be able to run the integration tests.
+
+[33mcommit 20fb0c4133da36eadd1f0ae38096fb1d42f1d676[m
+Author: Christoph Böhmwalder <christoph.boehmwalder@linbit.com>
+Date:   Fri Jul 3 10:18:13 2020 +0200
+
+    vendor changes for LINSTOR driver
+    
+    Update dependencies and add golinstor
+
+[33mcommit eeab301f7ded43f74a500199ef82f0a427f8fdc4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jul 6 21:17:18 2020 -0700
+
+    Skip downloading CRDs in ApplicationRestore if not uploaded
+
+[33mcommit d388b7b85e2b8e2897e27804ed009fedc299114d[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Jul 7 21:47:28 2020 +0530
+
+    disable webhook controller by default
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit cb6d155a6c9132654005bb331263b915d3cc56fb[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jul 6 20:14:03 2020 -0700
+
+    Skip backup of PVCs being deleted or in Pending state
+
+[33mcommit 42acd34471b2493040acb6dede0e8dc60bb2ab2d[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Thu Jul 2 11:50:49 2020 +0000
+
+    fix restore fail issue by removing unneccesary metadata fields
+      - change app reg names
+      - correct typo for couchbase appregistration
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 176e632c9d392e7e255ef5616de41d48ea1ab78e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jul 1 15:58:28 2020 -0700
+
+    [Portworx] Init driver from InspectVolume if required
+
+[33mcommit bc1dbc43d369c21abb1340db5e0c422081bc282b[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Jun 29 10:06:22 2020 -0700
+
+    Separate application backups and restores for all tests
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 39f960a75807bcf2f05c70157f231fb6399b9aa9[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 1 18:02:22 2020 +0530
+
+    allow activate/deactivate for migrated crds
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit f2d0fb072a1ae6257d343b95a76140db766a819b[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 1 11:55:43 2020 +0530
+
+    Migrate resource specifc crds only
+     - fix review comments
+     - use struct for registering app resources rather than csv parsing
+     - use group/version/kind while collecting resources
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit bb59ff5a4a461862d4e4fc6281cb883fcfc70ed9[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Jun 30 22:47:51 2020 +0530
+
+    add uts for appreg cli
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit a49c641ebbf30486a0b336113fccc9bb70a08798[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Jun 30 20:54:21 2020 +0530
+
+    skip migrating crd if app not registered
+       - fix duplicate app registration
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit be71d0de69a12e192db27f692887b4273338e149[m
+Author: Ram Suradkar <ram.suradkar@portworx.com>
+Date:   Tue Jun 30 06:16:10 2020 +0000
+
+    vendor updates for sched-ops
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 8464c12f8848a670a60f94444aba6a428f917864[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Jun 30 11:11:14 2020 +0530
+
+    Create app registration for already supported CRD's
+      - add storkctl option for retriving app reg
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit e1fc97ab90374bab47c55709f7a37b1b92edb832[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Jun 19 23:44:43 2020 +0530
+
+    Support generic CRD migration,backup and restore
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 6d7585c1c220ad3823f60a598cf8a6ba745a1ff6[m
+Author: Prashanth Kumar <prashanth.kumar@portworx.com>
+Date:   Tue Jun 30 08:54:27 2020 +0000
+
+    Adding volume size to restore CR
+
+[33mcommit 82133ed72e6bfb9d3a9ca2a02f70a810ab4fcfa6[m
+Author: Prashanth Kumar <prashanth.kumar@portworx.com>
+Date:   Tue Jun 30 08:52:14 2020 +0000
+
+    [Portworx]: Driver changes for the following
+    - Returning backup size zero for older portwrox driver which doesnt
+      support OSD Size() call
+    - Adding size to restore volumes
+
+[33mcommit 9255e7a9877535484b77a185b505b514ca6800df[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jun 15 16:00:10 2020 -0700
+
+    Add support for restoring specific objects
+    
+    Users can specify individual objects to restore by specifying them under
+    spec.includeResources in ApplicationRestore
+    By default all objects from the backup will be restored
+
+[33mcommit 5dfb8543bfb4e735e7de344fa05ea6e0fa6bfdec[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Jun 26 22:14:29 2020 +0530
+
+    Add applicationregistration CR to register custom CRD for backup, migration
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit b89dee5cd5334dcabafca9aec4d6ccc1cb13c4f2[m
+Author: siva-portworx <siva@portworx>
+Date:   Mon Jun 22 11:03:42 2020 +0000
+
+    corrected the typo in the failure reason.
+
+[33mcommit 04e8e89d92eae87d386e2683aaaea9edda83d0d8[m[33m ([m[1;31morigin/master_error_fix[m[33m)[m
+Author: siva-portworx <siva@portworx>
+Date:   Thu Jun 18 19:49:33 2020 +0000
+
+    Removed CR updates that leads to "object has be modified error".
+    
+            - In backupVolumes() and backupResources(), remove the
+              CR updates that can lead to "object has be modified error"
+              as two updates happens in the same cycle of reconciler.
+
+[33mcommit 32d39271602b0ec7a37512bb3dda4e2eadcc88fa[m
+Author: Dmytro Tsapko <dmytro.tsapko@gmail.com>
+Date:   Tue Jun 9 05:10:50 2020 +0300
+
+    [portworx] authorization for cluster manager calls is added
+    
+    Signed-off-by: Dmytro Tsapko <dmytro.tsapko@gmail.com>
+
+[33mcommit 56967162e4049d4970919842d0e897bedee754d0[m
+Author: stgleb <glebstepanov1992@gmail.com>
+Date:   Thu Jun 18 01:50:21 2020 +0300
+
+    STOR-200 Add prepare and verify pods for mysql
+
+[33mcommit a2bc3899256069f7e08df2cd251064f8ca5b9946[m
+Author: Prashanth Kumar <prashanth.kumar@portworx.com>
+Date:   Sun Jun 14 17:01:26 2020 +0000
+
+    Added fetching backup size of volume backup
+
+[33mcommit 7ec19c88322e891772b01d7a7357efb2998fedc8[m
+Author: Prashanth Kumar <prashanth.kumar@portworx.com>
+Date:   Fri Jun 12 15:01:58 2020 +0000
+
+    vendor update for libopenstorage to support cloud backup size proto
+
+[33mcommit 55bd790a06d16799e9e37f2a454a2d828d4c60de[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jun 18 19:58:25 2020 +0530
+
+    Disable auto-updating app scheduler as stork for app,
+    if disable annotations is applied
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit ca65f5006f4241a145d95c55803e3971c963e550[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jun 15 18:22:46 2020 -0700
+
+    Add events when deleting pods from health monitor
+
+[33mcommit 9660efb6ea32c5e63d87d31de1c2992a3fa3a3f8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jun 15 18:20:42 2020 -0700
+
+    [Portworx] Map node status None to Online
+    
+    During node start the status for all the nodes is set to None, this shouldn't
+    cause pod deletions from the health monitor
+
+[33mcommit 8b4b217b0ceb771d681230e92a4edf97036bb950[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Jun 5 15:43:25 2020 -0700
+
+    Integration test to check health check fix
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 2bfd7160ebc5341903f0fab2b939184479b62c1e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jun 8 16:05:30 2020 -0700
+
+    Add support to collect couchbase CRs
+    
+    Will be used during Migration, ApplicationClone and ApplicationBackup
+
+[33mcommit 23f558043bfbb8f3d8843bd417a4d7114f244ee7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 4 18:11:22 2020 -0700
+
+    Fix storkctl error message when suspending backup schedule
+
+[33mcommit 02a8ddb2603c1719dc5a1a4b09d24ab59ca52941[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 4 16:37:54 2020 -0700
+
+    Fix elapsed time for application backup when it hasn't started
+
+[33mcommit 1636003bf7169c4227a86dddfa74c7d7466caa6e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 4 16:37:42 2020 -0700
+
+    Bump version to 2.5.0
+
+[33mcommit 152a07be564fafa79fd4de3fa6ba665650155f5f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 4 14:38:34 2020 -0700
+
+    [Portworx] Add options to pass in incremental count frequency
+
+[33mcommit 0e091fb57413fbc5d52a9e127a91a8436c0e90e3[m
+Author: ram-infrac <35250819+ram-infrac@users.noreply.github.com>
+Date:   Fri Jun 5 10:24:42 2020 +0530
+
+    Update cmd/stork/stork.go
+    
+    Co-authored-by: Dinesh Israni <disrani@portworx.com>
+
+[33mcommit ff9aab6c2e23f47d29b6d3b2f624db080fe88c7f[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Jun 5 09:55:45 2020 +0530
+
+    add flag to enable/disable webhook controller
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit cd05e53933c96d8de63aeaf5d10d7c3c9fbc4427[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 4 14:40:56 2020 -0700
+
+    Add storageclass to s3 config in BackupLocation
+
+[33mcommit 302dab2f82005aff31268d17a32dfd3fc8de4ca7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 4 14:39:41 2020 -0700
+
+    Add -q flag to wget in Dockerfile
+
+[33mcommit fdc70d4eb5a52bf61f2837b99c015c5e5c644661[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jun 4 19:40:10 2020 +0530
+
+    use admission review request namespace to get volume info
+     - dont proceed if volume owner not found
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 0a5a4afe686e0c1fcc8dd85432e19d292c344642[m
+Author: Christoph Böhmwalder <christoph.boehmwalder@linbit.com>
+Date:   Fri May 22 11:58:28 2020 +0200
+
+    fix stork-scheduler RBAC role for Kubernetes 1.18
+    
+    While trying to deploy stork on a k8s cluster with version 1.18, we
+    noticed that some permission errors came up when deploying the scheduler.
+    This fixes the yaml to work for k8s 1.18.
+    
+    Signed-off-by: Christoph Böhmwalder <christoph.boehmwalder@linbit.com>
+
+[33mcommit 6343f8025385f5641edfe256d501bd53d3fe6198[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu May 28 10:15:12 2020 -0700
+
+    Add apt-get update to deploy script
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit c36af8e0b67efa4168d6efe2fb885b9038684d0e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 27 12:18:42 2020 -0700
+
+    [AWS] Use correct volume id for CSI
+
+[33mcommit 61e36d97273c09cb42bffa2e7089bc219ef42181[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed May 27 21:46:39 2020 +0530
+
+    Create clusterdomainstatus CR at controller init
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 46d7ea8e49b4da891f6f71240dbe8d7cdc8810fa[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 21 17:13:10 2020 -0700
+
+    [GCP] Parse zone and volume name for CSI PVCs
+
+[33mcommit 558b93ea72cd96edc84fa8f969ba21606fb06989[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 21 17:12:38 2020 -0700
+
+    Vendor update for gcp libaries
+
+[33mcommit 8809af2c5fde3ef727c2243c3ab18281d1c8f172[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 20 17:06:15 2020 -0700
+
+    Fix check for preparing jobs during restore
+
+[33mcommit 25d93f20fd76bc4143eb41d64629dc341fbe20ca[m
+Author: Christoph Böhmwalder <christoph.boehmwalder@linbit.com>
+Date:   Fri May 8 10:39:57 2020 +0200
+
+    specs: remove initializers field from specs
+    
+    The metadata.initializers field has been deprecated since Kubernetes
+    1.13, and has been completely removed in 1.16. So, when using a
+    Kubernetes version >=1.16, this errors out while creating the
+    deployment.
+    
+    Fix this by just removing the key in stork-deployment.yaml and
+    stork-scheduler.yaml.
+    
+    Signed-off-by: Christoph Böhmwalder <christoph.boehmwalder@linbit.com>
+
+[33mcommit d39c7e69afc409823034b6d7a6613c1cbe4ff037[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 19 13:23:58 2020 -0700
+
+    [GCP] Fix for using correct volume ID for CSI PVCs
+
+[33mcommit 11aa9b09300e1e1f3813318a6c74d76912779e24[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 19 13:16:56 2020 -0700
+
+    [AWS] Fix for using correct volume ID for CSI PVCs
+
+[33mcommit df398cd173852859f944d5af8edf2e51d0690c2c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 19 13:03:14 2020 -0700
+
+    [Azure] Fix for using correct volume ID for CSI PVCs
+
+[33mcommit cb9f1aed0259bb1e9bd3abcfffbf7c53dcec1fae[m
+Author: Dmytro Tsapko <dmytro.tsapko@gmail.com>
+Date:   Thu May 7 02:10:36 2020 +0300
+
+    [portworx] openstorage was updated
+    
+    Signed-off-by: Dmytro Tsapko <dmytro.tsapko@gmail.com>
+
+[33mcommit 29904ff46b62fb1f10fa6cf9ef9e5f0ce86e4f02[m
+Author: Dmytro Tsapko <dmytro.tsapko@gmail.com>
+Date:   Wed Apr 22 21:23:01 2020 +0300
+
+    [portworx] TLS related scheduler to driver communication updates.
+    1. TLS for Legacy REST API decided to be disabled.
+    2. possibility of loading CA cert from external file was added
+    
+    Signed-off-by: Dmytro Tsapko <dmytro.tsapko@gmail.com>
+
+[33mcommit c51d7a4d121f6be6a338abb5cde567fa7da09b11[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed May 13 22:49:06 2020 -0700
+
+    Vendor changes for security including torpedo, schedops and openstorage
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 9d288298785275d5c92e184353273f8542b710ae[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed May 13 22:43:44 2020 -0700
+
+    Changes for running stork with px security
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit cdb859759d74b1956c9fe974bf8998987f91f171[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 13 14:15:00 2020 -0700
+
+    [AWS] Add CSI provisioner name check
+
+[33mcommit fbd5a9e681f95f79b98eaf293ce5c45414c3c3fe[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 13 14:12:58 2020 -0700
+
+    [GCP] Add CSI provisioner name check
+
+[33mcommit 9af530b8399f5f35d6908c086129bf8a0847e21f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 13 14:10:13 2020 -0700
+
+    [Azure] Add CSI provisioner name check
+
+[33mcommit 13f7994c13763aaecf9d4e0e52df9c7655cae7f5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 13 14:39:34 2020 -0700
+
+    Update vendor dependencies
+
+[33mcommit 8b0aca75eb40ffca9a6851688ba499ebf08d7ece[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Apr 14 16:01:25 2020 -0700
+
+    Collect jobs from resource collector
+    
+    Since jobs might not be idempotent, restoring/cloning/migrating them are
+    optional. They will always be backed up
+
+[33mcommit e5a35793e40569654cee3537c49d235b7359d1ac[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu May 7 10:04:44 2020 -0700
+
+    change base docker image to redhat-ubi8
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 7442bd342b3041a0c2d9c088f5656c8700fdf5d1[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon May 11 12:26:51 2020 -0700
+
+    Change regex to pick individual focussed test
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit e6ec5554091c817553a6551950de14f55b76ecac[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Apr 27 15:58:32 2020 -0700
+
+    Add env variables for aws access to stork-test
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 3ae156cc74fc2be5d25a00fa2cabaa77683195d1[m[33m ([m[1;31morigin/master-pb438[m[33m)[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Apr 25 19:48:21 2020 -0700
+
+    During backup skip PVCs with unsupported drivers
+
+[33mcommit e03885db7dbc97fa8a7464f5a5dba1b04926f79b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Apr 24 20:48:13 2020 -0700
+
+    Don't block driver registration if init fails
+    
+    The init will be tried again when the APIs are called if init had failed
+
+[33mcommit e98e472b0fefbd3062ce4bdd089836a525f51c86[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Apr 13 10:46:54 2020 +0530
+
+    vendor update for openstorage
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit a6df695bdd20d0b511f83add217e68e888f388b4[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Apr 13 08:45:13 2020 +0530
+
+    [portworx]  cloudsnap restore api update
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 62e08ba1ab2635f88653a106bd5cc51f091e9edc[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Apr 18 23:53:29 2020 -0700
+
+    Allow drivers to return resources that should be restored before volumes
+    
+    This allows the Portworx driver to specify any secrets that it might require to
+    be created before starting the volume restore.
+    No-op in the other drivers for now.
+
+[33mcommit f154ad70c80df0f786306b3a05a84f5dcd35fb73[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Apr 18 18:24:47 2020 -0700
+
+    Ignore error when updating initial state for pre exec rule in backup
+    
+    The object could have been modified. This allows the reconcile to run again with
+    the updated object
+
+[33mcommit 76b5f677548811a5a501d228788d55299e5c1ae0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Apr 18 16:13:40 2020 -0700
+
+    Skip PV restore if bound to a PVC that shouldn't be restored
+
+[33mcommit 72693b859342d59d90dbac783ce653b3597e555b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Apr 17 23:44:24 2020 -0700
+
+    Fix pre exec rule failure in application backup
+    
+    Multiple updates were failing because of conflicts. Fetching latest object
+    before updating in pre exec path
+    Also if the pre exec rule fails the backup will be marked as Failed instead of
+    retrying
+
+[33mcommit e19b2d5b96ec6f0ae6cbe0c97c9bb38da94dc17f[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Apr 13 20:48:42 2020 +0530
+
+    update health check UT's for node status backupoff retries
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 2033f1fb65fa9238b56c63763b6cb2b08a149505[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Apr 9 21:03:24 2020 +0530
+
+    add backoff to check node status before deleting pods
+     - make node status check as async routine
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit c6bec7b08fc364d91b6cdc747415eecd4ee6b704[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Apr 9 21:02:52 2020 +0530
+
+    Add driver node inspect api
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit fdb9fa4bec10540e95bcfb47fb60ab6b9dd44221[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Apr 16 18:38:04 2020 -0700
+
+    During restore skip resources from namespaces that aren't provided in spec
+
+[33mcommit ded9302c7a5f92d2318c37ea4c9121f47a5f41d7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 13 15:22:37 2020 -0700
+
+    Create bucket during application backup if possible
+
+[33mcommit 8c65b881689a931d10fda2c6730f773328020598[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 13 15:22:23 2020 -0700
+
+    Vendor update
+
+[33mcommit dbb605fd07d291039f41d34c20425bb8d7e89793[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Apr 16 22:52:09 2020 -0700
+
+    [AWS] Retry snaps for internal errors
+
+[33mcommit b58853d44b97129b16172ef39a46654ae82dc3d8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Apr 16 15:55:18 2020 -0700
+
+    Return error if not able to fetch snapshot info in schedule controller
+
+[33mcommit c160c90f1df05a3f487467dc631163392a2a2346[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Apr 16 15:54:47 2020 -0700
+
+    [Portworx] Add failure reason for cloudsnap to message
+
+[33mcommit c2123470a0571264651dbb5ce92228c8510fc81b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 15 16:46:22 2020 -0700
+
+    For older backups missing the driver name, set the default
+
+[33mcommit 464474b0526c029a1576ac444b237a4aacea0a70[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 15 16:45:41 2020 -0700
+
+    Remove some cattle specific annotations from namespace for migration
+
+[33mcommit da9194746bf813590c011a5ccf9f69cbd5379cc2[m[33m ([m[1;31morigin/master_rulecr_update[m[33m)[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Apr 14 22:06:12 2020 +0530
+
+    Don't start webhook controller if driver is empty
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 69e5e26faf7612d7fbf2f59872cf382544759e29[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 13 17:55:09 2020 -0700
+
+    [AWS] Add backoff for snapshot API in case rate limit is hit
+
+[33mcommit d045c5911630f2e68a4a7dc579092804235edd26[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Apr 10 00:16:31 2020 -0700
+
+    Explicitly reset kubeconfig after every migration-backup loop
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit df8bcecf8f717824e9907712cdb7696446d9a821[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 8 22:14:23 2020 -0700
+
+    [Portworx] Add backup id to spec when checking status
+
+[33mcommit d5cbcca0f8f1b0fb01fab1cf6934780d51193271[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 8 22:14:03 2020 -0700
+
+    Mark backup as failed if preparin or uploading resources fails
+
+[33mcommit 6b16f8c2f4404ce339d8d6b08d68fdc82ca7db23[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Apr 3 14:39:36 2020 -0700
+
+    Integration test for application backup of a migrated app
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit f4c24a7b9ea2775df9acbec8145f6d3b157e2f3c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Apr 3 09:33:26 2020 -0700
+
+    Check if schedule policy exists in cache
+
+[33mcommit c8d0a7460c1f7919deb3c9da05b2b83bb54bda75[m
+Author: Serhii Aheienko <serhii.aheienko@gmail.com>
+Date:   Tue Mar 3 20:58:35 2020 +0200
+
+    Use controller-runtime manager
+    
+    Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>
+
+[33mcommit 17aee876f1ecf1ce9d2480c6ebed561997002f38[m
+Author: Serhii Aheienko <serhii.aheienko@gmail.com>
+Date:   Tue Mar 3 20:58:12 2020 +0200
+
+    Update dependencies
+    
+    Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>
+
+[33mcommit f93c2405bd1e2501402b1836cd6291bb63d34d6e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 24 17:46:00 2020 -0700
+
+    Vendor update for sched-ops
+
+[33mcommit 95db0243d6c04c47d8d096bcd12a66b57761522e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 24 17:45:34 2020 -0700
+
+    Merge service accounts when applying for restore
+
+[33mcommit 4b0367842c5c72ea26803e66ecf1b9b5a08c71d0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 26 19:17:17 2020 -0700
+
+    Don't update LasUpdateTime in application backup if status isn't being updated
+
+[33mcommit ebb49b970f04ea72b92c33a26e89af1b9db67639[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 24 18:22:57 2020 -0700
+
+    [Portworx] Check for annotation to skip backuplocation name check
+
+[33mcommit 70db754b57b25cdfd556182faa62257712aa9080[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 24 18:22:38 2020 -0700
+
+    Vendor update
+
+[33mcommit 073c11880fe797c44573650feb123733f968145d[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Mar 26 11:31:15 2020 +0530
+
+    Avoid adding duplicate volume to restore status
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 6e65288ed7cec2475330dc2f64a24f2ef7e2f0ba[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Mar 23 00:36:54 2020 -0700
+
+    Integration test for migration and reverse migraiton between two clusters
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit ca77db97beb9ea46d986e5c6d50694b6e1b241a9[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Mar 13 12:25:58 2020 -0700
+
+    Delete app backups before backuplocation in sync controller tests
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit e9fc93492186051a9cac3c5a57763c2037d75d4f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Mar 23 16:49:25 2020 -0700
+
+    Add annotation to collect objects that have an owner reference
+    
+    In case of objects created by operators, might still want to collect some
+    objects that are only created by the operator once
+
+[33mcommit b680bdac79563df7708eea5a41c384465dd2b746[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Mar 20 17:03:04 2020 -0700
+
+    Update sched-ops client for all packages
+
+[33mcommit 20ff8ae1edb28821ce3ad9e681a28aaa08a870fb[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Mar 17 19:57:17 2020 +0530
+
+    [portworx] handle in-place restore for vol repl gt 2 for px driver
+    
+     -  integration test check for in-place restore repl 3 vols
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 4e64a43b6dd60cf8b375877cd5953b8df7f6a6d3[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Mar 17 02:17:52 2020 -0700
+
+    Reduce wait time between checks for app backup
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit a5c3ec6de40dd218c517203b694d90b8dd93287b[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Mar 16 23:50:25 2020 -0700
+
+    Add parameter for secret name for cloud provider API access
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 545b9ebb6f4c0aa52d494b21748fb0cb1281a6f3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 12 14:40:00 2020 -0700
+
+    Add cache for schedule policy
+
+[33mcommit c53bd588fd85d9a2a7f4111ff6c8658378ff44df[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Mar 13 15:28:32 2020 -0700
+
+    Add parameter for path in backup location
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 5186ab68dc7e77a122948c378d80d7747be24720[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Mar 11 16:50:13 2020 -0700
+
+    Do not install storks-scheduler for non-PX backups
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit d0c6dce72628154410d88e590b705415e613bd24[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Mar 10 11:44:07 2020 -0700
+
+    Import k8s client auth, add gcloud binaries, aws authenticator in tests
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit b46a1fcd1c39b031fb7ecdaa5e53bc3fc60c3550[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 5 18:40:58 2020 -0800
+
+    [Azure] Check if snapshot or volume is created before starting new operation
+
+[33mcommit 4dbda80748afd799f8109517ff70c9a491c7aa7e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 5 16:08:18 2020 -0800
+
+    [GCP] Check if snapshot or volume is created before starting new operation
+
+[33mcommit 0286d275baaa504f67a76d04fa97f384b0cb102d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 5 14:36:21 2020 -0800
+
+    Use common helper to generate tags for snapshots and volumes
+
+[33mcommit 0094d7bc422e4482585746d59d9c784a538fdd0a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 5 14:20:09 2020 -0800
+
+    [AWS] Check if snapshot or volume is created before starting new operation
+    
+    Helps deal with crashes and when the operations are triggered but we aren't able
+    to store the status in the object
+
+[33mcommit 4e1265dc021f95885038607f2ccb31ae829d3e46[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Mar 6 17:10:47 2020 -0800
+
+    Set all configmap after default config map is correctly set
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit dd6528ea402a823b9749741f9ce1550d05ef62de[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Mar 5 17:48:12 2020 -0800
+
+    Import Azure, AWS stork vol  driver in test
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 4b00824317d818eae8076bf6b89a8c30e9f0d295[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Mar 5 11:17:32 2020 -0800
+
+    Remove vol driver from stork spec when not using PX driver
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 2a6c59b2d9f6ae0dfa935dcdefc7192b5ea83a41[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 3 18:31:49 2020 -0800
+
+    Add last update timestamp to backup and restore specs
+
+[33mcommit d027fd80a4a5e3245aa2a87446f710d354b8a009[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Mar 4 18:49:59 2020 -0800
+
+    Replace volume driver in stork specs for non-PX backends
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 4bc7695a549befbf83a11ebf04d19cb28311b6bc[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Mar 4 17:18:50 2020 -0800
+
+    Add apt-get install jq for ubuntu base images
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 342869040bbce579a9ca1e2b103134ff30b8c40c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Feb 25 16:45:21 2020 -0800
+
+    Add a reason field for the overall backup and restore status
+
+[33mcommit 29c97961b3aa7e03f85548f05127ef6e5cae0fec[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Mar 3 18:06:08 2020 -0800
+
+    Integration to start app backup when another is in progress
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit eb919d621dba880026faca698c80f92d6399609c[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Mar 2 21:35:21 2020 -0800
+
+    integration test to delete backuplocation during app backup
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 2ae626e5c64de5c67143a31697298f638478360e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Mar 2 15:31:10 2020 -0800
+
+    Add expected count for app backup schedule tests
+
+[33mcommit 68f3e25ef2827db3595dc7034da2e673c2baf1ec[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Mar 2 15:29:01 2020 -0800
+
+    Vendor update for sched-ops to fix validation in test
+
+[33mcommit 5471a7e067ee0d5488f6e567d818d13fe23cd692[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 27 12:43:43 2020 -0800
+
+    [Portworx] Add progress info for backup and restore to reason
+
+[33mcommit 1a0894e54ab8bfe39d40f36647cd1386efaa2517[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 26 19:17:53 2020 -0800
+
+    Get the correct pluralized name of resources for the dynamic client
+
+[33mcommit b517566728495db466e05af096b01e04bb14696e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 28 14:13:37 2020 -0800
+
+    Use correct type for length of backups in test
+
+[33mcommit 6f6efe4bf45d8ecfa10286d37c4fbb05a7671a13[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Feb 27 18:45:23 2020 -0800
+
+    Vendor update for torpedo azure, aws  vol drivers
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 2b2eb1f09dee98fb0e0a3c35bb72ff665b8eb302[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Feb 27 18:44:22 2020 -0800
+
+    Use aws, azure vol drivers from torpedo
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit af794e1527fca0d4370f08874dd05bf18c9780a6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 27 18:11:55 2020 -0800
+
+    Use correct API to delete backups in test
+
+[33mcommit abfb56253904f636b579f4c1af32407b8e66a240[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 27 12:49:55 2020 -0800
+
+    Check for correct number of appplication backups in schedule test
+
+[33mcommit 139343270baa3cca22f1c5e8743a20a750c61ca5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 26 17:40:49 2020 -0800
+
+    Update applicationbackupschedule test for new retain policy
+    
+    Backups created by schedule aren't deleted when the schedule is deleted
+
+[33mcommit 58785daf81b6fe0d2bf0f018b06e4fd217af3e4f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 19 15:55:08 2020 -0800
+
+    [Portworx] Don't migrate volumes which have the skipResource annotation
+
+[33mcommit f3228bec42288507a084d03f4a8284a755aac9c1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 19 16:25:42 2020 -0800
+
+    Cache the go cache directory in travis builds
+
+[33mcommit 699611ae6e52a136641f1e20650ba79f6a3fdc02[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 19 16:18:26 2020 -0800
+
+    Update make in travis to start 2 jobs at once
+
+[33mcommit aeb8b783b9a1a475fa555eb4fc737c08f580f0ca[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 19 15:39:44 2020 -0800
+
+    Set defaults for the spec in migration schedule
+
+[33mcommit aa166f45857a8d5576eb608fac6c2432a01c3c3a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 19 15:39:20 2020 -0800
+
+    Set the default reclaim policy to retain for application backup schedule
+
+[33mcommit 0fd730ccf20dda71264e30cb9a116861aa2aa11e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 19 15:59:00 2020 -0800
+
+    Collect CronJob objects for migration, backup and clones
+
+[33mcommit 705e53b68b3379538b326bfc3a97d5da749ce897[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Feb 24 23:03:31 2020 -0800
+
+    Vendor update for GCE torpedo driver
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit c8b52067ce1270643c9565d36b58390428afcbd3[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Feb 3 17:43:44 2020 -0800
+
+    Ability to deploy apps on cloud platforms
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 9d9feb71284a79e1d8fa0bbbda3c3ac078c8ba79[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 20 16:04:40 2020 -0800
+
+    Vendor update for sched-ops
+    
+    Fixes issue in integration test while checking for status
+
+[33mcommit df061d0810ec583d9a4ca41d679eaa869fd893c4[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Feb 18 19:22:09 2020 -0800
+
+    Scale down cassandra app after cloning
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 4e8943ff3d46225f6636e3f3672655c516a6ce81[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 13 20:41:48 2020 -0800
+
+    Remove initializer option from test script
+
+[33mcommit c975353e957a123d54acfab4bef3bbeda526e7d2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 13 14:44:06 2020 -0800
+
+    Fix events in webhookadmission controller
+    
+    Events need to be raised against an object. Raise it against the
+    deployment/statefulset/pod if we have it, otherwise raise it against the webhook
+    config
+
+[33mcommit 046dc744d6e7ec4d0a0abee6369620dc1b064a2d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 7 19:07:39 2020 -0800
+
+    Update APIs for k8s 1.16
+    
+    - Removed initializer since it has been deprecated since k8s 1.14
+    - Updated sched-ops APIs
+    - Updated printing from storkctl since APIs had changed
+
+[33mcommit 67b5cf0ec29dca0f0be53f21b45277fd9502b7aa[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 6 20:02:33 2020 -0800
+
+    Update vendor for k8s and dependencies to 1.16.6
+
+[33mcommit 350b6cb6e50c6f8bed133f921308d2ad3239e2cf[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Feb 10 22:33:37 2020 -0800
+
+    Fix regex to replace entire stork,stork_test image names
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 5823ef060e9d14e75de976bacf4f13e418c274cc[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 13 16:53:55 2020 -0800
+
+    Fix duplicate tags being checked for aws driver
+    
+    Use constants to avoid typos
+
+[33mcommit 38e7d20a5cf56e7c71eca01d8d66da0d42220a18[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 12 14:58:59 2020 -0800
+
+    [Azure] Store the resource group for volumes during snapshot
+    
+    Use it during restore so that it can be restored across resource groups
+
+[33mcommit 136de3ab7bac1057638fdb3a9cd71a23095d9e5f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Feb 11 14:00:41 2020 -0800
+
+    Change driver init error message to debug
+
+[33mcommit 323faeab5ae7319eb79ee2a83d3f192880e47514[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Feb 11 14:59:28 2020 -0800
+
+    Remove unused status types
+
+[33mcommit c0244eb623c67d3f6a858d44119de2630a7f3c0b[m
+Author: Arthur Lutz <arthur.lutz@logilab.fr>
+Date:   Tue Feb 11 12:50:38 2020 +0100
+
+    [README] typo fix
+
+[33mcommit 2a14501ef2b758af297d3366222425d950ec31ae[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 6 00:25:45 2020 -0800
+
+    Init the schedule package even if driver isn't specified
+
+[33mcommit 977f8cbb26b5e5a4a8576023dfc5f3fedba637f6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Dec 12 16:31:00 2019 -0800
+
+    Implementation for AWS driver
+    
+    Added support for ApplicationBackup and ApplicationRestore APIs
+
+[33mcommit 63b71c459fddc854ddce4e1d1c713e9c831f39eb[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Dec 12 16:29:22 2019 -0800
+
+    Vendor update for aws
+
+[33mcommit 241c1b39f4af7582a67adbde916653c00c3b19a6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 21 16:47:32 2020 -0800
+
+    Don't need to prepare PV when doing backup
+
+[33mcommit 8630944976dc472d05beaba7778a1df4d62c553a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 21 16:47:12 2020 -0800
+
+    Implementation for Azure driver
+    
+    Added support for ApplicationBackup and ApplicationRestore APIs
+
+[33mcommit 7c3a29584a43b60e091564936543817dbf2d2aa1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Dec 6 17:19:11 2019 -0800
+
+    Vendor update for azure dependencies
+
+[33mcommit 29a157cdd125c9b9f7b0b3d2457f431beb34c096[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jan 29 17:49:14 2020 -0800
+
+    Add support for gcp multi zone disks
+    
+    Also use zone from disk when creating snapshot and disk instead of the zone
+    where stork is running
+
+[33mcommit d55b799989020c56a5861887beb7ab8a1b6346ca[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Feb 5 08:49:35 2020 -0800
+
+    Increase wait time for synced backups to appear on the destination cluster
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 5b5621941971bc65d64c8a802174aae723fc22de[m
+Author: Serhii Aheienko <serhii.aheienko@gmail.com>
+Date:   Thu Jan 30 13:35:18 2020 +0200
+
+    Add Data export api definition
+    
+    Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>
+
+[33mcommit dae7f407ffe028c0f156776b37c98cd453593ff3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jan 24 13:23:07 2020 -0800
+
+    Use correct namespace when checking status of adminClusterPair
+
+[33mcommit d1f7095fb037600bb718e5ecaa0a6df5ab1d63f1[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Jan 21 14:40:25 2020 +0530
+
+    vendor update for sched-ops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 258723fd0feed24664be867139f19e80d0a1d280[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jan 20 22:14:13 2020 +0530
+
+    get stork namespace from env for webhook
+      - generate CN using namespace in env
+      - log server failure errors
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 2db938fa528ac8fa7cc98030ebd8157180eacd44[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jan 9 19:50:29 2020 +0530
+
+    generate self signed certificates for mutate webhook
+    admission controller
+       - sched-ops vendor updates
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 09f2784315ea29a0ff2e8484b0d255526e0451dc[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Dec 27 12:15:17 2019 +0530
+
+    add mutating webhook controller to stork
+      - start webhook server on 443
+      - add listner for mutate admission
+      - verify if deployment/ss using px volume and update
+    scheduler to stork
+      - update stork specs with webhook admission configuration
+      - fix errcheck warnings
+    handle pod scheduler update for webhook controller
+      - nil check for non persistentclaim source
+      - allow default app deployment
+      - update scheduler path to include pod spec path
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 87997a219d1746440a617477265f712156a98687[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jan 24 13:25:02 2020 -0800
+
+    Revert "Use correct namespace when checking status of adminClusterPair"
+    
+    This reverts commit c963f03b29357fd3326afb474b8f8d4ddf5a3533.
+
+[33mcommit c963f03b29357fd3326afb474b8f8d4ddf5a3533[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jan 24 13:23:07 2020 -0800
+
+    Use correct namespace when checking status of adminClusterPair
+
+[33mcommit fba23c30430f40f7a99bdec81d94d67f90aeedf4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jan 3 02:21:21 2020 -0800
+
+    Remove stale generated files
+
+[33mcommit 2a3c6a17d572970d683adecd819a953c5e7f093c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Dec 13 13:52:16 2019 -0800
+
+    Update start up parameters
+    
+    Start the application manager controllers even if no driver is specified
+
+[33mcommit 8748a0f36bd807dcce63089e211dbd6eaf2e0360[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Dec 6 17:19:11 2019 -0800
+
+    Vendor update
+
+[33mcommit 25d286f112b8c57b38737be311da23b314329376[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Oct 19 01:30:24 2019 -0700
+
+    GCE driver implementation
+    
+    Can be used to take snapshots of GCE PDs and restore them to PVCs
+
+[33mcommit 82217b2fa71de790b20f831b162fbbe010ec1f56[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Oct 17 22:38:43 2019 -0700
+
+    Changes for app backup/restore to work with multiple drivers
+    
+    - When taking a backup we will now look through PVCs in the namespace for all
+    supported drivers and try to create a backup
+    - The driver name will be stored in the backup object so that we know which
+    driver to use when doing the restore
+    - This also allows us to create a backup with multiple volume drivers in the
+    same backup
+    - Added an options field in the application backup CRD which can be used to
+    store info like projectID, zone, etc for cloud drives
+
+[33mcommit 44b7af4da13149fe8da7dbe31d31e1c22b8ffef9[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Sun Jan 19 23:00:46 2020 -0800
+
+    Increase wait time for backups to be synced
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit ef10d727b91499774ab383e12f02b326f26a03ed[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jan 17 12:06:26 2020 -0800
+
+    Disabling unittest because of bug in fake client
+
+[33mcommit 23da4bc8555004684b6dd1ff76eca184903ca94f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jan 16 18:50:55 2020 -0800
+
+    Add activate/deactive migration support for ibp objects
+
+[33mcommit fa8da1871df18f980582a99b83fe0c337185623f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jan 16 18:50:33 2020 -0800
+
+    Vendor update
+
+[33mcommit 7dc3df13f98522aa1a0604e0223877f9ab6c8c4c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Oct 9 17:15:01 2019 -0700
+
+    Add support for some CRDs to resourcecollector
+
+[33mcommit fd149960d627014354ad233a0675cc9c3e0e0ec1[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Fri Dec 13 14:15:09 2019 -0800
+
+    Add stork secrets implementation based on lsecrets.Instance()
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 4ac2b39d8e86570b99842ddb1eee7c3205df8dfe[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Nov 13 00:42:23 2019 -0800
+
+    Scaled integration test for app backup
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 54645c25047d6a27e15777c2f0f3ed014ac35739[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Dec 4 13:26:43 2019 +0530
+
+    fix staticcheck errors
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit f92709c17b81de61747e17d0b7ef6b28c605c68e[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Dec 4 12:34:13 2019 +0530
+
+    [portworx] bump px version for in place restore feature
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit fb8f8cb4452d8235a511516e312bb1c692cb9835[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Nov 22 21:00:59 2019 +0530
+
+    add integration test for migration cleanup feature
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 8026c7c36869492b5940cc8934c0ef1d7bf3f6e2[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Nov 26 19:18:17 2019 +0530
+
+    Move destination resource collection to migration controller
+     - use NewInstance() instead of changing singleton k8s instance in
+       resource collector
+     - collect old resources to purge inside migration controller instead
+       of resourcecollector pkg
+     - change migration cleanup status to migration purge
+     - collect resource from destination cluster using new resource
+    collector
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit ef30674a7ccafe91fd4f7a7b2392ef4f96dac9ea[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Nov 18 23:55:35 2019 +0530
+
+    Cleanup migrated resources from destination cluster
+       - modified GetResources() to accept cluster config to fetch resource from
+       - only fetch resources which has migration annotation
+       - find and delete cleaned up resources from dest cluster
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit df796e6cf246fff637588339d7b20aeafc5f865e[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Nov 12 23:56:30 2019 +0530
+
+     Add CleanupResources flag to migration specs
+       - add annotation to migrating resources by stork
+       - have stub to cleanup resources for dest cluster
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit a1da847c31d14ea0400c33c3392c1acd64b938de[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Nov 26 10:26:56 2019 +0530
+
+    Wait for volume restore to succeed
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 5ad0ac664eaadb93953c6b28e1740a4c4edb9928[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Nov 15 18:34:42 2019 -0800
+
+    Rename stage in VolumeSnapshotRestore
+
+[33mcommit e1dce3b483660f487c2d9038e3846a91e9482528[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 14 16:56:37 2019 -0800
+
+    Increase timeout for backup test
+
+[33mcommit c762b61282ce760618d5c2b6a30ba22d1d5e701d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 12 23:00:29 2019 -0800
+
+    Remove call to verifySnapshot for cloudsnap test
+
+[33mcommit 27d8b1ec0ac530b94524eeb9463734164f21b1ed[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Nov 11 14:46:58 2019 -0800
+
+    Verify snapshot instead of groupsnapshot
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit e10b370262ef1ff1231525956a17cc020aea4013[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Nov 11 13:17:54 2019 -0800
+
+    Wait for snapshot to complete in in-place restore tests
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 8e91de91cbfe9118bfc451b770c5c01703ce827c[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Nov 8 08:28:23 2019 -0800
+
+    [Portworx] fixes groupcsrestore feature
+    
+      - correct error msg for restore failure
+      - pass only one pool while doing haupdate
+      - add debugging for correct  poolids
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 77285813a5a3442b2a09f51bdb0244b6be689b1d[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Nov 7 11:18:45 2019 -0800
+
+    Ability to skip restore tests even when running individually.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 589f83239dfe6690868ee909ac0d56f11a897d55[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Oct 30 17:28:41 2019 -0700
+
+    Updates for storkctl
+    
+    - Add missing backupName when creating ApplicationRestore
+    - Add replacePolicy param when creating ApplicationClone and ApplicationRestore
+    - Fix alias clash for VolumeSnapshotRestore and ApplicationRestore
+
+[33mcommit 64e6b90ad5b6bacec47400c2ee47e1282b8d7bfa[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Nov 6 16:20:25 2019 -0800
+
+    Add vendor updates for auth groupvolumesnapshot.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit fde1fdca2bd6d87b55187d5101a37bb5feedb59b[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Nov 6 00:15:05 2019 -0800
+
+    Add test for group cloudsnap restore, flag to skip tests.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 02f776fcdd7db501a0309b8a182b222bc3df8821[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Nov 5 09:02:49 2019 -0800
+
+    pass poolids to Nodeid for ha update api
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit efcaadf1e8ecc80a73a9b1385d4559393d7faaf3[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Nov 4 16:48:21 2019 -0800
+
+    Parameterize stork volume driver for integration tests.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 82e4959488320b4f145f8af50dde37ce4c4d9add[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Nov 4 02:22:25 2019 -0800
+
+    enable cs inplace restore integration tests
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit dc4974e1cb9ac0abeeb7e90f8bae038fbd02bd1e[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Oct 31 12:15:40 2019 +0530
+
+    update ha increase api nodeid to poolids
+      - update gettoken api with vendor changes
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 12d6d093f6895e9088f230d47ba6ced9fd2aba58[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Oct 31 12:13:29 2019 +0530
+
+    vendor update openstorage/release-7.0
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit b2844ea9c522ed824f70c82e1276e2b672db7e9b[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Nov 1 16:43:32 2019 -0700
+
+    Remove sleep which is not required.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 5969ad9bac19eed82915e0ff3daa380a5ea5495f[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Nov 1 12:32:42 2019 -0700
+
+    If stork_test is running, tail pod logs.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 3b305535b27f177d209dce3e4f2554ea1388c550[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Oct 24 13:46:28 2019 -0700
+
+    Add API to wait for backup completion in integration tests.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit b4315735cda93292155d9f99b4e56743ee9a94b6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Oct 30 15:39:21 2019 -0700
+
+    Update google sdk and some python packages in container
+
+[33mcommit 0edbe2ce1c72172aab585ba6baf2008eba1b750d[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Oct 29 12:38:12 2019 -0700
+
+    Vendor update for torpedo.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit c1127c65a863a8530e0a288f536a113fef01f983[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon May 6 11:45:40 2019 -0700
+
+    Add ability to run in auth-enabled environment.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 17aa6d2fcc4a5dd9c7dfa446b3fc2ddcfd3f7fbd[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Oct 28 13:49:14 2019 -0700
+
+    Add selector labels to stork daemonset and cassandra example.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit ecdc6c2125b0df5ab04c60bdf3e6736bd59ccef1[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Oct 28 12:34:03 2019 -0700
+
+    Fix selector label.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 183987621be9e1f2c5a8556ece6cba89034fb6f5[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Oct 28 11:52:49 2019 -0700
+
+    Add selector to spec.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit deff958975694c7f3769a968cde0a76f6a5c42f7[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Oct 28 11:20:16 2019 -0700
+
+    Update API version to v1.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 35060e5a26d0dddbd53bef5b8c30f80e803e0a23[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 25 16:00:39 2019 -0700
+
+    Update spec version for deployments
+    
+    Also add csinodes permission for scheduler clusterrole,
+    required for k8s 1.16 onwards
+
+[33mcommit c938095c7e5aa3fae294af24b167e67f552c460c[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Oct 14 01:36:27 2019 -0700
+
+    Migration scale test.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit c232cfedb42d2bccd62dbb9d58496ccaa039dce0[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Oct 21 18:21:22 2019 -0700
+
+    Update torpedo vendor.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 0d54b386a278b6e20402d9cdf125bfb5f3216207[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Oct 19 01:31:08 2019 -0700
+
+    Update test flag parsing which was broken in go 1.13
+
+[33mcommit e340d820e733cdaba3a2e9b3ee690bb651345b8f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Oct 17 22:46:19 2019 -0700
+
+    Update go version in travis to 1.13.1
+
+[33mcommit 66ea6ffe433cdd17e375439e35983f322fc0afc4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Oct 17 22:45:56 2019 -0700
+
+    Vendor update
+
+[33mcommit c046355acd59894ef543c4be9d7881891d6775e3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Oct 9 18:04:50 2019 -0700
+
+    Groupsnapshot: If objects exist reuse them if they are the same
+    
+    Else delete and re-create them
+
+[33mcommit e3114609abac69b49174f2ae0d6fed87359bf783[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Sun Oct 13 10:00:07 2019 -0700
+
+    update vendor to use sched-ops kubernetes-1.11
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit cc2e9f96a038bba5e533f9213172ccab12b0b52e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Oct 9 18:05:59 2019 -0700
+
+    Bump version on master to 2.4.0
+
+[33mcommit 6a3497c42b2a12fd5b6337a2b81d760b91cbb5f4[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Oct 9 12:14:54 2019 -0700
+
+    Fix error with creation of stock-mock-time.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 283dfa2d646afcdbbdb59e69614169b3697f575f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Oct 9 01:25:35 2019 -0700
+
+    Use created config map for watch on mock time
+    
+    Previously if the mock time config map was not created we would end up using the
+    empty config map to start the watch
+
+[33mcommit fb628de7dcfb6ccfe0c92ed4ba4bcd7b9341c3dd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 4 19:28:22 2019 -0700
+
+    Add checks for some resources when collecting them
+    
+    - Secrets: Ignore autocreated secrets with well known prefix names
+    - ServiceAccounts: Ignore autocreated service accounts unless they have
+      non-default image pull secrets configured
+    - Ingress: Only collect namespaced scoped objects
+    - Role/RoleBinding: Ignore autocreated objects starting with "system:"
+
+[33mcommit f8ae20dc8570259da875992298e8a450bb6fee50[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 4 19:27:16 2019 -0700
+
+    Fix retry for Unauthorized errors when migrating resources
+
+[33mcommit 05b615774d3b9b9f351056f0cc59a6d66a31a300[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Sep 26 17:08:26 2019 -0700
+
+    Some optimizations for migration
+    
+    - Don't cancel migrations that are in Final stage
+    - Don't update migration schedule after prune if the object wasn't updated
+
+[33mcommit 10c3e3e72bb5e0511beed1d3265117265f188791[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Sep 28 14:18:23 2019 -0700
+
+    Ignore PVCs that are being deleted during backup
+
+[33mcommit 0362b76554980d2f3c5e25516c0d30b0c6141bc4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Sep 28 14:07:13 2019 -0700
+
+    Fix termination of backoff for cancelling backups
+
+[33mcommit 85080c7e6bca8b08ac05c9092c6917a41620aed5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Sep 27 17:09:49 2019 -0700
+
+    Add the old parameter for cluster-admin-namespace
+    
+    Added the message that it is deprecated
+
+[33mcommit fa4dd6972783a9e99394ef4f431d5693e98b5943[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Thu Sep 26 18:40:26 2019 -0700
+
+    Cluster domain tests: Wait till scale factor reduces to 0 before failover.
+
+[33mcommit d260c19a2f888a13cecb7ab75676e165c47df6f2[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Sep 26 14:21:14 2019 -0700
+
+    Remove incorrect check for reclaim policy.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 1ceddf079b835d0d7706d8b728e2a39dc987b469[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Sep 24 00:59:35 2019 -0700
+
+    Backup to and restore from S3, Azure, Google.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 599aea4030e917386351da19d7c21ebeb0e65f70[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Aug 13 17:48:04 2019 -0700
+
+    Cancel and fail backup if starting volume backup fails
+
+[33mcommit cfb91a641e74963c829927ca003db28412830933[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Sep 25 15:45:22 2019 -0700
+
+    Revert "Update travis for 2.3 branch"
+    
+    This reverts commit db3ec66dba91bc6ca150ce900953c093b9a52014.
+
+[33mcommit 7b52a5e7fa4573b48a1859d16ba4f36c3b4bb821[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Sep 24 16:25:50 2019 -0700
+
+    Check the scale factor of the application after scaling it down.
+
+[33mcommit db3ec66dba91bc6ca150ce900953c093b9a52014[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jan 30 19:23:58 2019 -0800
+
+    Update travis for 2.3 branch
+
+[33mcommit 252f6145c4a665c062bb846c152a68d6d8e4b196[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Sep 24 18:12:38 2019 -0700
+
+    Fix race in migration schedule integration test
+    
+    The prune for migrations might still be in progress, so add retries
+
+[33mcommit 8a05f413d630ac7ee240ddd4d7f17b38f6685245[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Sep 9 17:42:59 2019 -0700
+
+    Add migration test with startapp flag set to false.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit e7a053a135d33a809aef2ce5bf1cbad2a940379e[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Sep 23 23:54:49 2019 +0530
+
+    update UT's to additionally check for volume count for snapRestore
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 75e1685a38c35f699f148ce523b9f9bb9b25f331[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Sep 23 23:54:15 2019 +0530
+
+    vendor update portworx/sched-ops
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 030eba580b3244d9078c0aa0b9f4c5b804860b1d[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Sep 16 20:52:30 2019 +0530
+
+    Correct volume count for storkctl snaprestore output
+       - remove unnecessary logs
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit c27038598439486e23f6ca7bba3b82876e82e55e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Sep 20 15:57:10 2019 -0700
+
+    Don't migrate default rbac objects
+
+[33mcommit 01815b26d3054175803c6d84ffc747b90866abf8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Sep 19 17:44:54 2019 -0700
+
+    Retry migrations for Unauthorized errors
+    
+    The kube apiserver can sometimes return Unauthorized when running on the cloud
+    if there are temporary auth errors
+
+[33mcommit ae892f9156bdbb5bad9c96b62f7684f0fd1b9660[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Sep 20 16:14:43 2019 -0700
+
+    Update the number of workers to 10 for each controller
+    
+    Will make if configurable for each controller in the future
+
+[33mcommit 1d6146f1317ff5ab05f2773dccad82299cbbda7d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Sep 19 11:05:44 2019 -0700
+
+    Vendor update for snapshotter
+    
+    Adds cache when listing volumesnapshotdata instead of reading from
+    kube apiserver everytime
+
+[33mcommit fee9c8f36b864053218d92a1bb95fb701508acd7[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Sat Sep 21 09:56:52 2019 +0530
+
+    detect snapshot type while cleaning up restore objects
+    in volumesnapshotrestore
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit a3d5ce729068f35dc869692b7a7568fb40544d22[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Sep 20 23:32:01 2019 +0530
+
+    update torpedo api changes to integration-test
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit aa7bd73051250f5fb0ad2898edea339d2493a474[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Sep 20 05:09:11 2019 -0700
+
+    Vendor update torpedo
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 787a5ed469c69314befd7dcd9c7c8a45269cefb4[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Sep 20 17:11:32 2019 +0530
+
+    replace maps for restore volumeinfo in crd
+       - use pvc,namespace filed to extract volume information
+       - clean snapshot in-place restore for each volume
+       - show restore status for each volume
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 8ede2852f88dc462e98afc0ed9852c9c977b8c84[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Sep 20 01:08:39 2019 +0530
+
+    store pvc name and namespace mapping instead of whole pvcspec
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 4fa4511244de4ed413160adf9022510cbf031d68[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Sep 20 01:07:38 2019 +0530
+
+    add detail volume info snaprestore crds
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit c9e7e76b061d373818e077b73dd95f513744ae37[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Fri Sep 20 15:36:14 2019 -0700
+
+    Check ownership of VolumeAttachment before deleting
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 9e044d720820005da7289c035b674b3ebe11bb82[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Sep 20 14:45:34 2019 -0700
+
+    Revert changes made for testing.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 14e782fc2c7049e7255cdcbcc995bde4e9d4e72c[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Sep 20 14:25:43 2019 -0700
+
+    Use scale factor from destination cluster to scale source in failback.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 302785e0af3836fc691b0497c71492940422c902[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Sep 19 13:27:14 2019 -0700
+
+    Set old scale factor in failback test.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 545fc4666da109ca557a9ab3e97691f5d895daea[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Fri Sep 20 12:56:20 2019 -0700
+
+    Delete VolumeAttachments for down node or pod in unknown state
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 01ec37438733c3fbfeb211301567fc168d26549a[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Fri Sep 20 11:38:20 2019 -0700
+
+    Update vendor
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 3a9a677b79598b0743789b65410c87eeaa7b14bf[m
+Author: Luis Pabón <luis@portworx.com>
+Date:   Wed Sep 18 17:49:31 2019 -0700
+
+    Fix CSI unstructured object access
+
+[33mcommit a6c426c7187b0b74e0f880cd084734eb9ac15728[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Sep 19 22:38:21 2019 -0700
+
+    Reset config to source after backup sync controller test.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit f2d0a9436341ec357fcb74812ddcf8f53ff097da[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Sep 19 14:02:30 2019 -0700
+
+    Order snapshot tests to run before migration tests.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 4757bf0faa5ca18a825a2191a23259740b0d64e8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Sep 17 23:29:11 2019 -0700
+
+    Create annotations for app during migration if it doesn't exist
+    
+    Also remove noisy log message
+
+[33mcommit 4c87ec9e5c7d82ceb757fbc0d8fdecdff32d30bf[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Sep 17 11:27:59 2019 -0700
+
+    Use cassandra instead of mysql for clusterdomain migration.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 4241f55a4914edabdb06034687faf4d46afee503[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Sep 12 17:32:39 2019 -0700
+
+    Allow running of individual tests.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit be7040a0e3c8efdd52cce0d99ba3a432740387c8[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Sep 16 17:56:13 2019 -0700
+
+    Use name from the existing secret object as new obj might be nil.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 0d9a17c9366915f0ff7da31fdc43c84dfad01146[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Sep 12 17:59:32 2019 -0700
+
+    Update API group for stork-scheduler permission for replicaset
+
+[33mcommit a56395cd9c555c930029868a9a22fdc618967356[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Sep 11 12:26:21 2019 +0530
+
+    Don't add duplicate entry for already present imagepullSecrets
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 7a2c14100a8b0049bc65a7611561613f1b657977[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Sep 10 16:45:42 2019 +0530
+
+    Migrate image pull secrets associated with default service account
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit d7624f2f4e0d1da8cf229ef4327ffe1bb7aaf223[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Sep 11 17:02:45 2019 -0700
+
+    Don't set predicates or priorities for scheduler
+    
+    It picks up the defaults from k8s 1.10 onwards
+
+[33mcommit dad6473aab94a2b037e3ce4d70b32e3df4337c51[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Sep 4 15:10:10 2019 -0700
+
+    Create namespaces for restore if they don't already exist
+
+[33mcommit 69c001906756bf7dc5e34e22463e1fa509ade550[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Sep 4 15:02:00 2019 -0700
+
+    Remove owner ref from synced backups
+    
+    This was causing backups to be deleted by the k8s because the owner,
+    which is the backup schedule, won't be present on remote cluster
+
+[33mcommit c46f6dfa27d3a613deccb9e7bbfb7c3a5cf3421e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Aug 14 22:12:39 2019 -0700
+
+    Add check in monitor to skip duplicate offline nodes with same IP
+    
+    It is possible for the storage driver to return information for 2 nodes with the
+    same IP if a new node was re-using the IP from a node that was removed.
+    In that case the health monitor would incorrectly determine that the storage
+    driver was offline on the node.
+    
+    This change removes offline nodes with duplicate IPs
+
+[33mcommit e5ea8255801a5852cee711ee7c668902689a438b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Aug 28 19:27:58 2019 -0700
+
+    Convert reclaim policy to string before setting in unstructured object
+    
+    Can't set custom types using SetNestedField
+
+[33mcommit c39cbb36199212065a9cb5b8d13391ca5a0b6488[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Sep 3 15:49:46 2019 -0700
+
+    Create namespace mapping map in application restore if not present
+
+[33mcommit 54a430952512a9832831723f211cb1fe3bcdb964[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Aug 22 18:45:43 2019 -0700
+
+    Integration test for backup sync controller.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 4a0e6d84471783bdca391ab887cc8c24eeeec60c[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Aug 27 12:57:48 2019 -0700
+
+    Move the ClusterDomainsStatus.Info check within the retry task.
+    
+    - Stork will create the CDS object but it might not update the Info object
+      until it gets it back from the storage provider.
+
+[33mcommit 3224f511a5932974a793d9df5637eb122cdb6252[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Aug 26 17:57:54 2019 -0700
+
+    Increase wait time when waiting for cluster domain list.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit fce3389cc68a1893ac96daac6358bf43a4978ea6[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sun Aug 25 23:13:10 2019 -0700
+
+    Cluster Domain Integration Tests
+    
+    - Add a task wait and retry over ListClusterDomainStatus call
+      before concluding that the tests are not running in cluster domains
+      environment.
+
+[33mcommit faea830df8aac52591087439e01f1242cffb0d45[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Aug 24 22:21:13 2019 -0700
+
+    Update go version for travis build
+
+[33mcommit ca799b78d7fce4825107a78b6f11918dd3240cf3[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Aug 23 16:10:49 2019 -0700
+
+    Add quotes to the enable cluster domain flag.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit bc0e9926fd84d65fe0cfc91e423a22f30c419dba[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Aug 22 18:49:08 2019 -0700
+
+    Fix flag for enabling cluster domain tests in integration tests.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 53099ddfc07741866ff1580028bf5bf9c3ef1541[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Aug 20 16:33:21 2019 -0700
+
+    Add 'nil' param to ListNamespaces sched-ops method invocation.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 65127137a6ecbeefcd5dc355ff0b261b3e4d5017[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Aug 20 16:17:00 2019 -0700
+
+    Vendor Updates.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 9a8e7f56dd1813d1e195a211f69c92b32cc00bb8[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Mon Aug 19 23:03:18 2019 -0700
+
+    Add storage provisioner flag to stork-test.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit a2450e756afef7868435fd0726e0ae577036f442[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Aug 16 15:37:29 2019 -0700
+
+    Save the clone volume names after generating so that we can use them on failure
+
+[33mcommit 977657fd2b882139af3aa3a03b57e955a5389d7b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Aug 16 15:36:27 2019 -0700
+
+    [Portworx] Delete created volume clones on failures
+    
+    This ensure that all volumes are created together when retried
+
+[33mcommit 18ccdd37258bbf0c02a26df1ce387d6b76973938[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Aug 13 17:52:16 2019 -0700
+
+    Remove check for error when refreshing discovery helper
+    
+    The library takes care of the error
+
+[33mcommit 961ffa6085e6272afb5365b5caefd816fb976855[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Aug 13 17:46:56 2019 -0700
+
+    Replace collections helper with modifying objects directly
+
+[33mcommit 49e5c63fcaa6477679ac23786744a3a7c4292a5b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Aug 13 16:42:12 2019 -0700
+
+    Vendor update
+    
+    Update k8s pacakges to 1.11.9
+
+[33mcommit 974e7a2865b7cb944d9d2da3e874751fb2d84b77[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri Aug 16 17:05:52 2019 -0700
+
+    Integration test for label selector.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 63408fd629ad1bdab069c13b43d7d7e20919d843[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Aug 7 22:38:46 2019 +0530
+
+    Address review comments
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 391e8e24dfb7558f45a1e61395b18e9ac709b977[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Aug 7 01:40:44 2019 +0530
+
+    Cleanup restore objects upon CRD delete
+      - fix restore fails when haUpdate fails for restore vol
+      - make task add more unique
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit ddb55b7ad3aaee28308a7f9cb8416f6e4053554e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Aug 16 23:24:45 2019 -0700
+
+    Update cassandra version in integration test
+    
+    The older version has a bug which could lead to an empty commit log file
+    which causes issues during restart
+
+[33mcommit 8dff2de6e1abd01319f8469c1b5910910d4c2aa0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Aug 15 13:07:07 2019 -0700
+
+    Vendor update for torpedo
+    
+    Fixes test issue when creating rules
+
+[33mcommit 2e863970a599d0380243f6bce2cca972c26776d6[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Aug 14 17:29:38 2019 -0700
+
+    Integration tests for pre/post failing rules and spec files.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 6ca355dfdc77ae87a56d3cea78b44bf169110a0b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Aug 10 13:56:23 2019 -0700
+
+    Update version for Deployment and Statefulset
+
+[33mcommit 25a49dfd0136f64a0bca51bbf917fa07bdf6bf47[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Aug 10 13:55:49 2019 -0700
+
+    Vendor update for sched-ops and torpedo
+
+[33mcommit 168aab918faad8e4c1f6ef78b514ca81ed7c8f75[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Aug 10 13:42:23 2019 -0700
+
+    Pass in correct namespace when running pre/post exec rules for clone
+
+[33mcommit cf051db8390340eadcfa4d34426f0432ce033176[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Aug 8 23:31:33 2019 -0700
+
+    Integration tests for application clone with rules and label selectors
+
+[33mcommit fcf8665149b31784cf2927d77f3b9dbb019469aa[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Sun Aug 11 18:23:57 2019 -0700
+
+    Integration test for application backup with pre/post exec and missing rule.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 4df16d5f9f05fa34846c06af7a8864832c4f26c9[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Aug 12 19:20:14 2019 +0530
+
+    Disable CS inplace restore feature
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit cf19c5cf197d58ecae43319fda71c138da802019[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Aug 7 22:42:21 2019 +0530
+
+    Disable CSRestore integration tests
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 7c56efd2a9c3887f54c109e4e6ca3d09b8aa2972[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Aug 6 17:48:29 2019 -0700
+
+    Don't return error from schedule controllers if policy is invalid
+
+[33mcommit e73bbbf46645371e9a1d77da983369644c06d9e2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Aug 6 17:25:05 2019 -0700
+
+    Update for application backup and schedule
+    
+    - For schedule set retain policy to delete by default
+    - When deleting backup ignore NotFound error for backup location
+
+[33mcommit fa902c4fe37d48f8461269b7ad970bf54a3e6c67[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Aug 6 17:10:40 2019 -0700
+
+    Add integration tests for application backup schedule
+
+[33mcommit f2be98dff14d40d0847da46d2e01554d03e006a5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Aug 5 16:44:31 2019 -0700
+
+    [Portworx] Add version checks for application backup and snap restore
+
+[33mcommit 66c87147d31988a21d599f272232831d63a818b2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Aug 5 16:36:43 2019 -0700
+
+    storkctl subcommands for ApplicationBackupSchedule
+
+[33mcommit 755325f0c1e7e4dd3546cde3b3149cfca94ad89d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Aug 5 16:36:24 2019 -0700
+
+    Vendor update for sched-ops
+
+[33mcommit 19da95bd7280434afa8455f027ffdd6b6ba7c6ca[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Aug 2 16:14:39 2019 +0530
+
+    Validate snapshot for restore
+    
+    signed-off-by: ram <ram.suradkar@portworx.com>
+
+[33mcommit 1621151c727ae7a7e13f8956ab544735ca4647fe[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Jul 30 17:17:58 2019 -0700
+
+    Ability to add environment variables to be added to stork deployment in integration tests.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit c4177fe98e3c1dea241477fc633e052b1f2feb98[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jul 31 11:56:08 2019 +0530
+
+    Move snapshotrestore test before migration
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 3590d42dd351d03c44240ab8f02094f0198b9dc6[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Jul 23 13:46:05 2019 -0700
+
+    Comment tests to test out the job.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit a9f90d61a8e0070da79d2f1ebff445382400958e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jun 14 15:29:38 2019 -0700
+
+    Add field in BackupLocation to specify if backups should be synced
+
+[33mcommit f9424c1e5a27b843b523db3ba8bd4c93185d416a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jun 12 15:06:36 2019 -0700
+
+    Add TriggerTimestamp to ApplicationBackup
+    
+    Useful to keep creation time when backup objects are restored to another cluster
+    Also setting the default namespace mappings during restore if none are provided
+
+[33mcommit 3d3b2fbdc1e4f1d0afcd94a5ac3e5bb33bd8c934[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 6 13:10:59 2019 -0700
+
+    Add controller to sync backups
+    
+    - Scans all the backupLocation for backups
+    - If a backup from the backupLocation doesn't exist on a cluster create one with the
+    format <backupName>-<creationTimestamp> in the namespace. Scheduled backups
+    retain their original name since they already have a timestamp in the name
+    - The ReclaimPolicy it set to Retain for the synced objects so that deleting
+    them doesn't delete the backup from the BackupLocation
+
+[33mcommit 70e52e0195ff52371970ed6f5ef538b7b9bc684e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jun 3 18:19:20 2019 -0700
+
+    Destroy all contexts before waiting in integration test cleanup
+
+[33mcommit ac984c2d98ec36cd66fb5bbeaa2b3697ffa109e7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jul 24 16:48:53 2019 -0700
+
+    Add unit tests for health monitor
+
+[33mcommit 4b7941828e0afce2d9996979d6a0fd6ca080f3db[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jul 24 16:44:37 2019 -0700
+
+    [Monitor] Delete pods from node if it is in any phase
+    
+    A pod could be scheduled and the storage driver on the
+    node could go offline after that causing the pod to be
+    stuck in Pending state
+
+[33mcommit 0cfb3632eb514bd7967e9255d52d2cf200f5193f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jul 17 14:25:36 2019 -0700
+
+    Add API to resourcecollector package to delete objects
+    
+    This can be used when resources need to be deleted before creating them again.
+    Deletion needs to be done for all the objects beforehand because there could be
+    resources that have dependencies on other resources. For example, a PVC can't be
+    deleted if a pod is using it.
+
+[33mcommit c6cd98371924068bf34158131fc72d784a21886b[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jul 29 12:24:03 2019 +0530
+
+    Vendor updates torpedo
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit d9d40ac13184a6dcbbe37b341561d9cd4fcd8266[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Jul 26 23:35:27 2019 +0530
+
+    Use addTask instead of Schedule for creating group snap
+       - correct  api WaitOnDriverUpOnNode api
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 68963cd193e39d076030e55976871dfb34fd11ab[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jul 25 00:16:17 2019 +0530
+
+    Add integration test for snapshot restore
+       - grouplocalsnapshot restore
+       - cloudsnapshot restore
+       - addressed review comment
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 3b2fa929da49d3f1d5abc7b22815fb1ab439b47a[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Jun 28 00:40:30 2019 +0530
+
+    Basic integration test for snapshot in place restore
+      - Vendor changes for inplace restore intergration tests
+      - Fix namespace for inplacerestore crd
+      - Vendor update for sched-ops, torpedo
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 70f6a019ae327ec8f9cd6b29bb7377699ee6d56e[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jul 29 11:38:43 2019 +0530
+
+    Address review comments
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 9645ce32ed61bd67d957a191a837f9e324fae087[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri Jul 26 01:37:44 2019 +0530
+
+    Add retry for voldriver_restore api
+      - send proper rs while ha_update
+      - handle reconsiler failure condition properly
+      - use updatePVC sets
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit bb657322388b8e709571842c1066760a14bbdaf0[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Jul 9 17:15:43 2019 -0700
+
+    Update Gopkg.toml for dep failures.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit e9cfbbb1573f0fdd244467c40ae153ce562bf207[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Wed Jun 12 12:09:47 2019 -0700
+
+    Integration test for backup/restore. Replace policy - Delete.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit d9deefc8fdeea25008f7f61f5a1921e5cf0dc3f6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jul 16 14:41:36 2019 -0700
+
+    Add an integration test for application clone
+
+[33mcommit 65b79302f45bd7e869a06754753e016e516bab0c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jul 16 14:40:29 2019 -0700
+
+    ApplicationClone: Create destination namespace if it doesn't exist
+
+[33mcommit 883352abc1f8439d05aaa52c591c43e3f9c26da8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jul 15 16:07:50 2019 -0700
+
+    Vendor update for sched-ops and torpedo
+
+[33mcommit 5b48f8e27616baa6bb5d8376ac0b6a8b1d127d06[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jul 26 13:36:15 2019 -0700
+
+    Update permissions for stork-role
+    
+    Needed for application restore
+
+[33mcommit 5c904f33a5733fe62258fde9a3a25c8ed6129df9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jul 22 15:07:33 2019 -0700
+
+    [Portworx] Add labels to cloudsnap for application backups
+
+[33mcommit ebb387d43d4e429462a02b29b3d735c042d21aa3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 21 14:57:11 2019 -0700
+
+    Add controller for application backup schedule
+
+[33mcommit 987c6b555c31462f4201d04ab558fc0ec059a2d2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon May 20 17:08:05 2019 -0700
+
+    Add CRDs for ApplicationBackupSchedule
+
+[33mcommit bad6ba7adb6a063e4d1d952eb2c45fdfe5f9793d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jul 25 13:41:10 2019 -0700
+
+    Fix duplicate imports
+    
+    Was causing the latest staticcheck to fail
+
+[33mcommit cb94241e576eab5040957b31e7848ffba218f907[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jul 22 19:16:38 2019 -0700
+
+    Validate name and namespace when generating clusterpair
+
+[33mcommit 4a04e421eaf8c1f99e3620aac35985611b6da7a3[m
+Author: Luis Pabón <luis@portworx.com>
+Date:   Fri Jul 12 14:38:05 2019 -0700
+
+    Update vendor
+
+[33mcommit 9cce69a03693449c3b495b2a46d86be6547e8e0f[m
+Author: Luis Pabón <luis@portworx.com>
+Date:   Mon May 13 13:59:07 2019 -0700
+
+    CSI Support
+
+[33mcommit e8a3b7847fab86de6a2d075eac7a18d6db8948b8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jul 17 18:37:04 2019 -0700
+
+    Add -t to test2json to add timestamps
+
+[33mcommit 00d9152fefbf43ec5fe7988e902a31b38dff103f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jul 11 15:02:27 2019 -0700
+
+    Store snapshot schedule info in annotations instead of labels
+    
+    Values in labels have a smaller length limit and the info should be an
+    annotation anyways
+    
+    Fixes #415
+
+[33mcommit cd9f704867586af2b7e0bf65b9af303536d952a8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jul 10 15:46:29 2019 -0700
+
+    Allow users to specify annotation in pod if only local node should be preferred
+
+[33mcommit 00a97d76a7c7ca4e532cb26689e7378453c3ae9b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jul 1 13:00:58 2019 +0400
+
+    When uploading objects don't close writer async
+    
+    It can return errors which should be reported back
+
+[33mcommit 9181c724b6d73e719359e1b286afca0aaf54247c[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jun 27 14:27:00 2019 +0530
+
+    Fix correct restore volume name in log
+      - add volumeId in info log
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 274376b5342560c9ae1279e11e8035cbe2172e18[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu Jun 13 22:53:59 2019 +0530
+
+    Review comments
+      - handle repl update of volume
+      - delete orphaned objects once restore completes
+      - remove restoreType from CRD
+      - fix unique restore TaskID
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 5588558a2c858366130fc13bb6947e2090668277[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jun 12 22:30:15 2019 +0530
+
+    Rearrange snapshot restore controller
+       - prepare restore objects before in place restore
+       - check status of snapshots restore objects
+       - keep restorevol map and pvc list with snapshot restore
+         CRD
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 98ca860a8abade8d55ab512ed3b209ed3861fc03[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Wed Jun 12 01:14:04 2019 +0530
+
+    Add preparation stage for in-place snapshot restore
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 89a2d7d08a7d7196f4bc3cbccd9c887a756acfb0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 20 10:33:19 2019 +0400
+
+    Don't skip delete for PV and PVCs when replacing
+
+[33mcommit 8587c17d87c3f9e31daeccdb279faf7f05103dd5[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri May 31 17:04:50 2019 -0700
+
+    [Portworx] Fail Portworx driver init if service doesn't have required ports
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 28ff69936f09b5de52e308deae902c1035af11b8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 13 16:49:48 2019 -0700
+
+    Create annotations to store migration replicas if it doesn't exist
+
+[33mcommit 541a0f8afc1bb50d71c34053f60846e8203595a5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 13 14:33:28 2019 -0700
+
+    Ignore errors from discovery helper for aggregate APIs
+
+[33mcommit c4b4526c86e825fedbf50fc3b3835b90553a6d01[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 13 16:38:37 2019 -0700
+
+    Add support to collect Template objects
+
+[33mcommit 0300b1ba34ec8a393fe0a0bb8e5ba5459da50831[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 28 19:55:16 2019 -0700
+
+    Ignore error in storkctl if deploymentconfig type isn't found
+
+[33mcommit fdeaf4557546fa0222fa779a001033e1ec6706f0[m
+Author: Piyush Nimbalkar <piyush@portworx.com>
+Date:   Wed Jun 12 16:22:06 2019 -0700
+
+    Remove storage cluster CRD and controller
+    
+    Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>
+
+[33mcommit 603f5f576fb2a6b84f0c9afd1399802c538f6cf4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jun 10 17:17:27 2019 -0700
+
+    storkctl subcommands for backuplocation
+
+[33mcommit 1d50a5c6ac67372be4a3dd7f68031cc6c78b6ae2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jun 10 17:23:39 2019 -0700
+
+    Vendor update for sched-ops
+
+[33mcommit a302011186a76ef7c17b8d7176b37370ffd69b1c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 6 15:58:23 2019 -0700
+
+    storkctl subcommands for application clone
+
+[33mcommit 32ee7104f6da915108a7ab9ce87a1044f53f0f18[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 6 14:31:27 2019 -0700
+
+    storkctl subcommands for applicationbackup and applicationrestore
+
+[33mcommit 4e47e815ee834d6f6c1624aa6494f7394f0c7462[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon Jun 10 23:27:14 2019 +0530
+
+    sched-ops vendor update
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 8a907b88c09fb20c02dc4cb40f952f5b8fbefee2[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Jun 4 15:59:28 2019 +0530
+
+    Storkctl support for in-place restore
+    
+      - Pretty print snapshot-restore output
+      - Add UT's for storkctl snapshotRestore
+      - Review comments
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 0525e3e34e1917abefb01eeae7df412bd9ab6956[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Tue Jun 4 14:47:04 2019 +0530
+
+    Add unit test for restore check in extender_test
+       - adjust ut's to create pvc
+       - address review comments
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 326292106f8a84a9e8ba237dfb0ede2392d51000[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri May 31 19:18:51 2019 +0530
+
+    Add stork scheduler check for in-place restore
+    
+      - address review comments
+      - nil check for pvcclaim
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 9641642969ca2aa7bdd446680efbc1c97187dddd[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu May 2 01:18:26 2019 -0700
+
+    Add controller for In-place snapshot restore
+      - Fix go-lint errors
+      - Review comments
+      - Generated files for changed volumesnapshotCRD's
+      - Restore snapshot where pvc is in use by pods
+      - Move controller specific login from portworx driver to snapshot restore
+    controller
+      - Generated files by codegen
+      - Review comments
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 88c5d54ec2676d38c90fbfa3d8dd66ce2a451a70[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Thu May 2 01:16:32 2019 -0700
+
+    Add CRD for In-place volume snapshot restore
+       - codegen generated files
+       - Add controller for In-place snapshot restore
+       - Add support for local groupsnapshot in-place restore
+       - Fix go-lint errors
+       - Review comments
+       - Check restore status before calling driver's snapshot restore
+       - codegen generated files
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit ee02a051e0d487339d09d3acaf495f4971d9f1ed[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 30 20:44:35 2019 -0700
+
+    Update staticcheck for integration test
+    
+    It throws an error when giving the package name for some reason now
+
+[33mcommit 5c7a76edb581ea6031513e78e60817d1178a8488[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 29 22:03:14 2019 -0700
+
+    Fail migrations if local domain is inactive
+
+[33mcommit ec80b4110e13e59d54e210240ed8a35b6f144027[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 30 20:04:04 2019 -0700
+
+    Update permissions for all stork resources
+
+[33mcommit 988a58993dafc844f051fb7d2dd7f29632a617ad[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 29 22:04:11 2019 -0700
+
+    Update migration behavior for PVs
+    
+    - Set reclaim policy to Retain if volumes aren't being migrated
+    - Update PV if it already exists instead of deleting and creating
+
+[33mcommit 3633b8d73a47ffa3d4bc0ca84349d6a6d4a13b79[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 29 22:03:34 2019 -0700
+
+    Portworx: Return empty clusterdomain list if not set
+
+[33mcommit 31f54fd09fa55e771a677a1d1eec825dfd5febbd[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Wed May 29 17:43:05 2019 -0700
+
+    Portworx ClusterDomainsStatus: Do not fail on volume enumerate errors.
+    
+    - Add a new state SyncStatusUnknown when the driver fails to fetch the sync status.
+
+[33mcommit 12554e96b5f3ec6b4c0d0aac93726643b163e7b4[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue May 28 18:41:22 2019 -0700
+
+    integration test: Use remote cluster to activate/deactivate domains
+
+[33mcommit d1e467829e95c23c2d55fca861bd51300061159b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri May 3 22:19:33 2019 -0700
+
+    Fix type for annotation to not collect resources
+
+[33mcommit a80f31e6c39624f529102ba608e1b32edfb6e2dd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 2 23:20:59 2019 -0700
+
+    Controller for ApplicationClone CRD
+    
+    - ApplicationClone objects are only allowed to be created in the admin namespace
+    for now
+    - First the volumes for all the PVC are cloned
+    - Then the resources are copied from the source to destination namespace
+    - ClusterRole is not copied since it is a cluster scoped object
+    - ClusterRoleBinding is merged to have same binding for both namespaces
+
+[33mcommit 6f66e799199af79ee0dbb796475c62cf79487be9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 2 23:18:29 2019 -0700
+
+    Add interface in volume driver to Clone Volumes
+    
+    Also added implementation for portworx driver
+
+[33mcommit d8f7f2af82fb40354341887a154daf748728f762[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri May 17 18:42:57 2019 -0700
+
+    Add package to encrypt/decrypt using AES
+
+[33mcommit 004a47fbf98625b528582f96f4320e1ba0a11f52[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri May 17 18:41:15 2019 -0700
+
+    Update backup and restore controllers to use encryption key
+    
+    EncryptionKey is used up from the BackupLocation object
+
+[33mcommit 30b95a6a02f38d7624827b395df46acd4ed86096[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 1 15:28:49 2019 -0700
+
+    Vendor update for new dependencies
+
+[33mcommit 29546a4b5dc55003d1943d70f79dea43ad61cac1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 9 14:34:34 2019 -0700
+
+    Print stork image with `storkctl version` command
+
+[33mcommit 43128581471a0f81efdc0c683477d0d68701157b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 9 14:33:27 2019 -0700
+
+    Update stork parameters
+    
+    Don't print defaults, it is printed automatically
+    Set kube-system as the default admin namespace
+
+[33mcommit d4356d08d62c742e11be714f512c6d61aa7d0d89[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri May 3 15:13:44 2019 -0700
+
+    Add controllers for application backup and restore
+    
+    - Backup and restore is triggered for the volume first followed by the resources
+    - The location of the backup is specified by a BackupLocation
+    - The volume driver stores the volume backup in its format
+    - The resources are stored under <bucketName>/<namespace>/<backupName>/<backupUUID>
+    - This path is stored in the backup object
+    - An ApplicationRestore object needs to refer to an ApplicationBackup that it
+    wants to restore from
+
+[33mcommit c32f94c9fc24dd35ffb1dd2a43f786527eea3588[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 1 16:20:58 2019 -0700
+
+    Add interface to volume driver to backup and restore volumes
+    
+    Also added implementation for Portworx driver
+
+[33mcommit 0a696e689069f7a928cfe585cef65665f5c26bec[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 1 16:23:36 2019 -0700
+
+    Add package for objectstore abstraction
+    
+    The API takes a BackupLocation object and return a bucket handle
+    which can be used for CRUD operations
+
+[33mcommit 38b071f7abc0e907b7238a67aa15cf4ce1791ea1[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon May 27 17:37:59 2019 -0700
+
+    Update dep versions for sched-ops and torpedo packages
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit 5841c29b9adfecb9f876908b81e8db2e8cc82f34[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon May 27 10:54:38 2019 -0700
+
+    Add suspend and resume subcommands to storkctl
+
+[33mcommit 8a0d552989bb585b61a9266cecc5437ad0de2d85[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sun May 26 00:14:07 2019 -0700
+
+    vendor updates for sched-ops, torpedo and talisman
+
+[33mcommit 19f0f469468a2578f3c556eb655522c49612d67b[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon May 27 16:01:42 2019 -0700
+
+    Modify storkctl to show ClusterDomain's sync status
+    
+    - Use the updated ClusterDomainsStatus CRD and fetch the SyncStatus from it
+    - Modify storctl UTs
+
+[33mcommit 3255eccc342aef3a6fd7c798720cd2004f0d2bcd[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sun May 26 14:51:41 2019 -0700
+
+    Portworx: Determine cluster domain's sync status based on volume replicas
+    
+    - Modify Portworx's GetClusterDomains API
+    - Enumerate all portworx volumes and based on the current and create replica set
+      determine if a volume is in resync.
+      - Determine a cluster domain's sync status based on resyncing volumes and their nodes.
+    
+    Update the ClusterDomainsStatus controller to use the modified CRD.
+
+[33mcommit 8338eb362300bb34e4846b976149ceea82c69150[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sun May 26 00:06:17 2019 -0700
+
+    Modify ClusterDomainsStatus CRD
+    
+    - Remove Active and Inactive lists
+    - Add a ClusterDomainInfo object under Status
+    - Add new SyncStatus that indicates whether a cluster domain is in sync with other
+      cluster domains.
+
+[33mcommit c1406b3acc7eab1a49b4b756af72e14985fa4e05[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Mon May 27 23:26:53 2019 +0530
+
+    Add wait options for storkctl create migrations
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit 1f61136389475fcf5fe195d45934b36b46f07c27[m
+Author: Ram <ram.suradkar@portworx.com>
+Date:   Fri May 24 22:20:37 2019 +0530
+
+    Add wait poll support for storkctl activate clusterdomain
+    
+    Signed-off-by: Ram <ram.suradkar@portworx.com>
+
+[33mcommit fe496a5ced7a7a90349b6c5693f6be96629bf669[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri May 24 19:41:09 2019 -0700
+
+    Print N/A for volumes and resources when not migrating them
+
+[33mcommit f2e070eac4fc7dbd7609f8445730453122b507ed[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 23 18:03:23 2019 -0700
+
+    Create some default schedule policies
+    
+    Also update strokctl to use a default policy for migration schedule
+
+[33mcommit 8dd0ce7ed3c5d1690b88e6fe545bc43c6ece3a16[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 22 16:54:30 2019 -0700
+
+    Optimize migrations for clusterrole
+    
+    For clusterrole, get a list of crbs initially and use that to check if migration
+    is required
+    
+    Also skip deployer and builder service accounts which are automatically created
+    on  OCP
+
+[33mcommit 745b5402bd3840a2c9cc1236ef014023c1cc123a[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Tue May 21 14:42:48 2019 -0700
+
+    [Portworx] add idempotency for local snapshots
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 6824155a70d0af3da694bd3ebef9786506fab041[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 22 15:27:46 2019 -0700
+
+    Suspend migration schedules if the local clusterdomain is inactive
+
+[33mcommit 2e7d881098d6810e54572f702db58d0402b37407[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 22 15:11:00 2019 -0700
+
+    Trigger update for cluster domain status when updating domains
+
+[33mcommit ee5a514e89ffd7fb9a95cb84352f2de7823ba490[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 22 14:28:18 2019 -0700
+
+    Portworx: Populate local domain in cluster domain status
+
+[33mcommit 3b3b88ad83c66e3982e52d991d3988b544f50327[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 22 15:01:17 2019 -0700
+
+    Add local domain to clusterdomain status
+    
+    Also updated storkctl to print the local domain
+
+[33mcommit dabd39289000cd0627c5d357e97c17e8546549d0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 14 15:32:34 2019 -0700
+
+    Fix schedule to trigger if next trigger is exactly at current time
+    
+    Also added UT
+
+[33mcommit 9ae8cbc32804087dde87c78b25b7ac67e402e843[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon May 20 22:33:58 2019 -0700
+
+    Revert "Use correct spec for extender integration test"
+    
+    This reverts commit 27b8690fde2068f3cbbc29ad48c42f7d4f44e61f.
+
+[33mcommit 27b8690fde2068f3cbbc29ad48c42f7d4f44e61f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon May 20 14:31:42 2019 -0700
+
+    Use correct spec for extender integration test
+
+[33mcommit 068f895d4fe93f5ef1b2160f4b247b6d88ac7f1d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 16 17:50:12 2019 -0700
+
+    Add deploymentconfig to activate migrations for storkctl
+
+[33mcommit f6a79a813f095495cc5787392d5f06225797bc61[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Apr 20 14:57:37 2019 -0700
+
+    Add application manager package
+    
+    This will start the controller for all the application specific operators
+
+[33mcommit 35fc3c825d6a0d10f6b06793b6bbc0c936bd476d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 15 18:20:55 2019 -0700
+
+    Add CRDs for BackupLocation
+    
+    Used to specify the objectstore where backups can be stored.
+    Location is kept generic enough so as to allow non-objectstore targets to be
+    specified in the future.
+    The config can be provided inline or through a secret.
+    
+    Issue #284
+
+[33mcommit 64e7b605394a7891ac86ab9e2bb69568750ac4ef[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 15 15:17:47 2019 -0700
+
+    Add CRDs for Application Backup and Restore
+    
+    Issue #284
+
+[33mcommit 96ea49d2be33a9e965d6f34a982ecb285e3d46e6[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon May 13 18:21:28 2019 -0700
+
+    vendor update from openstorage
+    
+    - Fix openstorage pkg/grpcserver memory leak when grpc endpoint is incorrect.
+
+[33mcommit dbcc8060c420dbe8dc9c94ff9731bf6a1708881b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon May 6 14:38:25 2019 -0700
+
+    Add debug package to dump profiles
+    
+    SIGUSR1 can be used to dump memory and goroutine info
+    SIGUSR2 can be used to toggle collection of cpuprofile
+
+[33mcommit bbf85035f7263ab99d1244aa1b35332a9c6c3ff8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon May 13 18:28:46 2019 -0700
+
+    Fix matching of clusterdomain list
+
+[33mcommit c5e9722ba34b35729049d28212b333ec377660bd[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon May 13 11:21:08 2019 -0700
+
+    Print an error log when the controller fails to fetch cluster domain info.
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit bf4c7b2c7d41d41a80cd1929abe563db21b37ae4[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Fri May 10 18:20:03 2019 -0700
+
+    Use standard-verbose for gotestsum output.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit a97aef1ccaeee4c8d409a62faf3b7de2b4e79746[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 9 19:25:28 2019 -0700
+
+    Update vendor dependency
+
+[33mcommit 2ead79c6fb794609b89520943bdad30194f0bd05[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 9 19:24:46 2019 -0700
+
+    Add support to collect some additional resources
+    
+    - Role
+    - RoleBinding
+    - Ingress
+    
+    Also deleting loadBalancerIP from service resource
+
+[33mcommit 5434fb612d1075a6767a217b1e7eae4279938762[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu May 9 13:29:34 2019 -0700
+
+    Use gotestsum for stork test.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 2f53393411a0fd14bc1cca4acf2b3f5ffff53004[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 24 19:45:35 2019 -0700
+
+    Update google cloud sdk and use python3 in container
+    
+    Also update some python libraries
+
+[33mcommit 4a52ec8419ceac20e133cfb9d69398a95fde8be4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 7 14:47:28 2019 -0700
+
+    Add field in migration spec for admin cluster pair
+    
+    This can be used to migrate cluster scoped resources if an admin doesn't want to
+    provide access for those to individual users. The admin cluster pair needs to be
+    created in the admin namespace.
+
+[33mcommit 17485bdf10df161d0448d9ad17db4c936fbb35fa[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 7 13:33:57 2019 -0700
+
+    Update node info to have storageID and schedulerID
+    
+    Also update portworx driver to populate both for the nodes
+
+[33mcommit be02a94a680f8a424a242f71d3bf2b1aeed5cbbb[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon May 6 14:41:17 2019 -0700
+
+    Vendor update for sched-ops
+    
+    Fixes a memory leak when watches are re-established
+
+[33mcommit e3f9d69395b7cd8d8e7566cfbb6318fbaf8f1b17[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 2 15:58:49 2019 -0700
+
+    Add support to collect some ocp resources
+    
+    New supported resources are
+    - DeployemtConfig
+    - ImageStream
+    - Route
+
+[33mcommit 66189880a3f16478575144d3ed9c025b21d7a869[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 2 15:58:15 2019 -0700
+
+    Vendor update for DeploymentConfig
+
+[33mcommit 286c9dea6e4e54752102c5397c64b0178c5e6653[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 1 17:47:33 2019 -0700
+
+    Vendor update for sched-ops
+
+[33mcommit 94dff687c8a48895df3ed1c108304cf983241447[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 1 16:23:10 2019 -0700
+
+    Update watch API in health monitor
+
+[33mcommit e32745c8f534a33b61185991bae37288d75c140b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 15 20:01:10 2019 -0700
+
+    Move resource collection logic from migration controller
+    
+    * Can be used by other modules to get unstructured objects from a namepsace
+    and matching label selectors
+    * Added support to collect clusterrolebindings inlcuding users and groups for a
+    namespace
+    * Added merging of clusterrolebindings when applying resources
+
+[33mcommit 79c82f809f739aea8645fdc0f1faa7fdfc505aa2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 2 14:12:18 2019 -0700
+
+    Increase wait time in snapshotschedule test
+    
+    Gives it enough time to wait for the trigger and status to be updated
+
+[33mcommit a529afe888ac3bf6b6451fc1fe3bb73ea48784f4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Apr 25 16:35:57 2019 -0700
+
+    Upload storkctl from master branch to master path instead of latest
+
+[33mcommit 43cb1fd905460b6797e68684c96754cdf3dbcf36[m
+Author: Tapas Sharma <tapas@portworx.com>
+Date:   Wed Apr 17 13:03:52 2019 -0700
+
+     Define CRD for application cloning
+    0. This checkin defines the first level CRD for cloning applications
+    1. Added replace policy to the spec
+    2. Added ApplicationClone and ApplicationCloneList to register.go
+    3. Added ResourceInfo and VolumeInfo to the status of clone
+    4. Removed Namespace from the volumeInfo and resourceInfo
+    
+    Signed-off-by: Tapas Sharma <tapas@portworx.com>
+
+[33mcommit fd28b56985709e0effa9e297f224089ec1cdebaa[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Apr 20 14:58:51 2019 -0700
+
+    Remove the test directory from google cloud sdk
+
+[33mcommit 4082186164c46157a19d7eb3001026d586ba3cb5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Apr 13 20:28:23 2019 -0700
+
+    Switch gosimple to staticcheck and fix errors
+    
+    Also added static analysis checks for unit and integration tests
+    Added gocyclo target in Makefile but not enabled until we fix the issues
+    
+    Issue #287
+
+[33mcommit 4aab57ef7aa302767244bac7cbb3254ba7300229[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Apr 12 19:22:30 2019 -0700
+
+    Add events to pod from extender in case of errors
+
+[33mcommit 8ed66053a3020211573ca4466a880c26b1bec257[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 15 21:34:37 2019 -0700
+
+    Bump version to 2.3.0
+
+[33mcommit 10a46387bce2dd3176780a339154ca9c9e58dfc6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 15 21:34:21 2019 -0700
+
+    Revert "Update travis for 2.2 branch"
+    
+    This reverts commit 392c882377a6c0efbe3fe3e56f9800460ad8f236.
+
+[33mcommit 392c882377a6c0efbe3fe3e56f9800460ad8f236[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jan 30 19:23:58 2019 -0800
+
+    Update travis for 2.2 branch
+
+[33mcommit 5a0eac79d2bfeb1207a905b8690d66157b9d0d8f[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sun Apr 14 17:59:34 2019 -0700
+
+    vendor updates from sched-ops
+
+[33mcommit 6547b18b705e92d0e6e93d0bcffe5a3a55e87954[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sun Apr 14 17:58:53 2019 -0700
+
+    New specs for cluster domain integration tests
+
+[33mcommit 2ec3df6edf65b60f5468128ee54d53d7d929510b[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sun Apr 14 17:59:09 2019 -0700
+
+    Add integration tests for ClusterDomains.
+
+[33mcommit 89ed743b9df156b55af9e587e7a6cb000bffc4dc[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Apr 13 09:42:30 2019 -0700
+
+    Validate PVC before checking for auto created schedule
+
+[33mcommit 31d35f9ca641d398f6be88e91e98f611232bebe5[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Apr 12 18:46:38 2019 -0700
+
+    Normalize the clusterID before using it is a kubernetes resource name for ClusterDomainsStatus
+
+[33mcommit 5d9037d078ebb26eb9bf9f76043637a342760138[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Apr 12 13:06:23 2019 -0700
+
+    Add integration test for snapshotschedule created using storageclass
+
+[33mcommit 24c788d5492bb29cdb6c7cb62ede3bc2913b0cdc[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Apr 12 16:51:25 2019 -0700
+
+    Return nil when clusterpair is deleted without storage options
+
+[33mcommit f7d64f815e51190a576984a02952b3b9c7deecee[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Apr 12 16:08:13 2019 -0700
+
+    [Portworx] Return error if starting migration fails
+    
+    Previously the status was being set as failed. Returning error
+    ensures that the migration will be retried and events will be raised
+
+[33mcommit b357a1f4c8f21107929cb763b2d74ccda8197a54[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Apr 12 12:33:22 2019 -0700
+
+    Fix name in permission for cluster domain status object
+
+[33mcommit 63a164d98b11b59b51c73e697acdd26f44db8309[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 10 20:18:26 2019 -0700
+
+    Set default reclaim policy for snapshotschedule
+    
+    Also use time from schedule pacakge for creation time to help with integration
+    test
+
+[33mcommit de8bfc15b077ed011072c0bd0b19862c1ecf2e5a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 10 20:17:57 2019 -0700
+
+    Vendor update for sched-ops
+
+[33mcommit 80c792294d4602ebe236ba024f753a40098fc1c5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 8 12:33:34 2019 -0700
+
+    Integration tests for snapshot schedules
+
+[33mcommit 0b5389ad65e1f0fc7c511380838f8ae6061348b9[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Wed Apr 10 17:00:17 2019 -0700
+
+    [Portworx] Add IATSubtract option to auth token options
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit e18b842d07343fe74bdb64b41775c7d62458b630[m
+Author: Grant Griffiths <grant@portworx.com>
+Date:   Wed Apr 10 16:59:34 2019 -0700
+
+    Openstorage vendor update
+    
+    Signed-off-by: Grant Griffiths <grant@portworx.com>
+
+[33mcommit 5b81697e06891e184c87828052175a51b1d636a0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 10 09:30:36 2019 -0700
+
+    Add permissions for clusterdomain CRDs
+
+[33mcommit 61ac6b416c81dbaaabac1635c8b19fb0c77baad7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 8 19:10:35 2019 -0700
+
+    [Portworx] Take full cloudsnap for weekly and monthly schedules
+
+[33mcommit 1681683289f2ab5705f4c71012fa3388ca92a210[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 8 18:38:59 2019 -0700
+
+    [Portworx] Fix cloudsnap status check
+    
+    If status is present in VolumeSnapshotData return that,
+    else use the taskID to query the status instead of the volumeID
+
+[33mcommit c55607d93f483087c3ea4fca8e1aeadcf3ef9581[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 8 18:38:21 2019 -0700
+
+    [Portworx] Add owner information to cloudsnaps
+
+[33mcommit eb8fd1b2a6981a0c95dd078fce6629c101f03c61[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 8 18:36:38 2019 -0700
+
+    Add labels to scheduled snapshot descrbing the schedule
+
+[33mcommit 4eed9a6c422ee46da39b17f3dbf05f2b47fa9413[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Apr 8 18:35:54 2019 -0700
+
+    Vendor update for snapshot from external-storage
+
+[33mcommit 097d4b1f62335b96e27cbfa9957c40b2d55c9601[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Apr 9 17:30:28 2019 -0700
+
+    Ignore already exists error when creating clusterdomainsstatus CRD
+
+[33mcommit ffeddfbfaafa8baaa0d6dc415742d708953af80d[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Tue Apr 9 17:18:26 2019 -0700
+
+    Portworx Driver: Use cluster.Enumerate instead of cluster.Uuid.
+
+[33mcommit e3f339e07195dc706cb403b870ca8b341efe7684[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Mon Apr 8 13:34:54 2019 -0700
+
+    Portworx: Return an error when clusterID is empty
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit ea22ac2257f05a98eb549e75c275537ca63599b1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 3 22:29:15 2019 -0700
+
+    [Portworx] Only check version for online nodes
+
+[33mcommit 984d15b4c35019620355708345af68f39f93f163[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 3 22:28:43 2019 -0700
+
+    [Portworx] Add parsing for cluster pair mode
+
+[33mcommit cd421d22267464757a07362ca4c71c0ae289dabd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 3 22:28:16 2019 -0700
+
+    Vendor update for openstorage
+
+[33mcommit a33ab6d5f921011627b31e8d2ffee09adeb15320[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Mar 27 23:14:13 2019 -0700
+
+    [Portworx] Mark canceled migrations as Failed
+
+[33mcommit 0c9f5e45383072e88d09950e7f23dffd5e60a683[m
+Author: Luis Pabón <luis@portworx.com>
+Date:   Sun Mar 31 19:54:01 2019 -0700
+
+    Vet/Lint issues
+
+[33mcommit 11c7312c5cf55772d1ac41fca3e684587f913fae[m
+Author: Luis Pabón <luis@portworx.com>
+Date:   Sun Mar 31 19:34:14 2019 -0700
+
+    ClusterDomain supports auth
+
+[33mcommit 19f5865bebd0745081dc6689e43a5a3ed3eed00d[m
+Author: Luis Pabón <luis@portworx.com>
+Date:   Sun Mar 31 16:23:45 2019 -0700
+
+    TLS in Grpc
+
+[33mcommit 43cd3d7540e47af54fb1b14d179583744076079b[m
+Author: Luis Pabón <luis@portworx.com>
+Date:   Thu Mar 28 22:32:29 2019 -0700
+
+    Support for OpenStorage Auth
+    
+    Based from work on #302 by Paul Theunis
+    
+    Signed-off-by: Luis Pabón <luis@portworx.com>
+
+[33mcommit 8a9f655bc752c43e0bbf79363859eab6cb746cc7[m
+Author: Luis Pabón <luis@portworx.com>
+Date:   Thu Mar 28 22:32:08 2019 -0700
+
+    Vendor updates
+
+[33mcommit 218aba57bed9e70fedc706ff3be05a3ded5cdb07[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Sat Mar 30 10:32:07 2019 -0700
+
+    Add constraint on torpedo to branch stork-2.2
+
+[33mcommit ef0b429d6352bb8081ac566697bfb356f4151bb0[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Mar 28 15:09:56 2019 -0700
+
+    Integration test - restore from local group snapshots.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit 6775ef28c42bc64965a0de278c51bb79de3b850e[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Mar 29 17:06:43 2019 -0700
+
+    Added controllers for ClusterDomainsStatus and ClusterDomainUpdate CRD
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit 622fb0d4aaf4158a466281cdd3917c43ab9880e0[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Mar 29 17:06:00 2019 -0700
+
+    storkctl changes for cluster domains
+    
+    Added the following commands for storkctl to manage clusterdomains
+    
+    - storkctl get clusterdomainsstatus
+    - storkctl get clusterdomainupdate
+    - storkctl activate clusterdomain <name>
+    - storkctl activate clusterdomain --all
+    - storkctl deactivate clusterdomin
+    
+    Added UTs for storkctl
+
+[33mcommit 9e6c0f84f16032679df8cf55b56a49f8d07f0d31[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Mar 29 17:04:47 2019 -0700
+
+    Add Driver APIs for ClusterDomain changes
+    
+    Added the following new Driver APIs and implemented them for Portworx
+    - GetClusterID
+    - GetClusterDomains
+    - ActivateClusterDomain
+    - DeactivateClusterDomain
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit 5f2c707bad9303d2e7956d856f6afddd1dec8705[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Mar 29 17:03:10 2019 -0700
+
+    Update stork's vendor for ClusterDomain changes
+    
+    - openstorage -> release-6.0
+    - gossip
+    - sched-ops
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit f21dae3a1eddf214ef1e9a04fee2af7bd8c33f40[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Sat Mar 23 18:46:01 2019 -0700
+
+    storkctl support for group snapshots
+    
+    Fixes #226
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit e1c479e7ff2ff9d8dc3adccb40a6f532bc64c86f[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Mar 29 13:14:34 2019 -0700
+
+    Make ClusterDomain CRDs cluster scoped.
+
+[33mcommit 3df4dfb71ff5692e621d4caf6deb948373844945[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Mar 27 20:07:19 2019 -0700
+
+    Store finish timestamp for migration
+    
+    Also display elapesed time using storkctl
+
+[33mcommit f814202e9092bd289ecf72c072f87a0cdecbdb7b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 28 00:03:16 2019 -0700
+
+    Add pod watch permission required for health monitor
+
+[33mcommit ddecad8f1d7585ee555e47e8107b7c8242497933[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Mon Mar 25 14:06:52 2019 -0700
+
+    sched-ops vendor
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 1b8da1a3993a30ac3a1e6b1235d5e7b14fbaae18[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Mon Mar 25 14:06:42 2019 -0700
+
+    Add health monitor for unknown pods
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 356d61ce53a55a3ccb28aafce9a42c60e93e4846[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 26 21:18:33 2019 -0700
+
+    Fix bumping time in migration schedule test
+    
+    Adding 31 days for the monthly schedule test can cause the schedule to be
+    skipped for months with 30 days since the date of the month will be one ahead
+
+[33mcommit d66c40c2e2eb0d1e19cea741f215fc52630cd706[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 26 18:04:24 2019 -0700
+
+    Add support to migrate additional resources
+    
+    Following resources will also be migrated now:
+    - DaemonSets
+    - ServiceAccounts (except default)
+    - ClusterRoles (if used in the namespace)
+    - ClusterRoleBindings (if used in the namespace)
+
+[33mcommit 9622679af806e7a74150b786ebd72717dac5367b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 26 18:04:02 2019 -0700
+
+    Vendor update for sched-ops
+
+[33mcommit 946e005209ae0183ea303d71069d121b4c899813[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Mar 25 23:34:12 2019 -0700
+
+    Fixes for migration schedule tests
+    
+    - Sleep before checking for error message for invalid schedule. There could be
+    an error because the policy was not found since they are applied in a different
+    order. The next reconciliation will be after a minute
+    - Rollover to the next month/year when finding the right day
+
+[33mcommit af7c178bb47e4e0582daa83932c196fd27cbd16f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Mar 25 15:32:30 2019 -0700
+
+    Add annotation in PVC after creating snapshot schedule through SC
+    
+    This prevents the schedules from getting re-created if a user manually deletes
+    them
+
+[33mcommit ed8ce5f20b2f77f4b0c1c34ebd4a1a53b0f25c87[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Mar 22 20:08:01 2019 -0700
+
+    Add validation for interval policy
+
+[33mcommit 1cf300da36884670a4cb7d9699cc4344a966a888[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 21 22:59:25 2019 -0700
+
+    PVCWatcher: Ignore error if storageclass is not found during update
+
+[33mcommit 6d1c5bcc551af0ad1647e0c001c1800f738ac76c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 21 22:52:16 2019 -0700
+
+    Add missing permissions for volumesnapshot schedules
+
+[33mcommit 7bcf3b527ed4e102b785fa25b2993cb4e0c98e08[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Fri Mar 22 12:08:42 2019 -0700
+
+    Allow configuring portworx service in stork
+    
+    - Get the service name and namespace from env variables.
+    - Find the ports which PX uses from kubernetes service.
+    
+    Signed-off-by: Aditya Dani <aditya@portworx.com>
+
+[33mcommit 04ed0cea2414e3e6ad56ce0dfb19a60d2dbfb000[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Thu Mar 21 18:23:11 2019 -0700
+
+    Add node start and create separate storageclass for pvcownership test
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit da61b7e36da05cbf7e64fd2de6633b999f351587[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 21 00:21:33 2019 -0700
+
+    Start snapshot controller first
+
+[33mcommit dfafbe4b7f63f500fc2231a21f67c4a832e6c821[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Mar 20 23:59:52 2019 -0700
+
+    Update vendor for torpedo
+
+[33mcommit b48d80f423f817d0bd7fd7fb98eb8ae0306aa956[m
+Author: Rohit-PX <rohit@portworx.com>
+Date:   Tue Mar 19 12:00:19 2019 -0700
+
+    New test for verify pvc ownership fix.
+    
+    Signed-off-by: Rohit-PX <rohit@portworx.com>
+
+[33mcommit e75eb59e8b775f3b3e4c33e9797037b07b05d072[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Mar 20 12:58:55 2019 -0700
+
+    storkctl: Add all-namespaces param for subcommands
+    
+    migrationschedule and snapshotschedule were missing the param
+
+[33mcommit c08231487e32d8c8f78c7ab233e431c264d735ed[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Wed Mar 20 15:22:12 2019 -0700
+
+    Generated code for ClusterDomains CRD
+
+[33mcommit 6df7f550e09a7d954ed818609b3b42ff1d2ddbf7[m
+Author: Aditya Dani <aditya@portworx.com>
+Date:   Wed Mar 20 15:20:14 2019 -0700
+
+    Add CRDs for cluster domains
+    
+        - ClusterDomainsStatus
+        - ClusterDomainUpdate
+
+[33mcommit b79b7265ff5293dd2ad26018340b0ed5a622115e[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri Feb 22 18:43:45 2019 -0800
+
+    sched-ops and torpedo changes
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit c7a30a22f354fac788efcfd9e0539e003e637d82[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Thu Feb 21 17:49:02 2019 -0800
+
+    Integration tests for migration schedules
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 4543fbfff2420a643820135965b4b0c843be5b9b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Mar 13 14:18:45 2019 -0700
+
+    Add controller to watch for changes on PVCs
+    
+    Right now it creates snapshot schedules if specified in the
+    storageclass for a PVC
+
+[33mcommit 47c3eb8229d379c23ae11a825466d039b0ea07a3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Mar 13 14:17:30 2019 -0700
+
+    Add storkctl subcommands for snapshotschedule
+
+[33mcommit 3dfe119e2f26017c3ad3053b868f03360cbee54b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Mar 13 14:15:16 2019 -0700
+
+    Add controller for snapshot schedule
+    
+    * Similar to migration schedule, uses retain to decide how many snapshots to
+      keep
+    * Enable parameter can be used enable/disable a schedule
+    * ReclaimPolicy determines what happens to the snapshots triggered by the
+      schedule when the schedule is deleted. Setting to Delete will automatically
+      delete the snapshots when the corresponding PVC is deleted. Setting to Retain
+      (default) will not delete the snapshots.
+    * Moved the snapshot controllers under one path
+    
+    Issue #72
+
+[33mcommit 5bdd1ec5fe7f6236eb0e4fd1ef5e2dfb46a5a15b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Mar 13 14:11:36 2019 -0700
+
+    Vendor update for sched-ops
+
+[33mcommit 0d77e6352a29efa2bd43b77b34258a85d4d13b17[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Mar 13 14:11:08 2019 -0700
+
+    Add CRD for volume snapshot schedules
+    
+    Issue #72
+
+[33mcommit 40ca113d184edf8f44f8b3fcfd900dee8e54caa4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 19 16:52:33 2019 -0700
+
+    Add suspend flag to migrationschedule spec
+    
+    It is disabled by default
+    Also update storkctl for the flag
+
+[33mcommit f521df476cdb00a3107647102201465ec6ab8ddd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 19 16:08:52 2019 -0700
+
+    Extender: Return error if no replicas are online for a volume
+
+[33mcommit 55fc1bfff71c7bd3705593c34a20743dc21c7a56[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 14 17:47:10 2019 -0700
+
+    [Portworx] Don't rely on storage class to determine ownersip of PVC
+    
+    For statically created PVCs there might not be a storage class or annotations
+    with the provisioner. Looks at the volume source in that case to figure out
+    the owner
+
+[33mcommit 9a577f63072d4e7c374adc82728181649bd9e832[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 27 23:53:47 2019 -0800
+
+    Add integration tests for migrating with label selectors
+    
+    Issue #271
+
+[33mcommit c24cad3c69fd155763e4d9a18105b357bd71425f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 27 18:36:17 2019 -0800
+
+    Add support to use labels to select resources during migration
+    
+    Issue #271
+
+[33mcommit 2cd05389885a9fcdf8dabc480689eebff4ef086c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 12 14:53:43 2019 -0700
+
+    Update bool in migration specs to pointers so that we can set defaults
+
+[33mcommit 481eeb5564638fa4e62098c9bc75e2d47c23d2ab[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Feb 11 15:47:40 2019 -0800
+
+    Added UTs for activate/deactivate subcommands
+
+[33mcommit 6853c3582c43212fb038f7003cb229482c27478d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Feb 11 13:41:14 2019 -0800
+
+    Portworx: Return basic volume info in GetPodVolumes() even if Inspect fails
+
+[33mcommit f701e8e55be7cf4ad4c0ff945f1f619057533af7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Feb 11 13:39:35 2019 -0800
+
+    Add subcommands to activate and deactivate migrated applications
+    
+    The commands look at the deployments and statefulsets in the given namespaces
+    and update the replica count if they have an annotation specifying that the
+    application was migrated using stork
+
+[33mcommit a21a6f2af26064b5d39e5a7bd6a46f40b13bfc5c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Feb 4 14:52:04 2019 -0800
+
+    Add option to skip pairing of storage in ClusterPair
+    
+    Also added option in migration spec to skip migrating volumes
+    This is helpful in cases where the same storage is available from multiple
+    Kubernetes clusters
+
+[33mcommit cb95e0e650891e2b683896df8951995ec4d755a3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 28 16:49:43 2019 -0800
+
+    Recreate service during migration for conflicting node port
+
+[33mcommit 5bb9a6892dfd4ba3165b00c5005492e9013bf89f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 28 16:49:25 2019 -0800
+
+    Update vendor dependencies
+
+[33mcommit 940f663d48880cfc6c0bfa28564bec9e19247921[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Feb 12 17:38:34 2019 -0800
+
+    Added subcommands to storkctl for SchedulePolicy and MigrationSchedule
+    
+    - Added create, get and delete for MigrationSchedule
+    - Added get for SchedulePolicy
+    - Added UTs for both resources
+
+[33mcommit 248c6992c5bb116e961ce5b16e192cdf4faa9455[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Feb 12 17:35:00 2019 -0800
+
+    Add a controller for migration schedules
+    
+    - The MigrationSchedule object takes the same parameters as Migration Spec
+    - It also takes in a SchedulePolicyName
+    - The reconciler checks every minute if any new migrations need to be triggered
+    - The status for each migration is stored in the object. Only one successful
+    status is stored
+    - Only one migration can be triggered at a time
+    - The schedule package is used to check is a migration should be triggered for
+    each type of policy.
+    - Includes UTs for the schedule package to make sure triggers will fire
+    correctly
+
+[33mcommit e24ce0105d93c9d9b3baa1790f45a81c0b00ba55[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 13 16:51:20 2019 -0800
+
+    Update MigrationSchedule CRD to add Migration under Template.Spec
+    
+    This is similar to how deployments, statefulsets, etc have pod spec defined
+
+[33mcommit d0f8a22a1e4070ba70c132e6e4535d1a2152d19b[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Tue Feb 19 17:26:52 2019 -0800
+
+    Add support for configurable retry count
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit b6873b3f8542edf76699a067e9f3bbd66f7582e2[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed Feb 20 12:02:47 2019 -0800
+
+    add pull request template
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 9efcc832d41163c46a09d57fcef03f4740e017a8[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Mon Feb 18 09:45:54 2019 -0800
+
+    Allow users to update restore namespaces
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit f2bb4f6a1f57700dee981510e35a36af6941a766[m
+Author: Joost Buskermolen <joostbuskermolen@hotmail.com>
+Date:   Thu Feb 21 11:04:32 2019 +0100
+
+    Fixed a typo
+
+[33mcommit a21adfd82e8a01dba4a5ba2a96921de4bbe293b0[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Mon Feb 18 14:58:47 2019 -0800
+
+    Don't run fio load specs for scale test
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 9386f9a13e8a77c3a27c233132b54f77d6c53213[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Sat Feb 16 16:02:48 2019 -0800
+
+    update sched-ops vendor to PR branch
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 01638e4524a756e7fce0d365e044463305b9e824[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Sat Feb 16 15:17:00 2019 -0800
+
+    Add test to load volumes while group cloudsnap is being done
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 00e2c0d0f8dfff8f471fc56770c8108db57a88e3[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri Feb 15 08:12:30 2019 -0800
+
+    For groupsnap scale test, first create all and then verify
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit d4c34c6e2ec37143307e4b53acb7db13e8c5e4fa[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri Feb 15 11:47:13 2019 -0800
+
+    Use version pkg to compare resource versions
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 2338d1d42bf531859a85c3c73b3c17d68c4ae5c1[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri Feb 15 09:02:51 2019 -0800
+
+    Return status for failed cloudsnapshots
+    
+    - is any cloudsnap has failed, the get status API should not fail. Rather it should
+      return the failed tasks in the response so controller can log an event and then
+      reset and retry the group snapshot
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 2747b0908d60d4fa8c07992c74e36a4bce7deac5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 14 21:53:06 2019 -0800
+
+    Don't override pod variable when running command in the pod
+
+[33mcommit 6b36e9a4558b68e5f07ebfad017d7aa55d48db0b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 14 17:30:12 2019 -0800
+
+    Vendor update for sched-ops
+
+[33mcommit 25e3f7ae33e60befbdf98af45fe1c91872ea676a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 13 18:58:09 2019 -0800
+
+    Add gofmt to Makefile and fix errors that were found
+
+[33mcommit fcee7aeeff2e21cdb1463e31e11019a6a8c90f47[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 13 15:10:31 2019 -0800
+
+    Add --all-namespaces parameter to storkctl for get subcommands
+    
+    Also prints the namespace if the parameter is specified similar to kubectl
+
+[33mcommit 0e95b0854fd79a33609268acce27cc407bcf1eff[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 13 15:09:59 2019 -0800
+
+    Govendor update for sched-ops
+
+[33mcommit ecb1590558e592f87581c56edf484e33eda54940[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed Feb 13 11:51:14 2019 -0800
+
+    propagate group snap annotations to child volumesnapshots
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit f1bbe522f8fa020a7dc21900cfc267b62702277e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 13 15:58:13 2019 -0800
+
+    Copy storkctl for all architectures into the container
+
+[33mcommit 27f86f64a9369d1faec44cf494b1eac048ab199a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Feb 12 15:17:37 2019 -0800
+
+    Add CRDs for SchedulePolicy and MigrationSchedule
+
+[33mcommit f2d62e6ad10cafb1d0b91c27994259048ecd5917[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Feb 12 15:16:52 2019 -0800
+
+    Split up CRDs into different files
+
+[33mcommit 90214bd5013f7f435d969ada68d6d33e67d5418c[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Tue Feb 12 14:58:55 2019 -0800
+
+    Fix ready and pending snapshot conditions
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit b358d67e16cf592ae2d212e462659f72dc1e6352[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Feb 4 14:53:58 2019 -0800
+
+    Also set the namespace annotations from source cluster during migration
+
+[33mcommit d4fa569978ad4b5da75ef29dc1cf6459bf1b215f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 1 15:07:21 2019 -0800
+
+    Portworx: Set snapshot type for group localsnap
+    
+    Also assume local snap if type isn't set
+
+[33mcommit 5196a74117e40b1fee20f922764f74bbae5efbea[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jan 30 19:51:16 2019 -0800
+
+    Reset kubeconfig in case of failure in migration test
+
+[33mcommit a3a4eaed6a8a983efcec4ac348292225366247f6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jan 30 19:19:15 2019 -0800
+
+    Update version to 2.2.0
+
+[33mcommit fc42c75aeeb608368a2e84dc297a9bbc53e7f962[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jan 30 19:03:24 2019 -0800
+
+    Fix storage class in cassandra integration test
+
+[33mcommit e0c32e2ffb6774c360bde4c86abba66171a8bca7[m
+Author: Piyush Nimbalkar <piyush@portworx.com>
+Date:   Thu Dec 20 15:48:23 2018 -0800
+
+    Add a StorageCluster CRD to manage cluster
+    
+    - Added a controller which does nothing as of now except for watching over StorageCluster object
+    - The controller starts by default with stork, can be disabled using params
+    - Placement spec and node status in storage cluster CRD
+    - Using pointers for some fields so we can distinguish between an empty
+      value and default value
+    - Disabling cluster controller by default
+
+[33mcommit 16554cc4bb96be5f7076f5aa381ef40948b31de7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jan 25 13:38:34 2019 -0800
+
+    Add options to storkctl for migration pre/post exec rule
+
+[33mcommit ad6c521b2c3b4ddd6d9a2b2ab9bc3245d5a15755[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 22 19:21:08 2019 -0800
+
+    Add integration tests for migration pre/post exec rules
+
+[33mcommit 612c8e77375a7cca8120be5c7b03cc2e327d80e3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jan 18 21:00:50 2019 -0800
+
+    Add Pre/Post Exec rules for migration
+
+[33mcommit 183a546a48bfd6df2a903afb90bbff60f29188ac[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 22 19:18:31 2019 -0800
+
+    Vendor update
+
+[33mcommit ee251e39c92022714516c76f3bf296fd5fa83e3b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 29 18:51:51 2019 -0800
+
+    Update migration spec in integration test to point to correct namespace
+
+[33mcommit 9f690e7c9f9a4d980924fbeac9ad0a577bc5ea51[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 29 17:14:12 2019 -0800
+
+    Portworx: Use volumeName for cloudsnaps during inspect after restore
+
+[33mcommit 997b84355986b7d52f9658550dda4ede2fd11ed8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 29 12:59:40 2019 -0800
+
+    Updated vendor for torpedo and sched-ops
+
+[33mcommit 1be1eb98499bd52c4bcc97e4b7520d32d50e6786[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Thu Jan 17 15:59:30 2019 -0800
+
+    Add integration tests for group local and cloud snaps
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit a9102584511b7742fa582b3e391a5387d89709e4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 29 14:02:51 2019 -0800
+
+    Portworx: Use volumeID instead of volume name after creating snapshot
+
+[33mcommit 4042abb54093f253b427b94987732a760796385c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 15 18:11:16 2019 -0800
+
+    Don't delete clusterIP when migrating headless service
+
+[33mcommit 99de5e62d80bd530993ea99ee14305e23ef5f0cd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 15 18:09:48 2019 -0800
+
+    Rename groupvolumesnapshot rule fields to PreExec/PostExec
+    
+    Same generic names will be used in migration to be consistent
+
+[33mcommit 3ede620bf41c6539417fb40487e115c87831ce4b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jan 18 16:03:11 2019 -0800
+
+    Create directory for clusterpair spec in integration test
+
+[33mcommit 630d1f6b86b9bdf8fc10e01293bc82688b658efd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 14 13:39:34 2019 -0800
+
+    Update Rule CRD
+    
+    Renamed spec to rules. Spec should only be used for objects that
+    have to be reconciled (ie have a status)
+    
+    Also updated the examples.
+
+[33mcommit a34edf5799cfa146e72f62a8a18d3b0a0019eaac[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri Jan 18 12:17:15 2019 -0800
+
+    check for nil annotations on rule
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit ea08905b606590a62476855c0e76ab37358f4db2[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Thu Jan 17 09:34:11 2019 -0800
+
+    minimum resource version tracking needs to be per group snapshot
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 17dc4dee9f0945c0f4f3f55832c7859ab88ac7d9[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed Jan 16 15:45:01 2019 -0800
+
+    review comments
+    
+    - don't use group snapshot from caller on errors
+    - raise event for pod not found
+    - use map for duplicates
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit c6b1d371c602baf9b01e2aea2c78771521b9cfc2[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Tue Jan 15 12:22:18 2019 -0800
+
+    vendoring changes
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 35711364ebc52cb8728cc24e92683c9ddeb6fdff[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed Jan 16 13:26:56 2019 -0800
+
+    Fixes for rule recovery
+    
+    - Pods running rule commands were not being tracked in snapshot annotations
+    - Rule recovery was not getting invoked for group snapshots
+    - Existing pods in tracker were getting overridden by new pods
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 5253d5052949d96b3bc5712cf6bcd6264cdbc037[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed Jan 16 14:06:50 2019 -0800
+
+    validate pre and post checks in initial stage
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 3ae7cc09050ff59e4bd121dc96a1b83d640f8364[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 14 13:53:11 2019 -0800
+
+    Update README.md
+
+[33mcommit 2d46472b0799caf7c0c761da0eb1edce9a335fb8[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Mon Jan 7 10:59:07 2019 -0800
+
+    vendoring changes for group snapshots
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 706dd3e56f6af0425ef1cf57576fef1d6454a352[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri Dec 21 16:15:15 2018 -0800
+
+    Add controller for groupvolumesnapshot
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    Address review comments
+    
+    - process cloudsnap failed tasks
+    - revert local and cloudsnaps as soon as the first failure is observed
+    - allow deletes of legacy group snapshots
+    - group snapshot controller part of snapshot controller
+    - fix cassandra restore pvcs
+    - fix v1 imports
+    - fix duplicate events
+    - revert active cloudsnapshots too
+    - use groupsnap logger
+    - move specs to examples
+    - use explicit variables to track done and active IDs
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit d70a15dba2b384e421e7e44c82218dbf3c88291c[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Thu Dec 20 16:01:41 2018 -0800
+
+    Add group volume snapshot CRD
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit af099b96ee61bce5d0eb2ef23dfffdb46700f31f[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Mon Jan 7 11:38:31 2019 -0800
+
+    fix new gosimple checks
+    
+    - pkg/initializer/initializer.go:140:9: assigning the result of this type assertion to a variable (switch obj := obj.(type)) could eliminate the following type assertions:
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 5ae0e1ffdc04af5059cfd80eb6239af3dbf52e50[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Dec 18 00:28:48 2018 -0800
+
+    Update alpine packages and add ca-certs during docker build
+
+[33mcommit b8bce235e77fca8d34e736879d5f82d64485e992[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Dec 17 19:00:27 2018 -0800
+
+    Update master version to 2.1 for next release
+
+[33mcommit beb8947e4a00d6b05a870798c0d07537087cf763[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Dec 10 07:27:43 2018 -0800
+
+    Fix version regex in Portworx driver
+    
+    Issue #216
+
+[33mcommit c440015ec7e2fcd39d6f10af83f4e9fe1a5939dd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Dec 3 17:10:47 2018 -0800
+
+    Set theme jekyll-theme-cayman
+
+[33mcommit eb6edc454644c13869d95628cae85641cb3783c9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Dec 3 11:59:05 2018 -0800
+
+    [Portworx] Also check for CSI provisioner name for ownership
+
+[33mcommit c6eebc91ca8828327fc96228d8a207f36fc89270[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Nov 30 15:55:58 2018 -0800
+
+    Bump version to 2.0.0 (#212)
+
+[33mcommit 612f0d327810e739476388386e0656ee723bae82[m
+Author: ram-infrac <35250819+ram-infrac@users.noreply.github.com>
+Date:   Fri Nov 30 22:45:09 2018 +0530
+
+    Create mysql app before scheduling clusterpair (#211)
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit eb687e3c4ccb632f8875be841a3e6f0d46c94ce5[m
+Author: ram-infrac <35250819+ram-infrac@users.noreply.github.com>
+Date:   Fri Nov 30 12:45:57 2018 +0530
+
+    Add namespace to clusterpair and migration specs (#210)
+    
+    * Add namespace to clusterpair spec
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Make migration and cluster pair in same specs
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Add Name to clusterpair
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 1585dc5f02a75c3883b899f06353d635ae2c657f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 29 19:16:34 2018 -0800
+
+    Add name and namespace when generating clusterpair
+
+[33mcommit 1233c99cfec41a9741100729e115360291fee6c6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 29 17:50:07 2018 -0800
+
+    Print stork version during startup
+
+[33mcommit 9ed43d91b03bfb4aa2e3bfe3c56a78e7225926c1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 28 19:22:38 2018 -0800
+
+    Allow configuring an admin namespace that can migrate all other namespaces
+
+[33mcommit 449b5c6117ad9f54e976d1fded6fab3ff8b8ba74[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 28 19:14:06 2018 -0800
+
+    Add rule CRD register which was removed in code refactor
+
+[33mcommit 3609b8cc62a4e4e598804525bb22237b2920564d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 28 20:17:28 2018 -0800
+
+    Add UTs for all the log APIs
+
+[33mcommit beb68d5ac109f245532678978763457617a11403[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 28 19:04:29 2018 -0800
+
+    Update storkctl UTs to use base command
+
+[33mcommit a0866c5ab2006db8bf2d05f2255890199cdc5654[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 28 00:39:40 2018 -0800
+
+    UTs for storkctl migration subcommand
+
+[33mcommit 9a57de713aff11c1bc88d58764af575a2b80a001[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 27 09:33:42 2018 -0800
+
+    Add some more UTs for storkctl clusterpair commands
+
+[33mcommit e2ee65f042ee337b61fddcb14ac2db3e80953682[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 27 09:33:26 2018 -0800
+
+    Update dependencies for k8s client-go and sched-ops
+
+[33mcommit c191e60c8afb0a2b8ac16f528c773d6a13de1adf[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 21 14:03:39 2018 -0800
+
+    [strokctl] Add return after checkErr and use namespace when creating migration
+
+[33mcommit a020787024f043f4de0fc91603c93ba766e7371b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 21 14:04:46 2018 -0800
+
+    Add some more UTs for storkctl
+
+[33mcommit 91bfcd1f8ae0120faaf86f177ed7bc2ecd5696a6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 20 21:42:34 2018 -0800
+
+    Limit migration to namespace of migration object
+
+[33mcommit 9fa83ef7367c96ec9fcf95212fcb36e647a2259b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 20 19:36:49 2018 -0800
+
+    Vendor update for sched-ops and torpedo
+
+[33mcommit ced3376a21109a8206189999bb97e98844d72bfa[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 20 17:18:18 2018 -0800
+
+    Change clusterpair and migration to be namespaced
+
+[33mcommit 118edf7180827650eff50cff6644286bc77d418f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 20 21:56:17 2018 -0800
+
+    [Portworx] Add eta information to migration info
+
+[33mcommit 42f16dd296c9f84276230b29f17da2981de80594[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 20 21:56:00 2018 -0800
+
+    Vendor update for openstorage
+
+[33mcommit 4ad2fd1a21b4128620f0db093c478f4dba2a5667[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 27 09:38:11 2018 -0800
+
+    When logging pod info check for owner pointer before dereferencing
+    
+    Also added UT for pod log
+
+[33mcommit 1f416c77c53d18bb3f0ef678d199adfcd1cfd086[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 13 14:04:12 2018 -0800
+
+    Fix incorrect status update after resource migration
+
+[33mcommit bf5b9227af48cd65463d196cbc6d1de98bacdbcc[m
+Author: ram-infrac <35250819+ram-infrac@users.noreply.github.com>
+Date:   Tue Nov 20 14:26:48 2018 +0530
+
+    Add liveliness and readiness probe to mysql-1-pvc spec (#200)
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 78af18cfb5f2d5f737f425c4904b8327d36e2c61[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 13 20:31:39 2018 -0800
+
+    [Portworx] Implement cancellation of migration
+
+[33mcommit a166c619ec5368d1a11e5dc14ebb97709d03cfad[m
+Author: ram-infrac <35250819+ram-infrac@users.noreply.github.com>
+Date:   Sun Nov 18 17:26:04 2018 +0530
+
+    Add Basic sanity cloud migration integration tests (#176)
+    
+    * Govendor update for torpedo
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Add Sanity Integration test for Cloud Migration
+    
+        - Read configMap and dump cluster kubeconfig info
+        - Get remote cluster Info
+        - create clusterpair spec file
+        - apply migration spec file
+        - wait for application running on remote cluster
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Add createCRDObjects() under schedule interface
+    
+           -- added rescan API for specDir
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Changed test to accomodate Schedule() call
+    
+       - move migrs directory under specs/
+       - remove createCRDObjects() call
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Change cluster pair constant to match options section
+    
+         - remove unnecessary log
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Remove clusterpair parsing from stork-test
+    
+           - use storkctl to generate clusterpair
+           - move cloud_migration to migration test
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Vendor update for torpedo
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Review Changes
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Vendor updates for Torpedo
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * vendor updates
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Set k8s_ops to default after storkctl generate
+    
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+    
+    * Added generating configmap from remote kubeconfig in test-deply script
+    
+          - added review comments
+    Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>
+
+[33mcommit 23f54c23ed52f32654004763171819e594787f4e[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Thu Nov 15 18:07:09 2018 -0800
+
+    Add tests for pvc
+
+[33mcommit fdd9c8eaeeed0d260dd5d3bfc41cfd02034a8711[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Tue Nov 13 00:33:57 2018 -0800
+
+    Add tests for cluster pair and migration.
+    
+    Rename testSnapshotsCommon to testCommon for use in clusterPair tests
+    Refactor testCommon() for use in ClusterPair tests
+    
+    Comment out tests which need more work
+
+[33mcommit 3d8747d16e6df13d87a194723e2cc779b72aa44a[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Tue Nov 13 17:33:08 2018 -0800
+
+    Rearrange use of util.CheckErr() to fix unit test in failure scenario
+
+[33mcommit 42935e10a86c53c904e47d67576c32eae4761c6c[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Tue Nov 13 17:32:02 2018 -0800
+
+    Check for nil config.Contexts[currentContext]
+
+[33mcommit b61f4265e3ead39f98fc8002575bfc4df299825c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 13 14:27:27 2018 -0800
+
+    Update generated code for CRDs
+
+[33mcommit 3ebdcfde95b76d914dd5f50854f4ec284161be22[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 13 14:26:02 2018 -0800
+
+    Update code-generator dependecy to kubernetes-1.11.0
+
+[33mcommit 012ef5d832efb11c43ad541150afff8a1511b5e2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 13 13:11:03 2018 -0800
+
+    Remove clusterIP from service before migrating
+
+[33mcommit 67bf9e1dc87f1e2a43b3f88ec61049e78e8c810f[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Mon Nov 12 15:58:33 2018 -0800
+
+    Add tests for creating and deleting snapshots
+
+[33mcommit 4e184ab082c64aee7daca2bac65ce8e74732d091[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Mon Nov 12 19:07:40 2018 -0800
+
+    Replace fmt.Printf() with printMsg(), to use proper ioStreams.
+
+[33mcommit 3ab6bb1b83487d0ca2c26494f81ee57e69475ba9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Nov 9 18:52:03 2018 -0800
+
+    Add unittest for version subcommand
+
+[33mcommit 1fa341e1841ed7bbb7ba5a2a7e9285635c7221ea[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Nov 9 18:41:20 2018 -0800
+
+    Add version to storkctl
+    
+    - Use generated version in stork
+    - Use version-gitSHA
+
+[33mcommit ca18866a97ca2f6c168657dc8c36bd489bbc8e09[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Mon Nov 12 16:16:11 2018 -0800
+
+    "Atleast" should be "At least"
+
+[33mcommit 58d4546cde6bcd724550274d8642b6235673d497[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Nov 9 18:20:25 2018 -0800
+
+    Process all migrations before returning
+    
+    Still wait for all migrations to complete before updating status
+
+[33mcommit 14b751a545a2446af2046b271796c5ed36ce887d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Nov 9 00:48:10 2018 -0800
+
+    Set Kind in snapshot object before executing rule
+    
+    It doesn't seem to be set always when being passed in from the snapshot
+    controller. With that the GetObject() and UpdateObject() APIs can't determine
+    the objects type.
+
+[33mcommit d7de0de3c34a3db8ecd0bc69b938898023f1349f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 8 18:29:05 2018 -0800
+
+    Make sure namespaces exists before starting migration
+    
+    Also don't check for volume migration status if none are being migrated
+
+[33mcommit 59cd317e89dfe11c002e05efe8ef395e02ec7876[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Mon Oct 15 16:21:11 2018 -0700
+
+    Add test for snapshots
+    
+    - Add test functions for mock testing kubernetes API server
+      These functions are taken from 'get_test.go' in the kubernetes
+      repository.
+
+[33mcommit ad41e1ecc67d27a3419c738afad1864fc1034653[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Fri Nov 9 11:27:05 2018 -0800
+
+    Update dependencies
+
+[33mcommit 01d1b4770f98b9c73de21d720c3cbd7e732ddbb9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 8 15:44:33 2018 -0800
+
+    Push storkctl only from master
+
+[33mcommit c6b17627f07aa00d431fd916746258275377f9b3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 8 15:05:36 2018 -0800
+
+    Update dependencies
+
+[33mcommit 597bc3e30789118afec6b545a25470538af4683d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 8 14:57:13 2018 -0800
+
+    Use kubectl helper to deal with errors
+    
+    Error behavior can be overwritten for tests
+
+[33mcommit f84eb8ca1a6c4923d10a1b55da6fc5c6cdfd6a4f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 8 14:35:52 2018 -0800
+
+    Add auth providers to storkctl
+
+[33mcommit 990a3a54b3e30b9dc32668971c5c87ecb117d547[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 8 13:55:50 2018 -0800
+
+    Vendor update for sched-ops
+
+[33mcommit 7fcd63af6cce2ff0b034e05297a38319ee743ca5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 7 18:05:32 2018 -0800
+
+    Read files when generating cluster pair and populate inline
+
+[33mcommit b3e1f454d84f95ea2c18bebb1c529ed3dc309773[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 7 18:28:09 2018 -0800
+
+    Add empty PersistentVolumeRef to VolumeSnapshotData
+
+[33mcommit 81b85e586b4a84d0636be585d65d1635515b198e[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Mon Nov 5 18:06:12 2018 -0800
+
+    Add SetOutputFormat() to Factory interface
+    
+    This is needed to facilitate tests.
+
+[33mcommit 64894c894119f5997829d7ec0faa7f67862e3314[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 6 20:29:54 2018 -0800
+
+    Replace gcloud binary path in generated clusterpair
+
+[33mcommit a4887eb30babfa5166421bc4ec1851cc5d2f8523[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 6 20:15:24 2018 -0800
+
+    Only add info for current context when generating cluster pair
+
+[33mcommit 80057754a36499c88bd1929b6ba422c85c97cbbb[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 6 20:01:20 2018 -0800
+
+    Add gcloud to the stork container
+
+[33mcommit 1bf3f0c005e3293d11eefb075f0074c160ae2d7f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 6 18:53:18 2018 -0800
+
+    Update permissions for get and list of all resources
+
+[33mcommit decc97bf178062c75a0e0a7cc34caad15e0dc2ac[m
+Author: Craig Rodrigues <craig@portworx.com>
+Date:   Mon Nov 5 13:37:47 2018 -0800
+
+    Update golang version in travis to 1.11.2
+
+[33mcommit e201a7525d7e0f670d3b0eac8d8bf79dd15b61da[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sun Nov 4 00:00:28 2018 -0700
+
+    Add check to resolve hostname when matching nodes for k8s on DC/OS
+
+[33mcommit 9d67b9a286a312596e1d2a486d6398cddd247aed[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Nov 3 23:37:48 2018 -0700
+
+    Disable leader election for snapshot controller
+    
+    Leader election already happens in stork
+
+[33mcommit 55351568b6826b68cb6aa9e1fc80d4cbd123cdce[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Nov 2 23:42:22 2018 -0700
+
+    Fix extender unittest
+    
+    Also exit with error in Makefile if unittest fails
+
+[33mcommit 34f7be8cdfadfc64216db6484401151f6826b8bc[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Nov 2 22:27:48 2018 -0700
+
+    Don't use namespace for cluster resources with dynamic client
+
+[33mcommit 34ae11c2ed127ea6de9ea9cc9fea351d9c5c71e1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Nov 2 22:26:41 2018 -0700
+
+    Update branch to use for openstorage
+
+[33mcommit 021861735cb69f256c4cf03891636505faf84eab[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Nov 2 16:53:36 2018 -0700
+
+    Removed unused variables
+
+[33mcommit ed27912790cacad21df043642e8d963f32c0ab04[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 30 16:50:00 2018 -0700
+
+    Update generated code for CRDs
+
+[33mcommit ac00582e4ec2d7380ab9cd3a7977965a462868bf[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 30 15:35:23 2018 -0700
+
+    Switch from govendor to dep
+
+[33mcommit 4332391a181a54410d4e0b85b7625eb962be7111[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 12 15:31:17 2018 -0700
+
+    Govendor update
+    
+    Update k8s version to 1.11.0
+
+[33mcommit f1c7d85e684f9856546621144014e9768e8e8fc4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 9 16:55:08 2018 -0700
+
+    Refactor rule package
+    
+    Removed from snapshot package and added a separate package so that it can be
+    used by different modules
+    
+    Also fixed annotation to use the correct conventions. The old annotations can
+    still be used but they will be deprecated.
+
+[33mcommit 00b78f58e0dce0ad2552b5e47af0008bbfcbca37[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Oct 17 17:32:28 2018 -0700
+
+    Update storkctl to pass in streams
+    
+    Will be used by unit tests
+
+[33mcommit 46b6aeda499628e08ce6a2d9f3287e2041cb4709[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 1 21:07:35 2018 -0700
+
+    Disable CGO to allow binaries to run on alpine
+
+[33mcommit 3ef4d02ee27be1dc46a1ea6a964a27432748f0af[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Nov 1 12:46:54 2018 -0700
+
+    Add aws authenticator binary to the container
+    
+    Also use alpine instead of atomic and remove things added for
+    rhel registry
+
+[33mcommit faa6b7a05ccf65e5cf694bf3be2bc063ebeec6e4[m[33m ([m[1;33mtag: v1.3.0-beta1[m[33m)[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Oct 27 00:03:14 2018 -0700
+
+    Update version to 1.3.0-beta
+
+[33mcommit d7211031e8c806e6f207fedf917e4b0e342ced85[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 26 15:08:15 2018 -0700
+
+    Make the storctl binaries publicly accessible
+
+[33mcommit 7e43717fe0d9b12f2f6b6fd45df846d47ff83fb6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Oct 25 20:20:04 2018 -0700
+
+    Add command to generate clusterpair spec from destination cluster
+
+[33mcommit b6a1883c81c0318e46633a81c0403497a88001de[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Oct 25 17:17:44 2018 -0700
+
+    [Portworx] Add reason for migration failure
+
+[33mcommit befc40f2e55eaab85f4fc2a1b076b35f99e34b37[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Oct 25 17:17:22 2018 -0700
+
+    Govendor update for openstorage
+
+[33mcommit 723d782af0c7bc5c3d4ac0db29685ecf26b6e806[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Oct 25 15:47:13 2018 -0700
+
+    [Portworx] Add namespace to migration task Id
+    
+    The pvc name can exists across multiple namespaces
+    Also use task id to match status instead of volumename
+
+[33mcommit b88865a129c8fc19e6dbf44d665891b2f8b2cbc4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 23 20:21:53 2018 -0700
+
+    [Portworx] Update cloudsnap and cloudmigrate APIs to use taskIDs for idempotency
+
+[33mcommit 0a3eff3b4862689dc186cda0e3fc16f514cb93b0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 23 20:21:39 2018 -0700
+
+    Govendor update for openstorage
+
+[33mcommit ebdd417403d13b1b07c51fa2f9f649474877465a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 23 20:41:49 2018 -0700
+
+    Update permissions for migration and cluster pair
+    
+    Also remote extra permissions for CRDs and sync permissions in the daemonset
+    spec
+    
+    Issue #165
+
+[33mcommit 257bf61f348a836d7302bb296e8da1b36ebf8db3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 19 20:59:48 2018 -0700
+
+    Add command to create pvc from snapshot
+
+[33mcommit 9f2499d3b4fafc4ec1ec3bcc7faf879d01ad3584[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 19 19:16:33 2018 -0700
+
+    Upload storkctl binaries to s3
+
+[33mcommit a6dc36b574cc678857abb01be811e930d5e9d28b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 19 18:55:11 2018 -0700
+
+    Add storkctl to container
+
+[33mcommit abf1e99a5f902c630bbafdea4059ca1cfe318da2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 9 16:02:29 2018 -0700
+
+    Add timeouts for updated APIs
+
+[33mcommit 93ad80bc14f0d83a8f1dce890c9cf27289a2a9a2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 9 16:01:50 2018 -0700
+
+    Govendor update
+
+[33mcommit 20b16503157af232844ab87f8059c29eb9467576[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jun 27 14:23:45 2018 -0700
+
+    Add storkctl to manage stork resources
+    
+    - Subcommands added are create, get and delete
+    - Supported resources are
+      - volumesnapshots
+      - clusterpair
+      - migration
+    - Supports global parameters for namespace, kubeconfig, context and output
+      format through CmdFactory
+    - Binary is build for linux, darwin and windows
+    
+    Issue #80
+
+[33mcommit 2a03cba14fb1841cbda76668f1ce4d82be15086e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Sep 27 15:43:04 2018 -0700
+
+    Update migration object to be cluster scoped
+
+[33mcommit c199b0a30aac6545f7383b30b1d4d790f385b1a6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Sep 24 14:21:26 2018 -0700
+
+    Change driver registration log to debug
+
+[33mcommit 57de4b753abfddbf933b8f5f8f8e070493bfc9d1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Sep 24 13:49:12 2018 -0700
+
+    Update resync parameter for controller for time.Duraion
+
+[33mcommit bc319c510b3e4caa24aba77357641ab03c02022a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Sep 19 21:00:00 2018 -0700
+
+    Govendor update
+
+[33mcommit f988cd4a8544ab317d4344ce2145e7216b52ae03[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 12 14:44:21 2018 -0700
+
+    Update golang version in travis to 1.10.4
+
+[33mcommit f52b861d85a5ed8621eecad05eac5e0a26c3cd4a[m
+Author: Craig Rodrigues <rodrigc@FreeBSD.org>
+Date:   Fri Oct 12 14:33:00 2018 -0700
+
+    Add missing argument to logrus.Warnf (#156)
+
+[33mcommit 0634241b093712bddd9471ff549a236e0cd0a9ba[m
+Author: Craig Rodrigues <rodrigc@FreeBSD.org>
+Date:   Fri Oct 12 14:16:06 2018 -0700
+
+    Fix import path of golint (#157)
+
+[33mcommit 2eedbd8d2b412e5c540f5a1e8c960b789c8bfff5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Oct 8 17:44:09 2018 -0700
+
+    Add auth providers and default client config loading rules
+
+[33mcommit 97d7aacf3a7839c48d172852d518b9e6ffc41bf0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Oct 8 17:43:54 2018 -0700
+
+    Govendor update
+
+[33mcommit 150bf8f0a540c0e674e9f0928ccf5a2f3aff05cf[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Oct 8 15:56:34 2018 -0700
+
+    Don't create namespace if it already exists on remote cluster
+
+[33mcommit 6f3f1e4641b0338489cad2245550a8f5a85341f9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Oct 6 00:13:00 2018 -0700
+
+    Check if PV and PVC are owned by driver when migrating
+
+[33mcommit 8ef28ffea28fbe2cf4f8bdd67ddefea7d42aa2f3[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri Oct 5 10:10:03 2018 -0700
+
+    Group snapshot should wait till all PVCs are bound (#153)
+    
+    Fixes #152
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit bb74377883b97e153710cb3825cdcca3b7082a55[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Sep 27 19:19:09 2018 -0700
+
+    Start snapshot provisioner in background since it blocks
+
+[33mcommit 5bd7347a775eaa2fd102fd4b9780ffb707092276[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Sep 28 12:57:16 2018 -0700
+
+    Fix some issues found from Go Report Card
+
+[33mcommit ca466f7d1a8ba2ea1a6b1434519e21923d08faad[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri Sep 21 17:14:52 2018 -0700
+
+    Add docs for 3d snaps (#148)
+    
+    Fixes #147
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 760b94dad5d121e1d3323098c608cc83053c0c71[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Sep 10 14:02:05 2018 -0700
+
+    Start migration controller from cmd
+    
+    The controller manager needs to be started first followed by all the
+    other controllers
+
+[33mcommit 1e1e73201cf03970edf7fa4683fb4db960452ab9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Sep 10 13:51:35 2018 -0700
+
+    Add controllers for pairing and migration CRDs
+    
+    Pairing:
+    - When a pairing is created an API call is made to the storage driver to create
+    a pair. The k8s config is also verified to make sure we can talk to the remote
+    cluster
+    - When a pairing is deleted an API call is made to the storage driver to delete
+    its pairing too
+    
+    Migration:
+    - Takes in a cluster pair name to which migration should be done
+    - Users can choose to migration only volumes from storage driver or volumes +
+    resources (ie PVCs, deployments, statefulsets, etc)
+    - First volumes are migrated from storage driver and then resources are migrated
+    if requested
+    - Stage goes from Initial->Volumes->Application->Final
+    - Pods aren't migrated right now. Need to migrate pods which don't have a
+    replication controller
+    - Service account secrets are not migrated since they belong to a cluster
+    - Config can be set to not scale up applications (ie deployments, statefulsets)
+    on remote cluster. This will add an annotation to store what the replica count
+    was on source cluster
+    
+    Events are recorded for various success/failure steps.
+
+[33mcommit 63d66122d6617f06333e55a58125e7b0945f2b12[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Sep 10 13:50:27 2018 -0700
+
+    Add pairing and migration APIs to volume driver interface
+    
+    Add implementation in Portworx driver
+    Return NotImplemented for mock driver
+
+[33mcommit 18efa0bd4ffb6805893bccadb74f5ab9e7de74ac[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Sep 10 13:48:25 2018 -0700
+
+    Remove integration-test from default target
+
+[33mcommit 83f11dabf44de61d01723add05607e8adba843bb[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Sep 10 13:46:42 2018 -0700
+
+    Add controller package that can be used to watch for changes
+    
+    Modules can register for updates for particular types
+
+[33mcommit feb7f1822af28417c8219b12cf239c07521a5c41[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jul 26 14:47:48 2018 -0700
+
+    Govendor update
+
+[33mcommit ef54663320aafd3172491d06ac70be615ce1d688[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Sep 10 13:45:51 2018 -0700
+
+    Add CRDs for pairing and migration
+
+[33mcommit dc214de6633dac7f1145e41158c9596d17d91378[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jul 26 14:47:48 2018 -0700
+
+    Govendor update
+
+[33mcommit 5e9308aaa5e98edda465d57515575c5a91be5f39[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Sep 13 19:49:36 2018 -0700
+
+    Update health monitor to also use better node matching logic
+    
+    Issue #144
+
+[33mcommit cd98a94bde5823d8759c29a06245ae5f0e17cad2[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Sep 13 18:47:56 2018 -0700
+
+    Update test verification to also look at node IP to match nodes
+    
+    Issue #142
+
+[33mcommit 11e06757f1e53909e731790289ecc520830dec37[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Sep 13 15:45:51 2018 -0700
+
+    When matching nodes check for internalIP incase hostnames are different
+    
+    This is for environments like K8s on DC/OS where the kubelet is running
+    in a containerized environment and has a different hostname than the physical
+    node
+    
+    Issue #142
+
+[33mcommit fd7785c6bff6dc4fa04ad6fd68cd69d7fb259340[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Sep 6 17:44:50 2018 -0700
+
+    Add namespace and other info for logs
+
+[33mcommit d950d641d9c9ceda6d9e245100b076cd8ef7633a[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri Aug 24 13:50:35 2018 -0700
+
+     Rename storkrule to rule (#138)
+    
+    * Rename storkrule to rule
+    
+    Closes #128
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * update vendor
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * openstorage => libopenstorage
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 130c674ed2ee159bf86e770605d1b6c1f5bc6f64[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Aug 15 13:11:51 2018 -0700
+
+    Update integration test script to pass in test image
+
+[33mcommit 56ffaf4e559fcdd9f2e7ca25abb00fd94528478f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Aug 13 19:34:35 2018 -0700
+
+    Portworx: Update snapshot API call to not retry internally
+    
+    Also update cloudsnap status type from openstorage
+
+[33mcommit a04b42072a755ef4b35b2049c72af9e81891378c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Aug 13 19:32:50 2018 -0700
+
+    Govendor update
+
+[33mcommit ed62abf34c351bfec7c8932c1ea077dc800b642f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Aug 14 14:51:48 2018 -0700
+
+    Add option to integration test script to pick docker image name
+
+[33mcommit 2d35a36009d76af02a6ced8e7e61280f3219e127[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Thu Aug 9 14:40:11 2018 -0700
+
+    Background command fixes (#133)
+    
+    * Background command fixes
+    
+    1) Don't send the background termination channel if there are no background commands
+    2) Handle situations where there could be more than one background actions and the first one has a single pod
+    
+    Fixes #131
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Update mysql 3d snap test to handle one more background command action which runs on single pod
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * if any action fails, terminate all background jobs
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit fec363db2ab62b8ba23156752c2033d92fa32d06[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Mon Aug 6 19:59:56 2018 -0700
+
+    overide default cmdexecutor for tests (#130)
+    
+    * overide default cmdexecutor for tests
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * rename override annotation
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit bcd0e9af2f8028404908192b9bfe1a4b0b6fa480[m[33m ([m[1;33mtag: cmd-executor-v0.1[m[33m)[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Mon Aug 6 18:59:32 2018 -0700
+
+     Add support for 3d snapshots (#118)
+    
+    * vendoring changes
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Add support for 3d snapshots
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * update sched-ops to get crd api
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    *  addressing review comments
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Update sched ops vendor
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Address review comments
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Just send pvc list to rule api
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Review comments
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * validate snapshot rules before starting any snap operations
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 9b460bdf7ae3f30948347aeb130ba36c7dcc2f5e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jul 27 15:56:30 2018 -0700
+
+    Fix codegen to use correct vendor directory
+    
+    Also update generated code
+
+[33mcommit 92b40731b33e49a7ab423e635db75ff7b172683d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jul 27 15:56:55 2018 -0700
+
+    Govendor add k8s code-gen
+
+[33mcommit 454eadc891b46e01ce6caafcf707c37728320a0e[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Fri Jul 20 14:48:19 2018 -0700
+
+    Update sched-ops to fix snapshot validation
+    
+    - Updated sched-ops will now continue even if the first validation fails
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit c675875fc70ca8271958d60c76fc64fb4f2028fb[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Thu Jul 19 11:40:52 2018 -0700
+
+    fix group name
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 89616e05ca121f6a24de845909fa6b7e5e114603[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed Jul 18 19:02:14 2018 -0700
+
+    Update group name
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 9d12451f451ee67fce6c74cca8d53bbec04453ec[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed Jul 18 18:54:28 2018 -0700
+
+    workaround to update vendor manually until torpedo and sched-ops are updated
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 7b48bbd62fc92dd302a2ca93c47742d8696baf37[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed Jul 18 18:42:43 2018 -0700
+
+    rename stork.com
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit c7d67aaa77e15ff61c364498f4564bb3111217fa[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jul 10 13:10:29 2018 -0700
+
+    Update a test to hit path where node name is different from driver node ID
+
+[33mcommit 33e61579416980c5f25ef71218c46ba3504bc6bb[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed Jul 18 13:17:42 2018 -0700
+
+    fix integration tests (#122)
+    
+    The tests now explictly use the get snapshots call and also verify the volumesnapshot data
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 8358aea2b66f8d437aee409462da4b403ebd3fa4[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Tue Jul 17 18:09:46 2018 -0700
+
+     Check snapshot data before restoring from it (#121)
+    
+    * Update sched-ops vendor to get validate api for snapshot data
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Check snapshot data before restoring from it
+    Fixes #120
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 9f16cc0f713dd456d7af585a5d0fa712a6875b02[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jul 16 14:00:10 2018 -0700
+
+    Print node info on failure when checking scheduled node
+
+[33mcommit ab453b9161a1446526d8563d00fccfa55c418bf1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jul 10 14:18:18 2018 -0700
+
+    Add unittests for invalid requests to extender
+
+[33mcommit e20ae5a6631a5e3b9629c8d72ff0782bae2d2cbb[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Mon Jul 9 22:47:22 2018 -0700
+
+     Add CRD for stork rules (#115)
+    
+    * Add CRD for stork rules
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Add script to generate CRD and the generated files
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * build changes
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * changes to crd review comments
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Remove GOVET_PKGS from makefile and just use PKGS
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * fix tabs in makefile and remove unused comments in update-codegen.sh
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 051ed128d229cb6e8634d49fe1b884b678f03ff8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Jul 6 17:32:21 2018 -0700
+
+    Extender: Also check node name to match driver nodes
+    
+    Issue #112
+
+[33mcommit da0cf1214fcfd24715ce9fdd56ba2ea420639231[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jul 5 18:40:26 2018 -0700
+
+    Update travis to push image for all branches (#110)
+
+[33mcommit 4e2201c456ca9ebc6f63d739afa28327f47604ec[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jul 3 14:24:33 2018 -0700
+
+    Update specs in integration test instead of deleting and recreating
+
+[33mcommit 2e8188d5f413dd93b6bfba83ba992c4c6325f115[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Mon Jul 2 16:05:36 2018 -0700
+
+    Add an executor CLI for running async commands in pods (#104)
+    
+    * Add an executor CLI for running async commands in pods
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * review changes
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * address review comments
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * fix gosimple
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit af7f47e692c42246b3c544938dea707a06a4dba9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 28 20:35:50 2018 -0700
+
+    Check node cache with ID and hostname
+
+[33mcommit 05dbc099b9d0b2c192d210ddeedd4fc71ed618f0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Jun 27 15:00:29 2018 -0700
+
+    Add gosimple checker
+    
+    Also fix issues found by gosimple
+
+[33mcommit 47fdb22e42eea1e14e8f28c72dbfa57990a03cde[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed Jun 13 09:08:30 2018 -0700
+
+    don't enforce pv reference for describe of local snapshots
+    
+    Fixes #106
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 3a07e70fc5f4c0041a1da96d9fb0685b23216641[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sun Jun 10 19:41:16 2018 -0700
+
+    Add snapshot scale test
+
+[33mcommit bd5057d805cf0b503f9d0f9a909fd53c67ae7cfe[m[33m ([m[1;33mtag: v1.1.1[m[33m)[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 7 16:55:09 2018 -0700
+
+    Bump version to 1.1.1
+
+[33mcommit 45863a30e1544e9c86c9199be6d1647395b564c1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 7 16:39:00 2018 -0700
+
+    Add support to restore snapshots to different namespaces
+    
+    - When creating snapshots users need to provide comma seperated regexes
+    with "stork/snapshot-restore-namespaces" annotaion to specify which
+    namespaces the snapshot can be restored to
+    - When creating PVC from snapshots, if a snapshot exists in another
+    namespace, the snapshot namespace should be specified with
+    "stork/snapshot-source-namespace" annotation
+    
+    Issue #71
+
+[33mcommit 321b525e65a433abbc6de8b63d864f73cdbf8ca4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jun 7 03:19:43 2018 -0700
+
+    Add a cache for node info
+    
+    Querying the API server for each node takes too long and times
+    out the requests in a large cluster
+    
+    Issue #99
+
+[33mcommit 531a1a84f54d29d5b4b5685a32edaaa74286ac26[m[33m ([m[1;33mtag: v1.1[m[33m)[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Thu May 31 17:01:55 2018 -0700
+
+    Update vendor to pull in sched-ops fix for validating snaps (#97)
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 21ecd68f4c40cbf3eb9a2e3784996a227b5de23f[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed May 30 08:37:32 2018 -0700
+
+    retry inspect volumes for group snapshots (#95)
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 744bf489a533d33bd2ab5118d694816039fd33a2[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed May 23 23:27:23 2018 -0700
+
+    Ensure version check for group and cloud snapshot (#94)
+    
+    * Ensure version check for group and cloud snapshot
+    Fixes #82
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * retry on cluster enumerate
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 6bf00e23b10cb767376cf3db808e2fa33c7d39df[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed May 23 13:34:49 2018 -0700
+
+    update group snapshot annotation keys (#93)
+    
+    * update group snapshot annotation keys
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * remove unnecessary checks for labels
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 818bbdf3e7ed2ff9ed85f642908a9338df95523f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon May 21 18:04:16 2018 -0700
+
+    Make the health-monitor interval configurable
+    
+    Default is 120 seconds and minimum is 30 seconds
+    
+    Also update version for upcoming release
+
+[33mcommit 87cdd97964d3cd618ce3bbd589e35d0c12f7dfaa[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 17 16:54:12 2018 -0700
+
+    If no driver nodes found in filter request return error
+    
+    Fixes #89
+
+[33mcommit 99afb2aa72c097effaadb11fcd3c4edb14a20641[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Thu May 17 14:30:21 2018 -0700
+
+    Update vendor to allow error status conditions in failed volumesnapshots (#88)
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 50cc4666702d7cf2bd42e2f0fa8f2d208cdf81f6[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Wed May 16 13:59:10 2018 -0700
+
+    For group snapshots, include UUID of parent volumesnapshot in child volumesnapshots (#87)
+    
+    Fixes #86
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit fa7d602b8c0ce1c8630706ee9dc68dedb8609c97[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon May 14 15:37:06 2018 -0700
+
+    Update vendor for torpedo
+
+[33mcommit 1be992282d6da65ac594a5698b9e5a025091e7d4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Apr 26 15:16:40 2018 -0700
+
+    Update docs for initializer
+    
+    Issue #54
+
+[33mcommit ff8c0a94ed552fda85feb34212dfc7285816abb8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Apr 26 14:54:09 2018 -0700
+
+    Add statefulset to integration test to test initializer
+    
+    Issue #54
+
+[33mcommit 22a4ae0b978560ef6e91c1ae5fb787c96bc1045f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 29 13:48:11 2018 -0700
+
+    Add initializer spec
+    
+    Also update deployment spec with comment to enable initializer
+    
+    Issue #54
+
+[33mcommit 7ea4eeb0ff2351bcb075a139bb1475e5d82861cc[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Mar 2 22:32:04 2018 -0800
+
+    Add initializer to update scheduler name
+    
+    Scheduler name is updated only if pod is using a volume by the
+    specified driver
+    
+    - Also added cmd args to enable/disable features
+    - Need a different initializer for v1, v1beta1 and v1beta2
+    - Updated test script to enable test with initializer
+    - Updated APIs for k8s 1.10
+    
+    Issue #54
+    Issue #9
+
+[33mcommit 609a15b3cb4f094e15515a53c72ba5e14c771528[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 8 17:38:38 2018 -0700
+
+    Govendor update k8s libraries to 1.10
+
+[33mcommit 72da8b1bb38cf2fbb10d8feea16bd6803ccb600d[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Sun May 13 14:44:59 2018 -0700
+
+    Fix cloudsnap integration to check only data volumes in use (#84)
+    
+    * Fix cloudsnap integration to check only data volumes in use
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * extract common func to parse data volumes
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit 6a3595d944acdc233713e4d2e25386ae97a4d090[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Thu May 10 17:01:33 2018 -0700
+
+    verify scheduled node only for mysql-data-1 (#83)
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit b355c25df712f4b03bacd0936aea6a9eb2eecf8e[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Thu May 10 13:59:52 2018 -0700
+
+     Add support for cloud and group snapshots (#78)
+    
+    * vendoring changes
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Add supports for cloud and group snapshots
+    Fixes #61
+    Fixes #55
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * fix travis build
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Address review comments. Key changes
+    1) Wait indefinitely for cloudsnap completion
+    2) Revert group snaps on partial completions
+    3) cloudsnap restore support
+    4) add cloudsnap test
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Review comments
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * vendor update for cloudsnap operation type
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * review comments
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+    
+    * Add missing secrets vendor
+    
+    Signed-off-by: Harsh Desai <harsh@portworx.com>
+
+[33mcommit db0f19df337c3c53ed4b76808f34c00f39c2ed53[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu May 3 12:12:43 2018 -0700
+
+    Use correct volume name for snapshot in torpedo
+
+[33mcommit e77632d4719cc9cc39bc528f88be37165bdd0f92[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 2 16:48:46 2018 -0700
+
+    Govendor update for torpedo and sched-ops
+
+[33mcommit fca8c002c358645ccecebf10ee528078da8525ba[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed May 2 16:22:32 2018 -0700
+
+    Portworx: Return NotImplemented for FindSnapshot
+
+[33mcommit 5367db20ec559509336f48ce583608b5b8cd8d37[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 1 13:11:11 2018 -0700
+
+    Update stork specs to remove predicate not present in 1.9.x
+
+[33mcommit 779a017c68ee9e79f2fcfe540255f61e669660c8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 1 12:40:18 2018 -0700
+
+    Update SnapshotCreate API for Portworx driver
+    
+    Issue #55
+    Issue #61
+
+[33mcommit 1e9aa635ba9b1310c8e176f4530aa52fff30edef[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue May 1 12:40:03 2018 -0700
+
+    Govendor update for external-storage
+    
+    Issue #55
+    Issue #61
+    Issue #42
+    Issue #43
+    Issue #69
+
+[33mcommit 2bbd7d3a63c5a9f0278230c9e4673ecd73bd99d2[m
+Author: Harsh Desai <harsh@portworx.com>
+Date:   Tue Apr 24 12:37:18 2018 -0700
+
+    Fix docker tag in build instructions (#70)
+
+[33mcommit 1ed4f9f6a31faff5901ede6350de2a3d87268d20[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Apr 20 13:27:03 2018 -0700
+
+    Portworx: Use snapshot UID for snapshot name to make it unique
+    
+    Also add snapshot name and namespace as labels when creating the
+    snapshot
+    
+    Updated integration test
+    
+    Issue #67
+
+[33mcommit 39ca53c69d3215121a5d3b8f99cf571e5aea7c65[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Apr 19 13:22:19 2018 -0700
+
+    Pick clone volume correctly in test
+
+[33mcommit a3c786b41a0de2a4cd2482aeb08063c321f95f84[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Apr 18 15:23:31 2018 -0700
+
+    Update snapshot test to also expect snapshot volume
+
+[33mcommit a8a669ca260dd2f8786ff264b52c714ed5f981f5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Apr 17 18:57:31 2018 -0700
+
+    Update torpedo API calls for stopping driver
+
+[33mcommit 3ccb35122fcf746b895019bc5ca2c106e35179e5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Apr 17 18:54:21 2018 -0700
+
+    Govendor update sched-ops, torpedo and dependencies
+
+[33mcommit 522688da2405233ff21317985407396af8ddfa4b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Apr 17 23:10:16 2018 +0000
+
+    Update ssh username and password from env variables
+
+[33mcommit 99b6266e3eee5ebf8c7b5e527ad620cb66b703f6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Apr 17 23:09:24 2018 +0000
+
+    Add storageclass permissions for scheduler, required for 1.10
+
+[33mcommit 733dcbae0aff13f530890a5373d2a9cbb2e4d23b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 16 22:59:25 2018 -0800
+
+    Add support for node locality awareness when priotizing nodes
+    
+    Also updated Portworx driver to return rack/zone/region info
+    
+    Issue #6
+
+[33mcommit 3510c416649cee4426cc8ad9ca07090363fff3c3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 16 21:07:25 2018 -0800
+
+    Replace k8sutils with sched-ops package
+    
+    Issue #17
+
+[33mcommit 247723c76f71240c5130f5f9529463b6bff58bb3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 16 19:59:53 2018 -0800
+
+    Govendor update for torpedo and sched-ops
+
+[33mcommit 577ca9c050bff35bda2e75466065175fd596128d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Apr 6 14:58:36 2018 -0700
+
+    Use correct path to replace stork tag
+
+[33mcommit b9a2aafafcab53d9eb4727f662b75fbb771c6414[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Apr 5 13:37:59 2018 -0700
+
+    Check PVC first for provisioner
+    
+    Issue #49
+
+[33mcommit 84ba7e8db90f5e4d6998b36f8de469517458d4c0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Apr 3 12:55:04 2018 -0700
+
+    Don't check source PV when restoring from snapshot
+    
+    The original PV could have been deleted.
+    
+    Issue #57
+
+[33mcommit 5dee852495a17a46ed422469f1aaa7c0fbc3de98[m
+Author: Piyush Nimbalkar <piyush@portworx.com>
+Date:   Fri Mar 30 15:13:15 2018 -0700
+
+    Add pvc namespace label to the volume on restoring snapshot
+
+[33mcommit 95a05becbadb91a9abfa90203f20a09d35561299[m
+Author: Piyush Nimbalkar <piyush@portworx.com>
+Date:   Fri Mar 30 15:06:45 2018 -0700
+
+    Add pvc name label to the restored snapshot
+
+[33mcommit 473c8bf68c3706dfc9f21cf4480536ecd252b4ee[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Mar 28 19:10:46 2018 -0700
+
+    Fail if any unit test hits errors
+
+[33mcommit 27e4f4f90aa73a413fac3899dd730bd6a6730ad6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sun Mar 4 15:16:36 2018 -0800
+
+    Fix error check in extender prioritize request
+
+[33mcommit d39ecfde1f5c56fc6f647efc476a3c96b776a00c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Mar 26 20:43:09 2018 -0700
+
+    Portworx driver: Check other sources for provisioner
+    
+    Issue #49
+
+[33mcommit 54bc88d83d811950d16204c985bc8164627498d9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 13 21:19:45 2018 -0700
+
+    Add codecoverage and badges
+
+[33mcommit 87d0c66d63b4ef0095a30248e3c8b9ff9e3cbf6e[m[33m ([m[1;33mtag: v1.0.3[m[33m)[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Mar 19 18:31:13 2018 -0700
+
+    Bump version to 1.0.3
+
+[33mcommit 47380187d3b595875d4a060a82782fec69fca439[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Mar 19 15:41:02 2018 -0700
+
+    Add some metadata to docker container
+
+[33mcommit be2c099b5a38f2290071fbb79d6e8901b65f6bb7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Mar 17 23:36:29 2018 -0700
+
+    Portworx driver: Check for source not being nil during inspect
+    
+    Issue #45
+
+[33mcommit 21dcb685ae5bd3401467a4568fec165fcf7d689e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Mar 13 21:41:47 2018 -0700
+
+    Create CODE_OF_CONDUCT.md
+
+[33mcommit 3f9ee2d62bda5767692f9e11de7ae3d41ae617c4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Mar 2 23:01:38 2018 +0000
+
+    Add instructions to use stork with default scheduler
+    
+    Issue #38
+
+[33mcommit 3a32d6f81bc42719ed29811af06e0346ed750cb7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 1 16:56:05 2018 -0800
+
+    Update spec to point to v1.0.2
+
+[33mcommit b535e8bbfe99ce34ae564c2cad493689435f9c05[m[33m ([m[1;33mtag: v1.0.2[m[33m)[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Mar 1 16:29:58 2018 -0800
+
+    Bump version to 1.0.2
+
+[33mcommit 749c9beb5a63b208e3c35f1f46f9f5d79ce5d2ab[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Feb 28 13:37:18 2018 -0800
+
+    Update test script to use master image tag
+
+[33mcommit 7206fe2657c9eba88edf2e61870b7b120e7f7d53[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 23 18:28:01 2018 -0800
+
+    Also check for short hostnames in filter request
+    
+    Issue #30
+
+[33mcommit 3818bbdd2f19d0472049642ac5b798d40f70a303[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 23 15:13:10 2018 -0800
+
+    Govendor add new dependencies
+
+[33mcommit c60ddf5412e0c7e3d33e8428fd8206a750bfc292[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 23 14:52:51 2018 -0800
+
+    Update sync cache for snapshot controller
+    
+    Issue #29
+
+[33mcommit 9bf8b5a92886911252c6209714c5d0a00be60895[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 23 15:56:34 2018 -0800
+
+    Check for short hostnames in extender by checking prefix
+    
+    Issue #30
+
+[33mcommit 6250ee576b8948facc827287b48e9777c5a57da4[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Feb 16 18:17:53 2018 -0800
+
+    Move the container to be based on atmoic
+    
+    Issue #27
+
+[33mcommit c09173e8fe495e3dff9157c7234220e56c42c4b7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 15 13:22:01 2018 -0800
+
+    Update README.md
+    
+    Fix formatting for snapshot spec example
+
+[33mcommit 80f737f2c9ae6e1795966afff3adf155fb8501e9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Feb 12 12:14:30 2018 -0800
+
+    Add note about predicates and priorities in spec
+
+[33mcommit 0fce6aec6759642f76b1a0938336d6a6b75dd115[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Feb 12 11:38:56 2018 -0800
+
+    Add configmap namespace for scheduler deployment
+
+[33mcommit 44aab7c9a6928f565d11f6c97d93cdd1bd4ab099[m[33m ([m[1;33mtag: v1.0.1[m[33m)[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Feb 5 14:44:13 2018 -0800
+
+    Update version to 1.0.1
+
+[33mcommit 89b6bb1effb25fd80f11b651792bdfc4ca30835a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Feb 1 13:23:57 2018 -0800
+
+    Convert hostname to lower case to match kubernetes hostnames
+    
+    Issue #24
+
+[33mcommit f49d2a57d24c630efd340d6289b76836e8d73143[m
+Author: jose nazario <jose.monkey.org@gmail.com>
+Date:   Wed Jan 31 15:18:36 2018 -0500
+
+    spelling fixes, no content changes (#23)
+
+[33mcommit deebae19e68fa807a01b8d5c3eba81d722c78223[m[33m ([m[1;33mtag: v1.0[m[33m, [m[1;33mtag: V1.0[m[33m)[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Jan 18 12:52:21 2018 -0800
+
+    Update specs to remove unnecessary fields
+
+[33mcommit 8a11127e781701ae0d3950c6c9ddcb504c860a85[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 9 14:16:58 2018 -0800
+
+    Update README.md
+
+[33mcommit cc3ecd9e25c3d43a96562a1c028f2f3fb0429cf3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 15 02:47:57 2018 +0400
+
+    Update stork spec to use v1.0
+
+[33mcommit 343e2816f902947ce993eec80fc1f5dc71261429[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 15 02:39:50 2018 +0400
+
+    Update version to 1.0
+
+[33mcommit 7a1d573b6113db1874e52d7c9c25fd7aaa6ec4ee[m[33m ([m[1;33mtag: v0.3.1[m[33m)[m
+Author: Gou Rao <gourao@users.noreply.github.com>
+Date:   Wed Jan 10 17:36:19 2018 -0800
+
+    Update README.md
+    
+    fix typo
+
+[33mcommit e791288f4f721e58bdaa9d43375b9f363eaa570b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Jan 9 19:07:15 2018 -0800
+
+    Wait for integration test to come out of Running state at the end
+
+[33mcommit 7b38516675a0cec2ace60c2fe0cfe2733086b008[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 8 21:10:41 2018 -0800
+
+    Check for correct status for integration test
+
+[33mcommit 4a5fe058f0f9e310a47c65e1f7b3e6194bbbb697[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 8 20:31:49 2018 -0800
+
+    Fix for using hostname instead of driver node ID
+    
+    The node IDs returned in volume info might not match the hostname
+
+[33mcommit 9da0fc8bd4d5cfd84d4c27fae4dd7773b842dd6a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 8 20:28:53 2018 -0800
+
+    Govendor update torpedo drivers
+
+[33mcommit 031b4c7f59faabbba6e4a17a772f320ddad8bde8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 8 15:11:26 2018 -0800
+
+    Update stork spec to use v0.3.1
+
+[33mcommit 9d0dd36ae1557e6d66c716b99f1df12d52a68a58[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 8 15:09:01 2018 -0800
+
+    Make test-deploy.sh executable
+
+[33mcommit 05c6ddfef37f14395dc76e636245bbd618844a43[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 8 14:54:11 2018 -0800
+
+    Update version to 0.3.1
+
+[33mcommit f3b978d3c6c036805d1f91ac7437407df5bed418[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 8 13:39:35 2018 -0800
+
+    Add script to deply and run stork integration tests
+
+[33mcommit 2296144226ae8b58ce8a70d92d186f4f7ca881c6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 8 10:55:44 2018 -0800
+
+    Remove stork-snapshot storageclass from integration test spec
+
+[33mcommit 458a84f8a006a70d8863fd1798a4b4cefcfbdfdb[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Jan 8 10:53:06 2018 -0800
+
+    Add stork-snapshot storageclass to spec
+
+[33mcommit 668470cf5d79cc9c5a8a3ae0e8baf4e699d0724e[m
+Author: hr1sh1kesh <hr1sh1kesh.deodhar@outlook.com>
+Date:   Wed Jan 3 16:06:23 2018 +0530
+
+    Fix RBAC permissions for stork-account on ConfigMaps
+
+[33mcommit fec13849080a9a3875f92ae2c5de5400414b30ae[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Dec 28 13:32:30 2017 +0400
+
+    Add specific permissions for stork and the scheduler
+
+[33mcommit f30d98f39219176e28b70cbcf781704a7c3b3382[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Dec 28 13:22:47 2017 +0400
+
+    Start extender on all replicas
+
+[33mcommit d82e6c377ecd08112c4ef26232d8da9c6ca2610d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Dec 20 06:17:10 2017 +0100
+
+    Update stork-scheduler.yaml
+
+[33mcommit 53f81d8487b86f4228e5717b182aefe1ac888e06[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Dec 19 21:05:45 2017 -0800
+
+    Update stork-scheduler.yaml
+    
+    Update spec to not run more than one pod per node
+
+[33mcommit 7fd4ae356261d4e61957a4cd213c81e3023ee06c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Dec 20 05:59:14 2017 +0100
+
+    Update stork-deployment.yaml
+    
+    Update stork spec to not run more than one pod per node
+
+[33mcommit f3cafb73a438a772adacd99a282a1425dd61298e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Dec 15 18:43:18 2017 -0800
+
+    Update stork to 0.3 in spec and cmd
+
+[33mcommit cda37a5847f47c04f7d765165f7b1eb43d6b947d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Dec 15 18:42:25 2017 -0800
+
+    Update README.md
+
+[33mcommit d65bdafa61bce7e2008fa88aeae0589f4c33f73a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Dec 15 18:40:11 2017 -0800
+
+    Update stork deploment spec to run 3 replicas
+    
+    Issue #10
+
+[33mcommit 5267f64ded2d2622ea6b9f230b0d8f29e0a28b65[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Dec 15 18:31:36 2017 -0800
+
+    Wait 1 minute before deleting pod in extender test
+
+[33mcommit 9cab0ebc3e66b4c7216e10815e7dbb25380006cf[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Dec 14 18:38:41 2017 -0800
+
+    Add support for leader election when starting up
+    
+    Leader election is enabled by default
+    Can specify lock object name and namespace as cmd args
+    
+    Issue #10
+
+[33mcommit bae23895e95f960cce3ca496e506ebde99aefd4f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Dec 14 18:37:54 2017 -0800
+
+    Govendor update
+
+[33mcommit 00b128afdb05c21d9e7350fffbfd8d5216c24120[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Dec 13 19:37:43 2017 -0800
+
+    Add basic integration tests for snapshot
+    
+    Issue #8
+
+[33mcommit 572c1b1ed4694899e37e4a8ba9a2be072238d86f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Dec 13 19:34:39 2017 -0800
+
+    Govendor update
+
+[33mcommit 1e50be0d9fc379cb83b901498114eef1bec77c63[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Dec 6 13:55:43 2017 -0800
+
+    Fix error check when stopping extender server
+
+[33mcommit da800c2b6a4e57ea291adf02f51cb7a4e596d1bf[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Dec 5 17:39:17 2017 -0800
+
+    Add timeout context for shutting down extender
+
+[33mcommit 4f4bbd0a2a94a0757486433d4944845be8081392[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Dec 5 16:58:11 2017 -0800
+
+    Replace Sirupsen with sirupsen in vendored packages
+
+[33mcommit f45ce061cd1b58b11f9b88515c69c0c469be9e0a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Dec 5 16:46:54 2017 -0800
+
+    Add support for snapshots
+    
+    Starts a snapshot controller as well as a provisioner to create PVC from
+    snapshots.
+    
+    Based on the snapshot work being done in kubernetes-incubator
+    
+    Issue #8
+
+[33mcommit 7e326f356bb5310fa2cd28b442148c2e19026c9a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Dec 13 19:38:41 2017 -0800
+
+    Update volume driver Init() to take interface parameter
+
+[33mcommit d2346ec8c40f86608a5bd81624f6dba445bc781e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Dec 14 00:03:13 2017 -0800
+
+    Add VolumeName and ParentID in volumeInfo
+
+[33mcommit cd21e73f31bd38fa5f13b5571abc6f1b107188c6[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Dec 5 16:45:25 2017 -0800
+
+    Implement snapshot plugin for Portworx driver
+    
+    Issue #8
+
+[33mcommit 1e1bf2b451db651b7b3387187ef4c3da567f2e9a[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Dec 5 16:31:34 2017 -0800
+
+    Govendor update
+
+[33mcommit 7631942690491240ea8f5133c5b819e2570d2e17[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Thu Dec 14 00:21:01 2017 -0800
+
+    Update stork-deployment to use v0.2
+
+[33mcommit b67596ad70a23ad757da952c95fbef04e63447fc[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Dec 11 21:48:31 2017 -0800
+
+    Update README.md
+    
+    Updated for HA scheduler
+
+[33mcommit 4be84d4c17321f80aa0e686b7169e86e5a4ab703[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Dec 11 21:45:58 2017 -0800
+
+    Delete stork-daemonset.yaml
+
+[33mcommit 89e4a2133f1ff138c51490b118aeb515b40cf0e0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Dec 11 21:45:12 2017 -0800
+
+    Update stork-scheduler.yaml
+    
+    Add lock object name for leader election
+
+[33mcommit 5ca3a853f435c9ed4e4cad5a6056ce02275355f6[m[33m ([m[1;33mtag: v0.2[m[33m)[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Dec 5 17:24:31 2017 -0800
+
+    Update version to 0.2
+
+[33mcommit fd2884ac9b3f91ba5c034ea404ce7c33ecadcb33[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 28 17:24:31 2017 -0800
+
+    Update ISSUE_TEMPLATE.md
+
+[33mcommit a3ca5200d0581b3347021a55d6aa16d3ca1fd649[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 27 18:58:25 2017 -0800
+
+    Fix typo
+
+[33mcommit e2a38f867f2a086bc5fe4343ae6dc6b8e7157228[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 27 14:20:45 2017 -0800
+
+    Update gitignore
+
+[33mcommit a321971f4d3751c90dbcf4841221e881c41a59ba[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 21 16:53:35 2017 -0800
+
+    Update travis to build integration tests
+
+[33mcommit 0448d5944a810d4fe44557a9a7492a35d4bd01cd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 21 16:27:45 2017 -0800
+
+    Replace Sirupsen with sirupsen packages
+
+[33mcommit 895e879d9762bbf7a26a5bb494217ab53e300d02[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 21 15:45:14 2017 -0800
+
+    Updates for Portworx driver
+    
+    - Fix typo in error struct
+    - Add check for length of volumes received from Inspect()
+
+[33mcommit 1c32343e58c596de2df147d197653e44a3d9b95b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 20 19:26:09 2017 -0800
+
+    Govendor update
+
+[33mcommit 6e2fd3e1f89b6f686498f0bdcf8f11beda01a3bf[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 20 19:24:20 2017 -0800
+
+    Integration tests for extender and health monitor
+    
+    - Using torpedo APIs to start pods
+    - Verifying filter and prioritize behavior
+    - Verifying pods are deleted and relocated if driver fails on a node
+    
+    Issue #2
+
+[33mcommit a59ddcdd0966c0eb6bc724dd2154351c782d4479[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 20 17:11:56 2017 -0800
+
+    Update for unit tests
+    
+    - Add tags for unit test
+    - Fix noDriverVolumeTest to use a non-Mock volume in pod
+
+[33mcommit 2cd6ed48aaee6e6078d2926322bb80c7a53bc3ee[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 13 18:22:55 2017 -0800
+
+    Add initial monitor to check for health of driver on nodes
+    
+    If driver on a node is unhealthy, delete all pods using the driver
+    on that node
+    
+    Issue #3
+
+[33mcommit dcf1ddbbbc2e830b7d5a8386e539814fb3c9ff37[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 13 18:19:12 2017 -0800
+
+    Update k8sutils to get all pods and delete a pod
+
+[33mcommit 50940c39dbe886e52ac19ebb762b8737c2c0fbbe[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 13 18:18:30 2017 -0800
+
+    Add Start and Stop for extender
+
+[33mcommit 862ba2151c41dd651456bd4c09d9c4621e2912e1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 27 17:12:10 2017 -0800
+
+    Update README.md
+
+[33mcommit ed14a426b4673c011b05b890ce6fde765f6b17f0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 27 17:11:18 2017 -0800
+
+    Update README.md
+
+[33mcommit 3bcd6d3b9060f6a9520f92fa9ffd5d498ffcba1f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 27 17:09:48 2017 -0800
+
+    Update stork-deployment.yaml
+
+[33mcommit 339e586b376806adb504f762a577fbe154b0df34[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 27 15:10:18 2017 -0800
+
+    Update README.md
+
+[33mcommit e636512d0fe569590b8b918887b11754604da84c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 27 15:09:49 2017 -0800
+
+    Create CONTRIBUTING.md
+
+[33mcommit 926cd3313513d51c7f03c9d2077c7150d8790f59[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Nov 27 14:57:15 2017 -0800
+
+    Create ISSUE_TEMPLATE.md
+    
+    Add issue template based on K8s template
+
+[33mcommit 586da254ebc883777d298d017a1d294711d4524d[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Nov 7 15:20:24 2017 -0800
+
+    Update README.md
+    
+    Add some badges
+
+[33mcommit 45137f4cb917a18aab93ca55d714ddeb78c9dee3[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 1 13:18:51 2017 -0700
+
+    Update .travis.yml
+
+[33mcommit 01ea5a696805de4ceb363e7c976cf38289daa317[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Wed Nov 1 12:30:29 2017 -0700
+
+    Update .travis.yml
+    
+    Push to latest tag if build and tests pass
+
+[33mcommit 294eab2c52179948ad081cc710800b02b67c017c[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 31 15:51:33 2017 -0700
+
+    Update travis to run unit tests
+
+[33mcommit d339c974c0cd63c1689fbb040cae25ffb59d668b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 31 15:40:48 2017 -0700
+
+    Add UTs for scheduler extender
+
+[33mcommit f092a13879dfca76bdd8a55b461b0b80682dd1f1[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 31 15:39:55 2017 -0700
+
+    Remove unused method from k8sutils
+
+[33mcommit 8310f288d30ae70d0ecd4166ebf366c277913949[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 31 15:39:07 2017 -0700
+
+    Assign default scores to nodes even if there are no volumes for a driver
+
+[33mcommit 772e14a2b0ba4fcccd713d9aaf13ed6b74d3c382[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 31 15:38:30 2017 -0700
+
+    Add Mock volume driver
+
+[33mcommit e24429bf087431d87f4dcedd2a15aa39c83e6992[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Oct 16 15:56:43 2017 -0700
+
+    Update README.md
+
+[33mcommit fdc62dbe2db6e397c30b66cd4d26a8bd3399a4e8[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Oct 16 15:50:22 2017 -0700
+
+    Update deployment instructions in README
+
+[33mcommit 4c9c1afd4365e8a1ac819d43bd39157fcd709ad7[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Mon Oct 16 14:27:00 2017 -0700
+
+    Update specs
+    
+    - Add separate specs for deployment and daemonset
+    - Add example mysql pod spec
+
+[33mcommit d66d5457ffc4723f46d900fb4abf468a9d91c0fd[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sun Oct 15 23:23:25 2017 -0700
+
+    Update stork spec
+    
+    - Fix typo in externder URL in config map
+    - Set hostNetwork to false for stork pod
+
+[33mcommit 0e4d120c7af1a85a19dc3e2491722c4b12011da9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sun Oct 15 19:39:05 2017 -0700
+
+    Update stork scheduler pod name in spec
+
+[33mcommit 0c4408a187d4fb5e61ff685dae2387a5be2d1d63[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sun Oct 15 19:32:24 2017 -0700
+
+    Move spec files
+    
+    - Added spec for scheduler which can be used if users don't want to change
+      the config for their default scheduler
+    - Added config map in stork spec which can be used by any scheduler
+
+[33mcommit c2047e86796a7bd8d823235275c326977763857f[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Oct 14 14:16:51 2017 -0700
+
+    Add pretest to travis build
+
+[33mcommit 531d0988f3692253a81d73110c4c06fbfe37c69b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Oct 14 14:15:44 2017 -0700
+
+    Add error checks
+
+[33mcommit 848c9f3d626a7c5bced0e9ca41d83188db6df935[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Oct 14 13:54:36 2017 -0700
+
+    Update deploy target in Makefile to only push docker image
+
+[33mcommit 8b24e2ed06c7e40d748f859505a23ec10e81ff1e[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Sat Oct 14 13:48:10 2017 -0700
+
+    Update .travis.yml
+
+[33mcommit 09dd095a127f7b0bd7984f7a90cd4cdf706fb3e9[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 13 20:47:34 2017 -0700
+
+    Update .travis.yml
+
+[33mcommit 7f795951fae21ce42cc3ec0b204c8780145cc895[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 13 20:43:15 2017 -0700
+
+    Update .travis.yml
+
+[33mcommit d04c3db91dba90da85dd3a0effc34b2bc4611466[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 13 20:23:13 2017 -0700
+
+    Add travis build
+
+[33mcommit 4674dc3ae5c80df99ecc76f08e0567475fc0e75b[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 13 19:43:23 2017 -0700
+
+    Make the priority scores into constants
+
+[33mcommit b2214887a6ec8be9ff192438a50d0892845078e0[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 13 19:42:52 2017 -0700
+
+    Update logs to print pod information to help with debugging
+
+[33mcommit 9d1faa6df04f25689786b36d09371a08a4946218[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 13 19:06:54 2017 -0700
+
+    Replace image name in pod spec with a tag
+
+[33mcommit 98ffffd62f216b001262ecda5911a3641abe5584[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Fri Oct 13 18:58:11 2017 -0700
+
+    Initial commit for a scheduler extender
+    
+    - Serves 'filter' and 'prioritize' requests
+    - Filters out nodes where the driver is not running or unhealthy
+    - Prioritizes nodes where the volume has been allocated
+      - For each volume on a node, the score is bumped by 100
+      - Any node that doesn't have data is given a score of 10 so that it
+        isn't ignored by the scheduler
+
+[33mcommit d6118dca35066c915a59e23e71b49574d277f510[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Oct 3 15:29:05 2017 -0700
+
+    Govendor update
+
+[33mcommit e1ef31eedeeacdffa8760aa88fc2bf2c1764a6f5[m
+Author: Dinesh Israni <disrani@portworx.com>
+Date:   Tue Sep 26 22:31:51 2017 -0700
+
+    Update readme
+
+[33mcommit a9a2a9ec1e18f8063b0940bf42cd7d2bd09667d6[m
+Author: Gou Rao <gourao@users.noreply.github.com>
+Date:   Tue Sep 26 11:21:26 2017 -0700
+
+    Update README.md
+
+[33mcommit af7dfd032898990740359501bc9ed91becfbe896[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Tue Sep 26 17:02:59 2017 +0000
+
+    new logo
+
+[33mcommit ff9853640cb11f8c8c374ec21d807fd33003f288[m
+Author: Gou Rao <gourao@users.noreply.github.com>
+Date:   Fri Sep 22 18:01:22 2017 -0700
+
+    Update README.md
+
+[33mcommit c896d9dcd56f6456f972e25015713c4b6c821685[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Thu Sep 7 18:45:28 2017 +0000
+
+    added a vendor dir
+
+[33mcommit b1931f336c02cd89092fce1bb86047d970a3084c[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 20:24:55 2017 +0000
+
+    Add pod spec example to readme
+
+[33mcommit 4021ab76b1cba1c0f66eef14d75614dcf4b5aa15[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 19:51:20 2017 +0000
+
+    Add pod spec example to readme
+
+[33mcommit e7988e32def210ceaa6d9ce8af831a01e3093cdb[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 19:44:06 2017 +0000
+
+    Add pod spec example to readme
+
+[33mcommit 87420d6c0815d80d29f7ac4082f1ae66bee76cb3[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 06:00:09 2017 +0000
+
+    redo logo
+
+[33mcommit eecf1be14776e24ee21eec52bda59f981c84734d[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 05:47:02 2017 +0000
+
+    redo logo
+
+[33mcommit b134fbc6bb06ca291861e11bbb29934b30ce9c0b[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 05:44:27 2017 +0000
+
+    redo logo
+
+[33mcommit 17dffab1dab6e9b2b21fe686c1a7de4a1453d3ee[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 05:42:00 2017 +0000
+
+    redo logo
+
+[33mcommit da0d9394feefac1e44931a095f0f5b4d791a1959[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 05:40:58 2017 +0000
+
+    redo logo
+
+[33mcommit 96af825a793cc0d0ebcb673b77a8ac6b36353e13[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 05:38:20 2017 +0000
+
+    redo logo
+
+[33mcommit 083d5c68ff27d00db39ff9111e4b6e7d52ebb320[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 05:37:45 2017 +0000
+
+    redo logo
+
+[33mcommit 9b93c3b2624cbd2b5a3b0556aafe436fb4ccb8e8[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 05:35:59 2017 +0000
+
+    redo logo
+
+[33mcommit a1f08c0ca06eb2f0a5d1d18150f7a966a51268c0[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 05:12:09 2017 +0000
+
+    initial skeleton framework
+
+[33mcommit 6df9f0dec16d433cef9ff28465cfcd1660844cae[m
+Author: Gou Rao <gou@portworx.com>
+Date:   Wed Sep 6 05:11:38 2017 +0000
+
+    initial skeleton framework
+
+[33mcommit e1f2f1578f1b02aca9dc0770fee9632788ee6344[m
+Author: venkatpx <venkat@portworx.com>
+Date:   Tue Sep 5 21:20:51 2017 -0700
+
+    Initial commit

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -302,13 +302,19 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		}
 
 		// Try to create the backupLocation path, just log error if it fails
-		err := a.createBackupLocationPath(backup)
+		backupLocation, err := storkops.Instance().GetBackupLocation(backup.Spec.BackupLocation, backup.Namespace)
 		if err != nil {
-			log.ApplicationBackupLog(backup).Errorf(err.Error())
-			a.recorder.Event(backup,
-				v1.EventTypeWarning,
-				string(stork_api.ApplicationBackupStatusFailed),
-				err.Error())
+			return fmt.Errorf("error getting backup location path: %v", err)
+		}
+		if backupLocation.Location.Type != stork_api.BackupLocationNFS {
+			err := a.createBackupLocationPath(backup)
+			if err != nil {
+				log.ApplicationBackupLog(backup).Errorf(err.Error())
+				a.recorder.Event(backup,
+					v1.EventTypeWarning,
+					string(stork_api.ApplicationBackupStatusFailed),
+					err.Error())
+			}
 		}
 
 		// Make sure the rules exist if configured

--- a/pkg/objectstore/nfs/nfs.go
+++ b/pkg/objectstore/nfs/nfs.go
@@ -1,0 +1,13 @@
+package nfs
+
+import (
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/objectstore/common"
+	"github.com/sirupsen/logrus"
+)
+
+// GetObjLockInfo fetches the object lock configuration of a bucket
+func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockInfo, error) {
+	logrus.Infof("object lock is not supported for nfs server")
+	return &common.ObjLockInfo{}, nil
+}

--- a/pkg/objectstore/objectstore.go
+++ b/pkg/objectstore/objectstore.go
@@ -7,6 +7,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/objectstore/azure"
 	"github.com/libopenstorage/stork/pkg/objectstore/common"
 	"github.com/libopenstorage/stork/pkg/objectstore/google"
+	"github.com/libopenstorage/stork/pkg/objectstore/nfs"
 	"github.com/libopenstorage/stork/pkg/objectstore/s3"
 	"gocloud.dev/blob"
 )
@@ -59,6 +60,8 @@ func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockIn
 		return azure.GetObjLockInfo(backupLocation)
 	case stork_api.BackupLocationS3:
 		return s3.GetObjLockInfo(backupLocation)
+	case stork_api.BackupLocationNFS:
+		return nfs.GetObjLockInfo(backupLocation)
 	default:
 		return nil, fmt.Errorf("invalid backupLocation type: %v", backupLocation.Location.Type)
 	}


### PR DESCRIPTION
- added NFS type to stork v1alpha1 APIs
- added objectlock specific API for for NFS
- skipped bucket exist check in Application backup
  controller specifically for NFS scenario

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: this is to enable NFS based backuplocation. 


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

