### PR TITLE
Cherry-pick antihyperconvergence and csi pod scheduling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: go
 go:
-  - 1.17.11
+  - 1.18.3
 before_install:
   - sudo apt-get update -yq || true
   - sudo apt-get install go-md2man -y

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ vet:
 	go vet -tags integrationtest github.com/libopenstorage/stork/test/integration_test
 
 staticcheck:
-	GOFLAGS="" go install honnef.co/go/tools/cmd/staticcheck@v0.2.2
+	GOFLAGS="" go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 	staticcheck $(PKGS)
 	staticcheck -tags integrationtest test/integration_test/*.go
 	staticcheck -tags unittest $(PKGS)

--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -657,6 +657,11 @@ func (a *aws) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPa
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *aws) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	a := &aws{}
 	err := a.Init(nil)

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -679,6 +679,11 @@ func (a *azure) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSON
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *azure) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	a := &azure{}
 	err := a.Init(nil)

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -1908,6 +1908,11 @@ func (c *csi) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPa
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *csi) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	c := &csi{}
 	err := c.Init(nil)

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -660,6 +660,11 @@ func (g *gcp) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPa
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *gcp) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	g := &gcp{}
 	err := g.Init(nil)

--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -1013,6 +1013,11 @@ func (k *kdmp) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONP
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *kdmp) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	a := &kdmp{}
 

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -449,6 +449,11 @@ func (l *linstor) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JS
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *linstor) GetCSIPodPrefix() (string, error) {
+	return "", &errors.ErrNotSupported{}
+}
+
 func init() {
 	l := &linstor{}
 	if err := storkvolume.Register(storkvolume.LinstorDriverName, l); err != nil {

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -143,16 +143,18 @@ func (m *Driver) ProvisionVolume(
 	replicaIndexes []int,
 	size uint64,
 	labels map[string]string,
+	isSharedV4Service bool,
 ) error {
 	if _, ok := m.volumes[volumeName]; ok {
 		return fmt.Errorf("volume %v already exists", volumeName)
 	}
 
 	volume := &storkvolume.Info{
-		VolumeID:   volumeName,
-		VolumeName: volumeName,
-		Size:       size,
-		Labels:     labels,
+		VolumeID:            volumeName,
+		VolumeName:          volumeName,
+		Size:                size,
+		Labels:              labels,
+		IsSharedV4SvcVolume: isSharedV4Service,
 	}
 
 	for i := 0; i < len(replicaIndexes); i++ {

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -143,18 +143,18 @@ func (m *Driver) ProvisionVolume(
 	replicaIndexes []int,
 	size uint64,
 	labels map[string]string,
-	isSharedV4Service bool,
+	needsAntiHyperconvergence bool,
 ) error {
 	if _, ok := m.volumes[volumeName]; ok {
 		return fmt.Errorf("volume %v already exists", volumeName)
 	}
 
 	volume := &storkvolume.Info{
-		VolumeID:            volumeName,
-		VolumeName:          volumeName,
-		Size:                size,
-		Labels:              labels,
-		IsSharedV4SvcVolume: isSharedV4Service,
+		VolumeID:                  volumeName,
+		VolumeName:                volumeName,
+		Size:                      size,
+		Labels:                    labels,
+		NeedsAntiHyperconvergence: needsAntiHyperconvergence,
 	}
 
 	for i := 0; i < len(replicaIndexes); i++ {

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -321,6 +321,11 @@ func (m *Driver) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSO
 	return nil, nil
 }
 
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *Driver) GetCSIPodPrefix() (string, error) {
+	return "px-csi-ext", nil
+}
+
 func init() {
 	if err := storkvolume.Register(driverName, &Driver{}); err != nil {
 		logrus.Panicf("Error registering mock volume driver: %v", err)

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -492,6 +492,7 @@ func (p *portworx) inspectVolume(volDriver volume.VolumeDriver, volumeID string)
 
 	info := &storkvolume.Info{}
 	info.VolumeID = vols[0].Id
+
 	info.VolumeName = vols[0].Locator.Name
 	for _, rset := range vols[0].ReplicaSets {
 		info.DataNodes = append(info.DataNodes, rset.Nodes...)
@@ -513,8 +514,9 @@ func (p *portworx) inspectVolume(volDriver volume.VolumeDriver, volumeID string)
 	for k, v := range vols[0].Locator.GetVolumeLabels() {
 		info.Labels[k] = v
 	}
-
+	info.IsSharedV4SvcVolume = vols[0].Spec.Sharedv4 && vols[0].Spec.Sharedv4ServiceSpec != nil
 	info.VolumeSourceRef = vols[0]
+
 	return info, nil
 }
 

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -155,6 +155,8 @@ const (
 	restoreNamePrefix = "in-place-restore-"
 	restoreTaskPrefix = "restore-"
 
+	csiPodNamePrefix = "px-csi-ext"
+
 	// Annotation to skip checking if the backup is being done to the same
 	// BackupLocationName
 	skipBackupLocationNameCheckAnnotation = "portworx.io/skip-backup-location-name-check"
@@ -4057,6 +4059,11 @@ func (p *portworx) CleanupRestoreResources(*storkapi.ApplicationRestore) error {
 // GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
 func (p *portworx) GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {
 	return p.getVirtLauncherPatches(podNamespace, pod)
+}
+
+// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+func (a *portworx) GetCSIPodPrefix() (string, error) {
+	return csiPodNamePrefix, nil
 }
 
 func (p *portworx) getVirtLauncherPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -514,7 +514,7 @@ func (p *portworx) inspectVolume(volDriver volume.VolumeDriver, volumeID string)
 	for k, v := range vols[0].Locator.GetVolumeLabels() {
 		info.Labels[k] = v
 	}
-	info.IsSharedV4SvcVolume = vols[0].Spec.Sharedv4 && vols[0].Spec.Sharedv4ServiceSpec != nil
+	info.NeedsAntiHyperconvergence = vols[0].Spec.Sharedv4 && vols[0].Spec.Sharedv4ServiceSpec != nil
 	info.VolumeSourceRef = vols[0]
 
 	return info, nil

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -273,6 +273,8 @@ type Info struct {
 	Labels map[string]string
 	// VolumeSourceRef is a optional reference to the source of the volume
 	VolumeSourceRef interface{}
+	// IsSharedV4SvcVolume is a flag for figuring if it's  sharedv4 service volume
+	IsSharedV4SvcVolume bool
 }
 
 // NodeStatus Status of driver on a node

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -141,6 +141,9 @@ type Driver interface {
 	// GetPodPatches returns driver-specific json patches to mutate the pod in a webhook
 	GetPodPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error)
 
+	// GetCSIPodPrefix returns prefix for the csi pod names in the deployment
+	GetCSIPodPrefix() (string, error)
+
 	// GroupSnapshotPluginInterface Interface for group snapshots
 	GroupSnapshotPluginInterface
 	// ClusterPairPluginInterface Interface to pair clusters

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -273,8 +273,8 @@ type Info struct {
 	Labels map[string]string
 	// VolumeSourceRef is a optional reference to the source of the volume
 	VolumeSourceRef interface{}
-	// IsSharedV4SvcVolume is a flag for figuring if it's  sharedv4 service volume
-	IsSharedV4SvcVolume bool
+	// NeedsAntiHyperconvergence is a flag for figuring if Pod needs anti-hyperconvergence
+	NeedsAntiHyperconvergence bool
 }
 
 // NodeStatus Status of driver on a node

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -30,7 +30,6 @@ const (
 	nodeWaitFactor       = 2
 	nodeWaitSteps        = 5
 
-	CSIPodNamePrefix           = "px-csi-ext"
 	storageDriverOfflineReason = "StorageDriverOffline"
 )
 
@@ -149,7 +148,7 @@ func (m *Monitor) podMonitor() error {
 		if podUnknownState {
 			csiPodPrefix, err := m.Driver.GetCSIPodPrefix()
 			if err == nil && strings.HasPrefix(pod.Name, csiPodPrefix) {
-				msg = "Force deleting csi-ext-pod as it's in unknown state."
+				msg = "Force deleting csi pod as it's in unknown state."
 				storklog.PodLog(pod).Infof(msg)
 			} else {
 				owns, err := m.doesDriverOwnPodVolumes(pod)
@@ -257,7 +256,7 @@ func (m *Monitor) cleanupDriverNodePods(node *volume.NodeInfo) {
 		var msg string
 		csiPodPrefix, err := m.Driver.GetCSIPodPrefix()
 		if err == nil && strings.HasPrefix(pod.Name, csiPodPrefix) {
-			msg = fmt.Sprintf("Deleting px-csi-ext pod from Node %v due to volume driver status: %v (%v)", pod.Spec.NodeName, node.Status, node.RawStatus)
+			msg = fmt.Sprintf("Deleting csi pod from Node %v due to volume driver status: %v (%v)", pod.Spec.NodeName, node.Status, node.RawStatus)
 
 		} else {
 			msg = fmt.Sprintf("Deleting Pod from Node %v due to volume driver status: %v (%v)", pod.Spec.NodeName, node.Status, node.RawStatus)

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -106,13 +106,13 @@ func setup(t *testing.T) {
 	err = driver.UpdateNodeStatus(5, volume.NodeOffline)
 	require.NoError(t, err, "Error setting node status to Offline")
 
-	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil)
+	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil, false)
 	require.NoError(t, err, "Error provisioning volume")
 
-	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil)
+	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil, false)
 	require.NoError(t, err, "Error provisioning volume")
 
-	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil)
+	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil, false)
 	require.NoError(t, err, "Error provisioning volume")
 
 	eventBroadcaster := record.NewBroadcaster()


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>feature
>improvement
>unit-test


**What this PR does / why we need it**:
Cherry pick Antihyperconvergence and CSI-Ext Pods Scheduling changes to 2.12.2

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
*Antihyperconvergence:
Stork will try to schedule application pods using SharedV4 service volumes to run on nodes where volume replica does not exist such that it uses NFS mountpoint and when a failover happens application pods will not be restarted.
 StorageClass parameter "stork.libopenstorage.org/preferRemoteNodeOnly": "true" can be used to strictly enforce this behavior.

*CSI-Ext Pods Scheduling:
Issue: 
When CSI is enabled, PVC provisioning goes through a deployment of 3 replicas of px-csi-ext-* pods. If PX on 
any of these nodes goes down, none of the PVC creations would succeed even if the PX cluster is operational. 
User Impact:
If PX goes down on a node where CSI Pod is deployed,  PVC requests on that Pod does not succeed.
Resolution:
Set Stork as the default scheduler for px-csi-ext-* pods. If Stork detects that these pods are running on an offline Portworx node, delete the CSI Pod. When Stork gets a scheduling request for such a Pod, it can place the Pods on the Node where PX is operational. 


```

**Does this change need to be cherry-picked to a release branch?**:
no

