### PR TITLE
Makefile changes to enable build system to use DOCK_BUILD_CNT

### DIFF
--- a/Dockerfile.cmdexecutor
+++ b/Dockerfile.cmdexecutor
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7-atomic
+FROM registry.access.redhat.com/ubi8-minimal:latest
 MAINTAINER Portworx Inc. <support@portworx.com>
 
 LABEL name="openstorage/cmdexecutor" \

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ DOCK_BUILD_CNT	:= golang:1.18.3
 docker-build:
 	@echo "Building using docker"
 	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork $(DOCK_BUILD_CNT) \
-		/bin/bash -c "cd /go/src/github.com/libopenstorage/stork; apt update || true && apt install go-md2man awscli -y; make -j 2 && make test && make container && \
-		make integration-test && make integration-test-container"
+		/bin/bash -c "cd /go/src/github.com/libopenstorage/stork; apt update || true && apt install go-md2man awscli -y; make -j 2 && make test && \
+		make integration-test"
 
 gocyclo:
 	GO111MODULE=off go get -u github.com/fzipp/gocyclo

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ px-statfs:
 	@echo "Building px_statfs.so"
 	@cd drivers/volume/portworx/px-statfs && gcc -g -shared -fPIC -o $(BIN)/px_statfs.so px_statfs.c -ldl -D__USE_LARGEFILE64
 
-container: help
+container: 
 	@echo "Building container: docker build --build-arg VERSION=$(DOCKER_HUB_STORK_TAG) --build-arg RELEASE=$(DOCKER_HUB_STORK_TAG) --tag $(STORK_IMG) -f Dockerfile . "
 	sudo docker build --build-arg VERSION=$(DOCKER_HUB_STORK_TAG) --build-arg RELEASE=$(DOCKER_HUB_STORK_TAG) --tag $(STORK_IMG) -f Dockerfile .
 

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ docker-build:
 	@echo "Building using docker"
 	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork $(DOCK_BUILD_CNT) \
 		/bin/bash -c "cd /go/src/github.com/libopenstorage/stork; apt update || true && apt install go-md2man awscli -y; make -j 2 && make test && \
-		make integration-test"
+		make integration-test; make help"
 
 gocyclo:
 	GO111MODULE=off go get -u github.com/fzipp/gocyclo

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,13 @@ check-fmt:
 do-fmt:
 	 gofmt -s -w $(GO_FILES)
 
+DOCK_BUILD_CNT	:= golang:1.18.3
+docker-build:
+	@echo "Building using docker"
+	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork $(DOCK_BUILD_CNT) \
+		/bin/bash -c "cd /go/src/github.com/libopenstorage/stork; apt update || true && apt install go-md2man awscli -y; make -j 2 && make test && make container && \
+		make integration-test && make integration-test-container"
+
 gocyclo:
 	GO111MODULE=off go get -u github.com/fzipp/gocyclo
 	gocyclo -over 15 $(GO_FILES)

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ integration-test:
 
 integration-test-container:
 	@echo "Building container: docker build --tag $(STORK_TEST_IMG) -f Dockerfile ."
-	@cd test/integration_test && sudo docker build --tag $(STORK_TEST_IMG) -f Dockerfile .
+	@cd test/integration_test && sudo docker build --pull --tag $(STORK_TEST_IMG) -f Dockerfile .
 
 integration-test-deploy:
 	sudo docker push $(STORK_TEST_IMG)
@@ -144,10 +144,10 @@ px-statfs:
 
 container: 
 	@echo "Building container: docker build --build-arg VERSION=$(DOCKER_HUB_STORK_TAG) --build-arg RELEASE=$(DOCKER_HUB_STORK_TAG) --tag $(STORK_IMG) -f Dockerfile . "
-	sudo docker build --build-arg VERSION=$(DOCKER_HUB_STORK_TAG) --build-arg RELEASE=$(DOCKER_HUB_STORK_TAG) --tag $(STORK_IMG) -f Dockerfile .
+	sudo docker build --pull --build-arg VERSION=$(DOCKER_HUB_STORK_TAG) --build-arg RELEASE=$(DOCKER_HUB_STORK_TAG) --tag $(STORK_IMG) -f Dockerfile .
 
 	@echo "Building container: docker build --tag $(CMD_EXECUTOR_IMG) -f Dockerfile.cmdexecutor ."
-	sudo docker build --tag $(CMD_EXECUTOR_IMG) -f Dockerfile.cmdexecutor .
+	sudo docker build --pull --tag $(CMD_EXECUTOR_IMG) -f Dockerfile.cmdexecutor .
 
 help:
 	@echo "Updating help file"


### PR DESCRIPTION
**What type of PR is this?**
>build improvement

**What this PR does / why we need it**:
This PR enables the build system to use DOCK_BUILD_CNT i.e go docker build container. 

Makefile updates with docker build --pull command to enable always pull the latest base feature while building. It's usually a good practice to use it to get upstream security fixes incorporated as soon as possible (instead of using stale, potentially vulnerable images)

**Does this PR change a user-facing CRD or CLI?**:
No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->


**Does this change need to be cherry-picked to a release branch?**:
No
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

