### PR TITLE
pb-3174: Added csi section in the case portworx volume restore.

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -397,6 +397,7 @@ func (a *aws) DeleteBackup(backup *storkapi.ApplicationBackup) (bool, error) {
 func (a *aws) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
+	namespaceMapping map[string]string,
 ) (*v1.PersistentVolume, error) {
 	if pv.Spec.CSI != nil {
 		pv.Spec.CSI.VolumeHandle = pv.Name

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -408,6 +408,7 @@ func (a *azure) DeleteBackup(backup *storkapi.ApplicationBackup) (bool, error) {
 func (a *azure) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
+	namespaceMapping map[string]string,
 ) (*v1.PersistentVolume, error) {
 	disk, err := a.diskClient.Get(context.TODO(), a.resourceGroup, pv.Name)
 	if err != nil {

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -89,7 +89,7 @@ type BackupObjectv1beta1Csi struct {
 	V1SnapshotRequired     bool
 }
 
-//  GetVolumeSnapshotContent retrieves a backed up volume snapshot
+// GetVolumeSnapshotContent retrieves a backed up volume snapshot
 func (cbo *csiBackupObject) GetVolumeSnapshot(snapshotID string) (interface{}, error) {
 	var vs interface{}
 	var ok bool
@@ -1170,6 +1170,7 @@ func (c *csi) DeleteBackup(backup *storkapi.ApplicationBackup) (bool, error) {
 func (c *csi) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
+	namespaceMapping map[string]string,
 ) (*v1.PersistentVolume, error) {
 	return pv, nil
 }

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -362,6 +362,7 @@ func (g *gcp) DeleteBackup(backup *storkapi.ApplicationBackup) (bool, error) {
 func (g *gcp) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
+	namespaceMapping map[string]string,
 ) (*v1.PersistentVolume, error) {
 	if pv.Spec.CSI != nil {
 		key, err := common.VolumeIDToKey(pv.Spec.CSI.VolumeHandle)

--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -576,6 +576,7 @@ func doKdmpDeleteJob(id string, driver drivers.Interface) (bool, error) {
 func (k *kdmp) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
+	namespaceMapping map[string]string,
 ) (*v1.PersistentVolume, error) {
 	return pv, nil
 }

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -395,6 +395,7 @@ func (l *linstor) Stop() error {
 func (l *linstor) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
+	namespaceMapping map[string]string,
 ) (*v1.PersistentVolume, error) {
 
 	return pv, nil

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -309,6 +309,7 @@ func (m *Driver) GetSnapshotType(snap *snapv1.VolumeSnapshot) (string, error) {
 func (m *Driver) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
+	namespaceMapping map[string]string,
 ) (*v1.PersistentVolume, error) {
 
 	return pv, nil

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -192,7 +192,7 @@ type MigratePluginInterface interface {
 	CancelMigration(*storkapi.Migration) error
 	// Update the PVC spec to point to the migrated volume on the destination
 	// cluster
-	UpdateMigratedPersistentVolumeSpec(*v1.PersistentVolume, *storkapi.ApplicationRestoreVolumeInfo) (*v1.PersistentVolume, error)
+	UpdateMigratedPersistentVolumeSpec(*v1.PersistentVolume, *storkapi.ApplicationRestoreVolumeInfo, map[string]string) (*v1.PersistentVolume, error)
 }
 
 // ClusterDomainsPluginInterface Interface to manage cluster domains

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -588,7 +588,7 @@ func (a *ApplicationCloneController) preparePVResource(
 		return err
 	}
 
-	_, err := a.volDriver.UpdateMigratedPersistentVolumeSpec(&pv, nil)
+	_, err := a.volDriver.UpdateMigratedPersistentVolumeSpec(&pv, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1293,7 +1293,7 @@ func (m *MigrationController) preparePVResource(
 	}
 	pv.Annotations[PVReclaimAnnotation] = string(pv.Spec.PersistentVolumeReclaimPolicy)
 	pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
-	_, err := m.volDriver.UpdateMigratedPersistentVolumeSpec(&pv, nil)
+	_, err := m.volDriver.UpdateMigratedPersistentVolumeSpec(&pv, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -142,6 +142,7 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	pvNameMappings map[string]string,
 	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
 	storageClassMappings map[string]string,
+	namespaceMappings map[string]string,
 ) (bool, error) {
 	var updatedName string
 	var present bool
@@ -208,7 +209,7 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	if err != nil {
 		return false, err
 	}
-	_, err = driver.UpdateMigratedPersistentVolumeSpec(&pv, volumeInfo)
+	_, err = driver.UpdateMigratedPersistentVolumeSpec(&pv, volumeInfo, namespaceMappings)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -820,7 +820,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		}
 		return true, nil
 	case "PersistentVolume":
-		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings)
+		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings, namespaceMappings)
 	case "PersistentVolumeClaim":
 		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings, storageClassMappings, vInfo)
 	case "ClusterRoleBinding":


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
pb-3174

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: Restore of portworx volume to portworx CSI volume was not adding csi section in the PV spec
User Impact: Some of environment are identifying the restore portworx CSI volume as csi volume.
Resolution: Adding csi section details for portworx csi restored volume.

```

**Does this change need to be cherry-picked to a release branch?**:
2.12

Testing:
Covered following cases:
1) restoring non-secure portworx volume to secure portworx csi volume.
2) restoring secure portworx volume to secure portworx csi volume.
3) restoring non-secure portworx volume to secure portworx csi volume, where the storage class was having template reference for the secret name and namespace.
4) restoring secure portworx volume to secure portworx csi volume, where the storage class was having template reference for the secret name and namespace.

Note:
```
Note able to test with RKE cluster. Installing portworx operator with px-security enabled is not working. 
Facing below error:
Events:
  Type     Reason                  Age                     From     Message
  ----     ------                  ----                    ----     -------
  Warning  FailedCreatePodSandBox  13s (x2028 over 7h23m)  kubelet  (combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "1fec59be470f6d45ecf27e720c08a21929104d9fb032378da4a61b4909edcd07": plugin type="calico" failed (add): error getting ClusterInformation: connection is unauthorized: Unauthorized
```