### PR TITLE
pb-3124: updated the storageclass and storage provisioner annotation, if storageclassmapping is present during restore.

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -13,6 +13,7 @@ import (
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/rbac"
+	"github.com/portworx/sched-ops/k8s/storage"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -68,6 +69,7 @@ type ResourceCollector struct {
 	coreOps          core.Ops
 	rbacOps          rbac.Ops
 	storkOps         storkops.Ops
+	storageOps       storage.Ops
 }
 
 // Options are the options passed to the ResourceCollector APIs that dictate how k8s
@@ -135,6 +137,11 @@ func (r *ResourceCollector) Init(config *restclient.Config) error {
 	if err != nil {
 		return err
 	}
+	r.storageOps, err = storage.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -13,6 +13,10 @@ const (
 	// PXIncrementalCountAnnotation is the annotation used to set cloud backup incremental count
 	// for volume
 	PXIncrementalCountAnnotation = "portworx.io/cloudsnap-incremental-count"
+	// StorageClassAnnotationKey - Annotation key for storageClass
+	StorageClassAnnotationKey = "volume.beta.kubernetes.io/storage-class"
+	// StorageProvisionerAnnotationKey - Annotation key for storage provisioner
+	StorageProvisionerAnnotationKey = "volume.beta.kubernetes.io/storage-provisioner"
 )
 
 // ParseKeyValueList parses a list of key=values string into a map


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
pb-3124: updated the storageclass and storage provisioner annotation, if storageclassmapping is present during restore.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: storgaclass and storage provision annotation of PVC are not updated during restore, if it is restored with storageclass mapping.
User Impact: It is confusion, whether restore happened with new storageclass from strorageclass mapping as annotation are pointing to older storageclass and storage provisioner.
Resolution: updating the annotaiton to the newer value of storageclass and storage provisioner based on the storageclass mapping.

```

**Does this change need to be cherry-picked to a release branch?**:
2.12 branch

Testing:
Initially had the pvc with mysql-sc storage and restore with px-csi storage class.
Verified that pvc annotation are updated with the new values.
Old pvc spec:
```
[root@siva-root-sprite-0 ~]# kubectl get sc
NAME                PROVISIONER                     RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
mysql-sc            kubernetes.io/portworx-volume   Delete          Immediate           false                  2d17h
px-csi              pxd.portworx.com                Delete          Immediate           false                  15h
px-proxy            kubernetes.io/portworx-volume   Delete          Immediate           true                   4d7h
stork-snapshot-sc   stork-snapshot                  Delete          Immediate           false                  4d8h
[root@siva-root-sprite-0 ~]# kubectl  get pvc -n mysql -o wide
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE   VOLUMEMODE
mysql-data   Bound    pvc-6e380a12-6bd0-4ecd-b831-413ed190fd9d   2Gi        RWO            mysql-sc       15h   Filesystem
[root@siva-root-sprite-0 ~]# kubectl get pvc mysql-data -n mysql -o yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"mysql-sc"},"labels":{"app":"mysql"},"name":"mysql-data","namespace":"mysql"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}}}}
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-class: mysql-sc
    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
  creationTimestamp: "2022-10-06T04:20:24Z"
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    app: mysql
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .: {}
          f:kubectl.kubernetes.io/last-applied-configuration: {}
          f:volume.beta.kubernetes.io/storage-class: {}
        f:labels:
          .: {}
          f:app: {}
      f:spec:
        f:accessModes: {}
        f:resources:
          f:requests:
            .: {}
            f:storage: {}
        f:volumeMode: {}
    manager: kubectl-client-side-apply
    operation: Update
    time: "2022-10-06T04:20:24Z"
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          f:pv.kubernetes.io/bind-completed: {}
          f:pv.kubernetes.io/bound-by-controller: {}
          f:volume.beta.kubernetes.io/storage-provisioner: {}
      f:spec:
        f:volumeName: {}
      f:status:
        f:accessModes: {}
        f:capacity:
          .: {}
          f:storage: {}
        f:phase: {}
    manager: kube-controller-manager
    operation: Update
    time: "2022-10-06T04:20:26Z"
  name: mysql-data
  namespace: mysql
  resourceVersion: "1267259"
  uid: 6e380a12-6bd0-4ecd-b831-413ed190fd9d
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 2Gi
  volumeMode: Filesystem
  volumeName: pvc-6e380a12-6bd0-4ecd-b831-413ed190fd9d
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 2Gi
  phase: Bound
[root@siva-root-sprite-0 ~]#
```
New pvc spec:
```
[root@siva-root-sprite-0 ~]# kubectl  get pvc -n mysql -o wide
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE     VOLUMEMODE
mysql-data   Bound    pvc-2b162a23-530e-4606-b07e-60d00e3f3791   2Gi        RWO            px-csi         2m11s   Filesystem
[root@siva-root-sprite-0 ~]# kubectl  get pvc mysql-data -n mysql -o yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"mysql-sc"},"labels":{"app":"mysql"},"name":"mysql-data","namespace":"mysql"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}}}}
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-class: px-csi <<<<<<<<<<<<<<<<
    volume.beta.kubernetes.io/storage-provisioner: pxd.portworx.com. <<<<<<<<<<<<<<<<
  creationTimestamp: "2022-10-06T21:13:51Z"
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    app: mysql
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .: {}
          f:kubectl.kubernetes.io/last-applied-configuration: {}
          f:pv.kubernetes.io/bind-completed: {}
          f:pv.kubernetes.io/bound-by-controller: {}
          f:volume.beta.kubernetes.io/storage-class: {}
          f:volume.beta.kubernetes.io/storage-provisioner: {}
        f:labels:
          .: {}
          f:app: {}
      f:spec:
        f:accessModes: {}
        f:resources:
          f:requests:
            .: {}
            f:storage: {}
        f:volumeMode: {}
        f:volumeName: {}
    manager: stork
    operation: Update
    time: "2022-10-06T21:13:51Z"
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:status:
        f:accessModes: {}
        f:capacity:
          .: {}
          f:storage: {}
        f:phase: {}
    manager: kube-controller-manager
    operation: Update
    time: "2022-10-06T21:14:14Z"
  name: mysql-data
  namespace: mysql
  resourceVersion: "1497384"
  uid: c0f367be-5ea9-4f1e-81b5-9d527e1d1426
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 2Gi
  volumeMode: Filesystem
  volumeName: pvc-2b162a23-530e-4606-b07e-60d00e3f3791
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 2Gi
  phase: Bound
[root@siva-root-sprite-0 ~]#
```
