### PR TITLE
PWX-28300: Add opsmanagers as the Plural form of MongoDBOpsManager CR plural set.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1051,6 +1051,8 @@ func (a *ApplicationBackupController) uploadCRDResources(backup *stork_api.Appli
 	ruleset.AddPlural("quota", "quotas")
 	ruleset.AddPlural("prometheus", "prometheuses")
 	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
+	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
+	ruleset.AddPlural("mongodb", "mongodb")
 	v1CrdApiReqrd, err := version.RequiresV1Registration()
 	if err != nil {
 		return err

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1529,6 +1529,8 @@ func (m *MigrationController) applyResources(
 	ruleset.AddPlural("quota", "quotas")
 	ruleset.AddPlural("prometheus", "prometheuses")
 	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
+	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
+	ruleset.AddPlural("mongodb", "mongodb")
 	// create CRD on destination cluster
 	for _, crd := range crdList.Items {
 		for _, v := range crd.Resources {

--- a/pkg/migration/controllers/resourcetransformation.go
+++ b/pkg/migration/controllers/resourcetransformation.go
@@ -223,6 +223,8 @@ func (r *ResourceTransformationController) validateTransformResource(ctx context
 	ruleset.AddPlural("quota", "quotas")
 	ruleset.AddPlural("prometheus", "prometheuses")
 	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
+	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
+	ruleset.AddPlural("mongodb", "mongodb")
 
 	for _, spec := range transform.Spec.Objects {
 		group, version, kind, err := getGVK(spec.Resource)

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -989,6 +989,8 @@ func (r *ResourceCollector) getDynamicClient(
 	ruleset.AddPlural("quota", "quotas")
 	ruleset.AddPlural("prometheus", "prometheuses")
 	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
+	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
+	ruleset.AddPlural("mongodb", "mongodb")
 	resource := &metav1.APIResource{
 		Name:       ruleset.Pluralize(strings.ToLower(objectType.GetKind())),
 		Namespaced: len(metadata.GetNamespace()) > 0,


### PR DESCRIPTION


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>improvement

**What this PR does / why we need it**:
    - MongoDB defines "opsmanagers" as the plural form for MongoDBOpsManager in its CRD definition.
    - However the default plural set provided by k8s simply converts the Kind name "MongoDBOpsManager" to its plural form as "mongodbopsmanagers"
    - This causes migrations to fail, since this object is not identified by k8s.
    - Explicitly set the plural form of MongoDBOpsManager as "opsmanagers"

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
Issue: Stork fails to apply MongoDBOpsManager objects on the target cluster since it fails with the error: "Error applying resource: the server could not find the requested resource". This happens since the plural form of MongoDBOpsManager CRD is defined as "opsmanagers" instead of "mongodbopsmanager"
User Impact: Migrations of MongoDB app deployed using the MongoDBOpsManager CR fails.
Resolution: Explicitly set the plural form of MongoDBOpsManager kind as "opsmanagers" in the plural set

```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 2.12

**Testing Notes**

Migrations failed with the below error without this change:
```
    - group: mongodb.com
      kind: MongoDBOpsManager
      name: myopsmanager
      namespace: default
      reason: Error applying resource: the server could not find the requested resource
      status: Failed
      transformedBy: ""
      version: v1

```
With this change migration of MongoDBOpsManager CR passes
```
    - group: mongodb.com
      kind: MongoDBOpsManager
      name: myopsmanager
      namespace: default
      reason: Resource migrated successfully
      status: Successful
      transformedBy: ""
      version: v1
```

