### PR TITLE
pb-3159: Add subpath and nfs mount option in BL

### DIFF
--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -127,7 +127,9 @@ type GoogleConfig struct {
 }
 
 type NfsConfig struct {
-	NfsServerAddr string `json:"nfsServerAddr"`
+	ServerAddr  string `json:"serverAddr"`
+	SubPath     string `json:"subPath"`
+	MountOption string `json:"mountOption"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -195,7 +197,13 @@ func (bl *BackupLocation) getMergedNfsConfig(client kubernetes.Interface) error 
 			return fmt.Errorf("error getting secretConfig for backupLocation: %v", err)
 		}
 		if val, ok := secretConfig.Data["serverAddr"]; ok && val != nil {
-			bl.Location.NfsConfig.NfsServerAddr = strings.TrimSuffix(string(val), "\n")
+			bl.Location.NfsConfig.ServerAddr = strings.TrimSuffix(string(val), "\n")
+		}
+		if val, ok := secretConfig.Data["subPath"]; ok && val != nil {
+			bl.Location.NfsConfig.SubPath = strings.TrimSuffix(string(val), "\n")
+		}
+		if val, ok := secretConfig.Data["mountOption"]; ok && val != nil {
+			bl.Location.NfsConfig.MountOption = strings.TrimSuffix(string(val), "\n")
 		}
 	}
 	return nil


### PR DESCRIPTION
The NfsConfig structure need to have subpath and mountOption to store the value passed from px-backup as part of backuplocation object.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?** Feature
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: Adds sub path and mount option to nfsConfig so that NFS based backuplocation can propagate the same for further processing.


**Does this PR change a user-facing CRD or CLI?**: No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

