### PR TITLE
 pb-3258: Added TriggeredFromxxx field for resourceExport as well

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1499,6 +1499,13 @@ func (a *ApplicationRestoreController) restoreResources(
 				resourceExport.Name = crName
 				resourceExport.Namespace = a.restoreAdminNamespace
 				resourceExport.Spec.Type = kdmpapi.ResourceExportBackup
+				resourceExport.Spec.TriggeredFrom = kdmputils.TriggeredFromStork
+				storkPodNs, err := k8sutils.GetStorkPodNamespace()
+				if err != nil {
+					logrus.Errorf("error in getting stork pod namespace: %v", err)
+					return err
+				}
+				resourceExport.Spec.TriggeredFromNs = storkPodNs
 				source := &kdmpapi.ResourceExportObjectReference{
 					APIVersion: restore.APIVersion,
 					Kind:       restore.Kind,


### PR DESCRIPTION
**What type of PR is this?**
> bug

**What this PR does / why we need it**:
```
 pb-3258: Added TriggeredFromxxx field for resourceExport as well
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
no

