### PR TITLE
PWX-24763: Implement FindSnapshot() for external snapshotter library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,8 +73,8 @@ replace (
 	//github.com/heptio/ark => github.com/heptio/ark v1.0.0
 	github.com/heptio/velero => github.com/heptio/velero v1.0.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 => github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
-	github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7
-	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7 => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7
+	github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc10
+	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc10 => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc10
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20220804223926-812cb10d08c4
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220922150029-c1d35df2436a

--- a/go.sum
+++ b/go.sum
@@ -1111,8 +1111,12 @@ github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114/go.
 github.com/libopenstorage/cloudops v0.0.0-20190815012442-6e0d676b6c3e/go.mod h1:quSDXGC3Fhc+pBwMRIi1Gk+kaSfBDZo5rRsftapTzGE=
 github.com/libopenstorage/cloudops v0.0.0-20200604165016-9cc0977d745e/go.mod h1:5Qie78eVLLXqLkLCq1+0HyJzjpdRCHyeg9LWlU0WPfU=
 github.com/libopenstorage/cloudops v0.0.0-20220420143942-8bdd341e5b41/go.mod h1:zigCEUGrJZbK/1FN6+SHMuMjS6vjeSKxuo0G4Ars4Cg=
+github.com/libopenstorage/external-storage v0.20.4-openstorage-rc10 h1:q21CLGSi9DhNBBuJuitquA/T6FwLV3KNZxaJpxQbOLc=
+github.com/libopenstorage/external-storage v0.20.4-openstorage-rc10/go.mod h1:nffpoeodwwp+wwngmBGbLBCd7TZ9GxHLtxKoaLRW6K4=
 github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7 h1:mHp7bfGyHwG4P8dhHEMJ775KLmcjv3tcA2Uc+5nGpXg=
 github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7/go.mod h1:nffpoeodwwp+wwngmBGbLBCd7TZ9GxHLtxKoaLRW6K4=
+github.com/libopenstorage/external-storage v0.20.4-openstorage-rc9 h1:Vg72X7TJsba3hBpytgxZH0Ip5MDVhZlusqBtkg6MWzE=
+github.com/libopenstorage/external-storage v0.20.4-openstorage-rc9/go.mod h1:nffpoeodwwp+wwngmBGbLBCd7TZ9GxHLtxKoaLRW6K4=
 github.com/libopenstorage/gossip v0.0.0-20190507031959-c26073a01952/go.mod h1:TjXt2Iz2bTkpfc4Q6xN0ttiNipTVwEEYoZSMZHlfPek=
 github.com/libopenstorage/gossip v0.0.0-20200808224301-d5287c7c8b24/go.mod h1:TjXt2Iz2bTkpfc4Q6xN0ttiNipTVwEEYoZSMZHlfPek=
 github.com/libopenstorage/gossip v0.0.0-20220309192431-44c895e0923e h1:4l9N2Sw8VGGUqe50yC2BnTFMRJuHJGpIGZcCUZ2S6gg=

--- a/pkg/snapshot/controllers/snapshot.go
+++ b/pkg/snapshot/controllers/snapshot.go
@@ -69,20 +69,15 @@ func (s *Snapshotter) Start(stopChannel <-chan struct{}) error {
 		return err
 	}
 	if ok {
-		err = client.CreateCRDV1(aeclientset)
+		err = client.CreateCRDV1(aeclientset, validateCRDTimeout, validateCRDInterval)
 		if err != nil {
 			return err
 		}
 	} else {
-		err = client.CreateCRD(aeclientset)
+		err = client.CreateCRD(aeclientset, validateCRDTimeout, validateCRDInterval)
 		if err != nil {
 			return err
 		}
-	}
-
-	err = client.WaitForSnapshotResource(snapshotClient)
-	if err != nil {
-		return err
 	}
 
 	plugins := make(map[string]snapshotvolume.Plugin)

--- a/pkg/snapshot/controllers/snapshotschedule.go
+++ b/pkg/snapshot/controllers/snapshotschedule.go
@@ -42,6 +42,7 @@ const (
 	storkRuleAnnotationPrefix            = "stork.libopenstorage.org"
 	preSnapRuleAnnotationKey             = storkRuleAnnotationPrefix + "/pre-snapshot-rule"
 	postSnapRuleAnnotationKey            = storkRuleAnnotationPrefix + "/post-snapshot-rule"
+	StorkSnapshotNameLabel               = "stork.libopenstorage.org/snapshotName"
 )
 
 // NewSnapshotScheduleController creates a new instance of SnapshotScheduleController.
@@ -317,6 +318,10 @@ func (s *SnapshotScheduleController) startVolumeSnapshot(snapshotSchedule *stork
 	}
 	snapshot.Metadata.Annotations[SnapshotScheduleNameAnnotation] = snapshotSchedule.Name
 	snapshot.Metadata.Annotations[SnapshotSchedulePolicyTypeAnnotation] = string(policyType)
+	if snapshot.Metadata.Labels == nil {
+		snapshot.Metadata.Labels = make(map[string]string)
+	}
+	snapshot.Metadata.Labels[StorkSnapshotNameLabel] = snapshotName
 	if snapshotSchedule.Spec.PreExecRule != "" {
 		_, err := storkops.Instance().GetRule(snapshotSchedule.Spec.PreExecRule, snapshotSchedule.Namespace)
 		if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -480,7 +480,7 @@ github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned
 github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned/scheme
 github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned/typed/volumesnapshot/v1
 github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned/typed/volumesnapshot/v1beta1
-# github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7 => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7
+# github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc7 => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc10
 ## explicit
 github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1
 github.com/kubernetes-incubator/external-storage/snapshot/pkg/client
@@ -1932,7 +1932,8 @@ sigs.k8s.io/yaml
 # github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
 # github.com/heptio/velero => github.com/heptio/velero v1.0.0
 # github.com/kubernetes-csi/external-snapshotter/client/v4 => github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
-# github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc7
+# github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc10
+# github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc10 => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc10
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20220804223926-812cb10d08c4
 # github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20220922150029-c1d35df2436a


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
External-Snapshotter list all volumesnapshotdata for each snapshotcreate() call, which causes too many call to kube-api server.  This PR add FindSnapshot() implementation for snapshotter plugin, which can filter out single volumesnapshotdata required for snapCreate request

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Issue: Too many call to volumesnapshotdata from external-snapshotter library
User Impact: On setup like rancher, too many calls to volumesnapshotdata api causes OOM in kube-api server pods
Resolution: Implement `FindSnapshot` plugin interface in portworx driver, which can filter out single volumesnapshotdata for required volumesnapshot

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 2.12

Jenkins : https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%202.12-dev%20%20C7/job/2.12-px-2.11-snapshot/249/console
latest integration job run : https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%202.12-dev%20%20C7/job/2.12-snapshot-k8s-1-23-0/284/console

Note: PR on externalsnapshotter need to be merged
