### PR TITLE
change container tags in travis to 23.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ cache:
     - $HOME/.cache/go-build
 script:
   - |
-    if [ "${TRAVIS_BRANCH}" == "master" ]; then
-      export DOCKER_HUB_STORK_TAG=master
-      export DOCKER_HUB_STORK_TEST_TAG=latest
-      export DOCKER_HUB_CMD_EXECUTOR_TAG=master
+    if [ "${TRAVIS_BRANCH}" == "23.2" ]; then
+      export DOCKER_HUB_STORK_TAG="${TRAVIS_BRANCH}"-dev
+      export DOCKER_HUB_STORK_TEST_TAG="${TRAVIS_BRANCH}"-dev
+      export DOCKER_HUB_CMD_EXECUTOR_TAG="${TRAVIS_BRANCH}"-dev
     else
       export DOCKER_HUB_STORK_TAG=`git rev-parse --short HEAD`
       export DOCKER_HUB_STORK_TEST_TAG=`git rev-parse --short HEAD`


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**What this PR does / why we need it**:
Change travis version so that it pushes the correct container tags for `23.2`

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

