### PR TITLE
Create storage class for AWS and azure in fio

### DIFF
--- a/test/integration_test/specs/mysql-fio/aws/aws-sc.yaml
+++ b/test/integration_test/specs/mysql-fio/aws/aws-sc.yaml
@@ -1,0 +1,18 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-sc 
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+reclaimPolicy: Delete
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fio-log
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+reclaimPolicy: Delete

--- a/test/integration_test/specs/mysql-fio/azure/azure-sc.yaml
+++ b/test/integration_test/specs/mysql-fio/azure/azure-sc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fio-sc
+provisioner: kubernetes.io/azure-disk
+parameters:
+  skuName: Standard_LRS
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fio-log
+provisioner: kubernetes.io/azure-disk
+parameters:
+  skuName: Standard_LRS


### PR DESCRIPTION
Signed-off-by: Rohit-PX <rkulkarni@purestorage.com>


**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
The specs for AWS and Azure storage classes need to created and present in the correct directory for stork tests/torpedo to deploy them

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
2.12

