### PR TITLE
pb-3109: moved the const definition and api between kdmp driver and applicationbackup controller code to utils pkg

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aquilax/truncate"
 	"github.com/go-openapi/inflect"
 	"github.com/libopenstorage/stork/drivers"
 	"github.com/libopenstorage/stork/drivers/volume"
@@ -26,6 +25,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/objectstore"
 	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	"github.com/libopenstorage/stork/pkg/rule"
+	"github.com/libopenstorage/stork/pkg/utils"
 	"github.com/libopenstorage/stork/pkg/version"
 	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
@@ -42,7 +42,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,30 +62,13 @@ const (
 	backupCancelBackoffFactor       = 1
 	backupCancelBackoffSteps        = math.MaxInt32
 
-	allNamespacesSpecifier          = "*"
-	backupVolumeBatchCountEnvVar    = "BACKUP-VOLUME-BATCH-COUNT"
-	defaultBackupVolumeBatchCount   = 3
-	backupResourcesBatchCount       = 15
-	maxRetry                        = 10
-	retrySleep                      = 10 * time.Second
-	genericBackupKey                = "BACKUP_TYPE"
-	prefixBackup                    = "backup"
-	prefixRestore                   = "restore"
-	applicationBackupCRNameKey      = kdmpAnnotationPrefix + "applicationbackup-cr-name"
-	applicationRestoreCRNameKey     = kdmpAnnotationPrefix + "applicationrestore-cr-name"
-	applicationBackupCRUIDKey       = kdmpAnnotationPrefix + "applicationbackup-cr-uid"
-	applicationRestoreCRUIDKey      = kdmpAnnotationPrefix + "applicationrestore-cr-uid"
-	kdmpAnnotationPrefix            = "kdmp.portworx.com/"
-	pxbackupAnnotationCreateByKey   = pxbackupAnnotationPrefix + "created-by"
-	pxbackupAnnotationCreateByValue = "px-backup"
-	backupObjectNameKey             = kdmpAnnotationPrefix + "backupobject-name"
-	restoreObjectNameKey            = kdmpAnnotationPrefix + "restoreobject-name"
-	pxbackupObjectUIDKey            = pxbackupAnnotationPrefix + "backup-uid"
-	pxbackupAnnotationPrefix        = "portworx.io/"
-	pxbackupObjectNameKey           = pxbackupAnnotationPrefix + "backup-name"
-	backupObjectUIDKey              = kdmpAnnotationPrefix + "backupobject-uid"
-	restoreObjectUIDKey             = kdmpAnnotationPrefix + "restoreobject-uid"
-	skipResourceAnnotation          = "stork.libopenstorage.org/skip-resource"
+	allNamespacesSpecifier        = "*"
+	backupVolumeBatchCountEnvVar  = "BACKUP-VOLUME-BATCH-COUNT"
+	defaultBackupVolumeBatchCount = 3
+	backupResourcesBatchCount     = 15
+	maxRetry                      = 10
+	retrySleep                    = 10 * time.Second
+	genericBackupKey              = "BACKUP_TYPE"
 )
 
 var (
@@ -1156,30 +1138,9 @@ func IsNFSBackuplocationType(
 	return false, nil
 }
 
-// getShortUID returns the first part of the UID
-func getShortUID(uid string) string {
-	if len(uid) < 8 {
-		return ""
-	}
-	return uid[0:7]
-}
-
-// getValidLabel - will validate the label to make sure the length is less 63 and contains valid label format.
-// If the length is greater then 63, it will truncate to 63 character.
-func getValidLabel(labelVal string) string {
-	if len(labelVal) > validation.LabelValueMaxLength {
-		labelVal = truncate.Truncate(labelVal, validation.LabelValueMaxLength, "", truncate.PositionEnd)
-		// make sure the truncated value does not end with the hyphen.
-		labelVal = strings.Trim(labelVal, "-")
-		// make sure the truncated value does not end with the dot.
-		labelVal = strings.Trim(labelVal, ".")
-	}
-	return labelVal
-}
-
 func getResourceExportCRName(opsPrefix, crUID, ns string) string {
-	name := fmt.Sprintf("%s-%s-%s", opsPrefix, getShortUID(crUID), ns)
-	name = getValidLabel(name)
+	name := fmt.Sprintf("%s-%s-%s", opsPrefix, utils.GetShortUID(crUID), ns)
+	name = utils.GetValidLabel(name)
 	return name
 }
 
@@ -1345,7 +1306,7 @@ func (a *ApplicationBackupController) backupResources(
 
 	if nfs {
 		// Check whether ResourceExport is preset or not
-		crName := getResourceExportCRName(prefixBackup, string(backup.UID), backup.Namespace)
+		crName := getResourceExportCRName(utils.PrefixBackup, string(backup.UID), backup.Namespace)
 		resourceExport, err := kdmpShedOps.Instance().GetResourceExport(crName, backup.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
@@ -1353,19 +1314,19 @@ func (a *ApplicationBackupController) backupResources(
 				resourceExport := &kdmpapi.ResourceExport{}
 				// Adding required label for debugging
 				labels := make(map[string]string)
-				labels[applicationBackupCRNameKey] = getValidLabel(backup.Name)
-				labels[applicationBackupCRUIDKey] = getValidLabel(getShortUID(string(backup.UID)))
+				labels[utils.ApplicationBackupCRNameKey] = utils.GetValidLabel(backup.Name)
+				labels[utils.ApplicationBackupCRUIDKey] = utils.GetValidLabel(utils.GetShortUID(string(backup.UID)))
 				// If backup from px-backup, update the backup object details in the label
-				if val, ok := backup.Annotations[pxbackupAnnotationCreateByKey]; ok {
-					if val == pxbackupAnnotationCreateByValue {
-						labels[backupObjectNameKey] = getValidLabel(backup.Annotations[pxbackupObjectNameKey])
-						labels[backupObjectUIDKey] = getValidLabel(backup.Annotations[pxbackupObjectUIDKey])
+				if val, ok := backup.Annotations[utils.PxbackupAnnotationCreateByKey]; ok {
+					if val == utils.PxbackupAnnotationCreateByValue {
+						labels[utils.BackupObjectNameKey] = utils.GetValidLabel(backup.Annotations[utils.PxbackupObjectNameKey])
+						labels[utils.BackupObjectUIDKey] = utils.GetValidLabel(backup.Annotations[utils.PxbackupObjectUIDKey])
 					}
 				}
 				resourceExport.Labels = labels
 				resourceExport.Annotations = make(map[string]string)
-				resourceExport.Annotations[skipResourceAnnotation] = "true"
-				resourceExport.Name = getResourceExportCRName(prefixBackup, string(backup.UID), backup.Namespace)
+				resourceExport.Annotations[utils.SkipResourceAnnotation] = "true"
+				resourceExport.Name = getResourceExportCRName(utils.PrefixBackup, string(backup.UID), backup.Namespace)
 				resourceExport.Namespace = backup.Namespace
 				resourceExport.Spec.Type = kdmpapi.ResourceExportBackup
 				source := &kdmpapi.ResourceExportObjectReference{
@@ -1639,7 +1600,7 @@ func (a *ApplicationBackupController) cleanupResources(
 	}
 	// Directly calling DeleteResourceExport with out checking backuplocation type.
 	// For other backuplocation type, expecting Notfound
-	crName := getResourceExportCRName(prefixBackup, string(backup.UID), backup.Namespace)
+	crName := getResourceExportCRName(utils.PrefixBackup, string(backup.UID), backup.Namespace)
 	err := kdmpShedOps.Instance().DeleteResourceExport(crName, backup.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		errMsg := fmt.Sprintf("failed to delete data export CR [%v]: %v", crName, err)

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -18,6 +18,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/objectstore"
 	"github.com/libopenstorage/stork/pkg/resourcecollector"
+	"github.com/libopenstorage/stork/pkg/utils"
 	"github.com/libopenstorage/stork/pkg/version"
 	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
@@ -1276,7 +1277,7 @@ func (a *ApplicationRestoreController) restoreResources(
 		}
 	} else {
 		// Check whether ResourceExport is preset or not
-		crName := getResourceExportCRName(prefixRestore, string(restore.UID), restore.Namespace)
+		crName := getResourceExportCRName(utils.PrefixRestore, string(restore.UID), restore.Namespace)
 		resourceExport, err := kdmpShedOps.Instance().GetResourceExport(crName, restore.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
@@ -1284,18 +1285,18 @@ func (a *ApplicationRestoreController) restoreResources(
 				resourceExport := &kdmpapi.ResourceExport{}
 				// Adding required label for debugging
 				labels := make(map[string]string)
-				labels[applicationRestoreCRNameKey] = getValidLabel(restore.Name)
-				labels[applicationRestoreCRUIDKey] = getValidLabel(getShortUID(string(restore.UID)))
+				labels[utils.ApplicationRestoreCRNameKey] = utils.GetValidLabel(restore.Name)
+				labels[utils.ApplicationRestoreCRUIDKey] = utils.GetValidLabel(utils.GetShortUID(string(restore.UID)))
 				// If restore from px-backup, update the restore object details in the label
-				if val, ok := backup.Annotations[pxbackupAnnotationCreateByKey]; ok {
-					if val == pxbackupAnnotationCreateByValue {
-						labels[restoreObjectNameKey] = getValidLabel(backup.Annotations[pxbackupObjectNameKey])
-						labels[restoreObjectUIDKey] = getValidLabel(backup.Annotations[pxbackupObjectUIDKey])
+				if val, ok := backup.Annotations[utils.PxbackupAnnotationCreateByKey]; ok {
+					if val == utils.PxbackupAnnotationCreateByValue {
+						labels[utils.RestoreObjectNameKey] = utils.GetValidLabel(backup.Annotations[utils.PxbackupObjectNameKey])
+						labels[utils.RestoreObjectUIDKey] = utils.GetValidLabel(backup.Annotations[utils.PxbackupObjectUIDKey])
 					}
 				}
 				resourceExport.Labels = labels
 				resourceExport.Annotations = make(map[string]string)
-				resourceExport.Annotations[skipResourceAnnotation] = "true"
+				resourceExport.Annotations[utils.SkipResourceAnnotation] = "true"
 				resourceExport.Name = crName
 				resourceExport.Namespace = restore.Namespace
 				resourceExport.Spec.Type = kdmpapi.ResourceExportBackup
@@ -1524,7 +1525,7 @@ func (a *ApplicationRestoreController) cleanupResources(restore *storkapi.Applic
 	}
 	// Directly calling DeleteResourceExport with out checking backuplocation type.
 	// For other backuplocation type, expecting Notfound
-	crName := getResourceExportCRName(prefixBackup, string(restore.UID), restore.Namespace)
+	crName := getResourceExportCRName(utils.PrefixBackup, string(restore.UID), restore.Namespace)
 	err := kdmpShedOps.Instance().DeleteResourceExport(crName, restore.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		errMsg := fmt.Sprintf("failed to delete data export CR [%v]: %v", crName, err)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"github.com/aquilax/truncate"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"strings"
 )
 
@@ -13,6 +15,44 @@ const (
 	// PXIncrementalCountAnnotation is the annotation used to set cloud backup incremental count
 	// for volume
 	PXIncrementalCountAnnotation = "portworx.io/cloudsnap-incremental-count"
+
+	// PrefixBackup - prefix string that will be used for the kdmp backup job
+	PrefixBackup = "backup"
+	// PrefixRestore prefix string that will be used for the kdmp restore job
+	PrefixRestore = "restore"
+
+	// KdmpAnnotationPrefix - KDMP annotation prefix
+	KdmpAnnotationPrefix = "kdmp.portworx.com/"
+	// ApplicationBackupCRNameKey - key name to store the applicationbackup CR name with KDMP annotation prefix
+	ApplicationBackupCRNameKey = KdmpAnnotationPrefix + "applicationbackup-cr-name"
+	// ApplicationBackupCRUIDKey - key name to store the applicationbackup CR UID with KDMP annotation prefix
+	ApplicationBackupCRUIDKey = KdmpAnnotationPrefix + "applicationbackup-cr-uid"
+	// BackupObjectNameKey - annotation key value for backup object name with KDMP annotation prefix
+	BackupObjectNameKey = KdmpAnnotationPrefix + "backupobject-name"
+	// BackupObjectUIDKey - annotation key value for backup object UID with KDMP annotation prefix
+	BackupObjectUIDKey = KdmpAnnotationPrefix + "backupobject-uid"
+	// ApplicationRestoreCRNameKey - key name to store the applicationrestore CR name with KDMP annotation prefix
+	ApplicationRestoreCRNameKey = KdmpAnnotationPrefix + "applicationrestore-cr-name"
+	// ApplicationRestoreCRUIDKey - key name to store the applicationrestore CR UID with KDMP annotation prefix
+	ApplicationRestoreCRUIDKey = KdmpAnnotationPrefix + "applicationrestore-cr-uid"
+	// RestoreObjectNameKey - key name to store the restore object name with KDMP annotation prefix
+	RestoreObjectNameKey = KdmpAnnotationPrefix + "restoreobject-name"
+	// RestoreObjectUIDKey - key name to store the restore object UID with KDMP annotation prefix
+	RestoreObjectUIDKey = KdmpAnnotationPrefix + "restoreobject-uid"
+
+	// PxbackupAnnotationPrefix - px-backup annotation prefix
+	PxbackupAnnotationPrefix = "portworx.io/"
+	// PxbackupAnnotationCreateByKey - annotation key name to indicate whether the CR was created by px-backup or stork
+	PxbackupAnnotationCreateByKey = PxbackupAnnotationPrefix + "created-by"
+	// PxbackupAnnotationCreateByValue - annotation key value for create-by key for px-backup
+	PxbackupAnnotationCreateByValue = "px-backup"
+
+	// PxbackupObjectUIDKey -annotation key name for backup object UID with px-backup prefix
+	PxbackupObjectUIDKey = PxbackupAnnotationPrefix + "backup-uid"
+	// PxbackupObjectNameKey - annotation key name for backup object name with px-backup prefix
+	PxbackupObjectNameKey = PxbackupAnnotationPrefix + "backup-name"
+	// SkipResourceAnnotation - annotation value to skip resource during resource collector
+	SkipResourceAnnotation = "stork.libopenstorage.org/skip-resource"
 )
 
 // ParseKeyValueList parses a list of key=values string into a map
@@ -29,4 +69,25 @@ func ParseKeyValueList(expressions []string) (map[string]string, error) {
 	}
 
 	return matchLabels, nil
+}
+
+// GetValidLabel - will validate the label to make sure the length is less 63 and contains valid label format.
+// If the length is greater then 63, it will truncate to 63 character.
+func GetValidLabel(labelVal string) string {
+	if len(labelVal) > validation.LabelValueMaxLength {
+		labelVal = truncate.Truncate(labelVal, validation.LabelValueMaxLength, "", truncate.PositionEnd)
+		// make sure the truncated value does not end with the hyphen.
+		labelVal = strings.Trim(labelVal, "-")
+		// make sure the truncated value does not end with the dot.
+		labelVal = strings.Trim(labelVal, ".")
+	}
+	return labelVal
+}
+
+// GetShortUID returns the first part of the UID
+func GetShortUID(uid string) string {
+	if len(uid) < 8 {
+		return ""
+	}
+	return uid[0:7]
 }


### PR DESCRIPTION
**What type of PR is this?**
>cleanup

**What this PR does / why we need it**:
```
pb-3109: moved the const definition and api between kdmp driver and applicationbackup controller code to utils pkg
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.12

