### PR TITLE
PWX-27511: applicationactivated to be set to true as part of storkctl activate only and false as part of stockctl deactivate.

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -54,6 +54,8 @@ const (
 	// StorkMigrationName is the annotation used to identify resource migrated by
 	// migration CRD name
 	StorkMigrationName = "stork.libopenstorage.org/migrationName"
+	// StorkMigrationNamespace is the annotation used to identify migration CRD's namespace
+	StorkMigrationNamespace = "stork.libopenstorage.org/migrationNamespace"
 	// StorkMigrationTime is the annotation used to specify time of migration
 	StorkMigrationTime = "stork.libopenstorage.org/migrationTime"
 	// StorkMigrationCRDActivateAnnotation is the annotation used to keep track of
@@ -1786,6 +1788,7 @@ func (m *MigrationController) applyResources(
 		}
 		pv.Annotations[StorkMigrationAnnotation] = "true"
 		pv.Annotations[StorkMigrationName] = migration.GetName()
+		pv.Annotations[StorkMigrationNamespace] = migration.GetNamespace()
 		pv.Annotations[StorkMigrationTime] = time.Now().Format(nameTimeSuffixFormat)
 		pv.Annotations = m.getParsedAnnotations(pv.Annotations, clusterPair)
 		pv.Labels = m.getParsedLabels(pv.Labels, clusterPair)
@@ -1912,6 +1915,7 @@ func (m *MigrationController) applyResources(
 		}
 		pvc.Annotations[StorkMigrationAnnotation] = "true"
 		pvc.Annotations[StorkMigrationName] = migration.GetName()
+		pvc.Annotations[StorkMigrationNamespace] = migration.GetNamespace()
 		pvc.Annotations[StorkMigrationTime] = time.Now().Format(nameTimeSuffixFormat)
 		pvc.Annotations[resourcecollector.StorkResourceHash] = strconv.FormatUint(objHash, 10)
 		pvc.Annotations = m.getParsedAnnotations(pvc.Annotations, clusterPair)
@@ -2086,6 +2090,7 @@ func (m *MigrationController) applyResources(
 			}
 			migrAnnot[StorkMigrationAnnotation] = "true"
 			migrAnnot[StorkMigrationName] = migration.GetName()
+			migrAnnot[StorkMigrationNamespace] = migration.GetNamespace()
 			migrAnnot[StorkMigrationTime] = time.Now().Format(nameTimeSuffixFormat)
 			migrAnnot = m.getParsedAnnotations(migrAnnot, clusterPair)
 

--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -15,7 +15,6 @@ import (
 	"github.com/libopenstorage/stork/pkg/schedule"
 	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
-	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
@@ -122,19 +121,7 @@ func (m *MigrationScheduleController) handle(ctx context.Context, migrationSched
 		if _, ok := migrationSchedule.GetAnnotations()[StorkMigrationScheduleCopied]; ok {
 			// check status of all migrated app in cluster
 			logrus.Infof("Migration schedule is on dr cluster, checking migrated app status")
-			isActivated, err := getMigratedAppStatus(migrationSchedule)
-			if err != nil {
-				return err
-			}
-			migrationSchedule.Status.ApplicationActivated = isActivated
-			msg := fmt.Sprintf("Setting AppActive status to: %v", isActivated)
-			m.recorder.Event(migrationSchedule,
-				v1.EventTypeWarning,
-				"AppsActivated",
-				msg)
-			log.MigrationScheduleLog(migrationSchedule).Warn(msg)
 			return m.client.Update(context.TODO(), migrationSchedule)
-
 		}
 	}
 	if !(*migrationSchedule.Spec.Suspend) {
@@ -535,40 +522,4 @@ func (m *MigrationScheduleController) createCRD() error {
 		return err
 	}
 	return apiextensions.Instance().ValidateCRDV1beta1(resource, validateCRDTimeout, validateCRDInterval)
-}
-
-func getMigratedAppStatus(migrationSchedule *stork_api.MigrationSchedule) (bool, error) {
-	for _, ns := range migrationSchedule.Spec.Template.Spec.Namespaces {
-		deployList, err := apps.Instance().ListDeployments(ns, meta.ListOptions{LabelSelector: fmt.Sprintf("%v=%v", StorkMigrationAnnotation, "true")})
-		if err != nil {
-			return false, err
-		}
-		for _, deploy := range deployList.Items {
-			logrus.Debugf("Checking deploy %v/%v", deploy.Name, deploy.GetLabels()[StorkMigrationAnnotation])
-			if *deploy.Spec.Replicas > 0 {
-				logrus.Warnf("Deploy active %v/%v", deploy.Name, deploy.Namespace)
-				return true, nil
-			}
-			if deploy.Status.ObservedGeneration > 1 {
-				logrus.Warnf("Deploy updated %v/%v", deploy.Name, deploy.Namespace)
-				return true, nil
-			}
-		}
-
-		// check statefulset status
-		stsList, err := apps.Instance().ListStatefulSets(ns, meta.ListOptions{LabelSelector: fmt.Sprintf("%v=%v", StorkMigrationAnnotation, "true")})
-		if err != nil {
-			return false, err
-		}
-		for _, sts := range stsList.Items {
-			if *sts.Spec.Replicas > 0 {
-				return true, nil
-			}
-			if sts.Status.ObservedGeneration > 1 {
-				logrus.Warnf("Deploy updated %v/%v", sts.Name, sts.Namespace)
-				return true, nil
-			}
-		}
-	}
-	return false, nil
 }


### PR DESCRIPTION
Signed-off-by: Diptiranjan

**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
With Autosuspend enabled in migrations, the decision of apps activated or deactivated in target cluster will be only decided by storkctl activate/deactivate command.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Migration gets suspended after failback if autosuspend is enabled.
User Impact: After failback, the existing migration schedule is not getting resumed which makes the secondary cluster not synced. 
Resolution: With the fix, the primary cluster's migrationschedule will correctly detect if migration can be resumed to secondary.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
no
-->

