### PR TITLE
pb-3131: Added load balancer service type as well to reset the nodeport in resourcecollector.

### DIFF
--- a/pkg/resourcecollector/service.go
+++ b/pkg/resourcecollector/service.go
@@ -63,7 +63,8 @@ func (r *ResourceCollector) updateService(
 		return err
 	}
 
-	if service.Spec.Type == v1.ServiceTypeNodePort {
+	if service.Spec.Type == v1.ServiceTypeNodePort ||
+		service.Spec.Type == v1.ServiceTypeLoadBalancer {
 		for i := range service.Spec.Ports {
 			service.Spec.Ports[i].NodePort = 0
 		}


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
```
pb-3131: Added load balancer service type as well to reset the nodeport in resourcecollector.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: Load balancer service were not getting restored
User Impact: Application using load balancer need manually way of restoring the service.
Resolution: Resetting the nodport value to zero, so that during restore of load balance, it will get new available for port value."

```

**Does this change need to be cherry-picked to a release branch?**:
2.12

**Testing:**
Took backup of px-backup namespace and restore on the small cluster with different namespace, it was successful.
```
[root@siva-whip-nose-1 ~]# kubectl  get svc -n central1
NAME                                     TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)               AGE
px-backup                                ClusterIP      10.233.17.88    <none>        10002/TCP,10001/TCP   25s
px-backup-ui                             LoadBalancer   10.233.45.143   <pending>     80:30468/TCP          25s
px-central-ui                            LoadBalancer   10.233.57.137   <pending>     80:30455/TCP          25s
pxc-backup-mongodb-headless              ClusterIP      None            <none>        27017/TCP             24s
pxcentral-apiserver                      ClusterIP      10.233.27.164   <none>        10005/TCP,10006/TCP   24s
pxcentral-backend                        ClusterIP      10.233.4.251    <none>        80/TCP                24s
pxcentral-frontend                       ClusterIP      10.233.37.97    <none>        80/TCP                24s
pxcentral-keycloak-headless              ClusterIP      None            <none>        80/TCP,8443/TCP       24s
pxcentral-keycloak-http                  ClusterIP      10.233.48.20    <none>        80/TCP,8443/TCP       23s
pxcentral-keycloak-postgresql            ClusterIP      10.233.0.47     <none>        5432/TCP              23s
pxcentral-keycloak-postgresql-headless   ClusterIP      None            <none>        5432/TCP              23s
pxcentral-lh-middleware                  ClusterIP      10.233.41.78    <none>        8091/TCP,8092/TCP     23s
pxcentral-mysql                          ClusterIP      10.233.18.222   <none>        3306/TCP              23s
[root@siva-whip-nose-1 ~]# kubectl  get svc -n central
NAME                                     TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)               AGE
px-backup                                ClusterIP      10.233.10.76    <none>        10002/TCP,10001/TCP   50m
px-backup-ui                             LoadBalancer   10.233.7.223    <pending>     80:30465/TCP          50m
px-central-ui                            LoadBalancer   10.233.3.210    <pending>     80:30082/TCP          50m
pxc-backup-mongodb-headless              ClusterIP      None            <none>        27017/TCP             50m
pxcentral-apiserver                      ClusterIP      10.233.26.166   <none>        10005/TCP,10006/TCP   50m
pxcentral-backend                        ClusterIP      10.233.26.108   <none>        80/TCP                50m
pxcentral-frontend                       ClusterIP      10.233.56.121   <none>        80/TCP                50m
pxcentral-keycloak-headless              ClusterIP      None            <none>        80/TCP,8443/TCP       50m
pxcentral-keycloak-http                  ClusterIP      10.233.30.126   <none>        80/TCP,8443/TCP       50m
pxcentral-keycloak-postgresql            ClusterIP      10.233.23.247   <none>        5432/TCP              50m
pxcentral-keycloak-postgresql-headless   ClusterIP      None            <none>        5432/TCP              50m
pxcentral-lh-middleware                  ClusterIP      10.233.62.71    <none>        8091/TCP,8092/TCP     50m
pxcentral-mysql                          ClusterIP      10.233.14.120   <none>        3306/TCP              50m
[root@siva-whip-nose-1 ~]#
```
Verified with the debug statements that during restore the values are reset before applying:
```
time="2022-10-01T11:53:57Z" level=info msg="Applying Service central1/px-backup" ApplicationRestoreName=central-restore1-899bc0e ApplicationRestoreUID=cedbf993-9e93-47f3-8498-49f5ed50731c Namespace=central1
time="2022-10-01T11:53:57Z" level=info msg="Applying Service central1/px-backup-ui" ApplicationRestoreName=central-restore1-899bc0e ApplicationRestoreUID=cedbf993-9e93-47f3-8498-49f5ed50731c Namespace=central1
time="2022-10-01T11:53:57Z" level=info msg="sivakumar --- Service Type LoadBalancer"
time="2022-10-01T11:53:57Z" level=info msg="sivakumar -- service name px-backup-ui Setting nodeport to zero"
time="2022-10-01T11:53:58Z" level=info msg="Applying Service central1/px-central-ui" ApplicationRestoreName=central-restore1-899bc0e ApplicationRestoreUID=cedbf993-9e93-47f3-8498-49f5ed50731c Namespace=central1
time="2022-10-01T11:53:58Z" level=info msg="sivakumar --- Service Type LoadBalancer"
time="2022-10-01T11:53:58Z" level=info msg="sivakumar -- service name px-central-ui Setting nodeport to zero"
time="2022-10-01T11:53:58Z" level=info msg="Applying Service central1/pxc-backup-mongodb-headless" ApplicationRestoreName=central-restore1-899bc0e ApplicationRestoreUID=cedbf993-9e93-47f3-8498-49f5ed50731c Namespace=central1

time="2022-10-01T11:53:58Z" level=info msg="Applying Service central1/pxcentral-apiserver" ApplicationRestoreName=central-restore1-899bc0e ApplicationRestoreUID=cedbf993-9e93-47f3-8498-49f5ed50731c Namespace=central1
```
