### PR TITLE
linter-tools cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,10 @@ revive: $(GOPATH)/bin/revive
 
 pretest: check-fmt vet errcheck staticcheck
 
+docker-pretest:
+	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork $(DOCK_BUILD_CNT) \
+	  make -C /go/src/github.com/libopenstorage/stork check-fmt vet errcheck staticcheck
+
 test:
 	echo "" > coverage.txt
 	for pkg in $(PKGS);	do \


### PR DESCRIPTION
* updated Makefile-rules to download linter tools only if they are missing

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

improvement

**What this PR does / why we need it**:
The go-linter tools (such as `staticcheck`, `errcheck`) were downloaded/installed with every `make all` build.

* updated Makefile-rules to download the go-linter tools only if they are missing from `$GOPATH/bin` directory
* updated tools-build syntax to use `go install` instead of deprecated `go get`
* also added `make revive` linter
* the `make all` now looks "cleaner":

```
$ make all
Building the stork binary
/go/src/github.com/libopenstorage/stork/cmd/stork
Building storkctl
/go/src/github.com/libopenstorage/stork/cmd/storkctl
/go/src/github.com/libopenstorage/stork/cmd/storkctl
/go/src/github.com/libopenstorage/stork/cmd/storkctl
Building command executor binary
/src/github.com/libopenstorage/stork/cmd/cmdexecutor
# gofmt check ...
# go-vet checks ...
# errcheck checks ...
# staticcheck checks ...
Building px_statfs.so
/src/github.com/libopenstorage/stork/drivers/volume/portworx/px-statfs
```

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
no
