### PR TITLE
 pb-3157: Added fixes to add proper storage class and provisioner name for PV and PVC during restore.

### DIFF
--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -2,6 +2,8 @@ package resourcecollector
 
 import (
 	"fmt"
+	"github.com/libopenstorage/stork/pkg/utils"
+	"github.com/sirupsen/logrus"
 
 	"github.com/libopenstorage/stork/drivers/volume"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
@@ -10,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8shelper "k8s.io/component-helpers/storage/volume"
 )
 
 func (r *ResourceCollector) pvToBeCollected(
@@ -90,9 +93,44 @@ func (r *ResourceCollector) pvToBeCollected(
 func (r *ResourceCollector) preparePVResourceForCollection(
 	object runtime.Unstructured,
 ) error {
+	var pv v1.PersistentVolume
+	var currentSc string
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &pv); err != nil {
+		return err
+	}
+	// Some time pv spec does not contains the storage class.
+	// In that case, we will get it from pvc spec.
+	if len(pv.Spec.StorageClassName) == 0 {
+		pvc, err := r.coreOps.GetPersistentVolumeClaim(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
+		if err != nil {
+			return err
+		}
+		currentSc, err = utils.GetStorageClassNameForPVC(pvc)
+		if err != nil {
+			// Not returning error as there might be some cases, where PVC might not have storage class.
+			// A case where a PV can be manually bind mounted to a volume ( backend storage volume)
+			logrus.Debugf("preparePVResourceForCollection: failed to fetch storage class from PVC %v: %v", pv.Spec.ClaimRef.Name, err)
+		}
+	} else {
+		currentSc = pv.Spec.StorageClassName
+	}
 	err := unstructured.SetNestedField(object.UnstructuredContent(), nil, "spec", "claimRef")
 	if err != nil {
 		return err
+	}
+	if len(currentSc) > 0 {
+		annotations, found, err := unstructured.NestedStringMap(object.UnstructuredContent(), "metadata", "annotations")
+		if err != nil {
+			return err
+		}
+		if !found {
+			annotations = make(map[string]string)
+		}
+		annotations[CurrentStorageClassName] = currentSc
+		if err := unstructured.SetNestedStringMap(object.UnstructuredContent(), annotations, "metadata", "annotations"); err != nil {
+			return err
+		}
+		object.SetUnstructuredContent(object.UnstructuredContent())
 	}
 	return unstructured.SetNestedField(object.UnstructuredContent(), "", "spec", "storageClassName")
 }
@@ -103,6 +141,7 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	object runtime.Unstructured,
 	pvNameMappings map[string]string,
 	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
+	storageClassMappings map[string]string,
 ) (bool, error) {
 	var updatedName string
 	var present bool
@@ -119,6 +158,30 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	if updatedName, present = pvNameMappings[pv.Name]; !present {
 		return true, nil
 	}
+	// get the storage class name from the CurrentStorageClassName annotation
+	var oldSc string
+	var exists bool
+	var newSc string
+	if pv.Annotations != nil {
+		if val, ok := pv.Annotations[CurrentStorageClassName]; ok {
+			oldSc = val
+			// delete CurrentStorageClassName annotation before applying
+			delete(pv.Annotations, CurrentStorageClassName)
+			if newSc, exists = storageClassMappings[oldSc]; exists && len(newSc) > 0 {
+				// If the oldSc is present the storageclass map, get the new sc and update it in the pv spec
+				// Get the provisioner name from the new sc and update it
+				storageClass, err := r.storageOps.GetStorageClass(newSc)
+				if err != nil {
+					return false, fmt.Errorf("failed in getting the storage class [%v]: %v", newSc, err)
+				}
+				pv.Annotations[k8shelper.AnnDynamicallyProvisioned] = storageClass.Provisioner
+				pv.Spec.StorageClassName = newSc
+			} else {
+				// if the storageclass map does not have the oldSc name, update the PV spec with the oldSC itself before applying.
+				pv.Spec.StorageClassName = oldSc
+			}
+		}
+	}
 
 	pv.Name = updatedName
 	var driverName string
@@ -130,6 +193,7 @@ func (r *ResourceCollector) preparePVResourceForApply(
 			break
 		}
 	}
+
 	// in case of non-restore call make sure resourcecollector
 	// checks proper driver by looking at pv name
 	if driverName == "" {

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -50,6 +50,9 @@ const (
 	// TransformedResourceName is the annotation used to check if resource has been updated
 	// as per transformation rules
 	TransformedResourceName = "stork.libopenstorage.org/resourcetransformation-name"
+	// CurrentStorageClassName is the annotation used to store the current storage class of the PV before
+	// taking backup as we will reset it to empty.
+	CurrentStorageClassName = "stork.libopenstorage.org/current-storage-class-name"
 
 	// ServiceKind for k8s service resources
 	ServiceKind = "Service"
@@ -817,7 +820,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		}
 		return true, nil
 	case "PersistentVolume":
-		return r.preparePVResourceForApply(object, pvNameMappings, vInfo)
+		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings)
 	case "PersistentVolumeClaim":
 		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings, storageClassMappings, vInfo)
 	case "ClusterRoleBinding":

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"github.com/libopenstorage/stork/drivers"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	"strings"
 )
 
@@ -65,4 +66,19 @@ func GetTrimmedGroupName(group string) string {
 		}
 	}
 	return group
+}
+
+// GetStorageClassNameForPVC - Get the storageClass name from the PVC spec
+func GetStorageClassNameForPVC(pvc *v1.PersistentVolumeClaim) (string, error) {
+	var scName string
+	if pvc.Spec.StorageClassName != nil && len(*pvc.Spec.StorageClassName) > 0 {
+		scName = *pvc.Spec.StorageClassName
+	} else {
+		scName = pvc.Annotations[v1.BetaStorageClassAnnotation]
+	}
+
+	if len(scName) == 0 {
+		return "", fmt.Errorf("PVC: %s does not have a storage class", pvc.Name)
+	}
+	return scName, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
```
     pb-3157: Added fixes to add proper storage class and provisioner name
    for PV and PVC during restore.

            - Added logic to store the storage class in CurrentStorageClassName annotation for PV spec, so that it can used
              during restore.
            - Before applying pv spec updating correct storage class and provisioner name based of storageclass map.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
It will be similar to pb-3124

**Does this change need to be cherry-picked to a release branch?**:
2.12

Testing:
```
Testcase1:
1) Pvc having storage class name in the spec
2) PVC having volume.beta.kubernetes.io/storage-provisioner: annotation
3) PV having pv.kubernetes.io/provisioned-by annotation
4) PV having storage class name in the spec

Source: 
--------
[root@siva-root-sprite-0 ~]# kubectl  get pvc mysql-data -n mysql-bz -o yaml | grep storage-provisioner
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"storageClassName":"mysql-sc","volumeMode":"Filesystem"}}
    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
          f:volume.beta.kubernetes.io/storage-provisioner: {}
[root@siva-root-sprite-0 ~]# kubectl  get pvc mysql-data -n mysql-bz -o yaml | grep storageClassName
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"storageClassName":"mysql-sc","volumeMode":"Filesystem"}}
        f:storageClassName: {}
  storageClassName: mysql-sc
[root@siva-root-sprite-0 ~]#

[root@siva-root-sprite-0 ~]# kubectl  get pv pvc-b9bbf6cc-cf8d-46c1-b853-6ce6cb318ed2 -o yaml | grep storageClassName
        f:storageClassName: {}
  storageClassName: mysql-sc
[root@siva-root-sprite-0 ~]# kubectl  get pv pvc-b9bbf6cc-cf8d-46c1-b853-6ce6cb318ed2 -o yaml | grep provisioned-by
    pv.kubernetes.io/provisioned-by: kubernetes.io/portworx-volume
          f:pv.kubernetes.io/provisioned-by: {}
[root@siva-root-sprite-0 ~]#

Destination:
------------
[root@siva-root-sprite-0 ~]# kubectl  get pvc -n mysql-bz-tc1-res1
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mysql-data   Bound    pvc-e3a05240-d04d-4df7-9cf7-e52e19b1d07c   2Gi        RWO            px-csi         4s
[root@siva-root-sprite-0 ~]#

[root@siva-root-sprite-0 ~]# kubectl  get pvc mysql-data -n mysql-bz-tc1-res1 -o yaml | grep storage-provisioner
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"storageClassName":"mysql-sc","volumeMode":"Filesystem"}}
    volume.beta.kubernetes.io/storage-provisioner: pxd.portworx.com
          f:volume.beta.kubernetes.io/storage-provisioner: {}
[root@siva-root-sprite-0 ~]# kubectl  get pvc mysql-data -n mysql-bz-tc1-res1 -o yaml | grep storageClassName
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"storageClassName":"mysql-sc","volumeMode":"Filesystem"}}
        f:storageClassName: {}
  storageClassName: px-csi
[root@siva-root-sprite-0 ~]# kubectl  get pv pvc-e3a05240-d04d-4df7-9cf7-e52e19b1d07c -o yaml | grep storageClassName
        f:storageClassName: {}
  storageClassName: px-csi
[root@siva-root-sprite-0 ~]# kubectl  get pv pvc-e3a05240-d04d-4df7-9cf7-e52e19b1d07c -o yaml | grep provisioned-by
    pv.kubernetes.io/provisioned-by: pxd.portworx.com
          f:pv.kubernetes.io/provisioned-by: {}
[root@siva-root-sprite-0 ~]#

```
```
Testcase2:
-----------
1) Pvc having storage class name in the spec
2) PVC having volume.beta.kubernetes.io/storage-provisioner: annotation
3) PV having pv.kubernetes.io/provisioned-by annotation
4) PV does not have storage class name

Source:
--------
[root@siva-root-sprite-0 ~]# kubectl  get pvc -n mysql-bz
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mysql-data   Bound    pvc-b9bbf6cc-cf8d-46c1-b853-6ce6cb318ed2   2Gi        RWO            mysql-sc       11h
[root@siva-root-sprite-0 ~]# kubectl  get pv pvc-b9bbf6cc-cf8d-46c1-b853-6ce6cb318ed2 -n mysql-bz -o yaml  | grep storageClassName
[root@siva-root-sprite-0 ~]#

Destination:
------------
[root@siva-root-sprite-0 ~]# kubectl  get pvc -n mysql-bz-tc2-res1
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mysql-data   Bound    pvc-1038fbe2-bb59-497b-9f90-eaaa68402cfd   2Gi        RWO            px-csi         28s
[root@siva-root-sprite-0 ~]# kubectl  get pvc mysql-data -n mysql-bz-tc2-res1 -o yaml | grep storage-provisioner
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"storageClassName":"mysql-sc","volumeMode":"Filesystem"}}
    volume.beta.kubernetes.io/storage-provisioner: pxd.portworx.com
          f:volume.beta.kubernetes.io/storage-provisioner: {}
[root@siva-root-sprite-0 ~]# kubectl  get pvc mysql-data -n mysql-bz-tc2-res1 -o yaml | grep storageClassName
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"storageClassName":"mysql-sc","volumeMode":"Filesystem"}}
        f:storageClassName: {}
  storageClassName: px-csi
[root@siva-root-sprite-0 ~]# kubectl  get pv pvc-1038fbe2-bb59-497b-9f90-eaaa68402cfd -o yaml | grep storageClassName
        f:storageClassName: {}
  storageClassName: px-csi
[root@siva-root-sprite-0 ~]# kubectl  get pv pvc-1038fbe2-bb59-497b-9f90-eaaa68402cfd -o yaml | grep provisioned-by
    pv.kubernetes.io/provisioned-by: pxd.portworx.com
          f:pv.kubernetes.io/provisioned-by: {}
[root@siva-root-sprite-0 ~]#

```

```
Testcase3:
-----------
1) PVC having stroage class name in the annotation
2) PVC having volume.beta.kubernetes.io/storage-provisioner: annotation
3) PV having pv.kubernetes.io/provisioned-by annotation
4) PV having storage class name in the spec

Source:
--------
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc mysql-data -n mysql-bz -o yaml | grep storage-provisioner
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"mysql-sc","volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"volumeMode":"Filesystem"}}
    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
          f:volume.beta.kubernetes.io/storage-provisioner: {}
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc mysql-data -n mysql-bz -o yaml | grep storageClassName
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc mysql-data -n mysql-bz -o yaml | grep volume.beta.kubernetes.io/storage-class
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"mysql-sc","volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"volumeMode":"Filesystem"}}
    volume.beta.kubernetes.io/storage-class: mysql-sc
          f:volume.beta.kubernetes.io/storage-class: {}
[root@siva-root-sprite-0 mysql-1-pvc]#  kubectl  get pvc -n mysql-bz
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mysql-data   Bound    pvc-64dd3d92-987e-41f8-a7d3-c8ad1fd7519d   2Gi        RWO            mysql-sc       11m
[root@siva-root-sprite-0 mysql-1-pvc]#  kubectl  get pv pvc-64dd3d92-987e-41f8-a7d3-c8ad1fd7519d -o yaml | grep storageClassName
        f:storageClassName: {}
  storageClassName: mysql-sc
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pv pvc-64dd3d92-987e-41f8-a7d3-c8ad1fd7519d -o yaml | grep provisioned-by
    pv.kubernetes.io/provisioned-by: kubernetes.io/portworx-volume
          f:pv.kubernetes.io/provisioned-by: {}
[root@siva-root-sprite-0 mysql-1-pvc]#


Destination:
------------
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc -n mysql-bz-tc3-res1
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mysql-data   Bound    pvc-a09dc74f-8b64-47e6-944e-44a1455eaffa   2Gi        RWO            px-csi         10s
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc -n mysql-bz-tc3-res1 -o yaml | grep storage-provisioner
        {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"mysql-sc","volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"volumeMode":"Filesystem"}}
      volume.beta.kubernetes.io/storage-provisioner: pxd.portworx.com
            f:volume.beta.kubernetes.io/storage-provisioner: {}
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc -n mysql-bz-tc3-res1 -o yaml | grep storageClassName
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc -n mysql-bz-tc3-res1 -o yaml | grep volume.beta.kubernetes.io/storage-class
        {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"mysql-sc","volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"volumeMode":"Filesystem"}}
      volume.beta.kubernetes.io/storage-class: px-csi
            f:volume.beta.kubernetes.io/storage-class: {}
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pv pvc-a09dc74f-8b64-47e6-944e-44a1455eaffa -o yaml | grep storageClassName
        f:storageClassName: {}
  storageClassName: px-csi
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pv pvc-a09dc74f-8b64-47e6-944e-44a1455eaffa -o yaml | grep provisioned-by
    pv.kubernetes.io/provisioned-by: pxd.portworx.com
          f:pv.kubernetes.io/provisioned-by: {}
[root@siva-root-sprite-0 mysql-1-pvc]#
```
```
Testcase4:
1) PVC having stroage class name in the annotation
2) PVC having volume.beta.kubernetes.io/storage-provisioner: annotation
3) PV having pv.kubernetes.io/provisioned-by annotation
4) PV does not have storage class name


Source:
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc -n mysql-bz
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mysql-data   Bound    pvc-64dd3d92-987e-41f8-a7d3-c8ad1fd7519d   2Gi        RWO            mysql-sc       19m
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pv pvc-64dd3d92-987e-41f8-a7d3-c8ad1fd7519d
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                 STORAGECLASS   REASON   AGE
pvc-64dd3d92-987e-41f8-a7d3-c8ad1fd7519d   2Gi        RWO            Delete           Bound    mysql-bz/mysql-data                           19m
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pv pvc-64dd3d92-987e-41f8-a7d3-c8ad1fd7519d -o yaml | grep storageClassName
[root@siva-root-sprite-0 mysql-1-pvc]#



Destination:
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc -n mysql-bz-tc4-res1
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
mysql-data   Bound    pvc-5046851e-0a59-40a6-8deb-2c6ac9ba5d11   2Gi        RWO            px-csi         13m
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc -n mysql-bz-tc4-res1 -o yaml | grep storage-provisioner
        {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"mysql-sc","volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"volumeMode":"Filesystem"}}
      volume.beta.kubernetes.io/storage-provisioner: pxd.portworx.com
            f:volume.beta.kubernetes.io/storage-provisioner: {}
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc -n mysql-bz-tc4-res1 -o yaml | grep storageClassName
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pvc -n mysql-bz-tc4-res1 -o yaml | grep volume.beta.kubernetes.io/storage-class
        {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"mysql-sc","volume.beta.kubernetes.io/storage-provisioner":"kubernetes.io/portworx-volume"},"labels":{"app.kubernetes.io/instance":"tst","app.kubernetes.io/name":"zookeeper"},"name":"mysql-data","namespace":"mysql-bz"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"volumeMode":"Filesystem"}}
      volume.beta.kubernetes.io/storage-class: px-csi
            f:volume.beta.kubernetes.io/storage-class: {}
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pv pvc-5046851e-0a59-40a6-8deb-2c6ac9ba5d11  -o yaml | grep storageClassName
        f:storageClassName: {}
  storageClassName: px-csi
[root@siva-root-sprite-0 mysql-1-pvc]# kubectl  get pv pvc-5046851e-0a59-40a6-8deb-2c6ac9ba5d11  -o yaml | grep provisioned-by
    pv.kubernetes.io/provisioned-by: pxd.portworx.com
          f:pv.kubernetes.io/provisioned-by: {}
[root@siva-root-sprite-0 mysql-1-pvc]#
```

```
NOTE: In all the case, create table in the mysql and validated that datas are in-sync in the restore volumes.
```
