### PR TITLE
pb-3338: Added support for handling default storage class request in the storageclass mapping.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -21,6 +21,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/sched-ops/k8s/storage"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -41,6 +42,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+const (
+	defaultStorageClass = "use-default-storage-class"
+)
+
+// isStorageClassMappingContainsDefault - will check whether any storageclass has use-default-storage-class
+// as destination storage class.
+func isStorageClassMappingContainsDefault(restore *storkapi.ApplicationRestore) bool {
+	for _, value := range restore.Spec.StorageClassMapping {
+		if value == defaultStorageClass {
+			return true
+		}
+	}
+	return false
+}
 
 // NewApplicationRestore creates a new instance of ApplicationRestoreController.
 func NewApplicationRestore(mgr manager.Manager, r record.EventRecorder, rc resourcecollector.ResourceCollector) *ApplicationRestoreController {
@@ -286,6 +302,49 @@ func (a *ApplicationRestoreController) handle(ctx context.Context, restore *stor
 		return nil
 	}
 
+	if len(restore.Spec.StorageClassMapping) >= 1 && isStorageClassMappingContainsDefault(restore) {
+		// Update the default storageclass name in storageclassmapping.
+		// storageclassMapping will have "use-default-storage-class" as destination storage class,
+		// If default storageclass need to be selected.
+		scList, err := storage.Instance().GetDefaultStorageClasses()
+		if err != nil {
+			log.ApplicationRestoreLog(restore).Errorf(err.Error())
+			a.recorder.Event(restore,
+				v1.EventTypeWarning,
+				string(storkapi.ApplicationRestoreStatusFailed),
+				err.Error())
+			return nil
+		}
+		// If more than one storageclass is set as default storageclass, update error event
+		if len(scList.Items) > 1 {
+			errMsg := "more than one storageclass is set as default on destination cluster"
+			log.ApplicationRestoreLog(restore).Errorf(errMsg)
+			a.recorder.Event(restore,
+				v1.EventTypeWarning,
+				string(storkapi.ApplicationRestoreStatusFailed),
+				errMsg)
+			return nil
+		}
+		// If no storageclass is set as default storageclass, update error event
+		if len(scList.Items) == 0 {
+			err := fmt.Errorf("no storageclass is set as default on destination cluster")
+			log.ApplicationRestoreLog(restore).Errorf(err.Error())
+			a.recorder.Event(restore,
+				v1.EventTypeWarning,
+				string(storkapi.ApplicationRestoreStatusFailed),
+				err.Error())
+			return nil
+		}
+		for key, value := range restore.Spec.StorageClassMapping {
+			if value == defaultStorageClass {
+				restore.Spec.StorageClassMapping[key] = scList.Items[0].Name
+			}
+		}
+		err = a.client.Update(context.TODO(), restore)
+		if err != nil {
+			return err
+		}
+	}
 	switch restore.Status.Stage {
 	case storkapi.ApplicationRestoreStageInitial:
 		// Make sure the namespaces exist


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
```
pb-3338: Added support for handling default storage class request in the
    storageclass mapping
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```
Issue: User are not able to select the default storageclass set on the destination cluster during restore.
User Impact: User should know the storageclass name on the destination cluster and was not able to select the storageclass that was set as default on the cluster.
Resolution: User can now select "use-default-storage-class" option int he storageclass mapping and internal, it will fetch the default storageclass set on the cluster for pvc provisioning. 
```

**Does this change need to be cherry-picked to a release branch?**:
23.2.1
```
Testing:

Tested by having two default storage class. The restore will fail and will update the CR with event.
Events:
  Type     Reason  Age                From   Message
  ----     ------  ----               ----   -------
  Warning  Failed  13s (x8 over 74s)  stork  more than one storageclass is set as default on destination cluster
Tested by not having default storage class. The restore will fail and will update the CR with event.
Events:
  Type     Reason  Age               From   Message
  ----     ------  ----              ----   -------
  Warning  Failed  4s (x6 over 44s)  stork  no storageclass is set as default on destination cluster
[root@ssubramani-pso-1 ~]#
Tested with one storageclass and restore completed with default storageclass.
```

Since it is a re-merge of the chages to the master. Will not wait for the travis. Will force push it.