### PR TITLE
PWX-29223: Remove finalizer when deleting CR during migration

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -2144,6 +2144,13 @@ func (m *MigrationController) applyResources(
 										obj.GetName(), deleteStart, createTime)
 									break
 								}
+								if obj.GetFinalizers() != nil {
+									obj.SetFinalizers(nil)
+									_, err = dynamicClient.Update(context.TODO(), obj, metav1.UpdateOptions{})
+									if err != nil {
+										log.MigrationLog(migration).Warnf("unable to delete finalizer for object %v", metadata.GetName())
+									}
+								}
 								log.MigrationLog(migration).Warnf("Object %v still present, retrying in %v", metadata.GetName(), deletedRetryInterval)
 								time.Sleep(deletedRetryInterval)
 							}


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
PWX-29223
Unable to migrate CRs due to "_Error applying resource: object is being deleted: kafkas.platform.confluent.io "kafka" already exists"_


**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Issue: Unable to migrate Confluent Kafka resources during failback.
User Impact: Confluent Kafka application failback unable to bring up the application
Resolution: Stork will now remove any finalizers on the CRs when deleting the resource during migration so that a new version of the resource can be recreated.
```

**Does this change need to be cherry-picked to a release branch?**:
yes 23.3/23.2


