### PR TITLE
PWX-27596: Limiting number of errored volumesnapshots in a volumesnapshotschedule.

### DIFF
--- a/pkg/snapshot/controllers/snapshotschedule.go
+++ b/pkg/snapshot/controllers/snapshotschedule.go
@@ -383,6 +383,7 @@ func (s *SnapshotScheduleController) pruneVolumeSnapshots(snapshotSchedule *stor
 			return err
 		}
 		numReady := 0
+		numError := 0
 
 		// Keep up to retainNum successful snapshot statuses and all failed snapshots
 		// until there is a successful one
@@ -395,9 +396,15 @@ func (s *SnapshotScheduleController) pruneVolumeSnapshots(snapshotSchedule *stor
 						deleteBefore = numVolumeSnapshots - i
 						break
 					}
+				} else if policyVolumeSnapshot[(numVolumeSnapshots-1-i)].Status == snapv1.VolumeSnapshotConditionError {
+					numError++
 				}
 			}
 			failedDeletes := make([]*stork_api.ScheduledVolumeSnapshotStatus, 0)
+			// If number of ready snapshots are greater than the retain value,
+			// delete all the snapshots before the deleteBefore index
+			// else as there are already snapshots more than the retain values
+			// try to delete the error snapshots more than the retain value
 			if numReady > int(retainNum) {
 				for i := 0; i < deleteBefore; i++ {
 					err := k8sextops.Instance().DeleteSnapshot(policyVolumeSnapshot[i].Name, snapshotSchedule.Namespace)
@@ -407,12 +414,39 @@ func (s *SnapshotScheduleController) pruneVolumeSnapshots(snapshotSchedule *stor
 						failedDeletes = append(failedDeletes, policyVolumeSnapshot[i])
 					}
 				}
+				// Remove all the ones we tried to delete above
+				snapshotSchedule.Status.Items[policyType] = policyVolumeSnapshot[deleteBefore:]
+				// And re-add the ones that failed so that we don't lose track
+				// of them
+				snapshotSchedule.Status.Items[policyType] = append(failedDeletes, snapshotSchedule.Status.Items[policyType]...)
+			} else if numError > 1 {
+				modPolicyVolumeSnapshot := make([]*stork_api.ScheduledVolumeSnapshotStatus, 0)
+				excessSnapshots := numVolumeSnapshots - int(retainNum)
+				includeIndex := 0
+				// Only going to loop till the last but one snapshot,
+				// we don't need to delete the latest snapshot which has just now been created but in error state
+				for i := 0; i < len(policyVolumeSnapshot)-1; i++ {
+					inList := true
+					if policyVolumeSnapshot[i].Status == snapv1.VolumeSnapshotConditionError {
+						log.VolumeSnapshotScheduleLog(snapshotSchedule).Infof("Going to delete snapshot %s in error state as part of pruning", policyVolumeSnapshot[i].Name)
+						err := k8sextops.Instance().DeleteSnapshot(policyVolumeSnapshot[i].Name, snapshotSchedule.Namespace)
+						if err != nil && !errors.IsNotFound(err) {
+							log.VolumeSnapshotScheduleLog(snapshotSchedule).Warnf("Error deleting %v: %v", policyVolumeSnapshot[i].Name, err)
+						} else {
+							excessSnapshots--
+							inList = false
+						}
+					}
+					if inList {
+						modPolicyVolumeSnapshot = append(modPolicyVolumeSnapshot, policyVolumeSnapshot[i])
+					}
+					includeIndex = i + 1
+					if excessSnapshots < 1 {
+						break
+					}
+				}
+				snapshotSchedule.Status.Items[policyType] = append(modPolicyVolumeSnapshot, policyVolumeSnapshot[includeIndex:]...)
 			}
-			// Remove all the ones we tried to delete above
-			snapshotSchedule.Status.Items[policyType] = policyVolumeSnapshot[deleteBefore:]
-			// And re-add the ones that failed so that we don't lose track
-			// of them
-			snapshotSchedule.Status.Items[policyType] = append(failedDeletes, snapshotSchedule.Status.Items[policyType]...)
 		}
 	}
 	return s.client.Update(context.TODO(), snapshotSchedule)


### PR DESCRIPTION
Also limiting the volumesnapshotname has been added.

Signed-Off-By: Diptiranjan

**What type of PR is this?**
improvement


**What this PR does / why we need it**:
Because of errored snapshots were growing once the snapshot failure on volume is seen, we need to limit the number of errored snapshots by smartly deleting the older errored snapshots.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
2.12
-->

**Test**
Functional tests for this have been updated in PWX-27596.