### PR TITLE
PWX-27136: Do not collect VirtualMachineInstanceMigration CR.

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -557,6 +557,8 @@ func (r *ResourceCollector) objectToBeCollected(
 		return r.dataVolumesToBeCollected(object)
 	case "VirtualMachineInstance":
 		return r.virtualMachineInstanceToBeCollected(object)
+	case "VirtualMachineInstanceMigration":
+		return r.virtualMachineInstanceMigrationToBeCollected(object)
 	case "Endpoints":
 		return r.endpointsToBeCollected(object)
 	case "MutatingWebhookConfiguration":

--- a/pkg/resourcecollector/virtualmachineinstance.go
+++ b/pkg/resourcecollector/virtualmachineinstance.go
@@ -7,3 +7,9 @@ func (r *ResourceCollector) virtualMachineInstanceToBeCollected(
 ) (bool, error) {
 	return false, nil
 }
+
+func (r *ResourceCollector) virtualMachineInstanceMigrationToBeCollected(
+	object runtime.Unstructured,
+) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
A `VirtualMachineInstanceMigration` CR gets created when a Live VM migration is triggered. Stork should not collect these objects while taking a backup or performing a migration of a namespace over cluster.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Issue: Stork would try to migrate the VirtualMachineInstanceMigration CR which gets created as a part of LiveVM migration. Since this CR is specific to a cluster the migration would partially fail.
User Impact: Stork migration of VirtualMachines would partially fail
Resolution: Stork will not collect VirtualMachineInstanceMigration CRs for migrations or while taking a backup. 

```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.12

