### PR TITLE
PWX-29480: Fixing plurals for WKC crds.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-openapi/inflect"
 	"github.com/libopenstorage/stork/drivers"
 	"github.com/libopenstorage/stork/drivers/volume"
 	"github.com/libopenstorage/stork/pkg/apis/stork"
@@ -1335,16 +1334,8 @@ func (a *ApplicationBackupController) uploadCRDResources(backup *stork_api.Appli
 	if err != nil {
 		return err
 	}
-	ruleset := inflect.NewDefaultRuleset()
-	ruleset.AddPlural("quota", "quotas")
-	ruleset.AddPlural("prometheus", "prometheuses")
-	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
-	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
-	ruleset.AddPlural("mongodb", "mongodb")
-	ruleset.AddPlural("wkc", "wkc")
-	ruleset.AddPlural("factsheet", "factsheet")
-	ruleset.AddPlural("datarefinery", "datarefinery")
-	
+	ruleset := resourcecollector.GetDefaultRuleSet()
+
 	v1CrdApiReqrd, err := version.RequiresV1Registration()
 	if err != nil {
 		return err

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1341,6 +1341,10 @@ func (a *ApplicationBackupController) uploadCRDResources(backup *stork_api.Appli
 	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
 	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
 	ruleset.AddPlural("mongodb", "mongodb")
+	ruleset.AddPlural("wkc", "wkc")
+	ruleset.AddPlural("factsheet", "factsheet")
+	ruleset.AddPlural("datarefinery", "datarefinery")
+	
 	v1CrdApiReqrd, err := version.RequiresV1Registration()
 	if err != nil {
 		return err

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-openapi/inflect"
 	"github.com/libopenstorage/stork/drivers/volume"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	storkcache "github.com/libopenstorage/stork/pkg/cache"
@@ -1664,7 +1663,7 @@ func (m *MigrationController) updateOwnerReferenceOnPVC(
 		return err
 	}
 
-	ruleset := m.getDefaultRuleSet()
+	ruleset := resourcecollector.GetDefaultRuleSet()
 	for _, srcPvc := range pvcsWithOwnerRef {
 		destPvc, err := remoteClient.adminClient.CoreV1().PersistentVolumeClaims(srcPvc.GetNamespace()).Get(context.TODO(), srcPvc.Name, metav1.GetOptions{})
 		if err != nil {
@@ -1746,7 +1745,7 @@ func (m *MigrationController) applyResources(
 		return err
 	}
 
-	ruleset := m.getDefaultRuleSet()
+	ruleset := resourcecollector.GetDefaultRuleSet()
 
 	// create CRD on destination cluster
 	for _, crd := range crdList.Items {
@@ -2478,20 +2477,4 @@ func (m *MigrationController) getVolumeOnlyMigrationResources(
 	}
 	resources = append(resources, objects.Items...)
 	return resources, pvcWithOwnerRef, nil
-}
-
-func (m *MigrationController) getDefaultRuleSet() *inflect.Ruleset {
-	// TODO: we should use k8s code generator logic to pluralize
-	// crd resources instead of depending on inflect lib
-	ruleset := inflect.NewDefaultRuleset()
-	ruleset.AddPlural("quota", "quotas")
-	ruleset.AddPlural("prometheus", "prometheuses")
-	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
-	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
-	ruleset.AddPlural("mongodb", "mongodb")
-	ruleset.AddPlural("wkc", "wkc")
-	ruleset.AddPlural("factsheet", "factsheet")
-	ruleset.AddPlural("datarefinery", "datarefinery")
-
-	return ruleset
 }

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -2489,5 +2489,9 @@ func (m *MigrationController) getDefaultRuleSet() *inflect.Ruleset {
 	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
 	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
 	ruleset.AddPlural("mongodb", "mongodb")
+	ruleset.AddPlural("wkc", "wkc")
+	ruleset.AddPlural("factsheet", "factsheet")
+	ruleset.AddPlural("datarefinery", "datarefinery")
+
 	return ruleset
 }

--- a/pkg/migration/controllers/resourcetransformation.go
+++ b/pkg/migration/controllers/resourcetransformation.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/go-openapi/inflect"
 	"github.com/libopenstorage/stork/drivers/volume"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/controllers"
@@ -219,15 +218,7 @@ func (r *ResourceTransformationController) validateTransformResource(ctx context
 		return nil
 	}
 
-	ruleset := inflect.NewDefaultRuleset()
-	ruleset.AddPlural("quota", "quotas")
-	ruleset.AddPlural("prometheus", "prometheuses")
-	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
-	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
-	ruleset.AddPlural("mongodb", "mongodb")
-	ruleset.AddPlural("wkc", "wkc")
-	ruleset.AddPlural("factsheet", "factsheet")
-	ruleset.AddPlural("datarefinery", "datarefinery")
+	ruleset := resourcecollector.GetDefaultRuleSet()
 
 	for _, spec := range transform.Spec.Objects {
 		group, version, kind, err := getGVK(spec.Resource)

--- a/pkg/migration/controllers/resourcetransformation.go
+++ b/pkg/migration/controllers/resourcetransformation.go
@@ -225,6 +225,9 @@ func (r *ResourceTransformationController) validateTransformResource(ctx context
 	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
 	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
 	ruleset.AddPlural("mongodb", "mongodb")
+	ruleset.AddPlural("wkc", "wkc")
+	ruleset.AddPlural("factsheet", "factsheet")
+	ruleset.AddPlural("datarefinery", "datarefinery")
 
 	for _, spec := range transform.Spec.Objects {
 		group, version, kind, err := getGVK(spec.Resource)

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -1082,15 +1082,7 @@ func (r *ResourceCollector) getDynamicClient(
 	}
 
 	// The default ruleset doesn't pluralize quotas correctly, so add that
-	ruleset := inflect.NewDefaultRuleset()
-	ruleset.AddPlural("quota", "quotas")
-	ruleset.AddPlural("prometheus", "prometheuses")
-	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
-	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
-	ruleset.AddPlural("mongodb", "mongodb")
-	ruleset.AddPlural("wkc", "wkc")
-	ruleset.AddPlural("factsheet", "factsheet")
-	ruleset.AddPlural("datarefinery", "datarefinery")
+	ruleset := GetDefaultRuleSet()
 	resource := &metav1.APIResource{
 		Name:       ruleset.Pluralize(strings.ToLower(objectType.GetKind())),
 		Namespaced: len(metadata.GetNamespace()) > 0,
@@ -1162,4 +1154,20 @@ func (r *ResourceCollector) prepareRancherApplicationResource(
 		}
 	}
 	return nil
+}
+
+func GetDefaultRuleSet() *inflect.Ruleset {
+	// TODO: we should use k8s code generator logic to pluralize
+	// crd resources instead of depending on inflect lib
+	ruleset := inflect.NewDefaultRuleset()
+	ruleset.AddPlural("quota", "quotas")
+	ruleset.AddPlural("prometheus", "prometheuses")
+	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
+	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
+	ruleset.AddPlural("mongodb", "mongodb")
+	ruleset.AddPlural("wkc", "wkc")
+	ruleset.AddPlural("factsheet", "factsheet")
+	ruleset.AddPlural("datarefinery", "datarefinery")
+
+	return ruleset
 }

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -1088,6 +1088,9 @@ func (r *ResourceCollector) getDynamicClient(
 	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
 	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
 	ruleset.AddPlural("mongodb", "mongodb")
+	ruleset.AddPlural("wkc", "wkc")
+	ruleset.AddPlural("factsheet", "factsheet")
+	ruleset.AddPlural("datarefinery", "datarefinery")
 	resource := &metav1.APIResource{
 		Name:       ruleset.Pluralize(strings.ToLower(objectType.GetKind())),
 		Namespaced: len(metadata.GetNamespace()) > 0,

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-openapi/inflect"
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	migration "github.com/libopenstorage/stork/pkg/migration/controllers"
+	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	"github.com/portworx/sched-ops/k8s/apps"
 	"github.com/portworx/sched-ops/k8s/batch"
 	"github.com/portworx/sched-ops/k8s/core"
@@ -372,16 +372,8 @@ func updateCRDObjects(ns string, activate bool, ioStreams genericclioptions.IOSt
 		util.CheckErr(err)
 		return
 	}
-	ruleset := inflect.NewDefaultRuleset()
-	ruleset.AddPlural("quota", "quotas")
-	ruleset.AddPlural("prometheus", "prometheuses")
-	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
-	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
-	ruleset.AddPlural("mongodb", "mongodb")
-	ruleset.AddPlural("wkc", "wkc")
-	ruleset.AddPlural("factsheet", "factsheet")
-	ruleset.AddPlural("datarefinery", "datarefinery")
-	
+	ruleset := resourcecollector.GetDefaultRuleSet()
+
 	for _, res := range crdList.Items {
 		for _, crd := range res.Resources {
 			var client k8sdynamic.ResourceInterface

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -378,6 +378,10 @@ func updateCRDObjects(ns string, activate bool, ioStreams genericclioptions.IOSt
 	ruleset.AddPlural("mongodbcommunity", "mongodbcommunity")
 	ruleset.AddPlural("mongodbopsmanager", "opsmanagers")
 	ruleset.AddPlural("mongodb", "mongodb")
+	ruleset.AddPlural("wkc", "wkc")
+	ruleset.AddPlural("factsheet", "factsheet")
+	ruleset.AddPlural("datarefinery", "datarefinery")
+	
 	for _, res := range crdList.Items {
 		for _, crd := range res.Resources {
 			var client k8sdynamic.ResourceInterface


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Support migrations of watson knowledge catalog crs.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Unable to find resource of Watson knowledge catalog.
User Impact: Migration was failing for Watson knowledge catalog.
Resolution: With right plurals for the crds, now migration is successful for Watson knowledge catalog.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
no
-->

