### PR TITLE
PWX-27273: Only set the ResourceMigrationFinishTs after purging the resources

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1025,6 +1025,15 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration, v
 		return err
 	}
 
+	migration.Status.Stage = stork_api.MigrationStageFinal
+	migration.Status.Status = stork_api.MigrationStatusSuccessful
+	for _, resource := range migration.Status.Resources {
+		if resource.Status != stork_api.MigrationStatusSuccessful {
+			migration.Status.Status = stork_api.MigrationStatusPartialSuccess
+			break
+		}
+	}
+
 	if *migration.Spec.PurgeDeletedResources {
 		if err := m.purgeMigratedResources(migration, resourceCollectorOpts); err != nil {
 			message := fmt.Sprintf("Error cleaning up resources: %v", err)
@@ -1038,15 +1047,6 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration, v
 	}
 
 	migration.Status.ResourceMigrationFinishTimestamp = metav1.Now()
-	migration.Status.Stage = stork_api.MigrationStageFinal
-	migration.Status.Status = stork_api.MigrationStatusSuccessful
-	for _, resource := range migration.Status.Resources {
-		if resource.Status != stork_api.MigrationStatusSuccessful {
-			migration.Status.Status = stork_api.MigrationStatusPartialSuccess
-			break
-		}
-	}
-
 	migration.Status.FinishTimestamp = metav1.Now()
 	err = m.updateMigrationCR(context.TODO(), migration)
 	if err != nil {


### PR DESCRIPTION




**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
- This change partially reverts - https://github.com/libopenstorage/stork/pull/1159

- Instead of setting the migration status after purging the resources, it sets it before so that a resource migration status of "Purged" does not affect the overall migration status.

- The ResourceMigrationFinishTimestamp is still set after purging is done.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No


**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.12
