### PR TITLE
PWX-27549: Monitor csi-ext pods and ensure they run on online portwor…

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -657,6 +657,11 @@ func (a *aws) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPa
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *aws) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	a := &aws{}
 	err := a.Init(nil)

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -679,6 +679,11 @@ func (a *azure) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSON
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *azure) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	a := &azure{}
 	err := a.Init(nil)

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -1908,6 +1908,11 @@ func (c *csi) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPa
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *csi) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	c := &csi{}
 	err := c.Init(nil)

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -660,6 +660,11 @@ func (g *gcp) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPa
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *gcp) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	g := &gcp{}
 	err := g.Init(nil)

--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -1013,6 +1013,11 @@ func (k *kdmp) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONP
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *kdmp) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	a := &kdmp{}
 

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -449,6 +449,11 @@ func (l *linstor) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JS
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *linstor) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	l := &linstor{}
 	if err := storkvolume.Register(storkvolume.LinstorDriverName, l); err != nil {

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -321,6 +321,11 @@ func (m *Driver) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSO
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *Driver) GetCSIPodPrefix() (string, error) {
+	return "px-csi-ext", nil
+}
+
 func init() {
 	if err := storkvolume.Register(driverName, &Driver{}); err != nil {
 		logrus.Panicf("Error registering mock volume driver: %v", err)

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -156,6 +156,8 @@ const (
 	restoreNamePrefix = "in-place-restore-"
 	restoreTaskPrefix = "restore-"
 
+	csiPodNamePrefix = "px-csi-ext"
+
 	// Annotation to skip checking if the backup is being done to the same
 	// BackupLocationName
 	skipBackupLocationNameCheckAnnotation = "portworx.io/skip-backup-location-name-check"
@@ -4073,6 +4075,11 @@ func (p *portworx) CleanupRestoreResources(*storkapi.ApplicationRestore) error {
 // GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
 func (p *portworx) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {
 	return p.getVirtLauncherPatches(podNamespace, pod)
+}
+
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *portworx) GetCSIPodPrefix() (string, error) {
+	return csiPodNamePrefix, nil
 }
 
 func (p *portworx) getVirtLauncherPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -141,6 +141,9 @@ type Driver interface {
 	// GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
 	GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error)
 
+	// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+	GetCSIPodPrefix() (string, error)
+
 	// GroupSnapshotPluginInterface Interface for group snapshots
 	GroupSnapshotPluginInterface
 	// ClusterPairPluginInterface Interface to pair clusters

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -30,7 +30,6 @@ const (
 	nodeWaitFactor       = 2
 	nodeWaitSteps        = 5
 
-	CSIPodNamePrefix           = "px-csi-ext"
 	storageDriverOfflineReason = "StorageDriverOffline"
 )
 
@@ -149,7 +148,7 @@ func (m *Monitor) podMonitor() error {
 		if podUnknownState {
 			csiPodPrefix, err := m.Driver.GetCSIPodPrefix()
 			if err == nil && strings.HasPrefix(pod.Name, csiPodPrefix) {
-				msg = "Force deleting csi-ext-pod as it's in unknown state."
+				msg = "Force deleting csi pod as it's in unknown state."
 				storklog.PodLog(pod).Infof(msg)
 			} else {
 				owns, err := m.doesDriverOwnPodVolumes(pod)
@@ -257,7 +256,7 @@ func (m *Monitor) cleanupDriverNodePods(node *volume.NodeInfo) {
 		var msg string
 		csiPodPrefix, err := m.Driver.GetCSIPodPrefix()
 		if err == nil && strings.HasPrefix(pod.Name, csiPodPrefix) {
-			msg = fmt.Sprintf("Deleting px-csi-ext pod from Node %v due to volume driver status: %v (%v)", pod.Spec.NodeName, node.Status, node.RawStatus)
+			msg = fmt.Sprintf("Deleting csi pod from Node %v due to volume driver status: %v (%v)", pod.Spec.NodeName, node.Status, node.RawStatus)
 
 		} else {
 			msg = fmt.Sprintf("Deleting Pod from Node %v due to volume driver status: %v (%v)", pod.Spec.NodeName, node.Status, node.RawStatus)


### PR DESCRIPTION
…x nodes

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>


**What type of PR is this?**
>feature

**What this PR does / why we need it**:
If Stork detects that px-csi-ext pods are running on an offline PX node, it can delete the pod.
When Stork gets a scheduling request for such a pod, it can place the pod on the node where PX is operational. 

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note

Issue: 
When CSI is enabled, PVC provisioning goes through a deployment of 3 replicas of px-csi-ext-* pods. If PX on 
any of these nodes goes down, none of the PVC creations would succeed even if the PX cluster is operational. 

User Impact:
If PX goes down on a node where CSI Pod is deployed,  PVC requests on that Pod does not succeed.

Resolution:
Set Stork as the default scheduler for px-csi-ext-* pods. If Stork detects that these pods are running on an offline Portworx node, delete the CSI Pod. When Stork gets a scheduling request for such a Pod, it can place the Pods on the Node where PX is operational. 

```
**Does this change need to be cherry-picked to a release branch?**:
yes 2.12.2