### PR TITLE
PWX-30112: Making default k8s-api-qps value as 1000 and k8s-api-burst as 2000.

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -186,12 +186,12 @@ func main() {
 		},
 		cli.IntFlag{
 			Name:  "k8s-api-qps",
-			Value: 100,
+			Value: 1000,
 			Usage: "Restrict number of k8s API requests from stork (default: 100 QPS)",
 		},
 		cli.IntFlag{
 			Name:  "k8s-api-burst",
-			Value: 100,
+			Value: 2000,
 			Usage: "Restrict number of k8s API requests from stork (default: 100 Burst)",
 		},
 		cli.BoolTFlag{


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

> Uncomment only one and also add the corresponding label in the PR:
>improvement

**What this PR does / why we need it**:
Increasing default k8 api qps and burst in stork for better performance.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->


**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.4
-->

