### PR TITLE
PB-3316: Removing storageprovisioner annotation along with beta version also while restoring pvcs.

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -630,7 +630,8 @@ func (k *kdmp) getRestorePVCs(
 				delete(pvc.Annotations, bindCompletedKey)
 				delete(pvc.Annotations, boundByControllerKey)
 				delete(pvc.Annotations, storageClassKey)
-				delete(pvc.Annotations, storageProvisioner)
+				delete(pvc.Annotations, k8shelper.AnnBetaStorageProvisioner)
+				delete(pvc.Annotations, k8shelper.AnnStorageProvisioner)
 				delete(pvc.Annotations, storageNodeAnnotation)
 				pvc.Annotations[KdmpAnnotation] = StorkAnnotation
 			}


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Removing storage provisioner and beta storage provisioner annotations from the restored pvcs for kdmp.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
no
-->

**Does this change need to be cherry-picked to a release branch?**:
<!--
2.12
-->

**Test**
Tested with restore of GKE to AKS using kdmp. Updated PB-3316.
