### PR TITLE
pb-3306: Removing setting of CR status to success before checking for all resources status

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1569,10 +1569,6 @@ func (a *ApplicationRestoreController) restoreResources(
 						resource.Status,
 						resource.Reason)
 				}
-				restore.Status.Stage = storkapi.ApplicationRestoreStageFinal
-				restore.Status.FinishTimestamp = metav1.Now()
-				restore.Status.Status = storkapi.ApplicationRestoreStatusSuccessful
-				restore.Status.Reason = "Volumes and resources were restored up successfully"
 			case kdmpapi.ResourceExportStatusInitial:
 				doCleanup = false
 			case kdmpapi.ResourceExportStatusPending:


### PR DESCRIPTION
**What type of PR is this?**
 Bug

**What this PR does / why we need it**:
`Removing setting of CR status to success before checking for all resources status`

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

Note: test result updated in the bug