### PR TITLE
PWX-30127: Add test for ExcludeSelectors param in MigrationSchedule

### DIFF
--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -68,6 +68,7 @@ func testMigration(t *testing.T) {
 	// TODO: waiting for https://portworx.atlassian.net/browse/STOR-281 to be resolved
 	if authTokenConfigMap == "" {
 		t.Run("labelSelectorTest", migrationLabelSelectorTest)
+		t.Run("labelExcludeSelectorTest", migrationLabelExcludeSelectorTest)
 		t.Run("intervalScheduleTest", migrationIntervalScheduleTest)
 		t.Run("dailyScheduleTest", migrationDailyScheduleTest)
 		t.Run("weeklyScheduleTest", migrationWeeklyScheduleTest)
@@ -436,6 +437,19 @@ func migrationLabelSelectorTest(t *testing.T) {
 		"cassandra",
 		[]string{"mysql-1-pvc"},
 		"label-selector-migration",
+		true,
+		false,
+		true,
+	)
+}
+
+func migrationLabelExcludeSelectorTest(t *testing.T) {
+	triggerMigrationTest(
+		t,
+		"migration-label-exclude-selector-test",
+		"cassandra",
+		[]string{"mysql-1-pvc"},
+		"label-exclude-selector-migration",
 		true,
 		false,
 		true,

--- a/test/integration_test/specs/label-exclude-selector-migration/migration.yaml
+++ b/test/integration_test/specs/label-exclude-selector-migration/migration.yaml
@@ -1,0 +1,16 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: Migration
+metadata:
+  name: cassandra-migration
+spec:
+  # This should be the name of the cluster pair
+  clusterPair: remoteclusterpair
+  # If set to false this will migrate only the volumes. No PVCs, apps, etc will be migrated
+  includeResources: true
+  # If set to false, the deployments and stateful set replicas will be set to 0 on the destination. There will be an annotation with "stork.openstorage.org/migrationReplicas" to store the replica count from the source
+  startApplications: true
+  # List of namespaces to migrate
+  namespaces:
+  - cassandra-migration-label-exclude-selector-test
+  excludeSelectors:
+    app: mysql


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
Adding integration test for excludeSelector param
https://portworx.atlassian.net/browse/PWX-30127

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes 23.4