### PR TITLE
ptx-13566: updating the destination namespace from the namespace mapping only when the namespace in SC is templatized.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2644,11 +2644,15 @@ func (p *portworx) UpdateMigratedPersistentVolumeSpec(
 				} else {
 					pv.Spec.CSI.ControllerExpandSecretRef.Name = val
 				}
-				// In the case of portworx volume backup, we will have namespace mapping always.
-				// So no need to check for the template string as we are going to change the value to destination namespace always.
-				// If user does not change the namespace, the source and destination namespace in the mapping will be same.
-				if _, ok := sc.Parameters[controllerExpandSecretNamespace]; ok {
+			}
+			if val, ok := sc.Parameters[controllerExpandSecretNamespace]; ok {
+				if pv.Spec.CSI.ControllerExpandSecretRef == nil {
+					pv.Spec.CSI.ControllerExpandSecretRef = &v1.SecretReference{}
+				}
+				if val == templatizedNamespace {
 					pv.Spec.CSI.ControllerExpandSecretRef.Namespace = dstNamespace
+				} else {
+					pv.Spec.CSI.ControllerExpandSecretRef.Namespace = val
 				}
 			}
 
@@ -2662,10 +2666,18 @@ func (p *portworx) UpdateMigratedPersistentVolumeSpec(
 				} else {
 					pv.Spec.CSI.NodePublishSecretRef.Name = val
 				}
-				if _, ok := sc.Parameters[nodePublishSecretNamespace]; ok {
+			}
+			if val, ok := sc.Parameters[nodePublishSecretNamespace]; ok {
+				if pv.Spec.CSI.NodePublishSecretRef == nil {
+					pv.Spec.CSI.NodePublishSecretRef = &v1.SecretReference{}
+				}
+				if val == templatizedNamespace {
 					pv.Spec.CSI.NodePublishSecretRef.Namespace = dstNamespace
+				} else {
+					pv.Spec.CSI.NodePublishSecretRef.Namespace = val
 				}
 			}
+
 			// Update driver (provisioner) name
 			pv.Spec.CSI.Driver = sc.Provisioner
 			// In the case of csi, will set pv.Spec.portworxVolume to nil as we will have csi section now.


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
ptx-13566

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
No, it will be covered as part of pb-3174

**Does this change need to be cherry-picked to a release branch?**:
Yes to 2.12 branch.
