### PR TITLE
pb-3505: port changes of NfsConfig to 2.12-nfs branch

### DIFF
--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -41,7 +41,7 @@ type BackupLocationItem struct {
 	S3Config           *S3Config     `json:"s3Config,omitempty"`
 	AzureConfig        *AzureConfig  `json:"azureConfig,omitempty"`
 	GoogleConfig       *GoogleConfig `json:"googleConfig,omitempty"`
-	NfsConfig          *NfsConfig    `json:"nfsConfig,omitempty"`
+	NFSConfig          *NFSConfig    `json:"nfsConfig,omitempty"`
 	SecretConfig       string        `json:"secretConfig"`
 	Sync               bool          `json:"sync"`
 	RepositoryPassword string        `json:"repositoryPassword"`
@@ -126,10 +126,11 @@ type GoogleConfig struct {
 	AccountKey string `json:"accountKey"`
 }
 
-type NfsConfig struct {
-	ServerAddr  string `json:"serverAddr"`
-	SubPath     string `json:"subPath"`
-	MountOption string `json:"mountOption"`
+type NFSConfig struct {
+	ServerAddr         string `json:"serverAddr"`
+	SubPath            string `json:"subPath"`
+	MountOptions       string `json:"mountOptions"`
+	NFSIOTimeoutInSecs string `json:"nfsIOTimeoutInSecs"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -188,8 +189,8 @@ func (bl *BackupLocation) UpdateFromClusterSecret(client kubernetes.Interface) e
 }
 
 func (bl *BackupLocation) getMergedNfsConfig(client kubernetes.Interface) error {
-	if bl.Location.NfsConfig == nil {
-		bl.Location.NfsConfig = &NfsConfig{}
+	if bl.Location.NFSConfig == nil {
+		bl.Location.NFSConfig = &NFSConfig{}
 	}
 	if bl.Location.SecretConfig != "" {
 		secretConfig, err := client.CoreV1().Secrets(bl.Namespace).Get(context.TODO(), bl.Location.SecretConfig, metav1.GetOptions{})
@@ -197,13 +198,13 @@ func (bl *BackupLocation) getMergedNfsConfig(client kubernetes.Interface) error 
 			return fmt.Errorf("error getting secretConfig for backupLocation: %v", err)
 		}
 		if val, ok := secretConfig.Data["serverAddr"]; ok && val != nil {
-			bl.Location.NfsConfig.ServerAddr = strings.TrimSuffix(string(val), "\n")
+			bl.Location.NFSConfig.ServerAddr = strings.TrimSuffix(string(val), "\n")
 		}
 		if val, ok := secretConfig.Data["subPath"]; ok && val != nil {
-			bl.Location.NfsConfig.SubPath = strings.TrimSuffix(string(val), "\n")
+			bl.Location.NFSConfig.SubPath = strings.TrimSuffix(string(val), "\n")
 		}
 		if val, ok := secretConfig.Data["mountOption"]; ok && val != nil {
-			bl.Location.NfsConfig.MountOption = strings.TrimSuffix(string(val), "\n")
+			bl.Location.NFSConfig.MountOptions = strings.TrimSuffix(string(val), "\n")
 		}
 	}
 	return nil


### PR DESCRIPTION
Following changes are made
	- NfsConfig structure name changed to NFSConfig
	- MountOption to MountOptions
	- Added a new variable NFSIOTimeoutInSecs

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: It ports the NFSConfig changes from strok master to 2.12-nfs branch.


**Does this PR change a user-facing CRD or CLI?**: No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: No 
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

