### PR TITLE
PB-3150: Handle GCE snapshot NotFound error in DeleteBackup

### DIFF
--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -347,6 +347,12 @@ func (g *gcp) DeleteBackup(backup *storkapi.ApplicationBackup) (bool, error) {
 		}
 		_, err := service.Snapshots.Delete(vInfo.Options["projectID"], vInfo.BackupID).Do()
 		if err != nil {
+			if gceErr, ok := err.(*googleapi.Error); ok {
+				if gceErr.Code == http.StatusNotFound {
+					// snapshot is already deleted
+					continue
+				}
+			}
 			return true, err
 		}
 	}


### PR DESCRIPTION



**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
If a DeleteBackup is invoked on the GCE driver in succession, the backup deletion will fail.
- Do not fail CancelBackup / DeleteBackup API if a snapshot was not found.


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->

```release-note
Issue: A repetitive call to delete a backup of GCE persistent disks would silently fail the backup deletion
User Impact: After deleting a backup, the kubernetes resource objects would not get deleted from the objectstore.
Resolution: Stork now handles NotFound error if returned by GCE on snapshot deletion.
```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.12

