### PR TITLE
PWX-29463: Add promote method to Px

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -66,6 +66,7 @@ type aws struct {
 	client *ec2.EC2
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.CloneNotSupported

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -55,6 +55,7 @@ type azure struct {
 	snapshotClient compute.SnapshotsClient
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.CloneNotSupported

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -166,6 +166,7 @@ type csi struct {
 
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.CloneNotSupported

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -50,6 +50,7 @@ type gcp struct {
 	service   *compute.Service
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.CloneNotSupported

--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -116,6 +116,7 @@ var (
 type kdmp struct {
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.CloneNotSupported

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -46,6 +46,7 @@ type linstor struct {
 	stopChannel chan struct{}
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.BackupRestoreNotSupported

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -38,6 +38,7 @@ const (
 type Driver struct {
 	storkvolume.ClusterPairNotSupported
 	storkvolume.MigrationNotSupported
+	storkvolume.ActionNotSupported
 	storkvolume.GroupSnapshotNotSupported
 	storkvolume.ClusterDomainsNotSupported
 	storkvolume.BackupRestoreNotSupported

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2491,7 +2491,7 @@ func (p *portworx) Failover(action *storkapi.Action) error {
 			volLocator.VolumeLabels = make(map[string]string)
 		}
 		volLocator.VolumeLabels["promote"] = "true"
-		if err := volDriver.Set(vol.GetId(), volLocator, vol.GetSpec()); err != nil {
+		if err := volDriver.Set(vol.GetId(), volLocator, nil); err != nil {
 			return fmt.Errorf("failed to promote %v: %v", vol.GetId(), err)
 		}
 		logrus.Infof("failover: promoted %v", vol.GetId())

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2438,8 +2438,9 @@ func (p *portworx) DeletePair(pair *storkapi.ClusterPair) error {
 	return nil
 }
 
-func (p *portworx) ActivateMigration(namespace string) error {
-	logrus.Debugf("ActivateMigration namespace: %s", namespace)
+func (p *portworx) Failover(action *storkapi.Action) error {
+	namespace := action.Namespace
+	logrus.Debugf("Failover: namespace %s", namespace)
 	volDriver, err := p.getAdminVolDriver() // TODO(dgoel): admin or user vol driver?
 	if err != nil {
 		return err
@@ -2461,7 +2462,7 @@ func (p *portworx) ActivateMigration(namespace string) error {
 		if err != nil {
 			return fmt.Errorf("error getting volume for PVC: %v", err)
 		}
-		logrus.Debugf("ActivateMigration volID: %v", volID)
+		logrus.Debugf("Failover: volID %v", volID)
 
 		volumes, err := volDriver.Inspect([]string{volID})
 		if err != nil {
@@ -2483,7 +2484,7 @@ func (p *portworx) ActivateMigration(namespace string) error {
 		if err := volDriver.Set(vol.GetId(), volLocator, vol.GetSpec()); err != nil {
 			return fmt.Errorf("failed to promote volume: %v", vol.GetId())
 		}
-		logrus.Debugf("ActivateMigration promoted %v", vol.GetId())
+		logrus.Debugf("Failover: promoted %v", vol.GetId())
 	}
 	return nil
 }

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2438,6 +2438,56 @@ func (p *portworx) DeletePair(pair *storkapi.ClusterPair) error {
 	return nil
 }
 
+func (p *portworx) ActivateMigration(namespace string) error {
+	logrus.Debugf("ActivateMigration namespace: %s", namespace)
+	volDriver, err := p.getAdminVolDriver() // TODO(dgoel): admin or user vol driver?
+	if err != nil {
+		return err
+	}
+
+	pvcList, err := core.Instance().GetPersistentVolumeClaims(namespace, nil)
+	if err != nil {
+		return fmt.Errorf("error getting list of volumes to migrate: %v", err)
+	}
+	for _, pvc := range pvcList.Items {
+		if !p.OwnsPVC(core.Instance(), &pvc) {
+			continue
+		}
+		if resourcecollector.SkipResource(pvc.Annotations) { // TODO(dgoel): do we need this?
+			continue
+		}
+
+		volID, err := core.Instance().GetVolumeForPersistentVolumeClaim(&pvc)
+		if err != nil {
+			return fmt.Errorf("error getting volume for PVC: %v", err)
+		}
+		logrus.Debugf("ActivateMigration volID: %v", volID)
+
+		volumes, err := volDriver.Inspect([]string{volID})
+		if err != nil {
+			return err
+		}
+		if len(volumes) != 1 {
+			return &errors.ErrNotFound{
+				ID:   volID,
+				Type: "Volume",
+			}
+		}
+		vol := volumes[0]
+
+		volLocator := vol.Locator
+		if volLocator.VolumeLabels == nil {
+			volLocator.VolumeLabels = make(map[string]string)
+		}
+		volLocator.VolumeLabels["promote"] = "true"
+		if err := volDriver.Set(vol.GetId(), volLocator, vol.GetSpec()); err != nil {
+			return fmt.Errorf("failed to promote volume: %v", vol.GetId())
+		}
+		logrus.Debugf("ActivateMigration promoted %v", vol.GetId())
+	}
+	return nil
+}
+
 func (p *portworx) StartMigration(migration *storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error) {
 	if !p.initDone {
 		if err := p.initPortworxClients(); err != nil {

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -188,6 +188,8 @@ type MigratePluginInterface interface {
 	// Start migration of volumes specified by the spec. Should only migrate
 	// volumes, not the specs associated with them
 	StartMigration(*storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error)
+	// Promote near-sync volumes when activating a migration
+	ActivateMigration(string) error
 	// Get the status of migration of the volumes specified in the status
 	// for the migration spec
 	GetMigrationStatus(*storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error)
@@ -420,6 +422,11 @@ type MigrationNotSupported struct{}
 // StartMigration returns ErrNotSupported
 func (m *MigrationNotSupported) StartMigration(*storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error) {
 	return nil, &errors.ErrNotSupported{}
+}
+
+// ActivateMigration returns ErrNotSupported
+func (m *MigrationNotSupported) ActivateMigration(string) error {
+	return &errors.ErrNotSupported{}
 }
 
 // GetMigrationStatus returns ErrNotSupported

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -150,6 +150,7 @@ type Driver interface {
 	ClusterPairPluginInterface
 	// MigratePluginInterface Interface to migrate data between clusters
 	MigratePluginInterface
+	ActionPluginInterface
 	// ClusterDomainsPluginInterface Interface to manage cluster domains
 	ClusterDomainsPluginInterface
 	// BackupRestorePluginInterface Interface to backup and restore volumes
@@ -188,8 +189,6 @@ type MigratePluginInterface interface {
 	// Start migration of volumes specified by the spec. Should only migrate
 	// volumes, not the specs associated with them
 	StartMigration(*storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error)
-	// Promote near-sync volumes when activating a migration
-	ActivateMigration(string) error
 	// Get the status of migration of the volumes specified in the status
 	// for the migration spec
 	GetMigrationStatus(*storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error)
@@ -198,6 +197,10 @@ type MigratePluginInterface interface {
 	// Update the PVC spec to point to the migrated volume on the destination
 	// cluster
 	UpdateMigratedPersistentVolumeSpec(*v1.PersistentVolume, *storkapi.ApplicationRestoreVolumeInfo, map[string]string) (*v1.PersistentVolume, error)
+}
+
+type ActionPluginInterface interface {
+	Failover(*storkapi.Action) error
 }
 
 // ClusterDomainsPluginInterface Interface to manage cluster domains
@@ -424,11 +427,6 @@ func (m *MigrationNotSupported) StartMigration(*storkapi.Migration) ([]*storkapi
 	return nil, &errors.ErrNotSupported{}
 }
 
-// ActivateMigration returns ErrNotSupported
-func (m *MigrationNotSupported) ActivateMigration(string) error {
-	return &errors.ErrNotSupported{}
-}
-
 // GetMigrationStatus returns ErrNotSupported
 func (m *MigrationNotSupported) GetMigrationStatus(*storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error) {
 	return nil, &errors.ErrNotSupported{}
@@ -444,6 +442,12 @@ func (m *MigrationNotSupported) UpdateMigratedPersistentVolumeSpec(
 	*v1.PersistentVolume,
 ) (*v1.PersistentVolume, error) {
 	return nil, &errors.ErrNotSupported{}
+}
+
+type ActionNotSupported struct{}
+
+func (m *ActionNotSupported) Failover(*storkapi.Action) error {
+	return &errors.ErrNotSupported{}
 }
 
 // GroupSnapshotNotSupported to be used by drivers that don't support group snapshots

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -79,7 +79,11 @@ func (ac *ActionController) handle(ctx context.Context, action *storkv1.Action) 
 	ac.updateStatus(action, storkv1.ActionStatusInProgress)
 	switch action.Spec.ActionType {
 	case storkv1.ActionTypeFailover:
-		logrus.Infof("performing action: failover")
+		err := ac.volDriver.Failover(action)
+		if err != nil {
+			ac.updateStatus(action, storkv1.ActionStatusFailed)
+			return err
+		}
 		resourceutils.ScaleReplicas(action.Namespace, true, printFunc, ac.config)
 		ac.updateStatus(action, storkv1.ActionStatusSuccessful)
 	default:


### PR DESCRIPTION
**What type of PR is this?**
feature

**What this PR does / why we need it**:
This PR adds an interface for `Action` to `volDriver` with a method `Failover`. It also adds implementation for `Failover` to Portworx volDriver that promotes nearsync volumes.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No