### PR TITLE
pb-3025: Added support to take backup of webhook

### DIFF
--- a/pkg/resourcecollector/webhook.go
+++ b/pkg/resourcecollector/webhook.go
@@ -1,0 +1,194 @@
+package resourcecollector
+
+import (
+	"github.com/libopenstorage/stork/pkg/version"
+	"github.com/sirupsen/logrus"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ResourceCollector) prepareMutatingWebHookForApply(
+	object runtime.Unstructured,
+	namespaceMappings map[string]string,
+) error {
+	ok, err := version.RequiresV1Webhooks()
+	if err != nil {
+		return err
+	}
+	if ok {
+		// v1 version
+		var webhookCfg admissionv1.MutatingWebhookConfiguration
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &webhookCfg); err != nil {
+			logrus.Errorf("mutatingWebHookToBeCollected: failed in getting mutating webhook: err %v", err)
+			return err
+		}
+		for _, webhook := range webhookCfg.Webhooks {
+			if webhook.ClientConfig.Service != nil {
+				if destNamespace, ok := namespaceMappings[webhook.ClientConfig.Service.Namespace]; ok {
+					// update the namespace with destination namespace
+					webhook.ClientConfig.Service.Namespace = destNamespace
+				}
+			}
+		}
+		o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhookCfg)
+		if err != nil {
+			return err
+		}
+		object.SetUnstructuredContent(o)
+		return nil
+	}
+	// v1beta1 version
+	var webhookCfg admissionv1beta1.MutatingWebhookConfiguration
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &webhookCfg); err != nil {
+		logrus.Errorf("mutatingWebHookToBeCollected: failed in getting mutating webhook: err %v", err)
+		return err
+	}
+	for _, webhook := range webhookCfg.Webhooks {
+		if webhook.ClientConfig.Service != nil {
+			if destNamespace, ok := namespaceMappings[webhook.ClientConfig.Service.Namespace]; ok {
+				// update the namespace with destination namespace
+				webhook.ClientConfig.Service.Namespace = destNamespace
+			}
+		}
+	}
+	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhookCfg)
+	if err != nil {
+		return err
+	}
+	object.SetUnstructuredContent(o)
+	return nil
+}
+
+func (r *ResourceCollector) prepareValidatingWebHookForApply(
+	object runtime.Unstructured,
+	namespaceMappings map[string]string,
+) error {
+	ok, err := version.RequiresV1Webhooks()
+	if err != nil {
+		return err
+	}
+	if ok {
+		// v1 version
+		var webhookCfg admissionv1.ValidatingWebhookConfiguration
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &webhookCfg); err != nil {
+			logrus.Errorf("validatingWebHookToBeCollected: failed in getting validating webhook: err %v", err)
+			return err
+		}
+		for _, webhook := range webhookCfg.Webhooks {
+			if webhook.ClientConfig.Service != nil {
+				if destNamespace, ok := namespaceMappings[webhook.ClientConfig.Service.Namespace]; ok {
+
+					// update the namespace with destination namespace
+					webhook.ClientConfig.Service.Namespace = destNamespace
+				}
+			}
+		}
+		o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhookCfg)
+		if err != nil {
+			return err
+		}
+		object.SetUnstructuredContent(o)
+		return nil
+	}
+	// v1beta1 version
+	var webhookCfg admissionv1beta1.ValidatingWebhookConfiguration
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &webhookCfg); err != nil {
+		logrus.Errorf("validatingWebHookToBeCollected: failed in getting validating webhook: err %v", err)
+		return err
+	}
+	for _, webhook := range webhookCfg.Webhooks {
+		if webhook.ClientConfig.Service != nil {
+			if destNamespace, ok := namespaceMappings[webhook.ClientConfig.Service.Namespace]; ok {
+				// update the namespace with destination namespace
+				webhook.ClientConfig.Service.Namespace = destNamespace
+			}
+		}
+	}
+	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&webhookCfg)
+	if err != nil {
+		return err
+	}
+	object.SetUnstructuredContent(o)
+	return nil
+}
+
+func (r *ResourceCollector) validatingWebHookToBeCollected(
+	object runtime.Unstructured,
+	namespace string,
+) (bool, error) {
+	ok, err := version.RequiresV1Webhooks()
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		// v1 version
+		var webhookCfg admissionv1.ValidatingWebhookConfiguration
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &webhookCfg); err != nil {
+			logrus.Errorf("validatingWebHookToBeCollected: failed in getting validating webhook: err %v", err)
+			return false, err
+		}
+		for _, webhook := range webhookCfg.Webhooks {
+			if webhook.ClientConfig.Service != nil {
+				if namespace == webhook.ClientConfig.Service.Namespace {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}
+	// v1beta1 version
+	var webhookCfg admissionv1beta1.ValidatingWebhookConfiguration
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &webhookCfg); err != nil {
+		logrus.Errorf("validatingWebHookToBeCollected: failed in getting validating webhook: err %v", err)
+		return false, err
+	}
+	for _, webhook := range webhookCfg.Webhooks {
+		if webhook.ClientConfig.Service != nil {
+			if namespace == webhook.ClientConfig.Service.Namespace {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func (r *ResourceCollector) mutatingWebHookToBeCollected(
+	object runtime.Unstructured,
+	namespace string,
+) (bool, error) {
+	ok, err := version.RequiresV1Webhooks()
+	if err != nil {
+		return false, err
+	}
+	if ok {
+		// v1 version
+		var webhookCfg admissionv1.MutatingWebhookConfiguration
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &webhookCfg); err != nil {
+			logrus.Errorf("mutatingWebHookToBeCollected: failed in getting mutating webhook: err %v", err)
+			return false, err
+		}
+		for _, webhook := range webhookCfg.Webhooks {
+			if webhook.ClientConfig.Service != nil {
+				if namespace == webhook.ClientConfig.Service.Namespace {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}
+	// v1beta1 version
+	var webhookCfg admissionv1beta1.MutatingWebhookConfiguration
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &webhookCfg); err != nil {
+		logrus.Errorf("mutatingWebHookToBeCollected: failed in getting mutating webhook: err %v", err)
+		return false, err
+	}
+	for _, webhook := range webhookCfg.Webhooks {
+		if webhook.ClientConfig.Service != nil {
+			if namespace == webhook.ClientConfig.Service.Namespace {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -24,6 +24,7 @@ var (
 const (
 	k8sMinVersionCSIDriverV1      = "1.22"
 	k8sMinVersionVolumeSnapshotV1 = "1.20"
+	K8sMinVersionWebhookv1        = "1.22"
 )
 
 // RequiresV1Registration returns true if crd needs to be registered as apiVersion V1
@@ -38,6 +39,23 @@ func RequiresV1Registration() (bool, error) {
 
 	}
 	if k8sVersion.GreaterThanOrEqual(k8sVer1_16) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// RequiresV1Webhooks returns true if V1 version of webhook object is needed
+func RequiresV1Webhooks() (bool, error) {
+	clusterK8sVersion, _, err := GetFullVersion()
+	if err != nil {
+		return false, err
+	}
+	requiredK8sVer, err := version.NewVersion(K8sMinVersionWebhookv1)
+	if err != nil {
+		return false, err
+
+	}
+	if clusterK8sVersion.GreaterThanOrEqual(requiredK8sVer) {
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
```
pb-3025: Added support to take backup of webhook

            - added prepareMutatingWebHookForApply, prepareValidatingWebHookForApply,
              validatingWebHookToBeCollected and mutatingWebHookToBeCollected apis
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Issue: webhook resources were not getting backed up.
User Impact: Some of the application using webhook were not coming up after restore.
Resolution: webhook are backed up based on the namespaces in the service present in the webhook

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.12 branch

Testing:
1) Had validatingwebhookconfiguration for the elasticsearch app.
![Screenshot 2022-09-07 at 3 49 32 PM](https://user-images.githubusercontent.com/52188641/188867909-676a242e-53a4-4ba4-98ae-1394514e7a7c.png)
2) Backup included the validatingwebhookconfiguration:
![Screenshot 2022-09-07 at 3 50 21 PM](https://user-images.githubusercontent.com/52188641/188868065-f48ed3e1-2306-47e0-a193-21ccfd82f4ed.png)
3) Restored to different namespace validatewebhookrestore1. checked the namespace in the service is updated with the new namespace based on the namespace mapping.
![Screenshot 2022-09-07 at 3 51 02 PM](https://user-images.githubusercontent.com/52188641/188868402-babedc69-2ac5-419f-b03d-536022f89f5d.png)
![Screenshot 2022-09-07 at 5 03 22 PM](https://user-images.githubusercontent.com/52188641/188868551-13223621-4cf2-440a-9e2a-1a3e502bb21d.png)
![Screenshot 2022-09-07 at 5 04 15 PM](https://user-images.githubusercontent.com/52188641/188868671-c6af4abb-b886-4459-a5ef-b41b55d0ef71.png)
