### PR TITLE
PB-3111: Support for nfs backuplocation in restore resources in application restore controller.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -71,16 +71,21 @@ const (
 	retrySleep                      = 10 * time.Second
 	genericBackupKey                = "BACKUP_TYPE"
 	prefixBackup                    = "backup"
+	prefixRestore                   = "restore"
 	applicationBackupCRNameKey      = kdmpAnnotationPrefix + "applicationbackup-cr-name"
+	applicationRestoreCRNameKey     = kdmpAnnotationPrefix + "applicationrestore-cr-name"
 	applicationBackupCRUIDKey       = kdmpAnnotationPrefix + "applicationbackup-cr-uid"
+	applicationRestoreCRUIDKey      = kdmpAnnotationPrefix + "applicationrestore-cr-uid"
 	kdmpAnnotationPrefix            = "kdmp.portworx.com/"
 	pxbackupAnnotationCreateByKey   = pxbackupAnnotationPrefix + "created-by"
 	pxbackupAnnotationCreateByValue = "px-backup"
 	backupObjectNameKey             = kdmpAnnotationPrefix + "backupobject-name"
+	restoreObjectNameKey            = kdmpAnnotationPrefix + "restoreobject-name"
 	pxbackupObjectUIDKey            = pxbackupAnnotationPrefix + "backup-uid"
 	pxbackupAnnotationPrefix        = "portworx.io/"
 	pxbackupObjectNameKey           = pxbackupAnnotationPrefix + "backup-name"
 	backupObjectUIDKey              = kdmpAnnotationPrefix + "backupobject-uid"
+	restoreObjectUIDKey             = kdmpAnnotationPrefix + "restoreobject-uid"
 	skipResourceAnnotation          = "stork.libopenstorage.org/skip-resource"
 )
 
@@ -1138,7 +1143,7 @@ func (a *ApplicationBackupController) uploadMetadata(
 	return a.uploadObject(backup, metadataObjectName, jsonBytes)
 }
 
-func (a *ApplicationBackupController) isNFSBackuplocationType(
+func IsNFSBackuplocationType(
 	backup *stork_api.ApplicationBackup,
 ) (bool, error) {
 	backupLocation, err := storkops.Instance().GetBackupLocation(backup.Spec.BackupLocation, backup.Namespace)
@@ -1183,7 +1188,7 @@ func (a *ApplicationBackupController) backupResources(
 ) error {
 	var err error
 	var resourceTypes []metav1.APIResource
-	nfs, err := a.isNFSBackuplocationType(backup)
+	nfs, err := IsNFSBackuplocationType(backup)
 	if err != nil {
 		logrus.Errorf("error in checking backuplocation type")
 	}


### PR DESCRIPTION
Signed-off-by: Diptiranjan


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
Need to support nfs backuplocation in application restore controller for resource applying.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
no

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
no
-->

