### PR TITLE
Handle checks for resource transformation spec paths

### DIFF
--- a/pkg/migration/controllers/resourcetransformation.go
+++ b/pkg/migration/controllers/resourcetransformation.go
@@ -270,6 +270,7 @@ func (r *ResourceTransformationController) validateTransformResource(ctx context
 					log.TransformLog(transform).Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, kind, resInfo.Namespace, resInfo.Name, err)
 					resInfo.Status = stork_api.ResourceTransformationStatusFailed
 					resInfo.Reason = err.Error()
+					return err
 				}
 				unstructured, ok := object.(*unstructured.Unstructured)
 				if !ok {

--- a/pkg/resourcecollector/resourcetransformation.go
+++ b/pkg/resourcecollector/resourcetransformation.go
@@ -84,19 +84,22 @@ func TransformResources(
 					var value interface{}
 					if path.Type == stork_api.KeyPairResourceType {
 						currMap, _, err := unstructured.NestedMap(content, strings.Split(path.Path, ".")...)
-						if err != nil {
-							return fmt.Errorf("unable to find suspend path, err: %v", err)
+						if err != nil || len(currMap) == 0 {
+							return fmt.Errorf("unable to find spec path, err: %v", err)
 						}
 						mapList := strings.Split(path.Value, ",")
 						for _, val := range mapList {
 							keyPair := strings.Split(val, ":")
+							if len(keyPair) != 2 {
+								return fmt.Errorf("invalid keypair value format :%s", keyPair)
+							}
 							currMap[keyPair[0]] = keyPair[1]
 						}
 						value = currMap
 					} else if path.Type == stork_api.SliceResourceType {
 						currList, _, err := unstructured.NestedSlice(content, strings.Split(path.Path, ".")...)
 						if err != nil {
-							return fmt.Errorf("unable to find suspend path, err: %v", err)
+							return fmt.Errorf("unable to find spec path, err: %v", err)
 						}
 						arrList := strings.Split(path.Value, ",")
 						for _, val := range arrList {

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -231,6 +231,9 @@ func GetOptions(policyName string, namespace string, policyType stork_api.Schedu
 		return schedulePolicy.Policy.Interval.Options, nil
 	case stork_api.SchedulePolicyTypeDaily:
 		options := schedulePolicy.Policy.Daily.Options
+		if len(options) == 0 {
+			options = make(map[string]string)
+		}
 		scheduledDay, ok := stork_api.Days[schedulePolicy.Policy.Daily.ForceFullSnapshotDay]
 		if ok {
 			currentDay := GetCurrentTime().Weekday()


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
NestedMap does not return error if spec path is not found in k8s object, causing nil entry to map. This PR add checks around for spec path provided in RT

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no


**Does this change need to be cherry-picked to a release branch?**:
2.12