### PR TITLE
PB-3211: Mapping nfs resource restore statuses to stork restore statuses and update.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1087,9 +1087,20 @@ func (a *ApplicationRestoreController) updateResourceStatus(
 func (a *ApplicationRestoreController) updateResourceStatusFromRestoreCR(
 	restore *storkapi.ApplicationRestore,
 	resource *kdmpapi.ResourceRestoreResourceInfo,
-	status storkapi.ApplicationRestoreStatusType,
+	status kdmpapi.ResourceRestoreStatus,
 	reason string,
 ) {
+	var resourceStatus storkapi.ApplicationRestoreStatusType
+	switch status {
+	case kdmpapi.ResourceRestoreStatusSuccessful:
+		resourceStatus = storkapi.ApplicationRestoreStatusSuccessful
+	case kdmpapi.ResourceRestoreStatusRetained:
+		resourceStatus = storkapi.ApplicationRestoreStatusRetained
+	case kdmpapi.ResourceRestoreStatusFailed:
+		resourceStatus = storkapi.ApplicationRestoreStatusFailed
+	case kdmpapi.ResourceRestoreStatusInProgress:
+		resourceStatus = storkapi.ApplicationRestoreStatusInProgress
+	}
 	updatedResource := &storkapi.ApplicationRestoreResourceInfo{
 		ObjectInfo: storkapi.ObjectInfo{
 			Name:      resource.Name,
@@ -1100,6 +1111,8 @@ func (a *ApplicationRestoreController) updateResourceStatusFromRestoreCR(
 				Kind:    resource.Kind,
 			},
 		},
+		Status: resourceStatus,
+		Reason: reason,
 	}
 	restore.Status.Resources = append(restore.Status.Resources, updatedResource)
 }
@@ -1540,7 +1553,7 @@ func (a *ApplicationRestoreController) restoreResources(
 					a.updateResourceStatusFromRestoreCR(
 						restore,
 						resource,
-						storkapi.ApplicationRestoreStatusType(resource.Status),
+						resource.Status,
 						resource.Reason)
 				}
 				restore.Status.Stage = storkapi.ApplicationRestoreStageFinal


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
bug

**What this PR does / why we need it**:
Need to map the proper resource restore statuses for nfs restores.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
no
-->

