### PR TITLE
pb-3138: Resetting the serviceAccountUID annotation in the secret.

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -828,6 +828,8 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		return false, r.prepareValidatingWebHookForApply(object, namespaceMappings)
 	case "MutatingWebhookConfiguration":
 		return false, r.prepareMutatingWebHookForApply(object, namespaceMappings)
+	case "Secret":
+		return false, r.prepareSecretForApply(object)
 	}
 	return false, nil
 }

--- a/pkg/resourcecollector/secret.go
+++ b/pkg/resourcecollector/secret.go
@@ -8,6 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	serviceAccountUIDKey = "kubernetes.io/service-account.uid"
+)
+
 func (r *ResourceCollector) secretToBeCollected(
 	object runtime.Unstructured,
 ) (bool, error) {
@@ -25,4 +29,31 @@ func (r *ResourceCollector) secretToBeCollected(
 	}
 	return true, nil
 
+}
+
+func (r *ResourceCollector) prepareSecretForApply(
+	object runtime.Unstructured,
+) error {
+	var secret v1.Secret
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &secret); err != nil {
+		logrus.Errorf("Error converting Secret object %v: %v", object, err)
+		return err
+	}
+	// Reset the " kubernetes.io/service-account.uid" annotation,
+	// so that it will update the uid of the newly created SA after restoring
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &secret)
+	if err != nil {
+		return err
+	}
+	if secret.Annotations != nil {
+		if _, ok := secret.Annotations[serviceAccountUIDKey]; ok {
+			secret.Annotations[serviceAccountUIDKey] = ""
+		}
+	}
+	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&secret)
+	if err != nil {
+		return err
+	}
+	object.SetUnstructuredContent(o)
+	return err
 }


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
    pb-3138: Resetting the serviceAccountUID annotation in the secret.

            - When applying the service account, it will get a new UID.
            - This UID need to be updated in the secret. Resetting the old
              UID to empty string, so that k8s will update the new UID of service
              account.
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Issue: The secret token for the service account was not getting applied during restore.
User Impact: Application bring fails some time, if they look for the old secret of the service account token
Resolution: Resetting the service account UID annotation of the secret, so that k8s will update the new UID of the restored service account.

```

**Does this change need to be cherry-picked to a release branch?**:
2.12

**Testing:**
Tested the fix on the QA setup, where minio app was failing.
