### PR TITLE
pb-3767: Moved the LargeResource flag and Resource count to status

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -28,18 +28,16 @@ type ApplicationBackup struct {
 
 // ApplicationBackupSpec is the spec used to backup applications
 type ApplicationBackupSpec struct {
-	Namespaces           []string                           `json:"namespaces"`
-	BackupLocation       string                             `json:"backupLocation"`
-	PlatformCredential   string                             `json:"platformCredential"`
-	RancherProjects      map[string]string                  `json:"rancherProjects"`
-	Selectors            map[string]string                  `json:"selectors"`
-	NamespaceSelector    string                             `json:"namespaceSelector"`
-	PreExecRule          string                             `json:"preExecRule"`
-	PostExecRule         string                             `json:"postExecRule"`
-	ReclaimPolicy        ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
-	SkipServiceUpdate    bool                               `json:"skipServiceUpdate"`
-	ResourceCount        int                                `json:"resourceCount"`
-	LargeResourceEnabled bool                               `json:"largeResourceEnabled"`
+	Namespaces         []string                           `json:"namespaces"`
+	BackupLocation     string                             `json:"backupLocation"`
+	PlatformCredential string                             `json:"platformCredential"`
+	RancherProjects    map[string]string                  `json:"rancherProjects"`
+	Selectors          map[string]string                  `json:"selectors"`
+	NamespaceSelector  string                             `json:"namespaceSelector"`
+	PreExecRule        string                             `json:"preExecRule"`
+	PostExecRule       string                             `json:"postExecRule"`
+	ReclaimPolicy      ApplicationBackupReclaimPolicyType `json:"reclaimPolicy"`
+	SkipServiceUpdate  bool                               `json:"skipServiceUpdate"`
 	// Options to be passed in to the driver
 	Options          map[string]string `json:"options"`
 	IncludeResources []ObjectInfo      `json:"includeResources"`
@@ -61,16 +59,18 @@ const (
 
 // ApplicationBackupStatus is the status of a application backup operation
 type ApplicationBackupStatus struct {
-	Stage               ApplicationBackupStageType       `json:"stage"`
-	Status              ApplicationBackupStatusType      `json:"status"`
-	Reason              string                           `json:"reason"`
-	Resources           []*ApplicationBackupResourceInfo `json:"resources"`
-	Volumes             []*ApplicationBackupVolumeInfo   `json:"volumes"`
-	BackupPath          string                           `json:"backupPath"`
-	TriggerTimestamp    metav1.Time                      `json:"triggerTimestamp"`
-	LastUpdateTimestamp metav1.Time                      `json:"lastUpdateTimestamp"`
-	FinishTimestamp     metav1.Time                      `json:"finishTimestamp"`
-	TotalSize           uint64                           `json:"totalSize"`
+	Stage                ApplicationBackupStageType       `json:"stage"`
+	Status               ApplicationBackupStatusType      `json:"status"`
+	Reason               string                           `json:"reason"`
+	Resources            []*ApplicationBackupResourceInfo `json:"resources"`
+	Volumes              []*ApplicationBackupVolumeInfo   `json:"volumes"`
+	BackupPath           string                           `json:"backupPath"`
+	TriggerTimestamp     metav1.Time                      `json:"triggerTimestamp"`
+	LastUpdateTimestamp  metav1.Time                      `json:"lastUpdateTimestamp"`
+	FinishTimestamp      metav1.Time                      `json:"finishTimestamp"`
+	TotalSize            uint64                           `json:"totalSize"`
+	ResourceCount        int                              `json:"resourceCount"`
+	LargeResourceEnabled bool                             `json:"largeResourceEnabled"`
 }
 
 // ObjectInfo contains info about an object being backed up or restored

--- a/pkg/apis/stork/v1alpha1/applicationrestore.go
+++ b/pkg/apis/stork/v1alpha1/applicationrestore.go
@@ -32,8 +32,6 @@ type ApplicationRestoreSpec struct {
 	IncludeResources             []ObjectInfo                        `json:"includeResources"`
 	StorageClassMapping          map[string]string                   `json:"storageClassMapping"`
 	RancherProjectMapping        map[string]string                   `json:"rancherProjectMapping"`
-	ResourceCount                int                                 `json:"resourceCount"`
-	LargeResourceEnabled         bool                                `json:"largeResourceEnabled"`
 }
 
 // ApplicationRestoreReplacePolicyType is the replace policy for the application restore
@@ -53,14 +51,16 @@ const (
 
 // ApplicationRestoreStatus is the status of a application restore operation
 type ApplicationRestoreStatus struct {
-	Stage               ApplicationRestoreStageType       `json:"stage"`
-	Status              ApplicationRestoreStatusType      `json:"status"`
-	Reason              string                            `json:"reason"`
-	Resources           []*ApplicationRestoreResourceInfo `json:"resources"`
-	Volumes             []*ApplicationRestoreVolumeInfo   `json:"volumes"`
-	FinishTimestamp     metav1.Time                       `json:"finishTimestamp"`
-	LastUpdateTimestamp metav1.Time                       `json:"lastUpdateTimestamp"`
-	TotalSize           uint64                            `json:"totalSize"`
+	Stage                ApplicationRestoreStageType       `json:"stage"`
+	Status               ApplicationRestoreStatusType      `json:"status"`
+	Reason               string                            `json:"reason"`
+	Resources            []*ApplicationRestoreResourceInfo `json:"resources"`
+	Volumes              []*ApplicationRestoreVolumeInfo   `json:"volumes"`
+	FinishTimestamp      metav1.Time                       `json:"finishTimestamp"`
+	LastUpdateTimestamp  metav1.Time                       `json:"lastUpdateTimestamp"`
+	TotalSize            uint64                            `json:"totalSize"`
+	ResourceCount        int                               `json:"resourceCount"`
+	LargeResourceEnabled bool                              `json:"largeResourceEnabled"`
 }
 
 // ApplicationRestoreResourceInfo is the info for the restore of a resource

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1575,8 +1575,8 @@ func (a *ApplicationBackupController) backupResources(
 			// update the flag and resource-count.
 			// Strip off the resource info it contributes to bigger size of AB CR in case of large number of resource
 			backup.Status.Resources = make([]*stork_api.ApplicationBackupResourceInfo, 0)
-			backup.Spec.ResourceCount = len(resourceInfos)
-			backup.Spec.LargeResourceEnabled = true
+			backup.Status.ResourceCount = len(resourceInfos)
+			backup.Status.LargeResourceEnabled = true
 		}
 		// Store the new status
 		err = a.client.Update(context.TODO(), backup)

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1448,8 +1448,8 @@ func (a *ApplicationRestoreController) restoreResources(
 		// update the flag and resource-count.
 		// Strip off the resource info it contributes to bigger size of application restore CR in case of large number of resource
 		restore.Status.Resources = make([]*storkapi.ApplicationRestoreResourceInfo, 0)
-		restore.Spec.ResourceCount = resourceCount
-		restore.Spec.LargeResourceEnabled = true
+		restore.Status.ResourceCount = resourceCount
+		restore.Status.LargeResourceEnabled = true
 	}
 	if err := a.client.Update(context.TODO(), restore); err != nil {
 		return err


### PR DESCRIPTION
- the LargeResourceEnabled flag and resource count is moved for Spec section to Status section for both Application backup & Resotre CR.


**What type of PR is this?** cleanup
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: We generally don't keep dynamically changing fields in CR's Spec section hence moved it to Status Section


**Does this PR change a user-facing CRD or CLI?**:  no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: no 
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: 23.3.1
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

Will update the Unit test... Backup has suceeded , CUrrently restore is in progress. Due Large Resource in nature it takes 3 Hrs for 13K resources. waiting for it complete . 
Backup Data
![Pasted Graphic 14](https://user-images.githubusercontent.com/15273500/230032887-7d928409-7d65-4630-b0a0-1d3a2526686f.png)

![Pasted Graphic 15](https://user-images.githubusercontent.com/15273500/230032931-cad3fe39-c809-4ce8-9f4e-64b64175f249.png)

Restore Passed 
![image](https://user-images.githubusercontent.com/15273500/230042427-04202df3-4c93-41cd-9e0c-d704faf55189.png)
 10002 + 1 for volume 
![image](https://user-images.githubusercontent.com/15273500/230043118-34ba8c74-a5e6-444a-ae19-2ae273bca2fe.png)
****