### PR TITLE
pb-3447: changes to upload snapshot.json for native csi driver.

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -40,17 +40,17 @@ import (
 )
 
 const (
-	// snapshotPrefix is appended to CSI backup snapshot
-	snapshotBackupPrefix = "backup"
-	// snapshotPrefix is appended to CSI restore snapshot
+	// SnapshotBackupPrefix is appended to CSI backup snapshot
+	SnapshotBackupPrefix = "backup"
+	// snapshotRestorePrefix is appended to CSI restore snapshot
 	snapshotRestorePrefix = "restore"
 	// snapshotClassNamePrefix is the prefix for snapshot classes per CSI driver
 	snapshotClassNamePrefix = "stork-csi-snapshot-class-"
 
-	// snapshotObjectName is the object stored for the volumesnapshot
-	snapshotObjectName = "snapshots.json"
-	// storageClassesObjectName is the object stored for storageclasses
-	storageClassesObjectName = "storageclasses.json"
+	// SnapshotObjectName is the object stored for the volumesnapshot
+	SnapshotObjectName = "snapshots.json"
+	// StorageClassesObjectName is the object stored for storageclasses
+	StorageClassesObjectName = "storageclasses.json"
 	// resourcesObjectName is the object stored for the all backup resources
 	resourcesObjectName = "resources.json"
 
@@ -66,12 +66,12 @@ const (
 	restoreUIDLabel        = "restoreUID"
 )
 
-// csiBackupObject represents a backup of a series of CSI objects
-type csiBackupObject struct {
+// CsiBackupObject represents a backup of a series of CSI objects
+type CsiBackupObject struct {
 	VolumeSnapshots          interface{} `json:"volumeSnapshots"`
 	VolumeSnapshotContents   interface{} `json:"volumeSnapshotContents"`
 	VolumeSnapshotClasses    interface{} `json:"volumeSnapshotClasses"`
-	v1VolumeSnapshotRequired bool
+	V1VolumeSnapshotRequired bool
 }
 
 // BackupObjectv1Csi represents a backup of a series of v1 VolumeSnapshot CSI objects
@@ -91,11 +91,11 @@ type BackupObjectv1beta1Csi struct {
 }
 
 // GetVolumeSnapshotContent retrieves a backed up volume snapshot
-func (cbo *csiBackupObject) GetVolumeSnapshot(snapshotID string) (interface{}, error) {
+func (cbo *CsiBackupObject) GetVolumeSnapshot(snapshotID string) (interface{}, error) {
 	var vs interface{}
 	var ok bool
 
-	if cbo.v1VolumeSnapshotRequired {
+	if cbo.V1VolumeSnapshotRequired {
 		vs, ok = cbo.VolumeSnapshots.(map[string]*kSnapshotv1.VolumeSnapshot)[snapshotID]
 	} else {
 		vs, ok = cbo.VolumeSnapshots.(map[string]*kSnapshotv1beta1.VolumeSnapshot)[snapshotID]
@@ -107,11 +107,11 @@ func (cbo *csiBackupObject) GetVolumeSnapshot(snapshotID string) (interface{}, e
 }
 
 // GetVolumeSnapshotContent retrieves a backed up volume snapshot content
-func (cbo *csiBackupObject) GetVolumeSnapshotContent(snapshotID string) (interface{}, error) {
+func (cbo *CsiBackupObject) GetVolumeSnapshotContent(snapshotID string) (interface{}, error) {
 	var vsc interface{}
 	var ok bool
 
-	if cbo.v1VolumeSnapshotRequired {
+	if cbo.V1VolumeSnapshotRequired {
 		vsc, ok = cbo.VolumeSnapshotContents.(map[string]*kSnapshotv1.VolumeSnapshotContent)[snapshotID]
 	} else {
 		vsc, ok = cbo.VolumeSnapshotContents.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)[snapshotID]
@@ -123,12 +123,12 @@ func (cbo *csiBackupObject) GetVolumeSnapshotContent(snapshotID string) (interfa
 }
 
 // GetVolumeSnapshotClass retrieves a backed up volume snapshot class
-func (cbo *csiBackupObject) GetVolumeSnapshotClass(snapshotID string) (interface{}, error) {
+func (cbo *CsiBackupObject) GetVolumeSnapshotClass(snapshotID string) (interface{}, error) {
 	var vsClass, vs interface{}
 	var vsClassName string
 	var ok bool
 
-	if cbo.v1VolumeSnapshotRequired {
+	if cbo.V1VolumeSnapshotRequired {
 		vs, ok = cbo.VolumeSnapshots.(map[string]*kSnapshotv1.VolumeSnapshot)[snapshotID]
 		if !ok {
 			logrus.Errorf("failed to retrieve volume snapshot for snapshot ID %s", snapshotID)
@@ -312,10 +312,6 @@ func (c *csi) OwnsPVCForBackup(
 	crBackupType string,
 	blType storkapi.BackupLocationType,
 ) bool {
-	// For CSI volume and backuplocation type is NFS, It will default to kdmp
-	if blType == storkapi.BackupLocationNFS {
-		return false
-	}
 	if cmBackupType == storkapi.ApplicationBackupGeneric || crBackupType == storkapi.ApplicationBackupGeneric {
 		// If user has forced the backupType in config map or applicationbackup CR, default to generic always
 		return false
@@ -455,7 +451,7 @@ func (c *csi) backupStorageClasses(storageClasses []*storagev1.StorageClass, bac
 		return err
 	}
 
-	err = c.uploadObject(backup, storageClassesObjectName, scBytes)
+	err = c.uploadObject(backup, StorageClassesObjectName, scBytes)
 	if err != nil {
 		return err
 	}
@@ -553,7 +549,7 @@ func (c *csi) StartBackup(
 }
 
 func (c *csi) getBackupSnapshotName(pvc *v1.PersistentVolumeClaim, backup *storkapi.ApplicationBackup) string {
-	return fmt.Sprintf("%s-%s-%s", snapshotBackupPrefix, getUIDLastSection(backup.UID), getUIDLastSection(pvc.UID))
+	return fmt.Sprintf("%s-%s-%s", SnapshotBackupPrefix, utils.GetUIDLastSection(backup.UID), utils.GetUIDLastSection(pvc.UID))
 }
 
 // uploadObject uploads the given data to the backup location specified in the backup object
@@ -614,18 +610,18 @@ func (c *csi) uploadCSIBackupObject(
 		return fmt.Errorf("failed to get volumesnapshot version supported by cluster")
 	}
 	if v1VolumeSnapshotRequired {
-		csiBackup = csiBackupObject{
+		csiBackup = CsiBackupObject{
 			VolumeSnapshots:          vsMap.(map[string]*kSnapshotv1.VolumeSnapshot),
 			VolumeSnapshotContents:   vsContentMap.(map[string]*kSnapshotv1.VolumeSnapshotContent),
 			VolumeSnapshotClasses:    vsClassMap.(map[string]*kSnapshotv1.VolumeSnapshotClass),
-			v1VolumeSnapshotRequired: true,
+			V1VolumeSnapshotRequired: true,
 		}
 	} else {
-		csiBackup = csiBackupObject{
+		csiBackup = CsiBackupObject{
 			VolumeSnapshots:          vsMap.(map[string]*kSnapshotv1beta1.VolumeSnapshot),
 			VolumeSnapshotContents:   vsContentMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent),
 			VolumeSnapshotClasses:    vsClassMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotClass),
-			v1VolumeSnapshotRequired: false,
+			V1VolumeSnapshotRequired: false,
 		}
 	}
 
@@ -636,7 +632,7 @@ func (c *csi) uploadCSIBackupObject(
 		return err
 	}
 
-	err = c.uploadObject(backup, snapshotObjectName, csiBackupBytes)
+	err = c.uploadObject(backup, SnapshotObjectName, csiBackupBytes)
 	if err != nil {
 		return err
 	}
@@ -809,6 +805,7 @@ func (c *csi) cleanupSnapshots(
 }
 
 func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
+	funct := "csi GetBackupStatus"
 	if c.snapshotClient == nil {
 		if err := c.Init(nil); err != nil {
 			return nil, err
@@ -954,13 +951,23 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 		vsMapLen = len(vsMap.(map[string]*kSnapshotv1beta1.VolumeSnapshot))
 		vsContentMapLen = len(vsContentMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent))
 	}
-	// if all have finished, add all VolumeSnapshot and VolumeSnapshotContent to objectstore
-	if !anyInProgress && vsContentMapLen > 0 && vsMapLen > 0 {
-		err := c.uploadCSIBackupObject(backup, vsMap, vsContentMap, vsClassMap)
-		if err != nil {
-			return nil, err
+
+	nfs, err := utils.IsNFSBackuplocationType(backup.Namespace, backup.Spec.BackupLocation)
+	if err != nil {
+		logrus.Errorf("%v error in checking backuplocation type: %v", funct, err)
+		return nil, err
+	}
+	// In the case of nfs backuplocation type, uploading of snapshot.json will
+	// happen as part of resource exexutor job as part of resource stage.
+	if !nfs {
+		// if all have finished, add all VolumeSnapshot and VolumeSnapshotContent to objectstore
+		if !anyInProgress && vsContentMapLen > 0 && vsMapLen > 0 {
+			err := c.uploadCSIBackupObject(backup, vsMap, vsContentMap, vsClassMap)
+			if err != nil {
+				return nil, err
+			}
+			log.ApplicationBackupLog(backup).Debugf("finished and uploaded %v snapshots and %v snapshotcontents", vsMapLen, vsContentMapLen)
 		}
-		log.ApplicationBackupLog(backup).Debugf("finished and uploaded %v snapshots and %v snapshotcontents", vsMapLen, vsContentMapLen)
 	}
 	return volumeInfos, nil
 }
@@ -968,7 +975,7 @@ func (c *csi) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 func (c *csi) recreateSnapshotForDeletion(
 	backup *storkapi.ApplicationBackup,
 	vbInfo *storkapi.ApplicationBackupVolumeInfo,
-	csiBackupObject *csiBackupObject,
+	csiBackupObject *CsiBackupObject,
 	snapshotClassCreatedForDriver map[string]bool,
 ) error {
 	var err error
@@ -1114,10 +1121,10 @@ func (c *csi) cleanupBackupLocation(backup *storkapi.ApplicationBackup) error {
 
 	objectPath := backup.Status.BackupPath
 	if objectPath != "" {
-		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, snapshotObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, SnapshotObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
 			return fmt.Errorf("error deleting resources for backup %v/%v: %v", backup.Namespace, backup.Name, err)
 		}
-		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, storageClassesObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+		if err = bucket.Delete(context.TODO(), filepath.Join(objectPath, StorageClassesObjectName)); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
 			return fmt.Errorf("error deleting resources for backup %v/%v: %v", backup.Namespace, backup.Name, err)
 		}
 	}
@@ -1195,7 +1202,7 @@ func (c *csi) UpdateMigratedPersistentVolumeSpec(
 
 func (c *csi) getRestoreStorageClasses(backup *storkapi.ApplicationBackup, resources []runtime.Unstructured) ([]runtime.Unstructured, error) {
 	storageClasses := make([]storagev1.StorageClass, 0)
-	storageClassesBytes, err := c.downloadObject(backup, backup.Spec.BackupLocation, backup.Namespace, storageClassesObjectName)
+	storageClassesBytes, err := c.downloadObject(backup, backup.Spec.BackupLocation, backup.Namespace, StorageClassesObjectName)
 	if err != nil {
 		return nil, err
 	}
@@ -1272,17 +1279,17 @@ func (c *csi) downloadObject(
 
 // getRestoreSnapshotsAndContent retrieves the volumeSnapshots and
 // volumeSnapshotContents associated with a backupID
-func (c *csi) getCSIBackupObject(backupName, backupNamespace string) (*csiBackupObject, error) {
+func (c *csi) getCSIBackupObject(backupName, backupNamespace string) (*CsiBackupObject, error) {
 	backup, err := storkops.Instance().GetApplicationBackup(backupName, backupNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("error getting backup spec for CSI restore: %v", err)
 	}
 
-	backupObjectBytes, err := c.downloadObject(backup, backup.Spec.BackupLocation, backup.Namespace, snapshotObjectName)
+	backupObjectBytes, err := c.downloadObject(backup, backup.Spec.BackupLocation, backup.Namespace, SnapshotObjectName)
 	if err != nil {
 		return nil, err
 	}
-	cboCommon := &csiBackupObject{}
+	cboCommon := &CsiBackupObject{}
 	if c.v1SnapshotRequired {
 		cbov1 := &BackupObjectv1Csi{}
 		err = json.Unmarshal(backupObjectBytes, cbov1)
@@ -1292,7 +1299,7 @@ func (c *csi) getCSIBackupObject(backupName, backupNamespace string) (*csiBackup
 		cboCommon.VolumeSnapshots = cbov1.VolumeSnapshots
 		cboCommon.VolumeSnapshotContents = cbov1.VolumeSnapshotContents
 		cboCommon.VolumeSnapshotClasses = cbov1.VolumeSnapshotClasses
-		cboCommon.v1VolumeSnapshotRequired = c.v1SnapshotRequired
+		cboCommon.V1VolumeSnapshotRequired = c.v1SnapshotRequired
 		return cboCommon, nil
 	}
 	cbov1beta1 := &BackupObjectv1beta1Csi{}
@@ -1303,7 +1310,7 @@ func (c *csi) getCSIBackupObject(backupName, backupNamespace string) (*csiBackup
 	cboCommon.VolumeSnapshots = cbov1beta1.VolumeSnapshots
 	cboCommon.VolumeSnapshotContents = cbov1beta1.VolumeSnapshotContents
 	cboCommon.VolumeSnapshotClasses = cbov1beta1.VolumeSnapshotClasses
-	cboCommon.v1VolumeSnapshotRequired = c.v1SnapshotRequired
+	cboCommon.V1VolumeSnapshotRequired = c.v1SnapshotRequired
 
 	return cboCommon, nil
 }
@@ -1495,7 +1502,7 @@ func (c *csi) restoreVolumeSnapshotContent(
 	return vsc, nil
 }
 
-func getUIDLastSection(uid types.UID) string {
+func GetUIDLastSection(uid types.UID) string {
 	parts := strings.Split(string(uid), "-")
 	uidLastSection := parts[len(parts)-1]
 
@@ -1506,17 +1513,17 @@ func getUIDLastSection(uid types.UID) string {
 }
 
 func (c *csi) getRestoreSnapshotName(existingSnapshotUID types.UID, restoreUID types.UID) string {
-	return fmt.Sprintf("%s-vs-%s-%s", snapshotRestorePrefix, getUIDLastSection(restoreUID), getUIDLastSection(existingSnapshotUID))
+	return fmt.Sprintf("%s-vs-%s-%s", snapshotRestorePrefix, utils.GetUIDLastSection(restoreUID), utils.GetUIDLastSection(existingSnapshotUID))
 }
 
 func (c *csi) getRestoreSnapshotContentName(existingSnapshotUID types.UID, restoreUID types.UID) string {
-	return fmt.Sprintf("%s-vsc-%s-%s", snapshotRestorePrefix, getUIDLastSection(restoreUID), getUIDLastSection(existingSnapshotUID))
+	return fmt.Sprintf("%s-vsc-%s-%s", snapshotRestorePrefix, utils.GetUIDLastSection(restoreUID), utils.GetUIDLastSection(existingSnapshotUID))
 }
 
 func (c *csi) createRestoreSnapshotsAndPVCs(
 	restore *storkapi.ApplicationRestore,
 	volumeBackupInfos []*storkapi.ApplicationBackupVolumeInfo,
-	csiBackupObject *csiBackupObject,
+	csiBackupObject *CsiBackupObject,
 ) ([]*storkapi.ApplicationRestoreVolumeInfo, error) {
 	var err error
 	volumeRestoreInfos := []*storkapi.ApplicationRestoreVolumeInfo{}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/aquilax/truncate"
 	"github.com/libopenstorage/stork/drivers"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
@@ -9,8 +11,8 @@ import (
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"strings"
 )
 
 const (
@@ -165,4 +167,14 @@ func IsNFSBackuplocationType(
 		return true, nil
 	}
 	return false, nil
+}
+
+func GetUIDLastSection(uid types.UID) string {
+	parts := strings.Split(string(uid), "-")
+	uidLastSection := parts[len(parts)-1]
+
+	if uidLastSection == "" {
+		uidLastSection = string(uid)
+	}
+	return uidLastSection
 }


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
```
pb-3447: changes to upload snapshot.json for native csi driver.

            - Conveerted come of the data structure and variable to public,
              so that it can be used in kdmp nfs executor job.
            - snapshot.json will be uploaded in nfs executor, if
              backuplocation is nfs type.
```

**Does this PR change a user-facing CRD or CLI?**:
N.A

**Is a release note needed?**:
Will release note it as new feature.

**Does this change need to be cherry-picked to a release branch?**:
No.

Testing:
snapshot.json from minio backuplocation:
```
{"volumeSnapshots":{"backup-aaa715bf6405-9f7465534d49":{"metadata":{"name":"backup-aaa715bf6405-9f7465534d49","namespace":"mysql-pso","uid":"4a7e8cee-7e30-4e3e-8c93-6bb5e130b84e","resourceVersion":"401015","generation":1,"creationTimestamp":"2023-01-29T07:14:41Z","finalizers":["snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection"],"managedFields":[{"manager":"stork","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:14:41Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{".":{},"f:source":{".":{},"f:persistentVolumeClaimName":{}},"f:volumeSnapshotClassName":{}}}},{"manager":"snapshot-controller","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:14:42Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{}},"f:status":{".":{},"f:boundVolumeSnapshotContentName":{},"f:creationTime":{},"f:readyToUse":{},"f:restoreSize":{}}}}]},"spec":{"source":{"persistentVolumeClaimName":"mysql-data"},"volumeSnapshotClassName":"stork-csi-snapshot-class-pure-csi"},"status":{"boundVolumeSnapshotContentName":"snapcontent-4a7e8cee-7e30-4e3e-8c93-6bb5e130b84e","creationTime":"2023-01-29T07:14:42Z","readyToUse":true,"restoreSize":"0"}}},"volumeSnapshotContents":{"backup-aaa715bf6405-9f7465534d49":{"metadata":{"name":"snapcontent-4a7e8cee-7e30-4e3e-8c93-6bb5e130b84e","uid":"3ae786e2-1357-4675-8413-2aa7de12a0b6","resourceVersion":"401013","generation":1,"creationTimestamp":"2023-01-29T07:14:41Z","finalizers":["snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection"],"managedFields":[{"manager":"snapshot-controller","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:14:41Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{".":{},"v:\"snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection\"":{}}},"f:spec":{".":{},"f:deletionPolicy":{},"f:driver":{},"f:source":{".":{},"f:volumeHandle":{}},"f:volumeSnapshotClassName":{},"f:volumeSnapshotRef":{".":{},"f:apiVersion":{},"f:kind":{},"f:name":{},"f:namespace":{},"f:resourceVersion":{},"f:uid":{}}}}},{"manager":"csi-snapshotter","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1beta1","time":"2023-01-29T07:14:42Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{".":{},"f:creationTime":{},"f:readyToUse":{},"f:restoreSize":{},"f:snapshotHandle":{}}}}]},"spec":{"volumeSnapshotRef":{"kind":"VolumeSnapshot","namespace":"mysql-pso","name":"backup-aaa715bf6405-9f7465534d49","uid":"4a7e8cee-7e30-4e3e-8c93-6bb5e130b84e","apiVersion":"snapshot.storage.k8s.io/v1","resourceVersion":"400994"},"deletionPolicy":"Retain","driver":"pure-csi","volumeSnapshotClassName":"stork-csi-snapshot-class-pure-csi","source":{"volumeHandle":"f691d82f-ca80-43bd-87c0-e2c1514605a8"}},"status":{"snapshotHandle":"PSO_siva_pso-pvc-720797b5-838b-4eb4-81a7-9f7465534d49.snapshot-4a7e8cee-7e30-4e3e-8c93-6bb5e130b84e","creationTime":1674976482000000000,"restoreSize":0,"readyToUse":true}}},"volumeSnapshotClasses":{"stork-csi-snapshot-class-pure-csi":{"metadata":{"name":"stork-csi-snapshot-class-pure-csi","uid":"82492a91-3225-4d2b-8449-0e2fcb4208f1","resourceVersion":"27020","generation":1,"creationTimestamp":"2023-01-28T12:00:06Z","managedFields":[{"manager":"stork","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-28T12:00:06Z","fieldsType":"FieldsV1","fieldsV1":{"f:deletionPolicy":{},"f:driver":{}}}]},"driver":"pure-csi","deletionPolicy":"Retain"}},"V1VolumeSnapshotRequired":true}
```
snapshot.json from nfs backuplocaiton:
```
[root@ssubramani-setup1-0 3e121b6f-e582-49a6-809d-d963694bd54c]# ls
crds.json  metadata.json  namespaces.json  resources.json  snapshots.json  storageclass.json
[root@ssubramani-setup1-0 3e121b6f-e582-49a6-809d-d963694bd54c]# cat snapshots.json
{"volumeSnapshots":{"backup-d963694bd54c-9f7465534d49":{"metadata":{"name":"backup-d963694bd54c-9f7465534d49","namespace":"mysql-pso","uid":"025d08f9-2c57-449b-a608-8defee43a9b0","resourceVersion":"405700","generation":1,"creationTimestamp":"2023-01-29T07:28:41Z","finalizers":["snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection"],"managedFields":[{"manager":"stork","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:28:41Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{".":{},"f:source":{".":{},"f:persistentVolumeClaimName":{}},"f:volumeSnapshotClassName":{}}}},{"manager":"snapshot-controller","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:28:42Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{}},"f:status":{".":{},"f:boundVolumeSnapshotContentName":{},"f:creationTime":{},"f:readyToUse":{},"f:restoreSize":{}}}}]},"spec":{"source":{"persistentVolumeClaimName":"mysql-data"},"volumeSnapshotClassName":"stork-csi-snapshot-class-pure-csi"},"status":{"boundVolumeSnapshotContentName":"snapcontent-025d08f9-2c57-449b-a608-8defee43a9b0","creationTime":"2023-01-29T07:28:41Z","readyToUse":true,"restoreSize":"0"}}},"volumeSnapshotContents":{"backup-d963694bd54c-9f7465534d49":{"metadata":{"name":"snapcontent-025d08f9-2c57-449b-a608-8defee43a9b0","uid":"196039c8-6e43-4378-b6a7-d075281424d6","resourceVersion":"405697","generation":1,"creationTimestamp":"2023-01-29T07:28:41Z","finalizers":["snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection"],"managedFields":[{"manager":"csi-snapshotter","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1beta1","time":"2023-01-29T07:28:41Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{".":{},"f:creationTime":{},"f:readyToUse":{},"f:restoreSize":{},"f:snapshotHandle":{}}}},{"manager":"snapshot-controller","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-29T07:28:41Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{".":{},"v:\"snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection\"":{}}},"f:spec":{".":{},"f:deletionPolicy":{},"f:driver":{},"f:source":{".":{},"f:volumeHandle":{}},"f:volumeSnapshotClassName":{},"f:volumeSnapshotRef":{".":{},"f:apiVersion":{},"f:kind":{},"f:name":{},"f:namespace":{},"f:resourceVersion":{},"f:uid":{}}}}}]},"spec":{"volumeSnapshotRef":{"kind":"VolumeSnapshot","namespace":"mysql-pso","name":"backup-d963694bd54c-9f7465534d49","uid":"025d08f9-2c57-449b-a608-8defee43a9b0","apiVersion":"snapshot.storage.k8s.io/v1","resourceVersion":"405683"},"deletionPolicy":"Retain","driver":"pure-csi","volumeSnapshotClassName":"stork-csi-snapshot-class-pure-csi","source":{"volumeHandle":"f691d82f-ca80-43bd-87c0-e2c1514605a8"}},"status":{"snapshotHandle":"PSO_siva_pso-pvc-720797b5-838b-4eb4-81a7-9f7465534d49.snapshot-025d08f9-2c57-449b-a608-8defee43a9b0","creationTime":1674977321000000000,"restoreSize":0,"readyToUse":true}}},"volumeSnapshotClasses":{"stork-csi-snapshot-class-pure-csi":{"metadata":{"name":"stork-csi-snapshot-class-pure-csi","uid":"82492a91-3225-4d2b-8449-0e2fcb4208f1","resourceVersion":"27020","generation":1,"creationTimestamp":"2023-01-28T12:00:06Z","managedFields":[{"manager":"stork","operation":"Update","apiVersion":"snapshot.storage.k8s.io/v1","time":"2023-01-28T12:00:06Z","fieldsType":"FieldsV1","fieldsV1":{"f:deletionPolicy":{},"f:driver":{}}}]},"driver":"pure-csi","deletionPolicy":"Retain"}},"V1VolumeSnapshotRequired":true}[root@ssubramani-setup1-0 3e121b6f-e582-49a6-809d-d963694bd54c]#
```

