### PR TITLE
pb-3505: vendor kdmp 1.2.3 to stork 2.12-nfs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.0
-	github.com/portworx/kdmp v0.4.1-0.20221123171404-53a7660f5795
+	github.com/portworx/kdmp v0.4.1-0.20230206133815-91b35fb37528
 	github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987
 	github.com/portworx/sched-ops v1.20.4-rc1.0.20221102055014-b3a55a3df5c8
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145

--- a/go.sum
+++ b/go.sum
@@ -1138,6 +1138,7 @@ github.com/libopenstorage/stork v1.4.1-0.20220414104250-3c18fd21ed95/go.mod h1:y
 github.com/libopenstorage/stork v1.4.1-0.20220902043617-635e642468d0/go.mod h1:oQ0lteROzRCxHMvESCSyOiY/9oqgO3Qrvfs5LI/jVCA=
 github.com/libopenstorage/stork v1.4.1-0.20220902111346-9dbf76d2db2c/go.mod h1:KNG/pkhMCdKXXFr0nKtYybWCx2ggLCoi+I7Onylwl64=
 github.com/libopenstorage/stork v1.4.1-0.20221103082056-65abc8cc4e80/go.mod h1:yX+IlCrUsZekC6zxL6zHE7sBPKIudubHB3EcImzeRbI=
+github.com/libopenstorage/stork v1.4.1-0.20230206103328-883ffb861be8/go.mod h1:J6q5Z1db0jCMRVXCC/ptFF8HOcjicxTxpz45O2iPuIE=
 github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1 h1:5vqfYYWm4b+lbkMtvvWtWBiqLbmLN6dNvWaa7wVsz/Q=
 github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1/go.mod h1:xwNGC7xiz/BQ/wbMkvHujL8Gjgseg+x41xMek7sKRRQ=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
@@ -1432,6 +1433,8 @@ github.com/portworx/kdmp v0.4.1-0.20221120133908-371b5c7190ff h1:KU7WhC+O8HsaFU1
 github.com/portworx/kdmp v0.4.1-0.20221120133908-371b5c7190ff/go.mod h1:v8uQbjGe6UFNyrZ+vFKgEu30wsaTc1qg0OYOKmVmUOE=
 github.com/portworx/kdmp v0.4.1-0.20221123171404-53a7660f5795 h1:JkUI/gVsYM3+z4QFtgaiicrQ/kwnSxBJGDQFPUAC7Go=
 github.com/portworx/kdmp v0.4.1-0.20221123171404-53a7660f5795/go.mod h1:v8uQbjGe6UFNyrZ+vFKgEu30wsaTc1qg0OYOKmVmUOE=
+github.com/portworx/kdmp v0.4.1-0.20230206133815-91b35fb37528 h1:O20tlLvvcsYE9YrmhGabnYwoawfyV3D1PjCOmn0H4PI=
+github.com/portworx/kdmp v0.4.1-0.20230206133815-91b35fb37528/go.mod h1:EXN0bAM+c4iK7Xxui/ZVVIGWepmsbGxrOgcoUDYwGLs=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200929023115-b312c7519467 h1:jkqzdbOnejgSN5HG/FLt4enNrozWT/K+nlmaRm3P1II=

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
@@ -294,7 +294,7 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 		}
 
 		if backupLocation.Location.Type != storkapi.BackupLocationNFS {
-			backupLocation.Location.NfsConfig = &storkapi.NfsConfig{}
+			backupLocation.Location.NFSConfig = &storkapi.NFSConfig{}
 		}
 		// start data transfer
 		id, err := startTransferJob(
@@ -305,9 +305,9 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			podDataPath,
 			utils.KdmpConfigmapName,
 			utils.KdmpConfigmapNamespace,
-			backupLocation.Location.NfsConfig.ServerAddr,
+			backupLocation.Location.NFSConfig.ServerAddr,
 			backupLocation.Location.Path,
-			backupLocation.Location.NfsConfig.MountOption,
+			backupLocation.Location.NFSConfig.MountOptions,
 		)
 		if err != nil && err != utils.ErrJobAlreadyRunning && err != utils.ErrOutOfJobResources {
 			msg := fmt.Sprintf("failed to start a data transfer job, dataexport [%v]: %v", dataExport.Name, err)
@@ -540,15 +540,7 @@ func (c *Controller) createJobCredCertSecrets(
 			}
 			return data, err
 		}
-		// filter out the pods that are create by us
-		count := len(pods)
-		for _, pod := range pods {
-			labels := pod.ObjectMeta.Labels
-			if _, ok := labels[drivers.DriverNameLabel]; ok {
-				count--
-			}
-		}
-		if count > 0 {
+		if len(pods) > 0 {
 			namespace = utils.AdminNamespace
 		}
 		blName = dataExport.Spec.Destination.Name

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/resourceexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/resourceexport/reconcile.go
@@ -372,14 +372,14 @@ func startNfsResourceJob(
 			drivers.WithNfsImageExecutorSourceNs(re.Spec.TriggeredFromNs),
 			drivers.WithRestoreExport(re.Name),
 			drivers.WithJobNamespace(re.Namespace),
-			drivers.WithNfsServer(bl.Location.NfsConfig.ServerAddr),
+			drivers.WithNfsServer(bl.Location.NFSConfig.ServerAddr),
 			drivers.WithNfsExportDir(bl.Location.Path),
 			drivers.WithAppCRName(re.Spec.Source.Name),
 			drivers.WithAppCRNamespace(re.Spec.Source.Namespace),
 			drivers.WithNamespace(re.Namespace),
 			drivers.WithResoureBackupName(re.Name),
 			drivers.WithResoureBackupNamespace(re.Namespace),
-			drivers.WithNfsMountOption(bl.Location.NfsConfig.MountOption),
+			drivers.WithNfsMountOption(bl.Location.NFSConfig.MountOptions),
 		)
 	case drivers.NFSRestore:
 		return drv.StartJob(
@@ -387,14 +387,14 @@ func startNfsResourceJob(
 			drivers.WithNfsImageExecutorSourceNs(re.Spec.TriggeredFromNs),
 			drivers.WithRestoreExport(re.Name),
 			drivers.WithJobNamespace(re.Namespace),
-			drivers.WithNfsServer(bl.Location.NfsConfig.ServerAddr),
+			drivers.WithNfsServer(bl.Location.NFSConfig.ServerAddr),
 			drivers.WithNfsExportDir(bl.Location.Path),
 			drivers.WithAppCRName(re.Spec.Source.Name),
 			drivers.WithAppCRNamespace(re.Spec.Source.Namespace),
 			drivers.WithNamespace(re.Namespace),
 			drivers.WithResoureBackupName(re.Name),
 			drivers.WithResoureBackupNamespace(re.Namespace),
-			drivers.WithNfsMountOption(bl.Location.NfsConfig.MountOption),
+			drivers.WithNfsMountOption(bl.Location.NFSConfig.MountOptions),
 		)
 	}
 	return "", fmt.Errorf("unknown data transfer driver: %s", drv.Name())

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/drivers.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/drivers.go
@@ -51,7 +51,7 @@ const (
 	CertFileName         = "public.crt"
 	CertSecretName       = "tls-s3-cert"
 	CertMount            = "/etc/tls-s3-cert"
-	NfsMount             = "/mnt/nfs-target/"
+	NfsMount             = "/tmp/nfs-target/"
 )
 
 // Driver job options.

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackup.go
@@ -448,15 +448,7 @@ func buildJob(jobName string, jobOptions drivers.JobOpts) (*batchv1.Job, error) 
 	}
 	var resourceNamespace string
 	var live bool
-	// filter out the pods that are create by us
-	count := len(pods)
-	for _, pod := range pods {
-		labels := pod.ObjectMeta.Labels
-		if _, ok := labels[drivers.DriverNameLabel]; ok {
-			count--
-		}
-	}
-	if count > 0 {
+	if len(pods) > 0 {
 		resourceNamespace = utils.AdminNamespace
 		live = true
 	} else {

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/utils/utils.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/utils/utils.go
@@ -383,10 +383,10 @@ func GetKopiaExecutorImageRegistryAndSecret(source, sourceNs string) (string, st
 func CreateNfsSecret(secretName string, backupLocation *storkapi.BackupLocation, namespace string, labels map[string]string) error {
 	credentialData := make(map[string][]byte)
 	credentialData["type"] = []byte(backupLocation.Location.Type)
-	credentialData["serverAddr"] = []byte(backupLocation.Location.NfsConfig.ServerAddr)
+	credentialData["serverAddr"] = []byte(backupLocation.Location.NFSConfig.ServerAddr)
 	credentialData["password"] = []byte(backupLocation.Location.RepositoryPassword)
 	credentialData["path"] = []byte(backupLocation.Location.Path)
-	credentialData["subPath"] = []byte(backupLocation.Location.NfsConfig.SubPath)
+	credentialData["subPath"] = []byte(backupLocation.Location.NFSConfig.SubPath)
 
 	err := CreateJobSecret(secretName, namespace, credentialData, labels)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -691,7 +691,7 @@ github.com/pierrec/lz4/internal/xxh32
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20221123171404-53a7660f5795
+# github.com/portworx/kdmp v0.4.1-0.20230206133815-91b35fb37528
 ## explicit
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1


### PR DESCRIPTION
vendor kdmp 1.2.3 to stork 2.12-nfs

Signed-off-by: Lalatendu Das <ldas@purestorage.com>


**What type of PR is this?** bug
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: It brings NFSConfig defination to 2.12-nfs


**Does this PR change a user-facing CRD or CLI?**: no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: no
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: no
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

