### PR TITLE
PB-3430: support for uploading storageclasses.json to nfs backuplocation

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1157,19 +1157,6 @@ func (a *ApplicationBackupController) uploadMetadata(
 	return a.uploadObject(backup, metadataObjectName, jsonBytes)
 }
 
-func IsNFSBackuplocationType(
-	backup *stork_api.ApplicationBackup,
-) (bool, error) {
-	backupLocation, err := storkops.Instance().GetBackupLocation(backup.Spec.BackupLocation, backup.Namespace)
-	if err != nil {
-		return false, fmt.Errorf("error getting backup location path for backup [%v/%v]: %v", backup.Namespace, backup.Name, err)
-	}
-	if backupLocation.Location.Type == stork_api.BackupLocationNFS {
-		return true, nil
-	}
-	return false, nil
-}
-
 func getResourceExportCRName(opsPrefix, crUID, ns string) string {
 	name := fmt.Sprintf("%s-%s-%s", opsPrefix, utils.GetShortUID(crUID), ns)
 	name = utils.GetValidLabel(name)
@@ -1181,7 +1168,7 @@ func (a *ApplicationBackupController) backupResources(
 ) error {
 	var err error
 	var resourceTypes []metav1.APIResource
-	nfs, err := IsNFSBackuplocationType(backup)
+	nfs, err := utils.IsNFSBackuplocationType(backup.Namespace, backup.Spec.BackupLocation)
 	if err != nil {
 		logrus.Errorf("error in checking backuplocation type: %v", err)
 		return err

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -286,7 +286,7 @@ func (a *ApplicationRestoreController) handle(ctx context.Context, restore *stor
 		return err
 	}
 
-	nfs, err := IsNFSBackuplocationType(backup)
+	nfs, err := utils.IsNFSBackuplocationType(backup.Namespace, backup.Spec.BackupLocation)
 	if err != nil {
 		logrus.Errorf("error in checking backuplocation type")
 	}
@@ -546,7 +546,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 	namespacedName.Namespace = restore.Namespace
 	namespacedName.Name = restore.Name
 	restoreCompleteList := make([]*storkapi.ApplicationRestoreVolumeInfo, 0)
-	nfs, err := IsNFSBackuplocationType(backup)
+	nfs, err := utils.IsNFSBackuplocationType(backup.Namespace, backup.Spec.BackupLocation)
 	if err != nil {
 		logrus.Errorf("error in checking backuplocation type")
 		return err
@@ -1457,7 +1457,7 @@ func (a *ApplicationRestoreController) restoreResources(
 		log.ApplicationRestoreLog(restore).Errorf("Error getting backup: %v", err)
 		return err
 	}
-	nfs, err := IsNFSBackuplocationType(backup)
+	nfs, err := utils.IsNFSBackuplocationType(backup.Namespace, backup.Spec.BackupLocation)
 	if err != nil {
 		logrus.Errorf("error in checking backuplocation type: %v", err)
 		return err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"github.com/aquilax/truncate"
 	"github.com/libopenstorage/stork/drivers"
+	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/core"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -150,4 +152,17 @@ func GetShortUID(uid string) string {
 		return ""
 	}
 	return uid[0:7]
+}
+
+func IsNFSBackuplocationType(
+	namespace, name string,
+) (bool, error) {
+	backupLocation, err := storkops.Instance().GetBackupLocation(name, namespace)
+	if err != nil {
+		return false, fmt.Errorf("error getting backup location path for backup [%v/%v]: %v", namespace, name, err)
+	}
+	if backupLocation.Location.Type == stork_api.BackupLocationNFS {
+		return true, nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
>feature

**What this PR does / why we need it**:
```
PB-3430: support for uploading storageclasses.json to nfs backuplocation

            - For native csi driver, added support for uploading the
              storageclasses.json to nfs backuplocation target
            - For nfs backuplocation, the storageclasses.json will be
              uploaded in the resource stage along with other resource json files,
              as part of nfs executer job.
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
NA

**Does this change need to be cherry-picked to a release branch?**:
No

Testing:
- Added some hack to validate the fix:
     - Remove the check to default the csi to kdmp, in the case of nfs backuplocation.
     - Also commented out the code to upload the snapshot.json. This will be supported in the next PR.
- Verified the content of the storageclasses.json between s3 bucket and nfs backuplocation target:
```
S3 bucket backuplocation:
[{"kind":"StorageClass","apiVersion":"storage.k8s.io/v1","metadata":{"name":"pure-block","uid":"04141da1-9b8d-41c2-b9fb-6c6c09269968","creationTimestamp":"2023-01-16T08:19:40Z","labels":{"app.kubernetes.io/managed-by":"Helm","chart":"pure-pso","generator":"helm","kubernetes.io/cluster-service":"true","release":"pure-pso"},"annotations":{"csi.storage.k8s.io/fstype":"xfs","meta.helm.sh/release-name":"pure-pso","meta.helm.sh/release-namespace":"pso"},"managedFields":[{"manager":"helm","operation":"Update","apiVersion":"storage.k8s.io/v1","time":"2023-01-16T08:19:40Z","fieldsType":"FieldsV1","fieldsV1":{"f:allowVolumeExpansion":{},"f:metadata":{"f:annotations":{".":{},"f:csi.storage.k8s.io/fstype":{},"f:meta.helm.sh/release-name":{},"f:meta.helm.sh/release-namespace":{}},"f:labels":{".":{},"f:app.kubernetes.io/managed-by":{},"f:chart":{},"f:generator":{},"f:kubernetes.io/cluster-service":{},"f:release":{}}},"f:mountOptions":{},"f:parameters":{".":{},"f:backend":{},"f:createoptions":{},"f:csi.storage.k8s.io/fstype":{}},"f:provisioner":{},"f:reclaimPolicy":{},"f:volumeBindingMode":{}}}]},"provisioner":"pure-csi","parameters":{"backend":"block","createoptions":"-q","csi.storage.k8s.io/fstype":"xfs"},"reclaimPolicy":"Delete","mountOptions":["discard"],"allowVolumeExpansion":true,"volumeBindingMode":"Immediate"}]
```   
```
NFS Backuplocation:
[root@sivakumar-1 2ebceebd-9dbc-4764-92ac-78f3efdbcb28]# pwd
/nfs/mysql-pure/jan23-1-nfs-27d0d69/2ebceebd-9dbc-4764-92ac-78f3efdbcb28
[root@sivakumar-1 2ebceebd-9dbc-4764-92ac-78f3efdbcb28]# cat storageclass.json
[{"kind":"StorageClass","apiVersion":"storage.k8s.io/v1","metadata":{"name":"pure-block","uid":"04141da1-9b8d-41c2-b9fb-6c6c09269968","creationTimestamp":"2023-01-16T08:19:40Z","labels":{"app.kubernetes.io/managed-by":"Helm","chart":"pure-pso","generator":"helm","kubernetes.io/cluster-service":"true","release":"pure-pso"},"annotations":{"csi.storage.k8s.io/fstype":"xfs","meta.helm.sh/release-name":"pure-pso","meta.helm.sh/release-namespace":"pso"},"managedFields":[{"manager":"helm","operation":"Update","apiVersion":"storage.k8s.io/v1","time":"2023-01-16T08:19:40Z","fieldsType":"FieldsV1","fieldsV1":{"f:allowVolumeExpansion":{},"f:metadata":{"f:annotations":{".":{},"f:csi.storage.k8s.io/fstype":{},"f:meta.helm.sh/release-name":{},"f:meta.helm.sh/release-namespace":{}},"f:labels":{".":{},"f:app.kubernetes.io/managed-by":{},"f:chart":{},"f:generator":{},"f:kubernetes.io/cluster-service":{},"f:release":{}}},"f:mountOptions":{},"f:parameters":{".":{},"f:backend":{},"f:createoptions":{},"f:csi.storage.k8s.io/fstype":{}},"f:provisioner":{},"f:reclaimPolicy":{},"f:volumeBindingMode":{}}}]},"provisioner":"pure-csi","parameters":{"backend":"block","createoptions":"-q","csi.storage.k8s.io/fstype":"xfs"},"reclaimPolicy":"Delete","mountOptions":["discard"],"allowVolumeExpansion":true,"volumeBindingMode":"Immediate"}][root@sivakumar-1 2ebceebd-9dbc-4764-92ac-78f3efdbcb28]#
```

Dependent KDMP PR:
https://github.com/portworx/kdmp/pull/237