### PR TITLE
PWX-28055: Update stork integration tests to use kube scheduler confi…

### DIFF
--- a/specs/stork-deployment-deprecated.yaml
+++ b/specs/stork-deployment-deprecated.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stork-config
+  namespace: kube-system
+data:
+  # The default list of predicates and priorities can change depending on your version
+  # of Kubernetes, so please update those as required. The requirement to manually specify this
+  # list will go away with Kubernetes v1.10 where it will use the defaults if nothing is
+  # specified.
+  policy.cfg: |-
+    {
+      "kind": "Policy",
+      "apiVersion": "v1",
+      "extenders": [
+        {
+          "urlPrefix": "http://stork-service.kube-system.svc.cluster.local:8099",
+          "apiVersion": "v1beta1",
+          "filterVerb": "filter",
+          "prioritizeVerb": "prioritize",
+          "weight": 5,
+          "enableHttps": false,
+          "nodeCacheCapable": false
+        }
+      ]
+    }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stork-account
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+   name: stork-role
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: stork-role-binding
+subjects:
+- kind: ServiceAccount
+  name: stork-account
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: stork-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: stork-service
+  namespace: kube-system
+spec:
+  selector:
+    name: stork
+  ports:
+    - name: extender
+      protocol: TCP
+      port: 8099
+      targetPort: 8099
+    - name: webhook
+      protocol: TCP
+      port: 443
+      targetPort: 443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    tier: control-plane
+  name: stork
+  namespace: kube-system
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: stork
+  replicas: 3
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: stork
+        tier: control-plane
+    spec:
+      containers:
+      - command:
+        - /stork
+        - --driver=pxd
+        - --verbose
+        - --leader-elect=true
+        # Uncomment the line below if you want to enable the feature to
+        # automatically update schedulerName
+        #- --app-initializer=true
+        imagePullPolicy: Always
+        image: openstorage/stork:2.2.4
+        resources:
+          requests:
+            cpu: '0.1'
+        securityContext:
+          privileged: false
+        name: stork
+      hostPID: false
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "name"
+                    operator: In
+                    values:
+                    - stork
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: stork-account
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: stork-snapshot-sc
+provisioner: stork-snapshot

--- a/specs/stork-deployment.yaml
+++ b/specs/stork-deployment.yaml
@@ -8,22 +8,124 @@ data:
   # of Kubernetes, so please update those as required. The requirement to manually specify this
   # list will go away with Kubernetes v1.10 where it will use the defaults if nothing is
   # specified.
-  policy.cfg: |-
-    {
-      "kind": "Policy",
-      "apiVersion": "v1",
-      "extenders": [
-        {
-          "urlPrefix": "http://stork-service.kube-system.svc.cluster.local:8099",
-          "apiVersion": "v1beta1",
-          "filterVerb": "filter",
-          "prioritizeVerb": "prioritize",
-          "weight": 5,
-          "enableHttps": false,
-          "nodeCacheCapable": false
-        }
-      ]
-    }
+ stork-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 100
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: ""
+      qps: 50
+    enableContentionProfiling: true
+    enableProfiling: true
+    extenders:
+    - filterVerb: filter
+      httpTimeout: 5m0s
+      prioritizeVerb: prioritize
+      urlPrefix: http://stork-service.kube-system:8099
+      weight: 5
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: true
+      leaseDuration: 15s
+      renewDeadline: 10s
+      resourceLock: leases
+      resourceName: stork-scheduler
+      resourceNamespace: kube-system
+      retryPeriod: 2s
+    parallelism: 16
+    percentageOfNodesToScore: 0
+    podInitialBackoffSeconds: 1
+    podMaxBackoffSeconds: 10
+    profiles:
+    - pluginConfig:
+      - args:
+          apiVersion: kubescheduler.config.k8s.io/v1beta3
+          kind: DefaultPreemptionArgs
+          minCandidateNodesAbsolute: 100
+          minCandidateNodesPercentage: 10
+        name: DefaultPreemption
+      - args:
+          apiVersion: kubescheduler.config.k8s.io/v1beta3
+          hardPodAffinityWeight: 1
+          kind: InterPodAffinityArgs
+        name: InterPodAffinity
+      - args:
+          apiVersion: kubescheduler.config.k8s.io/v1beta3
+          kind: NodeAffinityArgs
+        name: NodeAffinity
+      - args:
+          apiVersion: kubescheduler.config.k8s.io/v1beta3
+          kind: NodeResourcesBalancedAllocationArgs
+          resources:
+          - name: cpu
+            weight: 1
+          - name: memory
+            weight: 1
+        name: NodeResourcesBalancedAllocation
+      - args:
+          apiVersion: kubescheduler.config.k8s.io/v1beta3
+          kind: NodeResourcesFitArgs
+          scoringStrategy:
+            resources:
+            - name: cpu
+              weight: 1
+            - name: memory
+              weight: 1
+            type: LeastAllocated
+        name: NodeResourcesFit
+      - args:
+          apiVersion: kubescheduler.config.k8s.io/v1beta3
+          defaultingType: System
+          kind: PodTopologySpreadArgs
+        name: PodTopologySpread
+      - args:
+          apiVersion: kubescheduler.config.k8s.io/v1beta3
+          bindTimeoutSeconds: 600
+          kind: VolumeBindingArgs
+        name: VolumeBinding
+      plugins:
+        bind: {}
+        filter: {}
+        multiPoint:
+          enabled:
+          - name: PrioritySort
+          - name: NodeUnschedulable
+          - name: NodeName
+          - name: TaintToleration
+            weight: 3
+          - name: NodeAffinity
+            weight: 2
+          - name: NodePorts
+          - name: NodeResourcesFit
+            weight: 1
+          - name: VolumeRestrictions
+          - name: EBSLimits
+          - name: GCEPDLimits
+          - name: NodeVolumeLimits
+          - name: AzureDiskLimits
+          - name: VolumeBinding
+          - name: VolumeZone
+          - name: PodTopologySpread
+            weight: 2
+          - name: InterPodAffinity
+            weight: 2
+          - name: DefaultPreemption
+          - name: NodeResourcesBalancedAllocation
+            weight: 1
+          - name: ImageLocality
+            weight: 1
+          - name: DefaultBinder
+        permit: {}
+        postBind: {}
+        postFilter: {}
+        preBind: {}
+        preFilter: {}
+        preScore: {}
+        queueSort: {}
+        reserve: {}
+        score: {}
+      schedulerName: stork
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/specs/stork-scheduler-deprecated.yaml
+++ b/specs/stork-scheduler-deprecated.yaml
@@ -26,7 +26,7 @@ rules:
     resources: ["endpoints"]
     verbs: ["delete", "get", "patch", "update"]
   - apiGroups: [""]
-    resources: ["nodes","namespaces"]
+    resources: ["nodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["pods"]
@@ -99,29 +99,30 @@ spec:
       containers:
       - command:
         - /usr/local/bin/kube-scheduler
-        - --bind-address=0.0.0.0
-        - --config=/etc/kubernetes/stork-config.yaml
-        image: k8s.gcr.io/kube-scheduler-amd64:<kube_version>
+        - --address=0.0.0.0
+        - --leader-elect=true
+        - --scheduler-name=stork
+        - --policy-configmap=stork-config
+        - --policy-configmap-namespace=kube-system
+        - --lock-object-name=stork-scheduler
+        image: gcr.io/google_containers/kube-scheduler-amd64:<kube_version>
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 10259
-            scheme: HTTPS
+            port: 10251
+            scheme: HTTP
           initialDelaySeconds: 15
         name: stork-scheduler
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 10259
-            scheme: HTTPS
+            port: 10251
+            scheme: HTTP
         resources:
           requests:
             cpu: '0.1'
         securityContext:
           privileged: false
-        volumeMounts:
-        - mountPath: /etc/kubernetes
-          name: scheduler-config
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -134,7 +135,3 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       hostPID: false
       serviceAccountName: stork-scheduler-account
-      volumes:
-      - configMap:
-          name: stork-config
-        name: scheduler-config


### PR DESCRIPTION
…g for K8s version 1.23+

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
Update Stork integration tests to use kube scheduler configuration when they are using daemonset px installs.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes

**Notes**:
-Stork test container is running a dash shell and  I couldn't find a straightforward way to do k8 version comparison. So I am breaking the string into the major and minor version and comparing.  Another option was to use  > with [[]] which are "bash" compatible syntaxes but we would need to update all scripts to use /bin/bash in that case and isn't portable. So I went ahead with the current approach.
- Reference Operator PR: https://github.com/libopenstorage/operator/pull/862

