### PR TITLE
PB-3413 - Add support to Rancher project mapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.1
 	github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20230207071213-7a8e221c9ebf
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rancher/norman v0.0.0-20230110004459-34230bb2787c
 	github.com/rancher/rancher/pkg/client v0.0.0-20230203155537-a67566517525
@@ -302,7 +302,7 @@ replace (
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20221216200022-d1c57a8ea854
 	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20230207113334-0b97b6052012
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230207071213-7a8e221c9ebf
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20230206162106-035fee117ba3
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3

--- a/go.sum
+++ b/go.sum
@@ -2253,8 +2253,8 @@ github.com/portworx/px-backup-api v1.2.2-0.20220822053657-49308ab319f1/go.mod h1
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987 h1:VNBTmIPjJRZ2QP64zdsrif3ELDHiMzoyNNX74VNHgZ8=
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987/go.mod h1:g3pw2lI2AjqAixUCRhaBdKTY98znsCPR7NGRrlpimVU=
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd h1:cjKFXeQwi1EYlkT1Rjcj6MgPwKjDUKuOx6iCQbQP09M=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd/go.mod h1:JbHASXqA/GXwFD4blS1DZkrxtS5llb98ViZgUerOtQA=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20230207071213-7a8e221c9ebf h1:Z/6zbNbOpW9bQBIXGQxJJMr61gHB1AusZjnF5h24MfQ=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20230207071213-7a8e221c9ebf/go.mod h1:JbHASXqA/GXwFD4blS1DZkrxtS5llb98ViZgUerOtQA=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.0.0-20230206162106-035fee117ba3 h1:UZE1bIdN10MDnO7CXSnM2js1ixtfH3gkOah8koCPvdY=
 github.com/portworx/torpedo v0.0.0-20230206162106-035fee117ba3/go.mod h1:6/JatmSXhilsjBkh46EUCDKRYo0zKP8OVrA7W00ER2I=

--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -28,14 +28,16 @@ type ApplicationBackup struct {
 
 // ApplicationBackupSpec is the spec used to backup applications
 type ApplicationBackupSpec struct {
-	Namespaces        []string                           `json:"namespaces"`
-	BackupLocation    string                             `json:"backupLocation"`
-	Selectors         map[string]string                  `json:"selectors"`
-	NamespaceSelector map[string]string                  `json:"namespaceSelector"`
-	PreExecRule       string                             `json:"preExecRule"`
-	PostExecRule      string                             `json:"postExecRule"`
-	ReclaimPolicy     ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
-	SkipServiceUpdate bool                               `json:"skipServiceUpdate"`
+	Namespaces         []string                           `json:"namespaces"`
+	BackupLocation     string                             `json:"backupLocation"`
+	PlatformCredential string                             `json:"platformCredential"`
+	RancherProjects    map[string]string                  `json:"rancherProjects"`
+	Selectors          map[string]string                  `json:"selectors"`
+	NamespaceSelector  map[string]string                  `json:"namespaceSelector"`
+	PreExecRule        string                             `json:"preExecRule"`
+	PostExecRule       string                             `json:"postExecRule"`
+	ReclaimPolicy      ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
+	SkipServiceUpdate  bool                               `json:"skipServiceUpdate"`
 	// Options to be passed in to the driver
 	Options          map[string]string `json:"options"`
 	IncludeResources []ObjectInfo      `json:"includeResources"`

--- a/pkg/apis/stork/v1alpha1/applicationrestore.go
+++ b/pkg/apis/stork/v1alpha1/applicationrestore.go
@@ -31,6 +31,7 @@ type ApplicationRestoreSpec struct {
 	IncludeOptionalResourceTypes []string                            `json:"includeOptionalResourceTypes"`
 	IncludeResources             []ObjectInfo                        `json:"includeResources"`
 	StorageClassMapping          map[string]string                   `json:"storageClassMapping"`
+	RancherProjectMapping        map[string]string                   `json:"rancherProjectMapping"`
 }
 
 // ApplicationRestoreReplacePolicyType is the replace policy for the application restore

--- a/pkg/apis/stork/v1alpha1/platformcredential.go
+++ b/pkg/apis/stork/v1alpha1/platformcredential.go
@@ -24,7 +24,6 @@ type PlatformCredential struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              PlatformCredentialSpec `json:"spec"`
-	Cluster           ClusterItem            `json:"cluster"`
 }
 
 type PlatformCredentialSpec struct {

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -2113,7 +2113,6 @@ func (in *PlatformCredential) DeepCopyInto(out *PlatformCredential) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
-	in.Cluster.DeepCopyInto(&out.Cluster)
 	return
 }
 

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/libopenstorage/stork/pkg/platform/rancher"
 	"github.com/libopenstorage/stork/pkg/utils"
 
 	"github.com/go-openapi/inflect"
@@ -34,11 +35,13 @@ import (
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/gcerrors"
 	v1 "k8s.io/api/core/v1"
+	v1networking "k8s.io/api/networking/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -964,6 +967,273 @@ func (a *ApplicationBackupController) prepareResources(
 	return nil
 }
 
+func (a *ApplicationBackupController) updateRancherProjectDetails(
+	backup *stork_api.ApplicationBackup,
+	objects []runtime.Unstructured,
+) error {
+	platformCredential, err := storkops.Instance().GetPlatformCredential(backup.Spec.PlatformCredential, backup.Namespace)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if platformCredential.Spec.Type == stork_api.PlatformCredentialRancher {
+		if err = updateRancherProjects(platformCredential, backup, objects); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func updateRancherProjects(
+	platformCredential *stork_api.PlatformCredential,
+	backup *stork_api.ApplicationBackup,
+	objects []runtime.Unstructured,
+) error {
+	projects := map[string]string{}
+	for _, o := range objects {
+		metadata, err := meta.Accessor(o)
+		if err != nil {
+			return err
+		}
+		resource := o.GetObjectKind().GroupVersionKind()
+		switch resource.Kind {
+		case "Deployment", "StatefulSet", "DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer", "ReplicaSet":
+			err := getProjectsFromPodNamespaceSelector(o, projects)
+			if err != nil {
+				return fmt.Errorf("error preparing %v resource %v: %v", o.GetObjectKind().GroupVersionKind().Kind, metadata.GetName(), err)
+			}
+		case "NetworkPolicy":
+			err := getProjectsFromNetworkPolicy(o, projects)
+			if err != nil {
+				return fmt.Errorf("error preparing %v resource %v: %v", o.GetObjectKind().GroupVersionKind().Kind, metadata.GetName(), err)
+			}
+		case "PersistentVolume":
+			err := getProjectsFromPV(o, projects)
+			if err != nil {
+				return fmt.Errorf("error preparing %v resource %v: %v", o.GetObjectKind().GroupVersionKind().Kind, metadata.GetName(), err)
+			}
+		case "PersistentVolumeClaim":
+			err := getProjectsFromPVC(o, projects)
+			if err != nil {
+				return fmt.Errorf("error preparing %v resource %v: %v", o.GetObjectKind().GroupVersionKind().Kind, metadata.GetName(), err)
+			}
+		default:
+		}
+	}
+
+	for _, namespace := range backup.Spec.Namespaces {
+		ns, err := core.Instance().GetNamespace(namespace)
+		if err != nil {
+			return err
+		}
+		for key, val := range ns.Annotations {
+			if strings.Contains(key, utils.CattleProjectPrefix) {
+				projects[val] = ""
+			}
+		}
+		for key, val := range ns.Labels {
+			if strings.Contains(key, utils.CattleProjectPrefix) {
+				projects[val] = ""
+			}
+		}
+	}
+
+	if err := updateProjectDiplayNames(projects, platformCredential); err != nil {
+		return err
+	}
+
+	backup.Spec.RancherProjects = projects
+
+	return nil
+}
+
+// updateProjectDiplayNames updates the projectIDs with project display names
+func updateProjectDiplayNames(
+	projects map[string]string,
+	platformCredential *stork_api.PlatformCredential,
+) error {
+	rancherClient := &rancher.Rancher{}
+	rancherClient.Init(*platformCredential.Spec.RancherConfig)
+	projectList, err := rancherClient.ListProjectNames()
+	if err != nil {
+		return err
+	}
+	for key, val := range projectList {
+		if _, ok := projects[key]; ok {
+			projects[key] = val
+		}
+		data := strings.Split(key, ":")
+		if len(data) == 2 {
+			if _, ok := projects[data[1]]; ok {
+				projects[key] = val
+				delete(projects, data[1])
+			}
+		}
+	}
+
+	// Deleting projectIds which is not existing in the cluster
+	for key, value := range projects {
+		if value == "" {
+			logrus.Warnf("unable to find project %v in the cluster, excluded from project mapping", key)
+			delete(projects, key)
+		}
+	}
+
+	return nil
+}
+
+func getProjectsFromPV(
+	object runtime.Unstructured,
+	projects map[string]string,
+) error {
+	var pv v1.PersistentVolume
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &pv); err != nil {
+		return err
+	}
+	for key, val := range pv.Annotations {
+		if strings.Contains(key, utils.CattleProjectPrefix) {
+			projects[val] = ""
+		}
+	}
+	for key, val := range pv.Labels {
+		if strings.Contains(key, utils.CattleProjectPrefix) {
+			projects[val] = ""
+		}
+	}
+	return nil
+}
+
+func getProjectsFromPVC(
+	object runtime.Unstructured,
+	projects map[string]string,
+) error {
+	var pvc v1.PersistentVolumeClaim
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &pvc); err != nil {
+		return err
+	}
+	for key, val := range pvc.Annotations {
+		if strings.Contains(key, utils.CattleProjectPrefix) {
+			projects[val] = ""
+		}
+	}
+	for key, val := range pvc.Labels {
+		if strings.Contains(key, utils.CattleProjectPrefix) {
+			projects[val] = ""
+		}
+	}
+	return nil
+}
+
+func getProjectsFromNetworkPolicy(
+	object runtime.Unstructured,
+	projects map[string]string,
+) error {
+	var networkPolicy v1networking.NetworkPolicy
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &networkPolicy); err != nil {
+		return fmt.Errorf("error converting to networkpolicy: %v", err)
+	}
+
+	// Get rancher projectId from network policy labels
+	for key, val := range networkPolicy.Labels {
+		if strings.Contains(key, utils.CattleProjectPrefix) {
+			projects[val] = ""
+		}
+	}
+
+	// Handle namespace selectors for Rancher Network Policies
+	ingressRule := networkPolicy.Spec.Ingress
+	for _, ingress := range ingressRule {
+		for _, fromPolicyPeer := range ingress.From {
+			if fromPolicyPeer.NamespaceSelector != nil {
+				for key, val := range fromPolicyPeer.NamespaceSelector.MatchLabels {
+					if strings.Contains(key, utils.CattleProjectPrefix) {
+						projects[val] = ""
+					}
+				}
+			}
+		}
+	}
+	egressRule := networkPolicy.Spec.Egress
+	for _, egress := range egressRule {
+		for _, toPolicyPeer := range egress.To {
+			if toPolicyPeer.NamespaceSelector != nil {
+				for key, val := range toPolicyPeer.NamespaceSelector.MatchLabels {
+					if strings.Contains(key, utils.CattleProjectPrefix) {
+						projects[val] = ""
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func getProjectsFromPodNamespaceSelector(
+	object runtime.Unstructured,
+	projects map[string]string,
+) error {
+	content := object.UnstructuredContent()
+	podSpecField, found, err := unstructured.NestedFieldCopy(content, "spec", "template", "spec")
+	if err != nil {
+		logrus.Warnf("Unable to parse object %v while handling"+
+			" rancher project mappings", object.GetObjectKind().GroupVersionKind().Kind)
+	}
+	podSpec, ok := podSpecField.(v1.PodSpec)
+	if found && ok {
+		// Anti Affinity
+		if podSpec.Affinity.PodAntiAffinity != nil {
+			// - handle PreferredDuringSchedulingIgnoredDuringExecution
+			for _, affinityTerm := range podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+				if affinityTerm.PodAffinityTerm.NamespaceSelector != nil {
+					for key, val := range affinityTerm.PodAffinityTerm.NamespaceSelector.MatchLabels {
+						if strings.Contains(key, utils.CattleProjectPrefix) {
+							projects[val] = ""
+						}
+					}
+				}
+			}
+			// Affinity
+			// - handle RequiredDuringSchedulingIgnoredDuringExecution
+			for _, affinityTerm := range podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+				if affinityTerm.NamespaceSelector != nil {
+					for key, val := range affinityTerm.NamespaceSelector.MatchLabels {
+						if strings.Contains(key, utils.CattleProjectPrefix) {
+							projects[val] = ""
+						}
+					}
+				}
+			}
+		}
+		// Affinity
+		if podSpec.Affinity.PodAffinity != nil {
+			// - handle PreferredDuringSchedulingIgnoredDuringExecution
+			for _, affinityTerm := range podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+				if affinityTerm.PodAffinityTerm.NamespaceSelector != nil {
+					for key, val := range affinityTerm.PodAffinityTerm.NamespaceSelector.MatchLabels {
+						if strings.Contains(key, utils.CattleProjectPrefix) {
+							projects[val] = ""
+						}
+					}
+				}
+			}
+			// - handle RequiredDuringSchedulingIgnoredDuringExecution
+			for _, affinityTerm := range podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+				if affinityTerm.NamespaceSelector != nil {
+					for key, val := range affinityTerm.NamespaceSelector.MatchLabels {
+						if strings.Contains(key, utils.CattleProjectPrefix) {
+							projects[val] = ""
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 // GetObjectPath construct the full base path for a given backup
 // The format is "namespace/backupName/backupUID" which will be unique for each backup
 func GetObjectPath(
@@ -1309,6 +1579,25 @@ func (a *ApplicationBackupController) backupResources(
 	// Do any additional preparation for the resources if required
 	if err = a.prepareResources(backup, allObjects); err != nil {
 		message := fmt.Sprintf("Error preparing resources for backup: %v", err)
+		backup.Status.Status = stork_api.ApplicationBackupStatusFailed
+		backup.Status.Stage = stork_api.ApplicationBackupStageFinal
+		backup.Status.Reason = message
+		backup.Status.LastUpdateTimestamp = metav1.Now()
+		err = a.client.Update(context.TODO(), backup)
+		if err != nil {
+			return err
+		}
+		a.recorder.Event(backup,
+			v1.EventTypeWarning,
+			string(stork_api.ApplicationBackupStatusFailed),
+			message)
+		log.ApplicationBackupLog(backup).Errorf(message)
+		return err
+	}
+
+	// get and update rancher project details
+	if err = a.updateRancherProjectDetails(backup, allObjects); err != nil {
+		message := fmt.Sprintf("Error updating rancher project details for backup: %v", err)
 		backup.Status.Status = stork_api.ApplicationBackupStatusFailed
 		backup.Status.Stage = stork_api.ApplicationBackupStageFinal
 		backup.Status.Reason = message

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -545,6 +545,7 @@ func (a *ApplicationCloneController) prepareResources(
 			pvNameMappings,
 			clone.Spec.IncludeOptionalResourceTypes,
 			nil,
+			nil,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/resourcecollector/networkpolicy.go
+++ b/pkg/resourcecollector/networkpolicy.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (r *ResourceCollector) prepareNetworkPolicyForCollection(
+func (r *ResourceCollector) prepareRancherNetworkPolicy(
 	object runtime.Unstructured,
 	opts Options,
 ) error {
@@ -20,6 +20,8 @@ func (r *ResourceCollector) prepareNetworkPolicyForCollection(
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &networkPolicy); err != nil {
 		return fmt.Errorf("error converting to networkpolicy: %v", err)
 	}
+
+	utils.ParseRancherProjectMapping(networkPolicy.Labels, opts.RancherProjectMappings)
 
 	// Handle namespace selectors for Rancher Network Policies
 	if len(opts.RancherProjectMappings) > 0 {

--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -143,6 +143,7 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
 	storageClassMappings map[string]string,
 	namespaceMappings map[string]string,
+	opts Options,
 ) (bool, error) {
 	var updatedName string
 	var present bool
@@ -182,6 +183,11 @@ func (r *ResourceCollector) preparePVResourceForApply(
 				pv.Spec.StorageClassName = oldSc
 			}
 		}
+	}
+
+	if opts.RancherProjectMappings != nil {
+		utils.ParseRancherProjectMapping(pv.Annotations, opts.RancherProjectMappings)
+		utils.ParseRancherProjectMapping(pv.Labels, opts.RancherProjectMappings)
 	}
 
 	pv.Name = updatedName

--- a/pkg/resourcecollector/persistentvolumeclaim.go
+++ b/pkg/resourcecollector/persistentvolumeclaim.go
@@ -56,6 +56,7 @@ func (r *ResourceCollector) preparePVCResourceForApply(
 	pvNameMappings map[string]string,
 	storageClassMappings map[string]string,
 	vInfos []*stork_api.ApplicationRestoreVolumeInfo,
+	opts Options,
 ) (bool, error) {
 	var pvc v1.PersistentVolumeClaim
 	var updatedName string
@@ -97,6 +98,12 @@ func (r *ResourceCollector) preparePVCResourceForApply(
 		}
 
 	}
+
+	if opts.RancherProjectMappings != nil {
+		utils.ParseRancherProjectMapping(pvc.Annotations, opts.RancherProjectMappings)
+		utils.ParseRancherProjectMapping(pvc.Labels, opts.RancherProjectMappings)
+	}
+
 	if len(storageClassMappings) > 0 {
 		// In the case of storageClassMappings, we need to reset the
 		// storage class annotation and the provisioner annotation

--- a/pkg/resourcecollector/pod.go
+++ b/pkg/resourcecollector/pod.go
@@ -52,7 +52,7 @@ func PreparePodSpecNamespaceSelector(
 
 	// Affinity
 	// - handle PreferredDuringSchedulingIgnoredDuringExecution
-	if podSpec.Affinity.PodAntiAffinity != nil {
+	if podSpec.Affinity.PodAffinity != nil {
 		for affinityIndex, affinityTerm := range podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
 			if affinityTerm.PodAffinityTerm.NamespaceSelector != nil {
 				for key, val := range affinityTerm.PodAffinityTerm.NamespaceSelector.MatchLabels {

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -20,6 +20,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/storage"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -707,7 +708,7 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 			}
 
 		case "NetworkPolicy":
-			err := r.prepareNetworkPolicyForCollection(o, opts)
+			err := r.prepareRancherNetworkPolicy(o, opts)
 			if err != nil {
 				return fmt.Errorf("error preparing NetworkPolicy resource %v: %v", metadata.GetName(), err)
 			}
@@ -808,6 +809,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 	pvNameMappings map[string]string,
 	optionalResourceTypes []string,
 	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
+	opts *Options,
 ) (bool, error) {
 	objectType, err := meta.TypeAccessor(object)
 	if err != nil {
@@ -843,9 +845,9 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		}
 		return true, nil
 	case "PersistentVolume":
-		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings, namespaceMappings)
+		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings, namespaceMappings, *opts)
 	case "PersistentVolumeClaim":
-		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings, storageClassMappings, vInfo)
+		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings, storageClassMappings, vInfo, *opts)
 	case "ClusterRoleBinding":
 		return false, r.prepareClusterRoleBindingForApply(object, namespaceMappings)
 	case "RoleBinding":
@@ -856,6 +858,11 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		return false, r.prepareMutatingWebHookForApply(object, namespaceMappings)
 	case "Secret":
 		return false, r.prepareSecretForApply(object)
+	case "NetworkPolicy":
+		return false, r.prepareRancherNetworkPolicy(object, *opts)
+	case "Deployment", "StatefulSet", "DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer", "ReplicaSet":
+		return false, r.prepareRancherApplicationResource(object, *opts)
+
 	}
 	return false, nil
 }
@@ -1020,4 +1027,37 @@ func (r *ResourceCollector) getDynamicClient(
 	}
 	return dynamicInterface.Resource(
 		object.GetObjectKind().GroupVersionKind().GroupVersion().WithResource(resource.Name)).Namespace(destNamespace), nil
+}
+
+func (r *ResourceCollector) prepareRancherApplicationResource(
+	object runtime.Unstructured,
+	opts Options,
+) error {
+	content := object.UnstructuredContent()
+	if len(opts.RancherProjectMappings) > 0 {
+		podSpecField, found, err := unstructured.NestedFieldCopy(content, "spec", "template", "spec")
+		if err != nil {
+			logrus.Warnf("Unable to parse object %v while handling"+
+				" rancher project mappings", object.GetObjectKind().GroupVersionKind().Kind)
+		}
+		var podSpec v1.PodSpec
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(podSpecField.(map[string]interface{}), &podSpec); err != nil {
+			return fmt.Errorf("error converting to podSpec: %v", err)
+		}
+		if found {
+			podSpecPtr := PreparePodSpecNamespaceSelector(
+				&podSpec,
+				opts.RancherProjectMappings,
+			)
+			o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&podSpecPtr)
+			if err != nil {
+				return err
+			}
+			if err := unstructured.SetNestedField(content, o, "spec", "template", "spec"); err != nil {
+				logrus.Warnf("Unable to set namespace selector for object %v while handling"+
+					" rancher project mappings", object.GetObjectKind().GroupVersionKind().Kind)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -82,3 +82,18 @@ func GetStorageClassNameForPVC(pvc *v1.PersistentVolumeClaim) (string, error) {
 	}
 	return scName, nil
 }
+
+// ParseRancherProjectMapping - maps the target projectId to the source projectId
+func ParseRancherProjectMapping(
+	data map[string]string,
+	projectMapping map[string]string,
+) {
+	for key, value := range data {
+		if strings.Contains(key, CattleProjectPrefix) {
+			if targetProjectID, ok := projectMapping[value]; ok &&
+				targetProjectID != "" {
+				data[key] = targetProjectID
+			}
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -937,7 +937,7 @@ github.com/portworx/px-object-controller/client/listers/objectservice/v1alpha1
 github.com/portworx/px-object-controller/pkg/client
 github.com/portworx/px-object-controller/pkg/controller
 github.com/portworx/px-object-controller/pkg/utils
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd => github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20230207071213-7a8e221c9ebf => github.com/portworx/sched-ops v1.20.4-rc1.0.20230207071213-7a8e221c9ebf
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -2240,7 +2240,7 @@ sigs.k8s.io/yaml
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20221216200022-d1c57a8ea854
 # github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20230207113334-0b97b6052012
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230207070155-2e0ef25efadd
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230207071213-7a8e221c9ebf
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20230206162106-035fee117ba3
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3


### PR DESCRIPTION
What type of PR is this? feature

**What this PR does / why we need it**: Add supports to perform project mapping for rancher platform
->  Extracts the associated rancher projects from k8s resources and updates the ApplicationBackup CR
->  Based on the project mapping available in the ApplicationRestore CR, it replaces the projects IDs in the required annotations, labels , namespace selectors with the target project ID



