### PR TITLE
pb-3571: Added changes to seperate mergeSupportedForResource required for rancher

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1052,7 +1052,9 @@ func updateProjectDisplayNames(
 	platformCredential *stork_api.PlatformCredential,
 ) error {
 	rancherClient := &rancher.Rancher{}
-	rancherClient.Init(*platformCredential.Spec.RancherConfig)
+	if err := rancherClient.Init(*platformCredential.Spec.RancherConfig); err != nil {
+		return err
+	}
 	projectList, err := rancherClient.ListProjectNames()
 	if err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
    pb-3571: Added changes to seperate mergeSupportedForResource required for rancher
 ```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
release note is not needed as it is a regression got introduced by rancher project PR.

**Does this change need to be cherry-picked to a release branch?**:
23.2.1 branch

Testing:
- Tested the restore with replace option on a already existing namespace.
- Now the restore went through fine.
![Screenshot 2023-02-21 at 10 01 24 PM](https://user-images.githubusercontent.com/52188641/220403995-d7f5ad46-4fa2-4163-a202-2f5334ed0855.png)
