### PR TITLE
PWX-28233: Add a nil check for SkipDeletedNamespaces in migration controller

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -347,7 +347,7 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 		for _, ns := range migration.Spec.Namespaces {
 			_, err := core.Instance().GetNamespace(ns)
 			if err != nil {
-				if *migration.Spec.SkipDeletedNamespaces {
+				if migration.Spec.SkipDeletedNamespaces != nil && *migration.Spec.SkipDeletedNamespaces {
 					// Instead of throwing an error here check for the SkipDeletedNamespaces  flag
 					// and based on that either throw an error or continue for deleted namespaces
 					migration.Status.Status = stork_api.MigrationStatusInitial


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
If a namespace listed in Migration or MigrationSchedule object, does not exist anymore stork would hit a nil panic if "SkipDeletedNamespaces" boolean is not set.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

-->
```release-note
Issue: Stork will hit a nil panic when SkipDeletedNamespaces is not set in Migration or MigrationSchedule object and a migation is requested for a deleted namespace.
User Impact: Stork pod will restart and migrations won't succeed.
Resolution: The nil panic is now handled in Stork. 

```

**Does this change need to be cherry-picked to a release branch?**:
Yes -2.12.2 
