### PR TITLE
PTX-12986: Ignore package not found error for apt-get install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 go:
   - 1.17.3
 before_install:
-  - sudo apt-get update -yq
+  - sudo apt-get update -yq || true
   - sudo apt-get install go-md2man -y
   - sudo apt-get install -y awscli
 cache:


### PR DESCRIPTION
We are seeing an issue with xenial-pgdg dist not found here https://apt.postgresql.org/pub/repos/apt/dists/xenial-pgdg/.

This is causing the Travis CI to fail, as a intermediate fix we are ignoring the error which we get from apr-get update as in some cases its not ok go ahead without latest binaries. If there are any issues with required package installation they would be caught at a later stage in the run.