### PR TITLE
Update golang version to 1.18.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: go
 go:
-  - 1.17.3
+  - 1.18.3
 before_install:
   - sudo apt-get update -yq || true
   - sudo apt-get install go-md2man -y

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ vet:
 	go vet -tags integrationtest github.com/libopenstorage/stork/test/integration_test
 
 staticcheck:
-	GOFLAGS="" go install honnef.co/go/tools/cmd/staticcheck@v0.2.2
+	GOFLAGS="" go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 	staticcheck $(PKGS)
 	staticcheck -tags integrationtest test/integration_test/*.go
 	staticcheck -tags unittest $(PKGS)


### PR DESCRIPTION
**What type of PR is this?**
Update golang version to 1.18.3

**What this PR does / why we need it**:
Update golang version to 1.18.3

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes 2.12.2
