### PR TITLE
PWX-29218: Do not log retry events during migration

### DIFF
--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -268,12 +268,15 @@ func (m *MigrationScheduleController) handle(ctx context.Context, migrationSched
 	err = m.pruneMigrations(migrationSchedule)
 	if err != nil {
 		msg := fmt.Sprintf("Error pruning old migrations: %v", err)
-		m.recorder.Event(migrationSchedule,
-			v1.EventTypeWarning,
-			string(stork_api.MigrationStatusFailed),
-			msg)
-		log.MigrationScheduleLog(migrationSchedule).Error(msg)
-		return err
+		// Don't need to log this event as Stork retries if it fails to update
+		if !strings.Contains(msg, ErrReapplyLatestVersionMsg) {
+			m.recorder.Event(migrationSchedule,
+				v1.EventTypeWarning,
+				string(stork_api.MigrationStatusFailed),
+				msg)
+			log.MigrationScheduleLog(migrationSchedule).Error(msg)
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>improvement

**What this PR does / why we need it**:
PWX-29218

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```Improvement
Stop logging unwanted migration retry events logs in migration and migrationschedule CR
```

