### PR TITLE
PWX-29754: Create or update the existing default-migration-policy's interval minutes to 30 instead of 1.

### DIFF
--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -42,6 +42,18 @@ func TestSchedule(t *testing.T) {
 func createDefaultPoliciesTest(t *testing.T) {
 	err := createDefaultPolicy()
 	require.NoError(t, err, "Error creating default policies")
+	err = createDefaultPolicy()
+	require.NoError(t, err, "Error recreating default policies")
+	schedulePolicy, err := storkops.Instance().GetSchedulePolicy("default-migration-policy")
+	require.NoError(t, err, "Error getting default-migration-policy")
+	schedulePolicy.Policy.Interval.IntervalMinutes = 1
+	_, err = storkops.Instance().UpdateSchedulePolicy(schedulePolicy)
+	require.NoError(t, err, "Error updating default-migration-policy")
+	err = createDefaultPolicy()
+	require.NoError(t, err, "Error recreating default policies after modifying default-migration-policy")
+	schedulePolicy, err = storkops.Instance().GetSchedulePolicy("default-migration-policy")
+	require.NoError(t, err, "Error getting default-migration-policy")
+	require.Equal(t, 30, schedulePolicy.Policy.Interval.IntervalMinutes, "Error updating the existing default-migration-policy's interval time")
 }
 
 func triggerIntervalRequiredTest(t *testing.T) {


### PR DESCRIPTION
Signed-Off-By: Diptiranjan


**What type of PR is this?**
improvement

**What this PR does / why we need it**:
As 1 minute migration policy was too aggressive, we are changing the default-migration-policy's interval to 30mins.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->

**Does this change need to be cherry-picked to a release branch?**:
<!--
23.4.0
-->

**Test**
Tested with fresh installation and upgrade case. 
Test results have been updated in PWX-29754