### PR TITLE
pb-3557: Added check to return from applicationbackup handler, if stage is already final.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -248,6 +248,10 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		return nil
 	}
 
+	// If the backup is already in final stage, return with out doing anything.
+	if backup.Status.Stage == stork_api.ApplicationBackupStageFinal {
+		return nil
+	}
 	if labelSelector := backup.Spec.NamespaceSelector; len(labelSelector) != 0 {
 		namespaces, err := core.Instance().ListNamespaces(labelSelector)
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
> bug

**What this PR does / why we need it**:
```
pb-3557: Added check to return from applicationbackup handler, if stage is already final.
```
**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: Some the restore fails to restore the volumes as the applicationbackup CR get over written during restore.
User Impact: Some time the restoring of volumes faces failure.
Resolution: Added check not to process any thing on the applicationbackup CR, if it is already in final stage.

```

**Does this change need to be cherry-picked to a release branch?**:
23.2.1