### PR TITLE
PWX-27385: Add a cache for StorageClasses & ApplicationRegistration.

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"github.com/libopenstorage/stork/pkg/cache"
 	"net/http"
 	"os"
 	"os/signal"
@@ -276,11 +277,20 @@ func run(c *cli.Context) {
 		log.SetLevel(log.DebugLevel)
 	}
 
+	qps := float32(c.Int("k8s-api-qps"))
+	burst := c.Int("k8s-api-burst")
+
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		log.Fatalf("Error getting cluster config: %v", err)
 	}
 
+	if qps > 0 {
+		config.QPS = qps
+	}
+	if burst > 0 {
+		config.Burst = burst
+	}
 	k8sClient, err := clientset.NewForConfig(config)
 	if err != nil {
 		log.Fatalf("Error getting client, %v", err)
@@ -289,6 +299,13 @@ func run(c *cli.Context) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(&core_v1.EventSinkImpl{Interface: k8sClient.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, api_v1.EventSource{Component: eventComponentName})
+
+	// Setup stork cache. We setup this cache for all the stork pods instead of just the leader pod.
+	// In this way, even the stork extender code can use this cache, since the extender filter/process
+	// requests can land on any stork pod.
+	if err := cache.CreateSharedInformerCache(config); err != nil {
+		log.Fatalf("failed to setup shared informer cache: %v", err)
+	}
 
 	// Create operator-sdk manager that will manage all controllers.
 	// Setup the controller manager before starting any watches / other controllers
@@ -352,7 +369,7 @@ func run(c *cli.Context) {
 	}
 
 	runFunc := func(context.Context) {
-		runStork(mgr, d, recorder, c)
+		runStork(mgr, d, recorder, c, qps, burst)
 	}
 
 	if c.BoolT("leader-elect") {
@@ -403,18 +420,17 @@ func displayLeader(name string) {
 	log.Infof("new leader detected, current leader: %s", name)
 }
 
-func runStork(mgr manager.Manager, d volume.Driver, recorder record.EventRecorder, c *cli.Context) {
+func runStork(mgr manager.Manager, d volume.Driver, recorder record.EventRecorder, c *cli.Context, qps float32, burst int) {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 
 	if err := rule.Init(); err != nil {
 		log.Fatalf("Error initializing rule: %v", err)
 	}
-	qps := c.Int("k8s-api-qps")
-	burst := c.Int("k8s-api-burst")
+
 	resourceCollector := resourcecollector.ResourceCollector{
 		Driver: d,
-		QPS:    float32(qps),
+		QPS:    qps,
 		Burst:  burst,
 	}
 	if err := resourceCollector.Init(nil); err != nil {

--- a/pkg/apis/stork/v1alpha1/resourcetransformation.go
+++ b/pkg/apis/stork/v1alpha1/resourcetransformation.go
@@ -96,7 +96,7 @@ type TransformResourceInfo struct {
 }
 
 // ResourceTransformationSpec is used to update k8s resources
-//before migration/restore
+// before migration/restore
 type ResourceTransformationSpec struct {
 	Objects []TransformSpecs `json:"transformSpecs"`
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,226 @@
+package cache
+
+import (
+	"fmt"
+	stork "github.com/libopenstorage/stork/pkg/apis/stork"
+	storkv1alpha1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	restclient "k8s.io/client-go/rest"
+	kcache "k8s.io/client-go/tools/cache"
+	"sync"
+	"time"
+)
+
+const (
+	defaultResyncPeriod = 30 * time.Second
+)
+
+var (
+	scResource     = schema.GroupVersionResource{Group: storagev1.GroupName, Version: storagev1.SchemeGroupVersion.Version, Resource: "storageclasses"}
+	appRegResource = schema.GroupVersionResource{Group: stork.GroupName, Version: "v1alpha1", Resource: storkv1alpha1.ApplicationRegistrationResourcePlural}
+)
+
+// SharedInformerCache  is an eventually consistent cache. The cache interface
+// provides APIs to fetch specific k8s objects from the cache. Only a subset
+// of k8s objects are currently managed by this cache.
+// DO NOT USE it when you need the latest and accurate copy of a CR.
+type SharedInformerCache interface {
+	// GetStorageClass returns the storage class if present in the cache.
+	GetStorageClass(storageClassName string) (*storagev1.StorageClass, error)
+
+	// GetStorageClassForPVC returns the storage class for the provided PVC if present in cache
+	GetStorageClassForPVC(pvc *corev1.PersistentVolumeClaim) (*storagev1.StorageClass, error)
+
+	// ListStorageClasses returns a list of storage classes from the cache
+	ListStorageClasses() (*storagev1.StorageClassList, error)
+
+	// GetApplicationRegistration returns the ApplicationRegistration CR from the cache
+	GetApplicationRegistration(name string) (*storkv1alpha1.ApplicationRegistration, error)
+
+	// ListApplicationRegistrations lists the application registration CRs from the cache
+	ListApplicationRegistrations() (*storkv1alpha1.ApplicationRegistrationList, error)
+}
+
+type cache struct {
+	scInformer     kcache.SharedIndexInformer
+	appRegInformer kcache.SharedIndexInformer
+}
+
+var (
+	cacheLock           sync.Mutex
+	sharedInformerCache *cache
+)
+
+func CreateSharedInformerCache(config *restclient.Config) error {
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+	if sharedInformerCache != nil {
+		return fmt.Errorf("shared informer cache already initialized")
+	}
+
+	dynInterface, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+	dynInformer := dynamicinformer.NewDynamicSharedInformerFactory(dynInterface, defaultResyncPeriod)
+	scInformer := dynInformer.ForResource(scResource).Informer()
+	appRegInformer := dynInformer.ForResource(appRegResource).Informer()
+
+	scInformer.AddEventHandler(kcache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			sc, ok := obj.(*storagev1.StorageClass)
+			if ok {
+				logrus.Infof("Added a new storage class to cache: %v (%v)", sc.Name, sc.Provisioner)
+			}
+		},
+	})
+
+	appRegInformer.AddEventHandler(kcache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			appReg, ok := obj.(*storkv1alpha1.ApplicationRegistration)
+			if ok {
+				logrus.Infof("Added a new application registration to cache: %v (%v)", appReg.Name, appReg.GroupVersionKind())
+			}
+		},
+	})
+
+	defer utilruntime.HandleCrash()
+
+	stopper := make(chan struct{})
+
+	go scInformer.Run(stopper)
+	go appRegInformer.Run(stopper)
+
+	// wait for the caches to synchronize before starting the worker
+	if !kcache.WaitForCacheSync(stopper, scInformer.HasSynced) {
+		err := fmt.Errorf("timed out waiting for caches to sync")
+		utilruntime.HandleError(err)
+		return err
+	}
+
+	if !kcache.WaitForCacheSync(stopper, appRegInformer.HasSynced) {
+		err := fmt.Errorf("timed out waiting for caches to sync")
+		utilruntime.HandleError(err)
+		return err
+	}
+
+	sharedInformerCache = &cache{
+		scInformer:     scInformer,
+		appRegInformer: appRegInformer,
+	}
+	return nil
+}
+
+func Instance() SharedInformerCache {
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+	return sharedInformerCache
+}
+
+// GetStorageClass returns the storage class if present in the cache.
+func (c *cache) GetStorageClass(storageClassName string) (*storagev1.StorageClass, error) {
+	obj, exists, err := c.scInformer.GetStore().GetByKey(storageClassName)
+	if err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, k8s_errors.NewNotFound(storagev1.Resource("storageclass"), storageClassName)
+	}
+	sc := storagev1.StorageClass{}
+	unstructuredObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse object into storage class")
+	}
+	if err := runtime.DefaultUnstructuredConverter.
+		FromUnstructured(unstructuredObj.UnstructuredContent(), &sc); err != nil {
+		return nil, fmt.Errorf("failed to parse object into storage class: %v", obj)
+	}
+
+	// Return a copy of the object
+	return sc.DeepCopy(), nil
+}
+
+// ListStorageClasses returns a list of storage classes from the cache
+func (c *cache) ListStorageClasses() (*storagev1.StorageClassList, error) {
+	objList := c.scInformer.GetStore().List()
+	scList := storagev1.StorageClassList{}
+	for _, obj := range objList {
+		sc := storagev1.StorageClass{}
+		unstructuredObj, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse object into storage class")
+		}
+		if err := runtime.DefaultUnstructuredConverter.
+			FromUnstructured(unstructuredObj.UnstructuredContent(), &sc); err != nil {
+			return nil, fmt.Errorf("failed to parse object into storage class: %v", obj)
+		}
+
+		// Add a copy of the object to the list
+		scList.Items = append(scList.Items, *sc.DeepCopy())
+	}
+	return &scList, nil
+}
+
+// GetStorageClassForPVC returns the storage class for the provided PVC if present in cache
+func (c *cache) GetStorageClassForPVC(pvc *corev1.PersistentVolumeClaim) (*storagev1.StorageClass, error) {
+	var scName string
+	if pvc.Spec.StorageClassName != nil && len(*pvc.Spec.StorageClassName) > 0 {
+		scName = *pvc.Spec.StorageClassName
+	} else {
+		scName = pvc.Annotations[corev1.BetaStorageClassAnnotation]
+	}
+
+	if len(scName) == 0 {
+		return nil, fmt.Errorf("PVC: %s does not have a storage class", pvc.Name)
+	}
+	return c.GetStorageClass(scName)
+}
+
+// GetApplicationRegistration returns the ApplicationRegistration CR from the cache
+func (c *cache) GetApplicationRegistration(name string) (*storkv1alpha1.ApplicationRegistration, error) {
+	obj, exists, err := c.appRegInformer.GetStore().GetByKey(name)
+	if err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, k8s_errors.NewNotFound(storkv1alpha1.Resource("applicationregistration"), name)
+	}
+	appReg := storkv1alpha1.ApplicationRegistration{}
+	unstructuredObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse object into application registration")
+	}
+	if err := runtime.DefaultUnstructuredConverter.
+		FromUnstructured(unstructuredObj.UnstructuredContent(), &appReg); err != nil {
+		return nil, fmt.Errorf("failed to parse object into application registration: %v", obj)
+	}
+	// Return a copy of the object
+	return appReg.DeepCopy(), nil
+}
+
+// ListApplicationRegistrations lists the application registration CRs from the cache
+func (c *cache) ListApplicationRegistrations() (*storkv1alpha1.ApplicationRegistrationList, error) {
+	objList := c.appRegInformer.GetStore().List()
+	appRegList := storkv1alpha1.ApplicationRegistrationList{}
+	for _, obj := range objList {
+		appReg := storkv1alpha1.ApplicationRegistration{}
+		unstructuredObj, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			return nil, fmt.Errorf("failed to parse object into application registration")
+		}
+		if err := runtime.DefaultUnstructuredConverter.
+			FromUnstructured(unstructuredObj.UnstructuredContent(), &appReg); err != nil {
+			return nil, fmt.Errorf("failed to parse object into application registration: %v", obj)
+		}
+		// Add a copy of the object to the list
+		appRegList.Items = append(appRegList.Items, *appReg.DeepCopy())
+	}
+	return &appRegList, nil
+}

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/pvcwatcher/pvcwatcher.go
+++ b/pkg/pvcwatcher/pvcwatcher.go
@@ -9,9 +9,9 @@ import (
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 	"github.com/libopenstorage/stork/drivers/volume"
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	storkcache "github.com/libopenstorage/stork/pkg/cache"
 	"github.com/libopenstorage/stork/pkg/controllers"
 	"github.com/portworx/sched-ops/k8s/core"
-	"github.com/portworx/sched-ops/k8s/storage"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -124,7 +124,7 @@ func (p *PVCWatcher) handleSnapshotScheduleUpdates(pvc *corev1.PersistentVolumeC
 	if storageClassName == "" {
 		return nil
 	}
-	storageClass, err := storage.Instance().GetStorageClass(storageClassName)
+	storageClass, err := storkcache.Instance().GetStorageClass(storageClassName)
 	// Ignore if storageclass cannot be found
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -3,6 +3,8 @@ package resourcecollector
 import (
 	"context"
 	"fmt"
+	storkcache "github.com/libopenstorage/stork/pkg/cache"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"strconv"
 	"strings"
 	"time"
@@ -16,7 +18,6 @@ import (
 	"github.com/portworx/sched-ops/k8s/storage"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -216,13 +217,15 @@ func (r *ResourceCollector) GetResourceTypes(
 		return nil, err
 	}
 	var crdResources []metav1.GroupVersionKind
-	crdList, err := r.storkOps.ListApplicationRegistrations()
+	crdList, err := storkcache.Instance().ListApplicationRegistrations()
 	if err != nil {
 		logrus.Warnf("Unable to get registered crds, err %v", err)
 	} else {
-		for _, crd := range crdList.Items {
-			for _, kind := range crd.Resources {
-				crdResources = append(crdResources, kind.GroupVersionKind)
+		if crdList != nil {
+			for _, crd := range crdList.Items {
+				for _, kind := range crd.Resources {
+					crdResources = append(crdResources, kind.GroupVersionKind)
+				}
 			}
 		}
 	}
@@ -264,19 +267,18 @@ func (r *ResourceCollector) GetResourcesForType(
 		objects.resourceMap = make(map[types.UID]bool)
 	}
 
-	crbs, err := r.rbacOps.ListClusterRoleBindings()
-	if err != nil {
-		if !apierrors.IsForbidden(err) {
-			return nil, err
-		}
-	}
-
 	gvr := schema.GroupVersionResource{
 		Group:    resource.Group,
 		Version:  resource.Version,
 		Resource: resource.Name,
 	}
 
+	crbs, err := r.rbacOps.ListClusterRoleBindings()
+	if err != nil {
+		if !apierrors.IsForbidden(err) {
+			return nil, err
+		}
+	}
 	for _, ns := range namespaces {
 		var dynamicClient dynamic.ResourceInterface
 		if !resource.Namespaced {
@@ -308,7 +310,7 @@ func (r *ResourceCollector) GetResourcesForType(
 				return nil, fmt.Errorf("error casting object: %v", o)
 			}
 
-			collect, err := r.objectToBeCollected(includeObjects, labelSelectors, objects.resourceMap, runtimeObject, crbs, ns, allDrivers, opts)
+			collect, err := r.objectToBeCollected(includeObjects, labelSelectors, objects.resourceMap, runtimeObject, ns, allDrivers, opts, crbs)
 			if err != nil {
 				return nil, fmt.Errorf("error processing object %v: %v", runtimeObject, err)
 			}
@@ -328,7 +330,11 @@ func (r *ResourceCollector) GetResourcesForType(
 	if err != nil {
 		return nil, err
 	}
-	err = r.prepareResourcesForCollection(modObjects, namespaces, opts)
+	crdList, err := storkcache.Instance().ListApplicationRegistrations()
+	if err != nil {
+		logrus.Warnf("Unable to get registered crds, err %v", err)
+	}
+	err = r.prepareResourcesForCollection(modObjects, namespaces, opts, crdList)
 	if err != nil {
 		return nil, err
 	}
@@ -353,16 +359,19 @@ func (r *ResourceCollector) GetResources(
 	// Map to prevent collection of duplicate objects
 	resourceMap := make(map[types.UID]bool)
 	var crdResources []metav1.GroupVersionKind
-	crdList, err := r.storkOps.ListApplicationRegistrations()
+	crdList, err := storkcache.Instance().ListApplicationRegistrations()
 	if err != nil {
 		logrus.Warnf("Unable to get registered crds, err %v", err)
 	} else {
-		for _, crd := range crdList.Items {
-			for _, kind := range crd.Resources {
-				crdResources = append(crdResources, kind.GroupVersionKind)
+		if crdList != nil {
+			for _, crd := range crdList.Items {
+				for _, kind := range crd.Resources {
+					crdResources = append(crdResources, kind.GroupVersionKind)
+				}
 			}
 		}
 	}
+
 	crbs, err := r.rbacOps.ListClusterRoleBindings()
 	if err != nil {
 		if !apierrors.IsForbidden(err) {
@@ -430,7 +439,7 @@ func (r *ResourceCollector) GetResources(
 					// With this now a user can choose to backup all resources in a ns and some
 					// selected resources from different ns
 
-					collect, err = r.objectToBeCollected(objectToInclude, labelSelectors, resourceMap, runtimeObject, crbs, ns, allDrivers, opts)
+					collect, err = r.objectToBeCollected(objectToInclude, labelSelectors, resourceMap, runtimeObject, ns, allDrivers, opts, crbs)
 					if err != nil {
 						if apierrors.IsForbidden(err) {
 							continue
@@ -456,7 +465,7 @@ func (r *ResourceCollector) GetResources(
 		return nil, err
 	}
 
-	err = r.prepareResourcesForCollection(allObjects, namespaces, opts)
+	err = r.prepareResourcesForCollection(allObjects, namespaces, opts, crdList)
 	if err != nil {
 		return nil, err
 	}
@@ -510,10 +519,10 @@ func (r *ResourceCollector) objectToBeCollected(
 	labelSelectors map[string]string,
 	resourceMap map[types.UID]bool,
 	object runtime.Unstructured,
-	crbs *rbacv1.ClusterRoleBindingList,
 	namespace string,
 	allDrivers bool,
 	opts Options,
+	crbs *rbacv1.ClusterRoleBindingList,
 ) (bool, error) {
 	metadata, err := meta.Accessor(object)
 	if err != nil {
@@ -647,11 +656,8 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 	objects []runtime.Unstructured,
 	namespaces []string,
 	opts Options,
+	crdList *stork_api.ApplicationRegistrationList,
 ) error {
-	crdList, err := r.storkOps.ListApplicationRegistrations()
-	if err != nil {
-		logrus.Warnf("Unable to get registered crds, err %v", err)
-	}
 	for _, o := range objects {
 		metadata, err := meta.Accessor(o)
 		if err != nil {
@@ -704,7 +710,6 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 						kind.Version == resourceKind.Version {
 						// remove status from crd
 						if !kind.KeepStatus {
-
 							delete(content, "status")
 						}
 

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -161,7 +161,6 @@ func triggerMigration(
 	return ctxs, preMigrationCtx
 }
 
-//
 // validateMigrationSummary validats the migration summary
 // currently we don't have an automated way to find out how many resources got deployed
 // through torpedo specs. For ex. a statefulset can have an inline PVC and that should

--- a/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicinformer
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamiclister"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory for all namespaces.
+func NewDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration) DynamicSharedInformerFactory {
+	return NewFilteredDynamicSharedInformerFactory(client, defaultResync, metav1.NamespaceAll, nil)
+}
+
+// NewFilteredDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory.
+// Listers obtained via this factory will be subject to the same filters as specified here.
+func NewFilteredDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions TweakListOptionsFunc) DynamicSharedInformerFactory {
+	return &dynamicSharedInformerFactory{
+		client:           client,
+		defaultResync:    defaultResync,
+		namespace:        namespace,
+		informers:        map[schema.GroupVersionResource]informers.GenericInformer{},
+		startedInformers: make(map[schema.GroupVersionResource]bool),
+		tweakListOptions: tweakListOptions,
+	}
+}
+
+type dynamicSharedInformerFactory struct {
+	client        dynamic.Interface
+	defaultResync time.Duration
+	namespace     string
+
+	lock      sync.Mutex
+	informers map[schema.GroupVersionResource]informers.GenericInformer
+	// startedInformers is used for tracking which informers have been started.
+	// This allows Start() to be called multiple times safely.
+	startedInformers map[schema.GroupVersionResource]bool
+	tweakListOptions TweakListOptionsFunc
+}
+
+var _ DynamicSharedInformerFactory = &dynamicSharedInformerFactory{}
+
+func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResource) informers.GenericInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	key := gvr
+	informer, exists := f.informers[key]
+	if exists {
+		return informer
+	}
+
+	informer = NewFilteredDynamicInformer(f.client, gvr, f.namespace, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	f.informers[key] = informer
+
+	return informer
+}
+
+// Start initializes all requested informers.
+func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	for informerType, informer := range f.informers {
+		if !f.startedInformers[informerType] {
+			go informer.Informer().Run(stopCh)
+			f.startedInformers[informerType] = true
+		}
+	}
+}
+
+// WaitForCacheSync waits for all started informers' cache were synced.
+func (f *dynamicSharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool {
+	informers := func() map[schema.GroupVersionResource]cache.SharedIndexInformer {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+
+		informers := map[schema.GroupVersionResource]cache.SharedIndexInformer{}
+		for informerType, informer := range f.informers {
+			if f.startedInformers[informerType] {
+				informers[informerType] = informer.Informer()
+			}
+		}
+		return informers
+	}()
+
+	res := map[schema.GroupVersionResource]bool{}
+	for informType, informer := range informers {
+		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	}
+	return res
+}
+
+// NewFilteredDynamicInformer constructs a new informer for a dynamic type.
+func NewFilteredDynamicInformer(client dynamic.Interface, gvr schema.GroupVersionResource, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions TweakListOptionsFunc) informers.GenericInformer {
+	return &dynamicInformer{
+		gvr: gvr,
+		informer: cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).List(context.TODO(), options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).Watch(context.TODO(), options)
+				},
+			},
+			&unstructured.Unstructured{},
+			resyncPeriod,
+			indexers,
+		),
+	}
+}
+
+type dynamicInformer struct {
+	informer cache.SharedIndexInformer
+	gvr      schema.GroupVersionResource
+}
+
+var _ informers.GenericInformer = &dynamicInformer{}
+
+func (d *dynamicInformer) Informer() cache.SharedIndexInformer {
+	return d.informer
+}
+
+func (d *dynamicInformer) Lister() cache.GenericLister {
+	return dynamiclister.NewRuntimeObjectShim(dynamiclister.New(d.informer.GetIndexer(), d.gvr))
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicinformer
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+)
+
+// DynamicSharedInformerFactory provides access to a shared informer and lister for dynamic client
+type DynamicSharedInformerFactory interface {
+	Start(stopCh <-chan struct{})
+	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+}
+
+// TweakListOptionsFunc defines the signature of a helper function
+// that wants to provide more listing options to API
+type TweakListOptionsFunc func(*metav1.ListOptions)

--- a/vendor/k8s.io/client-go/dynamic/dynamiclister/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamiclister/interface.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Lister helps list resources.
+type Lister interface {
+	// List lists all resources in the indexer.
+	List(selector labels.Selector) (ret []*unstructured.Unstructured, err error)
+	// Get retrieves a resource from the indexer with the given name
+	Get(name string) (*unstructured.Unstructured, error)
+	// Namespace returns an object that can list and get resources in a given namespace.
+	Namespace(namespace string) NamespaceLister
+}
+
+// NamespaceLister helps list and get resources.
+type NamespaceLister interface {
+	// List lists all resources in the indexer for a given namespace.
+	List(selector labels.Selector) (ret []*unstructured.Unstructured, err error)
+	// Get retrieves a resource from the indexer for a given namespace and name.
+	Get(name string) (*unstructured.Unstructured, error)
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamiclister/lister.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamiclister/lister.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ Lister = &dynamicLister{}
+var _ NamespaceLister = &dynamicNamespaceLister{}
+
+// dynamicLister implements the Lister interface.
+type dynamicLister struct {
+	indexer cache.Indexer
+	gvr     schema.GroupVersionResource
+}
+
+// New returns a new Lister.
+func New(indexer cache.Indexer, gvr schema.GroupVersionResource) Lister {
+	return &dynamicLister{indexer: indexer, gvr: gvr}
+}
+
+// List lists all resources in the indexer.
+func (l *dynamicLister) List(selector labels.Selector) (ret []*unstructured.Unstructured, err error) {
+	err = cache.ListAll(l.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*unstructured.Unstructured))
+	})
+	return ret, err
+}
+
+// Get retrieves a resource from the indexer with the given name
+func (l *dynamicLister) Get(name string) (*unstructured.Unstructured, error) {
+	obj, exists, err := l.indexer.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(l.gvr.GroupResource(), name)
+	}
+	return obj.(*unstructured.Unstructured), nil
+}
+
+// Namespace returns an object that can list and get resources from a given namespace.
+func (l *dynamicLister) Namespace(namespace string) NamespaceLister {
+	return &dynamicNamespaceLister{indexer: l.indexer, namespace: namespace, gvr: l.gvr}
+}
+
+// dynamicNamespaceLister implements the NamespaceLister interface.
+type dynamicNamespaceLister struct {
+	indexer   cache.Indexer
+	namespace string
+	gvr       schema.GroupVersionResource
+}
+
+// List lists all resources in the indexer for a given namespace.
+func (l *dynamicNamespaceLister) List(selector labels.Selector) (ret []*unstructured.Unstructured, err error) {
+	err = cache.ListAllByNamespace(l.indexer, l.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*unstructured.Unstructured))
+	})
+	return ret, err
+}
+
+// Get retrieves a resource from the indexer for a given namespace and name.
+func (l *dynamicNamespaceLister) Get(name string) (*unstructured.Unstructured, error) {
+	obj, exists, err := l.indexer.GetByKey(l.namespace + "/" + name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(l.gvr.GroupResource(), name)
+	}
+	return obj.(*unstructured.Unstructured), nil
+}

--- a/vendor/k8s.io/client-go/dynamic/dynamiclister/shim.go
+++ b/vendor/k8s.io/client-go/dynamic/dynamiclister/shim.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ cache.GenericLister = &dynamicListerShim{}
+var _ cache.GenericNamespaceLister = &dynamicNamespaceListerShim{}
+
+// dynamicListerShim implements the cache.GenericLister interface.
+type dynamicListerShim struct {
+	lister Lister
+}
+
+// NewRuntimeObjectShim returns a new shim for Lister.
+// It wraps Lister so that it implements cache.GenericLister interface
+func NewRuntimeObjectShim(lister Lister) cache.GenericLister {
+	return &dynamicListerShim{lister: lister}
+}
+
+// List will return all objects across namespaces
+func (s *dynamicListerShim) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	objs, err := s.lister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]runtime.Object, len(objs))
+	for index, obj := range objs {
+		ret[index] = obj
+	}
+	return ret, err
+}
+
+// Get will attempt to retrieve assuming that name==key
+func (s *dynamicListerShim) Get(name string) (runtime.Object, error) {
+	return s.lister.Get(name)
+}
+
+func (s *dynamicListerShim) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	return &dynamicNamespaceListerShim{
+		namespaceLister: s.lister.Namespace(namespace),
+	}
+}
+
+// dynamicNamespaceListerShim implements the NamespaceLister interface.
+// It wraps NamespaceLister so that it implements cache.GenericNamespaceLister interface
+type dynamicNamespaceListerShim struct {
+	namespaceLister NamespaceLister
+}
+
+// List will return all objects in this namespace
+func (ns *dynamicNamespaceListerShim) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	objs, err := ns.namespaceLister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]runtime.Object, len(objs))
+	for index, obj := range objs {
+		ret[index] = obj
+	}
+	return ret, err
+}
+
+// Get will attempt to retrieve by namespace and name
+func (ns *dynamicNamespaceListerShim) Get(name string) (runtime.Object, error) {
+	return ns.namespaceLister.Get(name)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1422,6 +1422,8 @@ k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
+k8s.io/client-go/dynamic/dynamicinformer
+k8s.io/client-go/dynamic/dynamiclister
 k8s.io/client-go/dynamic/fake
 k8s.io/client-go/informers
 k8s.io/client-go/informers/admissionregistration


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>improvement

**What this PR does / why we need it**:
The GetStorageClass and ListApplicationRegistration APIs are the most frequently used by k8s APIs by stork and they end up consuming a lot of k8s api rate limiting tokens. We end up with seeing the following log messages:

```
I1122 02:46:05.347107       1 request.go:668] Waited for 2.188254327s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/storage.k8s.io/v1/storageclasses/px-csi-block
I1122 02:46:15.347444       1 request.go:668] Waited for 2.193815761s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/storage.k8s.io/v1/storageclasses/px-ha-sc
I1122 02:46:25.547732       1 request.go:668] Waited for 2.192176912s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/storage.k8s.io/v1/storageclasses/px-ha-sc
I1122 02:46:35.746995       1 request.go:668] Waited for 2.191884856s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/storage.k8s.io/v1/storageclasses/px-ha-sc
``` 

This causes overall delays in completing operations like Migrations and Backups. 

This PR aims at introducing a shared cache for managing two objects:
- StorageClass
- ApplicationRegistration.

It uses the dynamic shared informer cache provided by k8s/client-go.
- This cache is eventually consistent. Hence storing StorageClasses and
  ApplicationRegistration objects which are not bound to change that often.
- The cache has a wrapper API to Get & List these two types of objects.
- Changed all the occurences of Gets & Lists to use this new cache in the
following places which tend to make the most number of k8s API calls:
  - Portworx Driver
  - Migration Controllers
  - PVC Watcher
  - Resource Collector


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
TBD
```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.12.1


**Testing Notes**
Currently testing on OCP.
- 44 PV and 44 PVC objects

With stork 2.12 the migration times for just PV and PVCs is 8mins
```
root@ip-10-13-107-197:~/metro-dr/demo-mongo# storkctl get migrations -n kube-system
NAME                                 CLUSTERPAIR     STAGE          STATUS       VOLUMES   RESOURCES   CREATED               ELAPSED                                  TOTAL BYTES TRANSFERRED
win-mig-interval-2022-11-22-031317   remotecluster   Final          Successful   0/0       88/88       22 Nov 22 03:13 UTC   Volumes () Resources (8m20.737726582s)   0
```

With these changes the time drops to 1min
```
root@ip-10-13-107-197:~/metro-dr/demo-mongo# storkctl get migrations -n kube-system         
NAME                                 CLUSTERPAIR     STAGE          STATUS       VOLUMES   RESOURCES   CREATED               ELAPSED                                  TOTAL BYTES
TRANSFERRED                                                                                                                                                                       
win-mig-interval-2022-11-22-023508   remotecluster   Final          Successful   0/0       88/88       22 Nov 22 02:35 UTC   Volumes () Resources (1m11.501437416s)   0
```

The improvement is almost 8x! However this improvement is only applicable if we are getting rate limited. If we are not getting rate limited, the minimum time taken will be around 1 min. 

Planning to do more tests as well as run this change through Migration, Backup & Scheduler integration tests.