### PR TITLE
PWX-24444: Antihyperconvergence scheduling of sharedv4 service pods

### DIFF
--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -143,16 +143,18 @@ func (m *Driver) ProvisionVolume(
 	replicaIndexes []int,
 	size uint64,
 	labels map[string]string,
+	isSharedV4Service bool,
 ) error {
 	if _, ok := m.volumes[volumeName]; ok {
 		return fmt.Errorf("volume %v already exists", volumeName)
 	}
 
 	volume := &storkvolume.Info{
-		VolumeID:   volumeName,
-		VolumeName: volumeName,
-		Size:       size,
-		Labels:     labels,
+		VolumeID:            volumeName,
+		VolumeName:          volumeName,
+		Size:                size,
+		Labels:              labels,
+		IsSharedV4SvcVolume: isSharedV4Service,
 	}
 
 	for i := 0; i < len(replicaIndexes); i++ {

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -143,18 +143,18 @@ func (m *Driver) ProvisionVolume(
 	replicaIndexes []int,
 	size uint64,
 	labels map[string]string,
-	isSharedV4Service bool,
+	needsAntiHyperconvergence bool,
 ) error {
 	if _, ok := m.volumes[volumeName]; ok {
 		return fmt.Errorf("volume %v already exists", volumeName)
 	}
 
 	volume := &storkvolume.Info{
-		VolumeID:            volumeName,
-		VolumeName:          volumeName,
-		Size:                size,
-		Labels:              labels,
-		IsSharedV4SvcVolume: isSharedV4Service,
+		VolumeID:                  volumeName,
+		VolumeName:                volumeName,
+		Size:                      size,
+		Labels:                    labels,
+		NeedsAntiHyperconvergence: needsAntiHyperconvergence,
 	}
 
 	for i := 0; i < len(replicaIndexes); i++ {

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -500,6 +500,7 @@ func (p *portworx) inspectVolume(volDriver volume.VolumeDriver, volumeID string)
 
 	info := &storkvolume.Info{}
 	info.VolumeID = vols[0].Id
+
 	info.VolumeName = vols[0].Locator.Name
 	for _, rset := range vols[0].ReplicaSets {
 		info.DataNodes = append(info.DataNodes, rset.Nodes...)
@@ -521,8 +522,9 @@ func (p *portworx) inspectVolume(volDriver volume.VolumeDriver, volumeID string)
 	for k, v := range vols[0].Locator.GetVolumeLabels() {
 		info.Labels[k] = v
 	}
-
+	info.IsSharedV4SvcVolume = vols[0].Spec.Sharedv4 && vols[0].Spec.Sharedv4ServiceSpec != nil
 	info.VolumeSourceRef = vols[0]
+
 	return info, nil
 }
 

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -522,7 +522,7 @@ func (p *portworx) inspectVolume(volDriver volume.VolumeDriver, volumeID string)
 	for k, v := range vols[0].Locator.GetVolumeLabels() {
 		info.Labels[k] = v
 	}
-	info.IsSharedV4SvcVolume = vols[0].Spec.Sharedv4 && vols[0].Spec.Sharedv4ServiceSpec != nil
+	info.NeedsAntiHyperconvergence = vols[0].Spec.Sharedv4 && vols[0].Spec.Sharedv4ServiceSpec != nil
 	info.VolumeSourceRef = vols[0]
 
 	return info, nil

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -273,6 +273,8 @@ type Info struct {
 	Labels map[string]string
 	// VolumeSourceRef is a optional reference to the source of the volume
 	VolumeSourceRef interface{}
+	// IsSharedV4SvcVolume is a flag for figuring if it's  sharedv4 service volume
+	IsSharedV4SvcVolume bool
 }
 
 // NodeStatus Status of driver on a node

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -273,8 +273,8 @@ type Info struct {
 	Labels map[string]string
 	// VolumeSourceRef is a optional reference to the source of the volume
 	VolumeSourceRef interface{}
-	// IsSharedV4SvcVolume is a flag for figuring if it's  sharedv4 service volume
-	IsSharedV4SvcVolume bool
+	// NeedsAntiHyperconvergence is a flag for figuring if Pod needs anti-hyperconvergence
+	NeedsAntiHyperconvergence bool
 }
 
 // NodeStatus Status of driver on a node

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -106,13 +106,13 @@ func setup(t *testing.T) {
 	err = driver.UpdateNodeStatus(5, volume.NodeOffline)
 	require.NoError(t, err, "Error setting node status to Offline")
 
-	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil)
+	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil, false)
 	require.NoError(t, err, "Error provisioning volume")
 
-	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil)
+	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil, false)
 	require.NoError(t, err, "Error provisioning volume")
 
-	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil)
+	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil, false)
 	require.NoError(t, err, "Error provisioning volume")
 
 	eventBroadcaster := record.NewBroadcaster()


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>


**What type of PR is this?**
>feature
>unit-test

**What this PR does / why we need it**:
- Introduce a new parameter stork.libopenstorage.org/preferRemoteNodeOnly parameter to be applied to StorageClass. 
Pods using this StorageClass should only be scheduled on the nodes where volume replica nodes do not exist. This behavior should be strictly enforced.
- For Pods using SharedV4 Service  volumes, Stork should give higher score to nodes where SharedV4 Service volumes do not exist.
- Refer to PWX-24444 for further details

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
*  Stork will try to schedule application pods using SharedV4 service volumes to run on nodes where volume replica does not exist such that it uses NFS mountpoint and when a failover happens application pods will not be restarted.
* StorageClass parameter "stork.libopenstorage.org/preferRemoteNodeOnly": "true" can be used to strictly enforce this behavior.


```

**Does this change need to be cherry-picked to a release branch?**:
yes 2.12.2

**Notes For the Reviewer**
- Pod annotation preferLocalNodeOnly doesn't apply for SharedV4 service volumes
- StorageClass parameter preferRemoteNodeOnly applies only to SharedV4 service volumes
- In case a Pod uses both SharedV4 service and regular volumes, scoring will prioritize antihyperconvergence based on sharedv4 volume replicas