### PR TITLE
PB-3397: Backed Nameapecs based on namespace label selector (#1258)

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -31,6 +31,7 @@ type ApplicationBackupSpec struct {
 	Namespaces        []string                           `json:"namespaces"`
 	BackupLocation    string                             `json:"backupLocation"`
 	Selectors         map[string]string                  `json:"selectors"`
+	NamespaceSelector map[string]string                  `json:"namespaceSelector"`
 	PreExecRule       string                             `json:"preExecRule"`
 	PostExecRule      string                             `json:"postExecRule"`
 	ReclaimPolicy     ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -240,6 +240,13 @@ func (in *ApplicationBackupSpec) DeepCopyInto(out *ApplicationBackupSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.NamespaceSelector != nil {
+		in, out := &in.NamespaceSelector, &out.NamespaceSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
 		*out = make(map[string]string, len(*in))

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -252,6 +252,24 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		return nil
 	}
 
+	if labelSelector := backup.Spec.NamespaceSelector; len(labelSelector) != 0 {
+		namespaces, err := core.Instance().ListNamespaces(labelSelector)
+		if err != nil {
+			errMsg := fmt.Sprintf("error listing namespaces with label selectors: %v, error: %v", labelSelector, err)
+			log.ApplicationBackupLog(backup).Error(errMsg)
+			a.recorder.Event(backup,
+				v1.EventTypeWarning,
+				string(stork_api.ApplicationBackupStatusFailed),
+				err.Error())
+			return nil
+		}
+		var selectedNamespaces []string
+		for _, namespace := range namespaces.Items {
+			selectedNamespaces = append(selectedNamespaces, namespace.Name)
+		}
+		backup.Spec.Namespaces = selectedNamespaces
+	}
+
 	// Check whether namespace is allowed to be backed before each stage
 	// Restrict backup to only the namespace that the object belongs
 	// except for the namespace designated by the admin


### PR DESCRIPTION
* PB-3397: Add Logic to support namespace label selector in the application backup controller
	- These feature is supported with manual and schedule backups
	- Currently Namespaces come along the application backup spec consider to be backed up, Now these namespaces are selected using the namespace selectors provided as part of the same spec at execution time.
	- Filtered namespaces that to be backed up are also updated to the data-store object while reconciling.


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

