### PR TITLE
pb-3162: Resetting secret token data for service account token before restoring

### DIFF
--- a/pkg/resourcecollector/secret.go
+++ b/pkg/resourcecollector/secret.go
@@ -44,6 +44,10 @@ func (r *ResourceCollector) prepareSecretForApply(
 	if secret.Annotations != nil {
 		if _, ok := secret.Annotations[serviceAccountUIDKey]; ok {
 			secret.Annotations[serviceAccountUIDKey] = ""
+			// Reset the secret token data to empty, so that new service account token will be updated by k8s, during restore.
+			if secret.Data["token"] != nil {
+				secret.Data["token"] = nil
+			}
 		}
 	}
 	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&secret)


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
```
pb-3162: Resetting secret token data for service account token before restoring
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: Service account secret was not updated with latest token value.
User Impact: Token value in the service account secret is old value. Using that token will with the restored application.
Resolution: Resetting the token to empty, so that new token will be update while restoring based on new service account on restore cluster.

```

**Does this change need to be cherry-picked to a release branch?**:
2.12
