### PR TITLE
Update version to 2.11.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifeq ($(BUILD_TYPE),debug)
 BUILDFLAGS += -gcflags "-N -l"
 endif
 
-RELEASE_VER := 2.11.4
+RELEASE_VER := 2.11.5
 BASE_DIR    := $(shell git rev-parse --show-toplevel)
 GIT_SHA     := $(shell git rev-parse --short HEAD)
 BIN         :=$(BASE_DIR)/bin


### PR DESCRIPTION
**What type of PR is this?**
> improvement

**What this PR does / why we need it**:
We need to rebuild stork image to get in the latest redhat base image to fix the following vulnerabilities

CVE-2022-1292 (OpenSSL command injection)
CVE-2022-27774 (curl credential vulnerability)


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
Following vulnerabilities are addressed in stork 2.11.5:
CVE-2022-27774
CVE-2022-1292
```

**Does this change need to be cherry-picked to a release branch?**:
PR is based off 2.11. Vulnerability is not present in master or 2.12 branch based images.

