### PR TITLE
Pb 3707 large resource count support

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -28,16 +28,18 @@ type ApplicationBackup struct {
 
 // ApplicationBackupSpec is the spec used to backup applications
 type ApplicationBackupSpec struct {
-	Namespaces         []string                           `json:"namespaces"`
-	BackupLocation     string                             `json:"backupLocation"`
-	PlatformCredential string                             `json:"platformCredential"`
-	RancherProjects    map[string]string                  `json:"rancherProjects"`
-	Selectors          map[string]string                  `json:"selectors"`
-	NamespaceSelector  string                             `json:"namespaceSelector"`
-	PreExecRule        string                             `json:"preExecRule"`
-	PostExecRule       string                             `json:"postExecRule"`
-	ReclaimPolicy      ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
-	SkipServiceUpdate  bool                               `json:"skipServiceUpdate"`
+	Namespaces           []string                           `json:"namespaces"`
+	BackupLocation       string                             `json:"backupLocation"`
+	PlatformCredential   string                             `json:"platformCredential"`
+	RancherProjects      map[string]string                  `json:"rancherProjects"`
+	Selectors            map[string]string                  `json:"selectors"`
+	NamespaceSelector    string                             `json:"namespaceSelector"`
+	PreExecRule          string                             `json:"preExecRule"`
+	PostExecRule         string                             `json:"postExecRule"`
+	ReclaimPolicy        ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
+	SkipServiceUpdate    bool                               `json:"skipServiceUpdate"`
+	ResourceCount        int                                `json:"resourceCount"`
+	LargeResourceEnabled bool                               `json:"largeResourceEnabled"`
 	// Options to be passed in to the driver
 	Options          map[string]string `json:"options"`
 	IncludeResources []ObjectInfo      `json:"includeResources"`

--- a/pkg/apis/stork/v1alpha1/applicationrestore.go
+++ b/pkg/apis/stork/v1alpha1/applicationrestore.go
@@ -32,6 +32,8 @@ type ApplicationRestoreSpec struct {
 	IncludeResources             []ObjectInfo                        `json:"includeResources"`
 	StorageClassMapping          map[string]string                   `json:"storageClassMapping"`
 	RancherProjectMapping        map[string]string                   `json:"rancherProjectMapping"`
+	ResourceCount                int                                 `json:"resourceCount"`
+	LargeResourceEnabled         bool                                `json:"largeResourceEnabled"`
 }
 
 // ApplicationRestoreReplacePolicyType is the replace policy for the application restore

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -686,7 +686,7 @@ func (a *ApplicationCloneController) applyResources(
 	if clone.Spec.ReplacePolicy == stork_api.ApplicationCloneReplacePolicyDelete {
 		err := a.resourceCollector.DeleteResources(
 			a.dynamicInterface,
-			objects)
+			objects, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -598,7 +598,7 @@ func (m *MigrationController) purgeMigratedResources(
 	if err != nil {
 		return err
 	}
-	err = m.resourceCollector.DeleteResources(dynamicInterface, toBeDeleted)
+	err = m.resourceCollector.DeleteResources(dynamicInterface, toBeDeleted, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,12 +1,15 @@
 package utils
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
+	"strings"
+
 	"github.com/libopenstorage/stork/drivers"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 const (
@@ -96,4 +99,15 @@ func ParseRancherProjectMapping(
 			}
 		}
 	}
+}
+
+// GetSizeOfObject - Gets the in-memory size of a object
+// It may include the golang runtime headers related to GC
+// If the structure object contains unexported field, then encoder will fail.
+func GetSizeOfObject(object interface{}) (int, error) {
+	buf := new(bytes.Buffer)
+	if err := gob.NewEncoder(buf).Encode(object); err != nil {
+		return 0, err
+	}
+	return buf.Len(), nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/libopenstorage/stork/drivers"
 	"github.com/portworx/sched-ops/k8s/core"
@@ -22,6 +23,16 @@ const (
 	PXIncrementalCountAnnotation = "portworx.io/cloudsnap-incremental-count"
 	// trimCRDGroupNameKey - groups name containing the string from this configmap field will be trimmed
 	trimCRDGroupNameKey = "TRIM_CRD_GROUP_NAME"
+	// QuitRestoreCrTimestampUpdate is sent in the channel to informs the go routine to stop any further update
+	QuitRestoreCrTimestampUpdate = 13
+	// UpdateRestoreCrTimestamp is sent in channel to signify go routine to update the timestamp
+	UpdateRestoreCrTimestamp = 11
+	// duration in which the restore CR to be updated
+	FifteenMinuteWait = 15 * time.Minute
+	// sleep interval for restore time stamp update go-routine to check channel for any data
+	SleepIntervalForCheckingChannel = 10 * time.Second
+	// RestoreCrChannelBufferSize is the count of maximum signals it can hold in restore CR update related channel
+	RestoreCrChannelBufferSize = 11
 )
 
 // ParseKeyValueList parses a list of key=values string into a map


### PR DESCRIPTION
**What type of PR is this?** feature
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: This adds support for taking backup which involves large count of resources. the pb-3696 explains in detail the root cause and its solution.

**Does this PR change a user-facing CRD or CLI?**: nope
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: yes
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: Large Resource count based backup fails due to GRPC & other payload size checks
User Impact: backup with large resource count will fail
Resolution 
Stripped the resource Info from backup and restore CRs to eliminate the GRPC & etcd payload limit.
```

**Does this change need to be cherry-picked to a release branch?**: no
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
**Unit test detail**
Note: the stork changes are vendored to px-backup and some changes in px-backup is done to exercise these unit tests 

Backup of 10K resources with single namespace
![Create Backup](https://user-images.githubusercontent.com/15273500/227780039-2cf6d73e-54d5-41df-8607-0fbf85de0081.png)
 Size of backup is around 1.7MB
![Pasted Graphic 1](https://user-images.githubusercontent.com/15273500/227780066-8b4b261b-a775-449a-a515-e0389533eaf0.png)
backup succeed
![Pasted Graphic 2](https://user-images.githubusercontent.com/15273500/227780087-b1686e2b-ccf1-4af5-bbad-cbfef568e752.png)
![backup info](https://user-images.githubusercontent.com/15273500/227780099-757469da-eb98-493d-aa55-f2c0052bfce2.png)
![Pasted Graphic 6](https://user-images.githubusercontent.com/15273500/227780106-63861681-bb7c-440f-a87e-29b41387a2a0.png)
The file shows resource.json 10000 resource 
![Pasted Graphic 7](https://user-images.githubusercontent.com/15273500/227780142-b35f728e-a4de-4bd2-a516-d41e3fa020d8.png)

**Multi name space with 35000 resources. CR size almost 7MB

![Pasted Graphic 4](https://user-images.githubusercontent.com/15273500/227780187-ac982985-b5c2-422e-97de-5a2ced79bd6e.png)
![Pasted Graphic 8](https://user-images.githubusercontent.com/15273500/227780194-6ef5f6e5-ccfc-403c-8c87-3b002ae06890.png)
![Pasted Graphic 9](https://user-images.githubusercontent.com/15273500/227780209-0df5f190-1bc1-4925-88f3-2530b92a07fc.png)

Restore Path Verification is done for below test cases
1. Restore with retain enebaled , the restore became partial success which is expected (10K configMaps)
2. restore with replace enabled (13k cm)
3. restore for ns having both volume and configMaps.

![Pasted Graphic 11](https://user-images.githubusercontent.com/15273500/229314016-11a50dbd-8cdd-4b66-bff8-feb97fc2daab.png)
![Pasted Graphic 10](https://user-images.githubusercontent.com/15273500/229314026-1c7c2f2a-9904-4781-a280-eddb755fe35e.png)
![image](https://user-images.githubusercontent.com/15273500/229351068-e2b238bb-c4f2-4131-b186-f0bcbf742b96.png)
![image](https://user-images.githubusercontent.com/15273500/229351094-6361cf51-1276-4ed7-ad55-32e4fea340c0.png)



