### PR TITLE
PWX-30157: Recreate pv if its csi.spec.volumeHandle does not match with PV name during  migration.

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1881,6 +1881,51 @@ func (m *MigrationController) applyResources(
 			updatedObjects = append(updatedObjects, o)
 		}
 	}
+
+	// find out the csi PVs and if the volumeHandle does not match with pv Name , delete those.
+	// https://portworx.atlassian.net/browse/PWX-30157
+	pvToPVCMapping := getpvToPVCMappingFromPVCObjects(pvcObjects)
+	var csiPVCAndPVObjects []runtime.Unstructured
+	for _, obj := range pvObjects {
+		var pv v1.PersistentVolume
+		var err error
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &pv); err != nil {
+			m.updateResourceStatus(
+				migration,
+				obj,
+				stork_api.MigrationStatusFailed,
+				fmt.Sprintf("Error unmarshalling pv resource: %v", err))
+			continue
+		}
+		if pv.Spec.CSI != nil {
+			respPV, err := remoteClient.adminClient.CoreV1().PersistentVolumes().Get(context.TODO(), pv.Name, metav1.GetOptions{})
+			if err != nil {
+				logrus.Errorf("error getting pv %s: %v", pv.Name, err)
+			}
+			if respPV.Spec.CSI != nil && respPV.Spec.CSI.VolumeHandle != pv.Name {
+				// Add the pvc object related to the PV for deleting
+				if _, ok := pvToPVCMapping[pv.Name]; ok {
+					csiPVCAndPVObjects = append(csiPVCAndPVObjects, pvToPVCMapping[pv.Name])
+				}
+				// Add the pv object to the list also for getting deleted
+				csiPVCAndPVObjects = append(csiPVCAndPVObjects, obj)
+			}
+		}
+	}
+	if len(csiPVCAndPVObjects) > 0 {
+		dynamicInterface, err := dynamic.NewForConfig(remoteClient.remoteAdminConfig)
+		if err != nil {
+			return err
+		}
+		err = m.resourceCollector.DeleteResources(
+			dynamicInterface,
+			csiPVCAndPVObjects)
+		if err != nil {
+			logrus.Errorf("error deleting csi pvcs and pvs: %v ", err)
+			return err
+		}
+	}
+
 	// create/update pv object with updated policy
 	for _, obj := range pvObjects {
 		var pv v1.PersistentVolume
@@ -2482,4 +2527,20 @@ func (m *MigrationController) getVolumeOnlyMigrationResources(
 	}
 	resources = append(resources, objects.Items...)
 	return resources, pvcWithOwnerRef, nil
+}
+
+func getpvToPVCMappingFromPVCObjects(pvcObjects []runtime.Unstructured) map[string]runtime.Unstructured {
+	pvToPVCMapping := make(map[string]runtime.Unstructured)
+	for _, obj := range pvcObjects {
+		var pvc v1.PersistentVolumeClaim
+		var err error
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &pvc); err != nil {
+			logrus.Errorf("Error unmarshalling pvc resource: %v", err)
+			continue
+		}
+		if len(pvc.Spec.VolumeName) > 0 {
+			pvToPVCMapping[pvc.Spec.VolumeName] = obj
+		}
+	}
+	return pvToPVCMapping
 }

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1884,7 +1884,7 @@ func (m *MigrationController) applyResources(
 
 	// find out the csi PVs and if the volumeHandle does not match with pv Name , delete those.
 	// https://portworx.atlassian.net/browse/PWX-30157
-	pvToPVCMapping := getpvToPVCMappingFromPVCObjects(pvcObjects)
+	pvToPVCMapping := getPVToPVCMappingFromPVCObjects(pvcObjects)
 	var csiPVCAndPVObjects []runtime.Unstructured
 	for _, obj := range pvObjects {
 		var pv v1.PersistentVolume
@@ -1901,6 +1901,7 @@ func (m *MigrationController) applyResources(
 			respPV, err := remoteClient.adminClient.CoreV1().PersistentVolumes().Get(context.TODO(), pv.Name, metav1.GetOptions{})
 			if err != nil {
 				logrus.Errorf("error getting pv %s: %v", pv.Name, err)
+				continue
 			}
 			if respPV.Spec.CSI != nil && respPV.Spec.CSI.VolumeHandle != pv.Name {
 				// Add the pvc object related to the PV for deleting
@@ -1913,13 +1914,10 @@ func (m *MigrationController) applyResources(
 		}
 	}
 	if len(csiPVCAndPVObjects) > 0 {
-		dynamicInterface, err := dynamic.NewForConfig(remoteClient.remoteAdminConfig)
-		if err != nil {
-			return err
-		}
 		err = m.resourceCollector.DeleteResources(
-			dynamicInterface,
-			csiPVCAndPVObjects)
+			remoteClient.remoteAdminInterface,
+			csiPVCAndPVObjects,
+			nil)
 		if err != nil {
 			logrus.Errorf("error deleting csi pvcs and pvs: %v ", err)
 			return err
@@ -2529,7 +2527,7 @@ func (m *MigrationController) getVolumeOnlyMigrationResources(
 	return resources, pvcWithOwnerRef, nil
 }
 
-func getpvToPVCMappingFromPVCObjects(pvcObjects []runtime.Unstructured) map[string]runtime.Unstructured {
+func getPVToPVCMappingFromPVCObjects(pvcObjects []runtime.Unstructured) map[string]runtime.Unstructured {
 	pvToPVCMapping := make(map[string]runtime.Unstructured)
 	for _, obj := range pvcObjects {
 		var pvc v1.PersistentVolumeClaim


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
>bug

**What this PR does / why we need it**:
For px csi volumes, the pv created directly has volumeHandle as the portworx volumeID. During migration we create the pv with volumeHandle as portworx volume Name in the secondary. During failback, even though the volume gets correctly migrated, but still the pv spec points to old volumeID as volumeHandle. 
The fix is to find this case during migration and recreate the PV with volumehandle as PV name.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Failback to primary when app uses px csi volumes fails as the volumeHandle points to old volume ID.
User Impact: App does not come up in primary after failback.
Resolution: With the fix of recreating pv and pointing the volumeHandle to volume name in its spec makes the app rightly use the pvc which gets properly bounded and app comes up fine.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 2.4.0
-->

**Test**:

1. Tested with migration with only csi pvcs.
2. Tested with migtation with both csi and non-csi pvcs.
Test results have been updated in PWX-30157

