### PR TITLE
pb-3683: vendored the latest kdmp from 1.2.5 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,10 +62,7 @@ require (
 	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
 )
 
-require (
-	github.com/portworx/kdmp v0.4.1-0.20230315073130-7af86b10aacb
-	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
-)
+require github.com/portworx/kdmp v0.4.1-0.20230316085313-95fc97e8493b
 
 require (
 	cloud.google.com/go v0.107.0 // indirect
@@ -302,7 +299,7 @@ replace (
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc10 => github.com/kubernetes-incubator/external-storage v0.25.1-openstorage-rc1
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20221216200022-d1c57a8ea854
-	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20230315073130-7af86b10aacb
+	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20230316085313-95fc97e8493b
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230228105744-505c1a2d8203
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20230216213348-6ba0e5494ad5
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -2172,8 +2172,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v1.0.5/go.mod h1:APVvOesVSAnne5SClsPxPdfvZTVDojXh1/G3qb5wjGI=
 github.com/portworx/dcos-secrets v0.0.0-20180616013705-8e8ec3f66611/go.mod h1:4hklRW/4DQpLqkcXcjtNprbH2tz/sJaNtqinfPWl/LA=
-github.com/portworx/kdmp v0.4.1-0.20230315073130-7af86b10aacb h1:e0F5fcYX1CAm2PmCRS/WYQ1fMxTQxatsToZ42D7Ajek=
-github.com/portworx/kdmp v0.4.1-0.20230315073130-7af86b10aacb/go.mod h1:VtbY8ASrnXjt+kr5loODtsYV9HwA1DxuQRtt5fRnfh0=
+github.com/portworx/kdmp v0.4.1-0.20230316085313-95fc97e8493b h1:LhSjQpdAOUReRqzy25b9lApPNzWJGWTb7nUoxhz/Yhc=
+github.com/portworx/kdmp v0.4.1-0.20230316085313-95fc97e8493b/go.mod h1:VtbY8ASrnXjt+kr5loODtsYV9HwA1DxuQRtt5fRnfh0=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200929023115-b312c7519467 h1:jkqzdbOnejgSN5HG/FLt4enNrozWT/K+nlmaRm3P1II=

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
@@ -485,9 +485,9 @@ func (c *Controller) createJobCredCertSecrets(
 			}
 		}
 		if count > 0 {
-			storkCm, err := core.Instance().GetConfigMap(k8sutils.StorkConfigMapName, k8sutils.DefaultAdminNamespace)
+			storkCm, err := core.Instance().GetConfigMap(k8sutils.StorkControllerConfigMapName, k8sutils.DefaultAdminNamespace)
 			if err != nil && !k8sErrors.IsNotFound(err) {
-				msg := fmt.Sprintf("error fetching admin namespace from stork configmap %s/%s: %v", k8sutils.DefaultAdminNamespace, k8sutils.StorkConfigMapName, err)
+				msg := fmt.Sprintf("error fetching admin namespace from stork configmap %s/%s: %v", k8sutils.DefaultAdminNamespace, k8sutils.StorkControllerConfigMapName, err)
 				logrus.Errorf(msg)
 				data := updateDataExportDetail{
 					status: kdmpapi.DataExportStatusFailed,
@@ -1279,7 +1279,7 @@ func (c *Controller) cleanUp(driver drivers.Interface, de *kdmpapi.DataExport) e
 	}
 	var namespace string
 	if len(pods) > 0 {
-		storkCm, err := core.Instance().GetConfigMap(k8sutils.StorkConfigMapName, k8sutils.DefaultAdminNamespace)
+		storkCm, err := core.Instance().GetConfigMap(k8sutils.StorkControllerConfigMapName, k8sutils.DefaultAdminNamespace)
 		if err != nil && !k8sErrors.IsNotFound(err) {
 			return err
 		}

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackup.go
@@ -436,7 +436,7 @@ func buildJob(jobName string, jobOptions drivers.JobOpts) (*batchv1.Job, error) 
 		}
 	}
 	if count > 0 {
-		storkCm, err := coreops.Instance().GetConfigMap(k8sutils.StorkConfigMapName, k8sutils.DefaultAdminNamespace)
+		storkCm, err := coreops.Instance().GetConfigMap(k8sutils.StorkControllerConfigMapName, k8sutils.DefaultAdminNamespace)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return nil, err
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -897,7 +897,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20230315073130-7af86b10aacb => github.com/portworx/kdmp v0.4.1-0.20230315073130-7af86b10aacb
+# github.com/portworx/kdmp v0.4.1-0.20230316085313-95fc97e8493b => github.com/portworx/kdmp v0.4.1-0.20230316085313-95fc97e8493b
 ## explicit; go 1.19
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1
@@ -2242,7 +2242,7 @@ sigs.k8s.io/yaml
 # github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc10 => github.com/kubernetes-incubator/external-storage v0.25.1-openstorage-rc1
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20221216200022-d1c57a8ea854
-# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20230315073130-7af86b10aacb
+# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20230316085313-95fc97e8493b
 # github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230228105744-505c1a2d8203
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20230216213348-6ba0e5494ad5
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
```
pb-3683: vendored the latest kdmp from 1.2.5 branch
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no ( vendor changes)

**Does this change need to be cherry-picked to a release branch?**:
23.2.1 and 23.3. branches.

