### PR TITLE
PWX-26900: Set the resource migration finish timestamp once pruning is done

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1021,15 +1021,6 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration, v
 		return err
 	}
 
-	migration.Status.ResourceMigrationFinishTimestamp = metav1.Now()
-	migration.Status.Stage = stork_api.MigrationStageFinal
-	migration.Status.Status = stork_api.MigrationStatusSuccessful
-	for _, resource := range migration.Status.Resources {
-		if resource.Status != stork_api.MigrationStatusSuccessful {
-			migration.Status.Status = stork_api.MigrationStatusPartialSuccess
-			break
-		}
-	}
 	if *migration.Spec.PurgeDeletedResources {
 		if err := m.purgeMigratedResources(migration, resourceCollectorOpts); err != nil {
 			message := fmt.Sprintf("Error cleaning up resources: %v", err)
@@ -1039,6 +1030,16 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration, v
 				string(stork_api.MigrationStatusPartialSuccess),
 				message)
 			return nil
+		}
+	}
+
+	migration.Status.ResourceMigrationFinishTimestamp = metav1.Now()
+	migration.Status.Stage = stork_api.MigrationStageFinal
+	migration.Status.Status = stork_api.MigrationStatusSuccessful
+	for _, resource := range migration.Status.Resources {
+		if resource.Status != stork_api.MigrationStatusSuccessful {
+			migration.Status.Status = stork_api.MigrationStatusPartialSuccess
+			break
 		}
 	}
 
@@ -1572,11 +1573,11 @@ func (m *MigrationController) applyResources(
 
 			res.ResourceVersion = ""
 			// if crds is applied as v1beta on k8s version 1.16+ it will have
-			// preservedUnkownField set and api version converted to v1 ,
+			// preservedUnknownField set and api version converted to v1 ,
 			// which cause issue while applying it on dest cluster,
 			// since we will be applying v1 crds with non-valid schema
 
-			// this converts `preserveUnknownFiels`(deprecated) to spec.Versions[*].xPreservedUnknown
+			// this converts `preserveUnknownFields`(deprecated) to spec.Versions[*].xPreservedUnknown
 			// equivalent
 			var updatedVersions []apiextensionsv1.CustomResourceDefinitionVersion
 			if res.Spec.PreserveUnknownFields {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug

**What this PR does / why we need it**:
Stork would report incorrect resource migration time since it did not consider the time taken to prune deleted resources from the target cluster.


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Yes
```release-note
Issue: Stork reported incorrect resource migration elapsed time when `purgeDeletedResources` is set on Migration.
User Impact: Resource migration elapsed time would be lesser than the actual time taken to complete the resource migraiton.
Resolution: Stork calculates the time taken to perform resource migration once it is done purging the deleted resources.

```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.12

