### PR TITLE
PWX-29253: Adding support for gke-gcloud-auth-plugin (#1312)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,19 @@ RUN python3 -m pip install awscli  && python3 -m pip install rsa --upgrade
 RUN curl -q -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
+#Install Google Cloud SDK
 ARG GCLOUD_SDK=google-cloud-sdk-418.0.0-linux-x86_64.tar.gz
-# Remove the test directories
-# Also don't need gsutil
+ARG GCLOUD_INSTALL_DIR="/usr/lib"
 RUN curl -q -o $GCLOUD_SDK https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
-    tar xf $GCLOUD_SDK && rm -rf $GCLOUD_SDK && \
-    rm -rf /google-cloud-sdk/platform/gsutil/third_party/oauth2client/tests \
-        /google-cloud-sdk/platform/gsutil/third_party/rsa/tests \
-        /google-cloud-sdk/platform/gsutil/third_party/httplib2/python2/httplib2/test \
-        /google-cloud-sdk/platform/gsutil && \
-    python3 -m pip install pyyaml>=5.1 rsa>=4.0 urllib3>=1.24.2 --upgrade -t /google-cloud-sdk/lib/third_party
+    tar xf $GCLOUD_SDK -C $GCLOUD_INSTALL_DIR && rm -rf $GCLOUD_SDK && \
+    rm -rf $GCLOUD_INSTALL_DIR/google-cloud-sdk/platform/gsutil \
+           $GCLOUD_INSTALL_DIR/google-cloud-sdk/RELEASE_NOTES
+ENV PATH "${PATH}:$GCLOUD_INSTALL_DIR/google-cloud-sdk/bin"
+#Install gke-gcloud-auth-plugin
+RUN gcloud components install gke-gcloud-auth-plugin
+#Create symlink /google-cloud-sdk/bin -> /usr/lib/google-cloud-sdk/bin for legacy cluster pair with gcp auth plugin
+RUN mkdir google-cloud-sdk
+RUN ln -s /usr/lib/google-cloud-sdk/bin /google-cloud-sdk/bin
 
 WORKDIR /
 

--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/libopenstorage/stork/pkg/cache"
 	"net/http"
 	"os"
 	"os/signal"
@@ -23,6 +22,7 @@ import (
 	_ "github.com/libopenstorage/stork/drivers/volume/portworx"
 	"github.com/libopenstorage/stork/pkg/apis"
 	"github.com/libopenstorage/stork/pkg/applicationmanager"
+	"github.com/libopenstorage/stork/pkg/cache"
 	"github.com/libopenstorage/stork/pkg/clusterdomains"
 	"github.com/libopenstorage/stork/pkg/dbg"
 	"github.com/libopenstorage/stork/pkg/extender"
@@ -208,6 +208,10 @@ func main() {
 			Usage: "Start the resource transformation controller (default: true)",
 		},
 	}
+
+	// Export USE_GKE_GCLOUD_AUTH_PLUGIN=True
+	log.Warnf("Export USE_GKE_GCLOUD_AUTH_PLUGIN=True")
+	os.Setenv("USE_GKE_GCLOUD_AUTH_PLUGIN", "True")
 
 	if err := app.Run(os.Args); err != nil {
 		log.Fatalf("Error starting stork: %v", err)

--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -8,18 +8,16 @@ RUN apt-get update && apt-get install -y python3-pip && apt-get install -y jq
 
 RUN pip3 install --upgrade pip
 
-ARG GCLOUD_SDK=google-cloud-sdk-269.0.0-linux-x86_64.tar.gz
-# Remove the test directories
-# Also don't need gsutil
-RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
-    tar xf $GCLOUD_SDK && rm -rf $GCLOUD_SDK && \
-    cp -r google-cloud-sdk/bin/* /usr/local/bin/  && \
-    cp -r google-cloud-sdk/lib/* /usr/local/lib/  && \
-    rm -rf /google-cloud-sdk/platform/gsutil/third_party/oauth2client/tests \
-        /google-cloud-sdk/platform/gsutil/third_party/rsa/tests \
-        /google-cloud-sdk/platform/gsutil/third_party/httplib2/python2/httplib2/test \
-        /google-cloud-sdk/platform/gsutil && \
-    python3 -m pip install pyyaml>=5.1 rsa>=4.0 urllib3>=1.24.2 --upgrade -t /google-cloud-sdk/lib/third_party
+#Install Google Cloud SDK
+ARG GCLOUD_SDK=google-cloud-sdk-418.0.0-linux-x86_64.tar.gz
+ARG GCLOUD_INSTALL_DIR="/usr/lib"
+RUN curl -q -o $GCLOUD_SDK https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
+    tar xf $GCLOUD_SDK -C $GCLOUD_INSTALL_DIR && rm -rf $GCLOUD_SDK && \
+    rm -rf $GCLOUD_INSTALL_DIR/google-cloud-sdk/platform/gsutil \
+           $GCLOUD_INSTALL_DIR/google-cloud-sdk/RELEASE_NOTES
+ENV PATH "${PATH}:$GCLOUD_INSTALL_DIR/google-cloud-sdk/bin"
+#Install gke-gcloud-auth-plugin
+RUN gcloud components install gke-gcloud-auth-plugin
 
 RUN wget -O /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
     chmod +x /usr/local/bin/aws-iam-authenticator


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
Add support for gke-gcloud-auth-plugin https://portworx.atlassian.net/browse/PWX-29253

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Added support for gke-gcloud-auth-plugin required for authenticating with GKE.
```

**Does this change need to be cherry-picked to a release branch?**:
yes 23.2

**Notes for the reviewer**:
- PWX-29253 reports error "configuration: interactiveMode must be specified". However this error is not present when using the storkctl binary from 23.2 build. This is due to the updated K8s APIs. We do not need to set an explicit Exec.InteractiveMode
- Changing the installation directory to /usr/lib for google-cloud-sdk as it should not be present in root directory
- platform/gsutil was being deleted from previous versions too. Also deleting RELEASE_NOTES(1 MB)
- python3 -m pip install to update third_party shouldn't be needed. 
- USE_GKE_GCLOUD_AUTH_PLUGIN should be set to true as per the doc [https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke ] I didn't observe any issues when it was not set on K8s v1.24.9-gke. But setting it nevertheless as the doc suggests it and we might run into issues on older K8s versions
- Creating symlink as the legacy auth plugin requires us to pass the path of gcloud https://github.com/libopenstorage/stork/blob/master/pkg/storkctl/clusterpair.go#:~:text=/google%2Dcloud%2Dsdk/bin/gcloud and we have set it to ./google-cloud-sdk/bin/gcloud. Symlink is required so that existing clusterpairs using this setting do not break with upgrade to the new Stork version
- Also updating integration-test container 
