### PR TITLE
Pb-3100 : Taking Genric backup if backuplocation type is NFS

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -678,6 +678,10 @@ func (p *portworx) GetClusterID() (string, error) {
 }
 
 func (p *portworx) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, cmBackupType string, crBackupType string) bool {
+	if cmBackupType == storkapi.ApplicationBackupGeneric {
+		// If user has forced the backupType in config map, default to generic always
+		return false
+	}
 	return p.IsSupportedPVC(coreOps, pvc, true)
 }
 

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -564,6 +564,15 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 					continue
 				}
 				var driverName string
+				backupLocation, err := storkops.Instance().GetBackupLocation(backup.Spec.BackupLocation, backup.Namespace)
+				if err != nil {
+					return err
+				}
+				// Generic Backup type is forced for all backup taken on a NFS backuplocation.
+				// This change will make portworx volume also to follow kdmp path.
+				if backupLocation.Location.Type == stork_api.BackupLocationNFS {
+					driverType = stork_api.ApplicationBackupGeneric
+				}
 				driverName, err = volume.GetPVCDriverForBackup(core.Instance(), &pvc, driverType, backup.Spec.BackupType)
 				if err != nil {
 					// Skip unsupported PVCs


### PR DESCRIPTION
If the backuplocation type is NFS then we will take a Generic backup for any type of volume.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: Even if user doesn't set kdmp-config's BACKUP-TYPE, for NFS backup location type, kdp driver will be chosen for taking backup. 


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

