### PR TITLE
pb-3062: Added code to create resource export CR for nfs resource

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aquilax/truncate"
 	"github.com/go-openapi/inflect"
 	"github.com/libopenstorage/stork/drivers"
 	"github.com/libopenstorage/stork/drivers/volume"
@@ -26,8 +27,10 @@ import (
 	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	"github.com/libopenstorage/stork/pkg/rule"
 	"github.com/libopenstorage/stork/pkg/version"
+	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/core"
+	kdmpShedOps "github.com/portworx/sched-ops/k8s/kdmp"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/gcerrors"
@@ -39,6 +42,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,13 +63,25 @@ const (
 	backupCancelBackoffFactor       = 1
 	backupCancelBackoffSteps        = math.MaxInt32
 
-	allNamespacesSpecifier        = "*"
-	backupVolumeBatchCountEnvVar  = "BACKUP-VOLUME-BATCH-COUNT"
-	defaultBackupVolumeBatchCount = 3
-	backupResourcesBatchCount     = 15
-	maxRetry                      = 10
-	retrySleep                    = 10 * time.Second
-	genericBackupKey              = "BACKUP_TYPE"
+	allNamespacesSpecifier          = "*"
+	backupVolumeBatchCountEnvVar    = "BACKUP-VOLUME-BATCH-COUNT"
+	defaultBackupVolumeBatchCount   = 3
+	backupResourcesBatchCount       = 15
+	maxRetry                        = 10
+	retrySleep                      = 10 * time.Second
+	genericBackupKey                = "BACKUP_TYPE"
+	prefixBackup                    = "backup"
+	applicationBackupCRNameKey      = kdmpAnnotationPrefix + "applicationbackup-cr-name"
+	applicationBackupCRUIDKey       = kdmpAnnotationPrefix + "applicationbackup-cr-uid"
+	kdmpAnnotationPrefix            = "kdmp.portworx.com/"
+	pxbackupAnnotationCreateByKey   = pxbackupAnnotationPrefix + "created-by"
+	pxbackupAnnotationCreateByValue = "px-backup"
+	backupObjectNameKey             = kdmpAnnotationPrefix + "backupobject-name"
+	pxbackupObjectUIDKey            = pxbackupAnnotationPrefix + "backup-uid"
+	pxbackupAnnotationPrefix        = "portworx.io/"
+	pxbackupObjectNameKey           = pxbackupAnnotationPrefix + "backup-name"
+	backupObjectUIDKey              = kdmpAnnotationPrefix + "backupobject-uid"
+	skipResourceAnnotation          = "stork.libopenstorage.org/skip-resource"
 )
 
 var (
@@ -1122,11 +1138,55 @@ func (a *ApplicationBackupController) uploadMetadata(
 	return a.uploadObject(backup, metadataObjectName, jsonBytes)
 }
 
+func (a *ApplicationBackupController) isNFSBackuplocationType(
+	backup *stork_api.ApplicationBackup,
+) (bool, error) {
+	backupLocation, err := storkops.Instance().GetBackupLocation(backup.Spec.BackupLocation, backup.Namespace)
+	if err != nil {
+		return false, fmt.Errorf("error getting backup location path: %v", err)
+	}
+	if backupLocation.Location.Type == stork_api.BackupLocationNFS {
+		return true, nil
+	}
+	return false, nil
+}
+
+// getShortUID returns the first part of the UID
+func getShortUID(uid string) string {
+	if len(uid) < 8 {
+		return ""
+	}
+	return uid[0:7]
+}
+
+// getValidLabel - will validate the label to make sure the length is less 63 and contains valid label format.
+// If the length is greater then 63, it will truncate to 63 character.
+func getValidLabel(labelVal string) string {
+	if len(labelVal) > validation.LabelValueMaxLength {
+		labelVal = truncate.Truncate(labelVal, validation.LabelValueMaxLength, "", truncate.PositionEnd)
+		// make sure the truncated value does not end with the hyphen.
+		labelVal = strings.Trim(labelVal, "-")
+		// make sure the truncated value does not end with the dot.
+		labelVal = strings.Trim(labelVal, ".")
+	}
+	return labelVal
+}
+
+func getResourceExportCRName(opsPrefix, crUID, ns string) string {
+	name := fmt.Sprintf("%s-%s-%s", opsPrefix, getShortUID(crUID), ns)
+	name = getValidLabel(name)
+	return name
+}
+
 func (a *ApplicationBackupController) backupResources(
 	backup *stork_api.ApplicationBackup,
 ) error {
 	var err error
 	var resourceTypes []metav1.APIResource
+	nfs, err := a.isNFSBackuplocationType(backup)
+	if err != nil {
+		logrus.Errorf("error in checking backuplocation type")
+	}
 	// Listing all resource types
 	if len(backup.Spec.ResourceTypes) != 0 {
 		optionalResourceTypes := []string{}
@@ -1278,6 +1338,100 @@ func (a *ApplicationBackupController) backupResources(
 		return err
 	}
 
+	if nfs {
+		// Check whether ResourceExport is preset or not
+		crName := getResourceExportCRName(prefixBackup, string(backup.UID), backup.Namespace)
+		resourceExport, err := kdmpShedOps.Instance().GetResourceExport(crName, backup.Namespace)
+		if err != nil {
+			if k8s_errors.IsNotFound(err) {
+				// create resource export CR
+				resourceExport := &kdmpapi.ResourceExport{}
+				// Adding required label for debugging
+				labels := make(map[string]string)
+				labels[applicationBackupCRNameKey] = getValidLabel(backup.Name)
+				labels[applicationBackupCRUIDKey] = getValidLabel(getShortUID(string(backup.UID)))
+				// If backup from px-backup, update the backup object details in the label
+				if val, ok := backup.Annotations[pxbackupAnnotationCreateByKey]; ok {
+					if val == pxbackupAnnotationCreateByValue {
+						labels[backupObjectNameKey] = getValidLabel(backup.Annotations[pxbackupObjectNameKey])
+						labels[backupObjectUIDKey] = getValidLabel(backup.Annotations[pxbackupObjectUIDKey])
+					}
+				}
+				resourceExport.Labels = labels
+				resourceExport.Annotations = make(map[string]string)
+				resourceExport.Annotations[skipResourceAnnotation] = "true"
+				resourceExport.Name = getResourceExportCRName(prefixBackup, string(backup.UID), backup.Namespace)
+				resourceExport.Namespace = backup.Namespace
+				source := &kdmpapi.ResourceExportObjectReference{
+					APIVersion: backup.APIVersion,
+					Kind:       backup.Kind,
+					Namespace:  backup.Namespace,
+					Name:       backup.Name,
+				}
+				backupLocation, err := storkops.Instance().GetBackupLocation(backup.Spec.BackupLocation, backup.Namespace)
+				if err != nil {
+					return fmt.Errorf("error getting backup location path: %v", err)
+				}
+				destination := &kdmpapi.ResourceExportObjectReference{
+					// TODO: .GetBackupLocation is not returning APIVersion and kind.
+					// Hardcoding for now.
+					// APIVersion: backupLocation.APIVersion,
+					// Kind:       backupLocation.Kind,
+					APIVersion: "stork.libopenstorage.org/v1alpha1",
+					Kind:       "BackupLocation",
+					Namespace:  backupLocation.Namespace,
+					Name:       backupLocation.Name,
+				}
+				resourceExport.Spec.Source = *source
+				resourceExport.Spec.Destination = *destination
+				_, err = kdmpShedOps.Instance().CreateResourceExport(resourceExport)
+				if err != nil {
+					logrus.Errorf("failed to create DataExport CR: %v", err)
+					return err
+				}
+				return nil
+			}
+			logrus.Errorf("failed to get backup resourceExport CR: %v", err)
+			// Will retry in the next cycle of reconciler.
+			return nil
+		} else {
+			var message string
+			// Check the status of the resourceExport CR and update it to the applicationBackup CR
+			switch resourceExport.Status {
+			case kdmpapi.ResourceExportStatusFailed:
+				message = fmt.Sprintf("Error uploading resources: %v", err)
+				backup.Status.Status = stork_api.ApplicationBackupStatusFailed
+				backup.Status.Stage = stork_api.ApplicationBackupStageFinal
+				backup.Status.Reason = message
+				backup.Status.LastUpdateTimestamp = metav1.Now()
+				err = a.client.Update(context.TODO(), backup)
+				if err != nil {
+					return err
+				}
+				a.recorder.Event(backup,
+					v1.EventTypeWarning,
+					string(stork_api.ApplicationBackupStatusFailed),
+					message)
+				log.ApplicationBackupLog(backup).Errorf(message)
+				return err
+			case kdmpapi.ResourceExportStatusSuccessful:
+				backup.Status.BackupPath = GetObjectPath(backup)
+				backup.Status.Stage = stork_api.ApplicationBackupStageFinal
+				backup.Status.FinishTimestamp = metav1.Now()
+				backup.Status.Status = stork_api.ApplicationBackupStatusSuccessful
+				backup.Status.Reason = "Volumes and resources were backed up successfully"
+			case kdmpapi.ResourceExportStatusInitial:
+			case kdmpapi.ResourceExportStatusPending:
+			case kdmpapi.ResourceExportStatusInProgress:
+				backup.Status.LastUpdateTimestamp = metav1.Now()
+			}
+			err = a.client.Update(context.TODO(), backup)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+	}
 	// Upload the resources to the backup location
 	if err = a.uploadResources(backup, allObjects); err != nil {
 		message := fmt.Sprintf("Error uploading resources: %v", err)
@@ -1367,6 +1521,11 @@ func (a *ApplicationBackupController) deleteBackup(backup *stork_api.Application
 			return true, nil
 		}
 		return true, err
+	}
+	// TODO: for nfs type, we need to invoke job based deletion.
+	// For now, skipping it.
+	if backupLocation.Location.Type == stork_api.BackupLocationNFS {
+		return true, nil
 	}
 	bucket, err := objectstore.GetBucket(backupLocation)
 	if err != nil {
@@ -1471,6 +1630,15 @@ func (a *ApplicationBackupController) cleanupResources(
 		if err := driver.CleanupBackupResources(backup); err != nil {
 			logrus.Errorf("unable to cleanup post backup resources, err: %v", err)
 		}
+	}
+	// Directly calling DeleteResourceExport with out checking backuplocation type.
+	// For other backuplocation type, expecting Notfound
+	crName := getResourceExportCRName(prefixBackup, string(backup.UID), backup.Namespace)
+	err := kdmpShedOps.Instance().DeleteResourceExport(crName, backup.Namespace)
+	if err != nil && !k8s_errors.IsNotFound(err) {
+		errMsg := fmt.Sprintf("failed to delete data export CR [%v]: %v", crName, err)
+		log.ApplicationBackupLog(backup).Errorf("%v", errMsg)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
>feature - nfs backuplocation support

**What this PR does / why we need it**:
```
pb-3062: Added code to create resource export CR for nfs resource backup.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no
**Does this change need to be cherry-picked to a release branch?**:
no

**Known and TODO issues:**
- Deletion of resources in the case of failed backup is not handled in this PR in the deleteBackup function. We need delete job to take care of it.
- Have duplicated some of the utility function and constant definition from kdmp driver code. Need to clean it up by moving them to separate utility pkg and reuse it.
**Testing:**
- Verified that resourceExport CR is created as expected.
- Will do complete testing once other part of the code is available.