### PR TITLE
PWX-28159: Fix health monitor and extender integration test failures

### DIFF
--- a/test/integration_test/extender_test.go
+++ b/test/integration_test/extender_test.go
@@ -299,10 +299,6 @@ func antihyperconvergenceTestPreferRemoteOnlyTest(t *testing.T) {
 		if schedNode.IsStorageDriverInstalled {
 			err = core.Instance().CordonNode(schedNode.Name, defaultWaitTimeout, defaultWaitInterval)
 			require.NoError(t, err, "Error cordorning k8s node for stork test pod")
-			defer func() {
-				err = core.Instance().UnCordonNode(schedNode.Name, defaultWaitTimeout, defaultWaitInterval)
-				require.NoError(t, err, "Error uncordorning k8s node for stork test pod")
-			}()
 		}
 	}
 
@@ -322,6 +318,13 @@ func antihyperconvergenceTestPreferRemoteOnlyTest(t *testing.T) {
 	require.Error(t, err, "Expected an error while scheduling the pod")
 
 	destroyAndWait(t, ctxs)
+
+	// Uncordon all the nodes after test
+	nodeNameMap := node.GetNodesByName()
+	for _, schedNode := range nodeNameMap {
+		err = core.Instance().UnCordonNode(schedNode.Name, defaultWaitTimeout, defaultWaitInterval)
+		require.NoError(t, err, "Error uncordorning k8s node for stork test pod")
+	}
 }
 
 func verifyAntihyperconvergence(t *testing.T, appNodes []node.Node, volumes []string) {


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>


**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
Fix integration test failures
1. extender_test : defer has function scope and uncordon was not being executed for all the nodes due to which subsequent tests were failing
2. health_monitor_test:  We have a 4 worker node config in our integration test jobs. 3 nodes to run CSI pods and one node for failover. So the logic to stop volume driver on other nodes is not needed to test failover so commented that code.
Absence of KubeSchedulerConfiguration based stork scheduler, make multiple pods to run on single node sometime and we end up stopping px on more nodes than we intended and can not find the node to failover. This can be re enabled once the fix is integrated in operator so keeping the code commented here.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes 2.12.2

