### PR TITLE
pb-3213: Send the triggeredFrom values to nfs specific CRs

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/utils"
 	"github.com/libopenstorage/stork/pkg/version"
 	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
+	kdmputils "github.com/portworx/kdmp/pkg/drivers/utils"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/core"
 	kdmpShedOps "github.com/portworx/sched-ops/k8s/kdmp"
@@ -1384,8 +1385,16 @@ func (a *ApplicationBackupController) backupResources(
 					Namespace:  backupLocation.Namespace,
 					Name:       backupLocation.Name,
 				}
+				resourceExport.Spec.TriggeredFrom = kdmputils.TriggeredFromStork
+				storkPodNs, err := k8sutils.GetStorkPodNamespace()
+				if err != nil {
+					logrus.Errorf("error in getting stork pod namespace: %v", err)
+					return err
+				}
+				resourceExport.Spec.TriggeredFromNs = storkPodNs
 				resourceExport.Spec.Source = *source
 				resourceExport.Spec.Destination = *destination
+
 				_, err = kdmpShedOps.Instance().CreateResourceExport(resourceExport)
 				if err != nil {
 					logrus.Errorf("failed to create DataExport CR: %v", err)

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -21,6 +21,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/utils"
 	"github.com/libopenstorage/stork/pkg/version"
 	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
+	kdmputils "github.com/portworx/kdmp/pkg/drivers/utils"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/core"
 	kdmpShedOps "github.com/portworx/sched-ops/k8s/kdmp"
@@ -691,6 +692,13 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 							Namespace:  backupLocation.Namespace,
 							Name:       backupLocation.Name,
 						}
+						resourceExport.Spec.TriggeredFrom = kdmputils.TriggeredFromStork
+						storkPodNs, err := k8sutils.GetStorkPodNamespace()
+						if err != nil {
+							logrus.Errorf("error in getting stork pod namespace: %v", err)
+							return err
+						}
+						resourceExport.Spec.TriggeredFromNs = storkPodNs
 						resourceExport.Spec.Source = *source
 						resourceExport.Spec.Destination = *destination
 						_, err = kdmpShedOps.Instance().CreateResourceExport(resourceExport)


### PR DESCRIPTION
The image registry and namespace details are passed via CR. This is passed to JOB to determine the executor image location.

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: this passes the TriggereFrom and namespace detail to JOB via the NFS resource export CR. this values are used to extract the executor image details


**Does this PR change a user-facing CRD or CLI?**:No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: NO
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: No
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

