### PR TITLE
PWX-29462: Add storkctl command for failover

### DIFF
--- a/pkg/resourceutils/updatereplicas.go
+++ b/pkg/resourceutils/updatereplicas.go
@@ -1,0 +1,346 @@
+package resourceutils
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-openapi/inflect"
+	migration "github.com/libopenstorage/stork/pkg/migration/controllers"
+	"github.com/portworx/sched-ops/k8s/apps"
+	"github.com/portworx/sched-ops/k8s/batch"
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/sched-ops/k8s/dynamic"
+	"github.com/portworx/sched-ops/k8s/openshift"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sdynamic "k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/cmd/util"
+)
+
+func ScaleReplicas(namespace string, activate bool, printFunc func(string, string), config *rest.Config) {
+	updateStatefulSets(namespace, activate, printFunc)
+	updateDeployments(namespace, activate, printFunc)
+	updateDeploymentConfigs(namespace, activate, printFunc)
+	updateIBPObjects("IBPPeer", namespace, activate, printFunc)
+	updateIBPObjects("IBPCA", namespace, activate, printFunc)
+	updateIBPObjects("IBPOrderer", namespace, activate, printFunc)
+	updateIBPObjects("IBPConsole", namespace, activate, printFunc)
+	updateVMObjects("VirtualMachine", namespace, true, printFunc)
+	updateCRDObjects(namespace, activate, printFunc, config)
+	updateCronJobObjects(namespace, activate, printFunc)
+}
+
+func updateStatefulSets(namespace string, activate bool, printFunc func(string, string)) {
+	statefulSets, err := apps.Instance().ListStatefulSets(namespace, metav1.ListOptions{})
+	if err != nil {
+		util.CheckErr(err)
+		return
+	}
+	for _, statefulSet := range statefulSets.Items {
+		if replicas, update := getUpdatedReplicaCount(statefulSet.Annotations, activate, printFunc); update {
+			statefulSet.Spec.Replicas = &replicas
+			_, err := apps.Instance().UpdateStatefulSet(&statefulSet)
+			if err != nil {
+				printFunc(fmt.Sprintf("Error updating replicas for statefulset %v/%v : %v", statefulSet.Namespace, statefulSet.Name, err), "err")
+				continue
+			}
+			printFunc(fmt.Sprintf("Updated replicas for statefulset %v/%v to %v", statefulSet.Namespace, statefulSet.Name, replicas), "out")
+		}
+
+	}
+}
+
+func updateDeployments(namespace string, activate bool, printFunc func(string, string)) {
+	deployments, err := apps.Instance().ListDeployments(namespace, metav1.ListOptions{})
+	if err != nil {
+		util.CheckErr(err)
+		return
+	}
+	for _, deployment := range deployments.Items {
+		if replicas, update := getUpdatedReplicaCount(deployment.Annotations, activate, printFunc); update {
+			deployment.Spec.Replicas = &replicas
+			_, err := apps.Instance().UpdateDeployment(&deployment)
+			if err != nil {
+				printFunc(fmt.Sprintf("Error updating replicas for deployment %v/%v : %v", deployment.Namespace, deployment.Name, err), "err")
+				continue
+			}
+			printFunc(fmt.Sprintf("Updated replicas for deployment %v/%v to %v", deployment.Namespace, deployment.Name, replicas), "out")
+		}
+	}
+}
+
+func updateDeploymentConfigs(namespace string, activate bool, printFunc func(string, string)) {
+	deployments, err := openshift.Instance().ListDeploymentConfigs(namespace)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			util.CheckErr(err)
+		}
+		return
+	}
+	for _, deployment := range deployments.Items {
+		if replicas, update := getUpdatedReplicaCount(deployment.Annotations, activate, printFunc); update {
+			deployment.Spec.Replicas = replicas
+			_, err := openshift.Instance().UpdateDeploymentConfig(&deployment)
+			if err != nil {
+				printFunc(fmt.Sprintf("Error updating replicas for deploymentconfig %v/%v : %v", deployment.Namespace, deployment.Name, err), "err")
+				continue
+			}
+			printFunc(fmt.Sprintf("Updated replicas for deploymentconfig %v/%v to %v", deployment.Namespace, deployment.Name, replicas), "out")
+		}
+	}
+}
+
+func updateCRDObjects(ns string, activate bool, printFunc func(string, string), config *rest.Config) {
+	crdList, err := storkops.Instance().ListApplicationRegistrations()
+	if err != nil {
+		util.CheckErr(err)
+		return
+	}
+	configClient, err := k8sdynamic.NewForConfig(config)
+	if err != nil {
+		util.CheckErr(err)
+		return
+	}
+	ruleset := inflect.NewDefaultRuleset()
+	ruleset.AddPlural("quota", "quotas")
+	ruleset.AddPlural("prometheus", "prometheuses")
+	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
+	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
+	ruleset.AddPlural("mongodb", "mongodb")
+	for _, res := range crdList.Items {
+		for _, crd := range res.Resources {
+			var client k8sdynamic.ResourceInterface
+			opts := &metav1.ListOptions{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       crd.Kind,
+					APIVersion: crd.Group + "/" + crd.Version},
+			}
+			gvk := schema.FromAPIVersionAndKind(opts.APIVersion, opts.Kind)
+			resourceInterface := configClient.Resource(gvk.GroupVersion().WithResource(ruleset.Pluralize(strings.ToLower(gvk.Kind))))
+			client = resourceInterface.Namespace(ns)
+			objects, err := client.List(context.TODO(), *opts)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					continue
+				}
+				util.CheckErr(err)
+				return
+			}
+			for _, o := range objects.Items {
+				annotations := o.GetAnnotations()
+				if annotations == nil {
+					printFunc(fmt.Sprintf("Warn: Skipping CR update %s-%s/%s, annotations not found", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName()), "err")
+					continue
+				}
+				if crd.SuspendOptions.Path != "" {
+					crd.NestedSuspendOptions = append(crd.NestedSuspendOptions, crd.SuspendOptions)
+				}
+				if len(crd.NestedSuspendOptions) == 0 {
+					continue
+				}
+				for _, suspend := range crd.NestedSuspendOptions {
+					specPath := strings.Split(suspend.Path, ".")
+					if len(specPath) > 1 {
+						var disableVersion interface{}
+						if suspend.Type == "bool" {
+							if val, err := strconv.ParseBool(suspend.Value); err != nil {
+								disableVersion = !activate
+							} else {
+								disableVersion = val
+								if activate {
+									disableVersion = !val
+								}
+							}
+						} else if suspend.Type == "int" {
+							replicas, _ := getSuspendIntOpts(o.GetAnnotations(), activate, suspend.Path, printFunc)
+							disableVersion = replicas
+						} else if suspend.Type == "string" {
+							suspend, err := getSuspendStringOpts(o.GetAnnotations(), activate, suspend.Path, printFunc)
+							if err != nil {
+								util.CheckErr(err)
+								return
+							}
+							disableVersion = suspend
+						} else {
+							util.CheckErr(fmt.Errorf("invalid type %v to suspend cr", crd.SuspendOptions.Type))
+							return
+						}
+						err := unstructured.SetNestedField(o.Object, disableVersion, specPath...)
+						if err != nil {
+							printFunc(fmt.Sprintf("Error updating \"%v\" for %v %v/%v to %v : %v", suspend.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), disableVersion, err), "err")
+							continue
+						}
+					}
+				}
+				_, err = client.Update(context.TODO(), &o, metav1.UpdateOptions{}, "")
+				if err != nil {
+					printFunc(fmt.Sprintf("Error updating CR %v %v/%v: %v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), "err")
+					continue
+				}
+				printFunc(fmt.Sprintf("Updated CR for %v %v/%v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName()), "out")
+				if !activate {
+					if crd.PodsPath == "" {
+						continue
+					}
+					podpath := strings.Split(crd.PodsPath, ".")
+					pods, found, err := unstructured.NestedStringSlice(o.Object, podpath...)
+					if err != nil {
+						printFunc(fmt.Sprintf("Error getting pods for %v %v/%v : %v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), "err")
+						continue
+					}
+					if !found {
+						continue
+					}
+					for _, pod := range pods {
+						err = core.Instance().DeletePod(o.GetNamespace(), pod, true)
+						printFunc(fmt.Sprintf("Error deleting pod %v for %v %v/%v : %v", pod, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), "err")
+						continue
+					}
+				}
+			}
+
+		}
+	}
+}
+
+func updateIBPObjects(kind string, namespace string, activate bool, printFunc func(string, string)) {
+	objects, err := dynamic.Instance().ListObjects(
+		&metav1.ListOptions{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       kind,
+				APIVersion: "ibp.com/v1alpha1"},
+		},
+		namespace)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			util.CheckErr(err)
+		}
+		return
+	}
+	for _, o := range objects.Items {
+		if replicas, update := getUpdatedReplicaCount(o.GetAnnotations(), activate, printFunc); update {
+			err := unstructured.SetNestedField(o.Object, int64(replicas), "spec", "replicas")
+			if err != nil {
+				printFunc(fmt.Sprintf("Error updating replicas for %v %v/%v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), err), "err")
+				continue
+			}
+			_, err = dynamic.Instance().UpdateObject(&o)
+			if err != nil {
+				printFunc(fmt.Sprintf("Error updating replicas for %v %v/%v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), err), "err")
+				continue
+			}
+			printFunc(fmt.Sprintf("Updated replicas for %v %v/%v to %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), replicas), "out")
+		}
+	}
+}
+
+func updateVMObjects(kind string, namespace string, activate bool, printFunc func(string, string)) {
+	objects, err := dynamic.Instance().ListObjects(
+		&metav1.ListOptions{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       kind,
+				APIVersion: "kubevirt.io/v1"},
+		},
+		namespace)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			util.CheckErr(err)
+		}
+		return
+	}
+	for _, o := range objects.Items {
+		path := []string{"spec", "running"}
+		unstructured.RemoveNestedField(o.Object, path...)
+		printFunc(fmt.Sprintf("Removed field for %v %v/%v", strings.ToLower(kind), o.GetNamespace(), o.GetName()), "out")
+	}
+}
+
+func updateCronJobObjects(namespace string, activate bool, printFunc func(string, string)) {
+	cronJobs, err := batch.Instance().ListCronJobs(namespace, metav1.ListOptions{})
+	if err != nil {
+		util.CheckErr(err)
+		return
+	}
+
+	for _, cronJob := range cronJobs.Items {
+		*cronJob.Spec.Suspend = !activate
+		_, err = batch.Instance().UpdateCronJob(&cronJob)
+		if err != nil {
+			printFunc(fmt.Sprintf("Error updating suspend option for cronJob %v/%v : %v", cronJob.Namespace, cronJob.Name, err), "err")
+			continue
+		}
+		printFunc(fmt.Sprintf("Updated suspend option for cronjob %v/%v to %v", cronJob.Namespace, cronJob.Name, !activate), "out")
+	}
+
+}
+func getSuspendStringOpts(annotations map[string]string, activate bool, path string, printFunc func(string, string)) (string, error) {
+	if val, present := annotations[migration.StorkAnnotationPrefix+path]; present {
+		suspend := strings.Split(val, ",")
+		if len(suspend) != 2 {
+			return "", fmt.Errorf("migrated annotation does not have proper values %s/%s", migration.StorkAnnotationPrefix+path, val)
+		}
+		if activate {
+			return suspend[0], nil
+		}
+		return suspend[1], nil
+	}
+	// for backward compatibility of old migrated cr's
+	crdOpts := migration.StorkMigrationCRDActivateAnnotation
+	if !activate {
+		crdOpts = migration.StorkMigrationCRDDeactivateAnnotation
+	}
+	suspend, present := annotations[crdOpts]
+	if !present {
+		return "", fmt.Errorf("required migration annotation not found %s", crdOpts)
+	}
+	return suspend, nil
+}
+
+func getSuspendIntOpts(annotations map[string]string, activate bool, path string, printFunc func(string, string)) (int64, bool) {
+	intOpts := ""
+	if val, present := annotations[migration.StorkAnnotationPrefix+path]; present {
+		intOpts = strings.Split(val, ",")[0]
+	} else if val, present := annotations[migration.StorkMigrationCRDActivateAnnotation]; present {
+		// for old migrated cr compatibility
+		intOpts = val
+	} else {
+		return 0, false
+	}
+	var replicas int64
+	if activate {
+		parsedReplicas, err := strconv.Atoi(intOpts)
+		if err != nil {
+			printFunc(fmt.Sprintf("Error parsing replicas for app : %v", err), "err")
+			return 0, false
+		}
+		replicas = int64(parsedReplicas)
+	} else {
+		replicas = 0
+	}
+	return replicas, true
+}
+
+func getUpdatedReplicaCount(annotations map[string]string, activate bool, printFunc func(string, string)) (int32, bool) {
+	if replicas, present := annotations[migration.StorkMigrationReplicasAnnotation]; present {
+		var updatedReplicas int32
+		if activate {
+			parsedReplicas, err := strconv.Atoi(replicas)
+			if err != nil {
+				printFunc(fmt.Sprintf("Error parsing replicas for app : %v", err), "err")
+				return 0, false
+			}
+			updatedReplicas = int32(parsedReplicas)
+		} else {
+			updatedReplicas = 0
+		}
+		return updatedReplicas, true
+	}
+
+	return 0, false
+}

--- a/pkg/storkctl/action.go
+++ b/pkg/storkctl/action.go
@@ -1,0 +1,88 @@
+package storkctl
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/cmd/util"
+)
+
+const (
+	failoverCommand             = "failover"
+	nameTimeSuffixFormat string = "2006-01-02-150405"
+)
+
+func newPerformCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	performCommands := &cobra.Command{
+		Use:   "perform",
+		Short: "Perform actions",
+	}
+
+	performCommands.AddCommand(
+		newFailoverCommand(cmdFactory, ioStreams),
+	)
+	return performCommands
+}
+
+func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	getClusterPairCommand := &cobra.Command{
+		Use:   failoverCommand,
+		Short: "Initiate failover for the given namespaces",
+		Run: func(c *cobra.Command, args []string) {
+			namespaces, err := cmdFactory.GetAllNamespaces()
+			if err != nil {
+				util.CheckErr(err)
+				return
+			}
+			for _, namespace := range namespaces {
+				if anyActionIncomplete(namespace) {
+					printMsg(
+						fmt.Sprintf("Cannot perform new action as an action is already scheduled/in-progress for %v", namespace),
+						ioStreams.Out)
+					continue
+				}
+				action := storkv1.Action{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      newActionName(storkv1.ActionTypeFailover),
+						Namespace: namespace,
+					},
+					Spec: storkv1.ActionSpec{
+						ActionType: storkv1.ActionTypeFailover,
+					},
+					Status: storkv1.ActionStatusScheduled,
+				}
+				_, err = storkops.Instance().CreateAction(&action)
+				if err != nil {
+					util.CheckErr(err)
+					return
+				}
+			}
+		},
+	}
+	return getClusterPairCommand
+}
+
+// check if there is already an Action scheduled or in-progress
+func anyActionIncomplete(namespace string) bool {
+	actionList, err := storkops.Instance().ListActions(namespace)
+	if err != nil {
+		util.CheckErr(err)
+		return false
+	}
+	for _, action := range actionList.Items {
+		if action.Status == storkv1.ActionStatusScheduled || action.Status == storkv1.ActionStatusInProgress {
+			return true
+		}
+	}
+	return false
+}
+
+func newActionName(action storkv1.ActionType) string {
+	return strings.Join([]string{string(action), time.Now().Format(nameTimeSuffixFormat)}, "-")
+}

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -9,23 +9,16 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
-	"github.com/go-openapi/inflect"
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
-	migration "github.com/libopenstorage/stork/pkg/migration/controllers"
-	"github.com/portworx/sched-ops/k8s/apps"
-	"github.com/portworx/sched-ops/k8s/batch"
+	"github.com/libopenstorage/stork/pkg/resourceutils"
 	"github.com/portworx/sched-ops/k8s/core"
-	"github.com/portworx/sched-ops/k8s/dynamic"
-	"github.com/portworx/sched-ops/k8s/openshift"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/portworx/sched-ops/task"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -200,22 +193,11 @@ func newActivateMigrationsCommand(cmdFactory Factory, ioStreams genericclioption
 						return
 					}
 					printMsg(fmt.Sprintf("Set the ApplicationActivated status in the MigrationSchedule %v/%v to true", migr.Namespace, migr.Name), ioStreams.Out)
-
 				}
 			}
 			for _, ns := range activationNamespaces {
-				updateStatefulSets(ns, true, ioStreams)
-				updateDeployments(ns, true, ioStreams)
-				updateDeploymentConfigs(ns, true, ioStreams)
-				updateIBPObjects("IBPPeer", ns, true, ioStreams)
-				updateIBPObjects("IBPCA", ns, true, ioStreams)
-				updateIBPObjects("IBPOrderer", ns, true, ioStreams)
-				updateIBPObjects("IBPConsole", ns, true, ioStreams)
-				updateVMObjects("VirtualMachine", ns, true, ioStreams)
-				updateCRDObjects(ns, true, ioStreams, config)
-				updateCronJobObjects(ns, true, ioStreams)
+				resourceutils.ScaleReplicas(ns, true, printFunc(ioStreams), config)
 			}
-
 		},
 	}
 	activateMigrationCommand.Flags().BoolVarP(&allNamespaces, "all-namespaces", "a", false, "Activate applications in all namespaces")
@@ -260,16 +242,7 @@ func newDeactivateMigrationsCommand(cmdFactory Factory, ioStreams genericcliopti
 			}
 
 			for _, ns := range deactivationNamespaces {
-				updateStatefulSets(ns, false, ioStreams)
-				updateDeployments(ns, false, ioStreams)
-				updateDeploymentConfigs(ns, false, ioStreams)
-				updateIBPObjects("IBPPeer", ns, false, ioStreams)
-				updateIBPObjects("IBPCA", ns, false, ioStreams)
-				updateIBPObjects("IBPOrderer", ns, false, ioStreams)
-				updateIBPObjects("IBPConsole", ns, false, ioStreams)
-				updateVMObjects("VirtualMachine", ns, true, ioStreams)
-				updateCRDObjects(ns, false, ioStreams, config)
-				updateCronJobObjects(ns, false, ioStreams)
+				resourceutils.ScaleReplicas(ns, false, printFunc(ioStreams), config)
 			}
 
 			for _, ns := range migrationScheduleNamespaces {
@@ -301,311 +274,18 @@ func newDeactivateMigrationsCommand(cmdFactory Factory, ioStreams genericcliopti
 	return deactivateMigrationCommand
 }
 
-func updateStatefulSets(namespace string, activate bool, ioStreams genericclioptions.IOStreams) {
-	statefulSets, err := apps.Instance().ListStatefulSets(namespace, metav1.ListOptions{})
-	if err != nil {
-		util.CheckErr(err)
-		return
-	}
-	for _, statefulSet := range statefulSets.Items {
-		if replicas, update := getUpdatedReplicaCount(statefulSet.Annotations, activate, ioStreams); update {
-			statefulSet.Spec.Replicas = &replicas
-			_, err := apps.Instance().UpdateStatefulSet(&statefulSet)
-			if err != nil {
-				printMsg(fmt.Sprintf("Error updating replicas for statefulset %v/%v : %v", statefulSet.Namespace, statefulSet.Name, err), ioStreams.ErrOut)
-				continue
-			}
-			printMsg(fmt.Sprintf("Updated replicas for statefulset %v/%v to %v", statefulSet.Namespace, statefulSet.Name, replicas), ioStreams.Out)
-		}
-
-	}
-}
-
-func updateDeployments(namespace string, activate bool, ioStreams genericclioptions.IOStreams) {
-	deployments, err := apps.Instance().ListDeployments(namespace, metav1.ListOptions{})
-	if err != nil {
-		util.CheckErr(err)
-		return
-	}
-	for _, deployment := range deployments.Items {
-		if replicas, update := getUpdatedReplicaCount(deployment.Annotations, activate, ioStreams); update {
-			deployment.Spec.Replicas = &replicas
-			_, err := apps.Instance().UpdateDeployment(&deployment)
-			if err != nil {
-				printMsg(fmt.Sprintf("Error updating replicas for deployment %v/%v : %v", deployment.Namespace, deployment.Name, err), ioStreams.ErrOut)
-				continue
-			}
-			printMsg(fmt.Sprintf("Updated replicas for deployment %v/%v to %v", deployment.Namespace, deployment.Name, replicas), ioStreams.Out)
+func printFunc(ioStreams genericclioptions.IOStreams) func(string, string) {
+	return func(msg, stream string) {
+		switch stream {
+		case "out":
+			printMsg(msg, ioStreams.Out)
+		case "err":
+			printMsg(msg, ioStreams.ErrOut)
+		default:
+			printMsg("printFunc received invalid stream", ioStreams.ErrOut)
+			printMsg(msg, ioStreams.ErrOut)
 		}
 	}
-}
-
-func updateDeploymentConfigs(namespace string, activate bool, ioStreams genericclioptions.IOStreams) {
-	deployments, err := openshift.Instance().ListDeploymentConfigs(namespace)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			util.CheckErr(err)
-		}
-		return
-	}
-	for _, deployment := range deployments.Items {
-		if replicas, update := getUpdatedReplicaCount(deployment.Annotations, activate, ioStreams); update {
-			deployment.Spec.Replicas = replicas
-			_, err := openshift.Instance().UpdateDeploymentConfig(&deployment)
-			if err != nil {
-				printMsg(fmt.Sprintf("Error updating replicas for deploymentconfig %v/%v : %v", deployment.Namespace, deployment.Name, err), ioStreams.ErrOut)
-				continue
-			}
-			printMsg(fmt.Sprintf("Updated replicas for deploymentconfig %v/%v to %v", deployment.Namespace, deployment.Name, replicas), ioStreams.Out)
-		}
-	}
-}
-
-func updateCRDObjects(ns string, activate bool, ioStreams genericclioptions.IOStreams, config *rest.Config) {
-	crdList, err := storkops.Instance().ListApplicationRegistrations()
-	if err != nil {
-		util.CheckErr(err)
-		return
-	}
-	configClient, err := k8sdynamic.NewForConfig(config)
-	if err != nil {
-		util.CheckErr(err)
-		return
-	}
-	ruleset := inflect.NewDefaultRuleset()
-	ruleset.AddPlural("quota", "quotas")
-	ruleset.AddPlural("prometheus", "prometheuses")
-	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
-	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
-	ruleset.AddPlural("mongodb", "mongodb")
-	for _, res := range crdList.Items {
-		for _, crd := range res.Resources {
-			var client k8sdynamic.ResourceInterface
-			opts := &metav1.ListOptions{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       crd.Kind,
-					APIVersion: crd.Group + "/" + crd.Version},
-			}
-			gvk := schema.FromAPIVersionAndKind(opts.APIVersion, opts.Kind)
-			resourceInterface := configClient.Resource(gvk.GroupVersion().WithResource(ruleset.Pluralize(strings.ToLower(gvk.Kind))))
-			client = resourceInterface.Namespace(ns)
-			objects, err := client.List(context.TODO(), *opts)
-			if err != nil {
-				if errors.IsNotFound(err) {
-					continue
-				}
-				util.CheckErr(err)
-				return
-			}
-			for _, o := range objects.Items {
-				annotations := o.GetAnnotations()
-				if annotations == nil {
-					printMsg(fmt.Sprintf("Warn: Skipping CR update %s-%s/%s, annotations not found", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName()), ioStreams.ErrOut)
-					continue
-				}
-				if crd.SuspendOptions.Path != "" {
-					crd.NestedSuspendOptions = append(crd.NestedSuspendOptions, crd.SuspendOptions)
-				}
-				if len(crd.NestedSuspendOptions) == 0 {
-					continue
-				}
-				for _, suspend := range crd.NestedSuspendOptions {
-					specPath := strings.Split(suspend.Path, ".")
-					if len(specPath) > 1 {
-						var disableVersion interface{}
-						if suspend.Type == "bool" {
-							if val, err := strconv.ParseBool(suspend.Value); err != nil {
-								disableVersion = !activate
-							} else {
-								disableVersion = val
-								if activate {
-									disableVersion = !val
-								}
-							}
-						} else if suspend.Type == "int" {
-							replicas, _ := getSuspendIntOpts(o.GetAnnotations(), activate, suspend.Path, ioStreams)
-							disableVersion = replicas
-						} else if suspend.Type == "string" {
-							suspend, err := getSuspendStringOpts(o.GetAnnotations(), activate, suspend.Path, ioStreams)
-							if err != nil {
-								util.CheckErr(err)
-								return
-							}
-							disableVersion = suspend
-						} else {
-							util.CheckErr(fmt.Errorf("invalid type %v to suspend cr", crd.SuspendOptions.Type))
-							return
-						}
-						err := unstructured.SetNestedField(o.Object, disableVersion, specPath...)
-						if err != nil {
-							printMsg(fmt.Sprintf("Error updating \"%v\" for %v %v/%v to %v : %v", suspend.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), disableVersion, err), ioStreams.ErrOut)
-							continue
-						}
-					}
-				}
-				_, err = client.Update(context.TODO(), &o, metav1.UpdateOptions{}, "")
-				if err != nil {
-					printMsg(fmt.Sprintf("Error updating CR %v %v/%v: %v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), ioStreams.ErrOut)
-					continue
-				}
-				printMsg(fmt.Sprintf("Updated CR for %v %v/%v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName()), ioStreams.Out)
-				if !activate {
-					if crd.PodsPath == "" {
-						continue
-					}
-					podpath := strings.Split(crd.PodsPath, ".")
-					pods, found, err := unstructured.NestedStringSlice(o.Object, podpath...)
-					if err != nil {
-						printMsg(fmt.Sprintf("Error getting pods for %v %v/%v : %v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), ioStreams.ErrOut)
-						continue
-					}
-					if !found {
-						continue
-					}
-					for _, pod := range pods {
-						err = core.Instance().DeletePod(o.GetNamespace(), pod, true)
-						printMsg(fmt.Sprintf("Error deleting pod %v for %v %v/%v : %v", pod, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), ioStreams.ErrOut)
-						continue
-					}
-				}
-			}
-
-		}
-	}
-}
-func updateIBPObjects(kind string, namespace string, activate bool, ioStreams genericclioptions.IOStreams) {
-	objects, err := dynamic.Instance().ListObjects(
-		&metav1.ListOptions{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       kind,
-				APIVersion: "ibp.com/v1alpha1"},
-		},
-		namespace)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			util.CheckErr(err)
-		}
-		return
-	}
-	for _, o := range objects.Items {
-		if replicas, update := getUpdatedReplicaCount(o.GetAnnotations(), activate, ioStreams); update {
-			err := unstructured.SetNestedField(o.Object, int64(replicas), "spec", "replicas")
-			if err != nil {
-				printMsg(fmt.Sprintf("Error updating replicas for %v %v/%v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), err), ioStreams.ErrOut)
-				continue
-			}
-			_, err = dynamic.Instance().UpdateObject(&o)
-			if err != nil {
-				printMsg(fmt.Sprintf("Error updating replicas for %v %v/%v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), err), ioStreams.ErrOut)
-				continue
-			}
-			printMsg(fmt.Sprintf("Updated replicas for %v %v/%v to %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), replicas), ioStreams.Out)
-		}
-	}
-}
-func updateVMObjects(kind string, namespace string, activate bool, ioStreams genericclioptions.IOStreams) {
-	objects, err := dynamic.Instance().ListObjects(
-		&metav1.ListOptions{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       kind,
-				APIVersion: "kubevirt.io/v1"},
-		},
-		namespace)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			util.CheckErr(err)
-		}
-		return
-	}
-	for _, o := range objects.Items {
-		path := []string{"spec", "running"}
-		unstructured.RemoveNestedField(o.Object, path...)
-		printMsg(fmt.Sprintf("Removed field for %v %v/%v", strings.ToLower(kind), o.GetNamespace(), o.GetName()), ioStreams.Out)
-	}
-}
-
-func updateCronJobObjects(namespace string, activate bool, ioStreams genericclioptions.IOStreams) {
-	cronJobs, err := batch.Instance().ListCronJobs(namespace, metav1.ListOptions{})
-	if err != nil {
-		util.CheckErr(err)
-		return
-	}
-
-	for _, cronJob := range cronJobs.Items {
-		*cronJob.Spec.Suspend = !activate
-		_, err = batch.Instance().UpdateCronJob(&cronJob)
-		if err != nil {
-			printMsg(fmt.Sprintf("Error updating suspend option for cronJob %v/%v : %v", cronJob.Namespace, cronJob.Name, err), ioStreams.ErrOut)
-			continue
-		}
-		printMsg(fmt.Sprintf("Updated suspend option for cronjob %v/%v to %v", cronJob.Namespace, cronJob.Name, !activate), ioStreams.Out)
-	}
-
-}
-func getSuspendStringOpts(annotations map[string]string, activate bool, path string, ioStreams genericclioptions.IOStreams) (string, error) {
-	if val, present := annotations[migration.StorkAnnotationPrefix+path]; present {
-		suspend := strings.Split(val, ",")
-		if len(suspend) != 2 {
-			return "", fmt.Errorf("migrated annotation does not have proper values %s/%s", migration.StorkAnnotationPrefix+path, val)
-		}
-		if activate {
-			return suspend[0], nil
-		}
-		return suspend[1], nil
-	}
-	// for backward compatibility of old migrated cr's
-	crdOpts := migration.StorkMigrationCRDActivateAnnotation
-	if !activate {
-		crdOpts = migration.StorkMigrationCRDDeactivateAnnotation
-	}
-	suspend, present := annotations[crdOpts]
-	if !present {
-		return "", fmt.Errorf("required migration annotation not found %s", crdOpts)
-	}
-	return suspend, nil
-}
-
-func getSuspendIntOpts(annotations map[string]string, activate bool, path string, ioStreams genericclioptions.IOStreams) (int64, bool) {
-	intOpts := ""
-	if val, present := annotations[migration.StorkAnnotationPrefix+path]; present {
-		intOpts = strings.Split(val, ",")[0]
-	} else if val, present := annotations[migration.StorkMigrationCRDActivateAnnotation]; present {
-		// for old migrated cr compatibility
-		intOpts = val
-	} else {
-		return 0, false
-	}
-	var replicas int64
-	if activate {
-		parsedReplicas, err := strconv.Atoi(intOpts)
-		if err != nil {
-			printMsg(fmt.Sprintf("Error parsing replicas for app : %v", err), ioStreams.ErrOut)
-			return 0, false
-		}
-		replicas = int64(parsedReplicas)
-	} else {
-		replicas = 0
-	}
-	return replicas, true
-}
-
-func getUpdatedReplicaCount(annotations map[string]string, activate bool, ioStreams genericclioptions.IOStreams) (int32, bool) {
-	if replicas, present := annotations[migration.StorkMigrationReplicasAnnotation]; present {
-		var updatedReplicas int32
-		if activate {
-			parsedReplicas, err := strconv.Atoi(replicas)
-			if err != nil {
-				printMsg(fmt.Sprintf("Error parsing replicas for app : %v", err), ioStreams.ErrOut)
-				return 0, false
-			}
-			updatedReplicas = int32(parsedReplicas)
-		} else {
-			updatedReplicas = 0
-		}
-		return updatedReplicas, true
-	}
-
-	return 0, false
 }
 
 func newGetMigrationCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {

--- a/pkg/storkctl/storkctl.go
+++ b/pkg/storkctl/storkctl.go
@@ -37,6 +37,7 @@ func NewCommand(cmdFactory Factory, in io.Reader, out io.Writer, errOut io.Write
 		newSuspendCommand(cmdFactory, ioStreams),
 		newResumeCommand(cmdFactory, ioStreams),
 		newVersionCommand(cmdFactory, ioStreams),
+		newPerformCommand(cmdFactory, ioStreams),
 	)
 
 	cmds.PersistentFlags().AddGoFlagSet(flag.CommandLine)


### PR DESCRIPTION
What type of PR is this?
Improvement

What this PR does / why we need it:
This PR adds a new storkctl command storkctl perform failover that uses the Action CRD to kick off the failover process.

Does this PR change a user-facing CRD or CLI?:
Yes. The change is needed as the previous storkctl activate migration command has an unobvious meaning and this change is part of the bigger effort to simplify the DR use.

Is a release note needed?:
No

Does this change need to be cherry-picked to a release branch?:
No