### PR TITLE
PB-3413 - Added changes to support rancher project mapping

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -28,14 +28,16 @@ type ApplicationBackup struct {
 
 // ApplicationBackupSpec is the spec used to backup applications
 type ApplicationBackupSpec struct {
-	Namespaces        []string                           `json:"namespaces"`
-	BackupLocation    string                             `json:"backupLocation"`
-	Selectors         map[string]string                  `json:"selectors"`
-	NamespaceSelector map[string]string                  `json:"namespaceSelector"`
-	PreExecRule       string                             `json:"preExecRule"`
-	PostExecRule      string                             `json:"postExecRule"`
-	ReclaimPolicy     ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
-	SkipServiceUpdate bool                               `json:"skipServiceUpdate"`
+	Namespaces         []string                           `json:"namespaces"`
+	BackupLocation     string                             `json:"backupLocation"`
+	PlatformCredential string                             `json:"platformCredential"`
+	RancherProjects    map[string]string                  `json:"rancherProjects"`
+	Selectors          map[string]string                  `json:"selectors"`
+	NamespaceSelector  map[string]string                  `json:"namespaceSelector"`
+	PreExecRule        string                             `json:"preExecRule"`
+	PostExecRule       string                             `json:"postExecRule"`
+	ReclaimPolicy      ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
+	SkipServiceUpdate  bool                               `json:"skipServiceUpdate"`
 	// Options to be passed in to the driver
 	Options          map[string]string `json:"options"`
 	IncludeResources []ObjectInfo      `json:"includeResources"`

--- a/pkg/apis/stork/v1alpha1/applicationrestore.go
+++ b/pkg/apis/stork/v1alpha1/applicationrestore.go
@@ -31,6 +31,7 @@ type ApplicationRestoreSpec struct {
 	IncludeOptionalResourceTypes []string                            `json:"includeOptionalResourceTypes"`
 	IncludeResources             []ObjectInfo                        `json:"includeResources"`
 	StorageClassMapping          map[string]string                   `json:"storageClassMapping"`
+	RancherProjectMapping        map[string]string                   `json:"rancherProjectMapping"`
 }
 
 // ApplicationRestoreReplacePolicyType is the replace policy for the application restore

--- a/pkg/apis/stork/v1alpha1/platformcredential.go
+++ b/pkg/apis/stork/v1alpha1/platformcredential.go
@@ -24,7 +24,6 @@ type PlatformCredential struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              PlatformCredentialSpec `json:"spec"`
-	Cluster           ClusterItem            `json:"cluster"`
 }
 
 type PlatformCredentialSpec struct {

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -2113,7 +2113,6 @@ func (in *PlatformCredential) DeepCopyInto(out *PlatformCredential) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
-	in.Cluster.DeepCopyInto(&out.Cluster)
 	return
 }
 

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1031,14 +1031,9 @@ func updateRancherProjects(
 				projects[val] = ""
 			}
 		}
-		for key, val := range ns.Labels {
-			if strings.Contains(key, utils.CattleProjectPrefix) {
-				projects[val] = ""
-			}
-		}
 	}
 
-	if err := updateProjectDiplayNames(projects, platformCredential); err != nil {
+	if err := updateProjectDisplayNames(projects, platformCredential); err != nil {
 		return err
 	}
 
@@ -1047,8 +1042,8 @@ func updateRancherProjects(
 	return nil
 }
 
-// updateProjectDiplayNames updates the projectIDs with project display names
-func updateProjectDiplayNames(
+// updateProjectDisplayNames updates the projectIDs with project display names
+func updateProjectDisplayNames(
 	projects map[string]string,
 	platformCredential *stork_api.PlatformCredential,
 ) error {

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1589,22 +1589,24 @@ func (a *ApplicationBackupController) backupResources(
 	}
 
 	// get and update rancher project details
-	if err = a.updateRancherProjectDetails(backup, allObjects); err != nil {
-		message := fmt.Sprintf("Error updating rancher project details for backup: %v", err)
-		backup.Status.Status = stork_api.ApplicationBackupStatusFailed
-		backup.Status.Stage = stork_api.ApplicationBackupStageFinal
-		backup.Status.Reason = message
-		backup.Status.LastUpdateTimestamp = metav1.Now()
-		err = a.client.Update(context.TODO(), backup)
-		if err != nil {
+	if len(backup.Spec.PlatformCredential) != 0 {
+		if err = a.updateRancherProjectDetails(backup, allObjects); err != nil {
+			message := fmt.Sprintf("Error updating rancher project details for backup: %v", err)
+			backup.Status.Status = stork_api.ApplicationBackupStatusFailed
+			backup.Status.Stage = stork_api.ApplicationBackupStageFinal
+			backup.Status.Reason = message
+			backup.Status.LastUpdateTimestamp = metav1.Now()
+			err = a.client.Update(context.TODO(), backup)
+			if err != nil {
+				return err
+			}
+			a.recorder.Event(backup,
+				v1.EventTypeWarning,
+				string(stork_api.ApplicationBackupStatusFailed),
+				message)
+			log.ApplicationBackupLog(backup).Errorf(message)
 			return err
 		}
-		a.recorder.Event(backup,
-			v1.EventTypeWarning,
-			string(stork_api.ApplicationBackupStatusFailed),
-			message)
-		log.ApplicationBackupLog(backup).Errorf(message)
-		return err
 	}
 
 	// Upload the resources to the backup location

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -545,6 +545,7 @@ func (a *ApplicationCloneController) prepareResources(
 			pvNameMappings,
 			clone.Spec.IncludeOptionalResourceTypes,
 			nil,
+			nil,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -705,7 +705,7 @@ func (a *ApplicationCloneController) applyResources(
 		retained := false
 		err = a.resourceCollector.ApplyResource(
 			a.dynamicInterface,
-			o)
+			o, nil)
 		if err != nil && errors.IsAlreadyExists(err) {
 			switch clone.Spec.ReplacePolicy {
 			case stork_api.ApplicationCloneReplacePolicyDelete:

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -207,7 +207,7 @@ func (a *ApplicationRestoreController) createNamespaces(backup *storkapi.Applica
 							annotations = make(map[string]string)
 						}
 						for k, v := range ns.GetAnnotations() {
-							if _, ok := annotations[k]; !ok {
+							if _, ok := annotations[k]; !ok && !strings.Contains(k, utils.CattleProjectPrefix) {
 								annotations[k] = v
 							}
 						}
@@ -216,10 +216,12 @@ func (a *ApplicationRestoreController) createNamespaces(backup *storkapi.Applica
 							labels = make(map[string]string)
 						}
 						for k, v := range ns.GetLabels() {
-							if _, ok := labels[k]; !ok {
+							if _, ok := labels[k]; !ok && !strings.Contains(k, utils.CattleProjectPrefix) {
 								labels[k] = v
 							}
 						}
+						utils.ParseRancherProjectMapping(annotations, rancherProjectMapping)
+						utils.ParseRancherProjectMapping(labels, rancherProjectMapping)
 					}
 					log.ApplicationRestoreLog(restore).Tracef("Namespace already exists, updating dest namespace %v", ns.Name)
 					_, err = core.Instance().UpdateNamespace(&v1.Namespace{
@@ -1279,7 +1281,9 @@ func (a *ApplicationRestoreController) applyResources(
 
 		err = a.resourceCollector.ApplyResource(
 			a.dynamicInterface,
-			o)
+			o,
+			&opts,
+		)
 		if err != nil && errors.IsAlreadyExists(err) {
 			switch restore.Spec.ReplacePolicy {
 			case storkapi.ApplicationRestoreReplacePolicyDelete:

--- a/pkg/resourcecollector/networkpolicy.go
+++ b/pkg/resourcecollector/networkpolicy.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (r *ResourceCollector) prepareNetworkPolicyForCollection(
+func (r *ResourceCollector) prepareRancherNetworkPolicy(
 	object runtime.Unstructured,
 	opts Options,
 ) error {
@@ -20,6 +20,8 @@ func (r *ResourceCollector) prepareNetworkPolicyForCollection(
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &networkPolicy); err != nil {
 		return fmt.Errorf("error converting to networkpolicy: %v", err)
 	}
+
+	utils.ParseRancherProjectMapping(networkPolicy.Labels, opts.RancherProjectMappings)
 
 	// Handle namespace selectors for Rancher Network Policies
 	if len(opts.RancherProjectMappings) > 0 {

--- a/pkg/resourcecollector/networkpolicy.go
+++ b/pkg/resourcecollector/networkpolicy.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -102,4 +104,46 @@ func (r *ResourceCollector) networkPolicyToBeCollected(
 	}
 
 	return true, nil
+}
+
+func (r *ResourceCollector) mergeAndUpdateNetworkPolicy(
+	object runtime.Unstructured,
+	opts *Options,
+) error {
+
+	if len(opts.RancherProjectMappings) == 0 {
+		return nil
+	}
+
+	var newNetworkPolicy v1.NetworkPolicy
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &newNetworkPolicy); err != nil {
+		return fmt.Errorf("error converting to networkpolicy: %v", err)
+	}
+
+	curNetworkPolicy, err := r.coreOps.GetNetworkPolicy(newNetworkPolicy.Name, newNetworkPolicy.Namespace)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err = r.coreOps.CreateNetworkPolicy(&newNetworkPolicy)
+		}
+		return err
+	}
+
+	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&curNetworkPolicy)
+	if err != nil {
+		return fmt.Errorf("error converting from networkPolicy to runtime.Unstructured: %v", err)
+	}
+	obj := &unstructured.Unstructured{}
+	obj.SetUnstructuredContent(content)
+
+	if err = r.prepareRancherNetworkPolicy(obj, *opts); err != nil {
+		return err
+	}
+
+	var parsedNetworkPolicy v1.NetworkPolicy
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &parsedNetworkPolicy); err != nil {
+		return fmt.Errorf("error converting to networkpolicy: %v", err)
+	}
+
+	_, err = r.coreOps.UpdateNetworkPolicy(&parsedNetworkPolicy)
+	return err
 }

--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -143,6 +143,7 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
 	storageClassMappings map[string]string,
 	namespaceMappings map[string]string,
+	opts Options,
 ) (bool, error) {
 	var updatedName string
 	var present bool
@@ -182,6 +183,11 @@ func (r *ResourceCollector) preparePVResourceForApply(
 				pv.Spec.StorageClassName = oldSc
 			}
 		}
+	}
+
+	if opts.RancherProjectMappings != nil {
+		utils.ParseRancherProjectMapping(pv.Annotations, opts.RancherProjectMappings)
+		utils.ParseRancherProjectMapping(pv.Labels, opts.RancherProjectMappings)
 	}
 
 	pv.Name = updatedName

--- a/pkg/resourcecollector/persistentvolumeclaim.go
+++ b/pkg/resourcecollector/persistentvolumeclaim.go
@@ -56,6 +56,7 @@ func (r *ResourceCollector) preparePVCResourceForApply(
 	pvNameMappings map[string]string,
 	storageClassMappings map[string]string,
 	vInfos []*stork_api.ApplicationRestoreVolumeInfo,
+	opts Options,
 ) (bool, error) {
 	var pvc v1.PersistentVolumeClaim
 	var updatedName string
@@ -97,6 +98,12 @@ func (r *ResourceCollector) preparePVCResourceForApply(
 		}
 
 	}
+
+	if opts.RancherProjectMappings != nil {
+		utils.ParseRancherProjectMapping(pvc.Annotations, opts.RancherProjectMappings)
+		utils.ParseRancherProjectMapping(pvc.Labels, opts.RancherProjectMappings)
+	}
+
 	if len(storageClassMappings) > 0 {
 		// In the case of storageClassMappings, we need to reset the
 		// storage class annotation and the provisioner annotation

--- a/pkg/resourcecollector/pod.go
+++ b/pkg/resourcecollector/pod.go
@@ -52,7 +52,7 @@ func PreparePodSpecNamespaceSelector(
 
 	// Affinity
 	// - handle PreferredDuringSchedulingIgnoredDuringExecution
-	if podSpec.Affinity.PodAntiAffinity != nil {
+	if podSpec.Affinity.PodAffinity != nil {
 		for affinityIndex, affinityTerm := range podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
 			if affinityTerm.PodAffinityTerm.NamespaceSelector != nil {
 				for key, val := range affinityTerm.PodAffinityTerm.NamespaceSelector.MatchLabels {

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -751,7 +751,7 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 			}
 
 		case "NetworkPolicy":
-			err := r.prepareNetworkPolicyForCollection(o, opts)
+			err := r.prepareRancherNetworkPolicy(o, opts)
 			if err != nil {
 				return fmt.Errorf("error preparing NetworkPolicy resource %v: %v", metadata.GetName(), err)
 			}
@@ -852,6 +852,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 	pvNameMappings map[string]string,
 	optionalResourceTypes []string,
 	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
+	opts *Options,
 ) (bool, error) {
 	objectType, err := meta.TypeAccessor(object)
 	if err != nil {
@@ -887,9 +888,9 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		}
 		return true, nil
 	case "PersistentVolume":
-		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings, namespaceMappings)
+		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings, namespaceMappings, *opts)
 	case "PersistentVolumeClaim":
-		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings, storageClassMappings, vInfo)
+		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings, storageClassMappings, vInfo, *opts)
 	case "ClusterRoleBinding":
 		return false, r.prepareClusterRoleBindingForApply(object, namespaceMappings)
 	case "RoleBinding":
@@ -900,6 +901,11 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		return false, r.prepareMutatingWebHookForApply(object, namespaceMappings)
 	case "Secret":
 		return false, r.prepareSecretForApply(object)
+	case "NetworkPolicy":
+		return false, r.prepareRancherNetworkPolicy(object, *opts)
+	case "Deployment", "StatefulSet", "DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer", "ReplicaSet":
+		return false, r.prepareRancherApplicationResource(object, *opts)
+
 	}
 	return false, nil
 }
@@ -1064,4 +1070,37 @@ func (r *ResourceCollector) getDynamicClient(
 	}
 	return dynamicInterface.Resource(
 		object.GetObjectKind().GroupVersionKind().GroupVersion().WithResource(resource.Name)).Namespace(destNamespace), nil
+}
+
+func (r *ResourceCollector) prepareRancherApplicationResource(
+	object runtime.Unstructured,
+	opts Options,
+) error {
+	content := object.UnstructuredContent()
+	if len(opts.RancherProjectMappings) > 0 {
+		podSpecField, found, err := unstructured.NestedFieldCopy(content, "spec", "template", "spec")
+		if err != nil {
+			logrus.Warnf("Unable to parse object %v while handling"+
+				" rancher project mappings", object.GetObjectKind().GroupVersionKind().Kind)
+		}
+		var podSpec v1.PodSpec
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(podSpecField.(map[string]interface{}), &podSpec); err != nil {
+			return fmt.Errorf("error converting to podSpec: %v", err)
+		}
+		if found {
+			podSpecPtr := PreparePodSpecNamespaceSelector(
+				&podSpec,
+				opts.RancherProjectMappings,
+			)
+			o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&podSpecPtr)
+			if err != nil {
+				return err
+			}
+			if err := unstructured.SetNestedField(content, o, "spec", "template", "spec"); err != nil {
+				logrus.Warnf("Unable to set namespace selector for object %v while handling"+
+					" rancher project mappings", object.GetObjectKind().GroupVersionKind().Kind)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -918,8 +918,8 @@ func (r *ResourceCollector) mergeSupportedForResource(
 		return false
 	}
 	switch objectType.GetKind() {
-	case "ClusterRoleBinding",
-		"ServiceAccount":
+	case "ClusterRoleBinding", "ServiceAccount", "NetworkPolicy", "Deployment", "StatefulSet",
+		"DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer", "ReplicaSet":
 		return true
 	}
 	return false
@@ -927,6 +927,8 @@ func (r *ResourceCollector) mergeSupportedForResource(
 
 func (r *ResourceCollector) mergeAndUpdateResource(
 	object runtime.Unstructured,
+	dynamicClient dynamic.ResourceInterface,
+	opts *Options,
 ) error {
 	objectType, err := meta.TypeAccessor(object)
 	if err != nil {
@@ -938,6 +940,11 @@ func (r *ResourceCollector) mergeAndUpdateResource(
 		return r.mergeAndUpdateClusterRoleBinding(object)
 	case "ServiceAccount":
 		return r.mergeAndUpdateServiceAccount(object)
+	case "NetworkPolicy":
+		return r.mergeAndUpdateNetworkPolicy(object, opts)
+	case "Deployment", "StatefulSet", "DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer", "ReplicaSet":
+		return r.mergeAndUpdateApplicationResource(object, dynamicClient, opts)
+
 	}
 	return nil
 }
@@ -946,6 +953,7 @@ func (r *ResourceCollector) mergeAndUpdateResource(
 func (r *ResourceCollector) ApplyResource(
 	dynamicInterface dynamic.Interface,
 	object runtime.Unstructured,
+	opts *Options,
 ) error {
 	dynamicClient, err := r.getDynamicClient(dynamicInterface, object)
 	if err != nil {
@@ -955,7 +963,7 @@ func (r *ResourceCollector) ApplyResource(
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) || strings.Contains(err.Error(), portallocator.ErrAllocated.Error()) {
 			if r.mergeSupportedForResource(object) {
-				return r.mergeAndUpdateResource(object)
+				return r.mergeAndUpdateResource(object, dynamicClient, opts)
 			} else if strings.Contains(err.Error(), portallocator.ErrAllocated.Error()) {
 				err = r.updateService(object)
 				if err != nil {
@@ -1070,6 +1078,33 @@ func (r *ResourceCollector) getDynamicClient(
 	}
 	return dynamicInterface.Resource(
 		object.GetObjectKind().GroupVersionKind().GroupVersion().WithResource(resource.Name)).Namespace(destNamespace), nil
+}
+
+func (r *ResourceCollector) mergeAndUpdateApplicationResource(
+	object runtime.Unstructured,
+	dynamicClient dynamic.ResourceInterface,
+	opts *Options) error {
+
+	if len(opts.RancherProjectMappings) == 0 {
+		return nil
+	}
+
+	metadata, err := meta.Accessor(object)
+	if err != nil {
+		return fmt.Errorf("error getting metadata from object: %v", err)
+	}
+
+	curAppResource, err := dynamicClient.Get(context.TODO(), metadata.GetName(), metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err = dynamicClient.Create(context.TODO(), object.(*unstructured.Unstructured), metav1.CreateOptions{})
+		}
+		return err
+	}
+	r.prepareRancherApplicationResource(curAppResource, *opts)
+
+	dynamicClient.Update(context.TODO(), curAppResource, metav1.UpdateOptions{})
+	return nil
 }
 
 func (r *ResourceCollector) prepareRancherApplicationResource(

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -82,3 +82,18 @@ func GetStorageClassNameForPVC(pvc *v1.PersistentVolumeClaim) (string, error) {
 	}
 	return scName, nil
 }
+
+// ParseRancherProjectMapping - maps the target projectId to the source projectId
+func ParseRancherProjectMapping(
+	data map[string]string,
+	projectMapping map[string]string,
+) {
+	for key, value := range data {
+		if strings.Contains(key, CattleProjectPrefix) {
+			if targetProjectID, ok := projectMapping[value]; ok &&
+				targetProjectID != "" {
+				data[key] = targetProjectID
+			}
+		}
+	}
+}


### PR DESCRIPTION
What type of PR is this? feature

**What this PR does / why we need it**: Add supports to perform project mapping for rancher platform
-> Extracts the associated rancher projects from k8s resources and updates the ApplicationBackup CR
-> Based on the project mapping available in the ApplicationRestore CR, it replaces the projects IDs in the required annotations, labels , namespace selectors with the target project ID


