### PR TITLE
pb-3773: Update restore CR with restored resources & state

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationrestore.go
+++ b/pkg/apis/stork/v1alpha1/applicationrestore.go
@@ -49,18 +49,29 @@ const (
 	ApplicationRestoreReplacePolicyRetain ApplicationRestoreReplacePolicyType = "Retain"
 )
 
+type ApplicationRestoreResourceStateType string
+
+const (
+	ApplicationRestoreResourcePreparing ApplicationRestoreResourceStateType = "Preparing"
+	ApplicationRestoreResourceDeleting  ApplicationRestoreResourceStateType = "Deleting"
+	ApplicationRestoreResourceVerifying ApplicationRestoreResourceStateType = "Verifying"
+	ApplicationRestoreResourceApplying  ApplicationRestoreResourceStateType = "Applying"
+)
+
 // ApplicationRestoreStatus is the status of a application restore operation
 type ApplicationRestoreStatus struct {
-	Stage                ApplicationRestoreStageType       `json:"stage"`
-	Status               ApplicationRestoreStatusType      `json:"status"`
-	Reason               string                            `json:"reason"`
-	Resources            []*ApplicationRestoreResourceInfo `json:"resources"`
-	Volumes              []*ApplicationRestoreVolumeInfo   `json:"volumes"`
-	FinishTimestamp      metav1.Time                       `json:"finishTimestamp"`
-	LastUpdateTimestamp  metav1.Time                       `json:"lastUpdateTimestamp"`
-	TotalSize            uint64                            `json:"totalSize"`
-	ResourceCount        int                               `json:"resourceCount"`
-	LargeResourceEnabled bool                              `json:"largeResourceEnabled"`
+	Stage                 ApplicationRestoreStageType         `json:"stage"`
+	Status                ApplicationRestoreStatusType        `json:"status"`
+	Reason                string                              `json:"reason"`
+	Resources             []*ApplicationRestoreResourceInfo   `json:"resources"`
+	Volumes               []*ApplicationRestoreVolumeInfo     `json:"volumes"`
+	FinishTimestamp       metav1.Time                         `json:"finishTimestamp"`
+	LastUpdateTimestamp   metav1.Time                         `json:"lastUpdateTimestamp"`
+	TotalSize             uint64                              `json:"totalSize"`
+	ResourceCount         int                                 `json:"resourceCount"`
+	LargeResourceEnabled  bool                                `json:"largeResourceEnabled"`
+	RestoredResourceCount int                                 `json:"restoredresourceCount"`
+	ResourceRestoreState  ApplicationRestoreResourceStateType `json:"resourcerestorestate"`
 }
 
 // ApplicationRestoreResourceInfo is the info for the restore of a resource

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
+	coreapi "k8s.io/kubernetes/pkg/apis/core"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -72,7 +73,6 @@ const (
 	kdmpDriverOnly                = "kdmp"
 	nonKdmpDriverOnly             = "nonkdmp"
 	mixedDriver                   = "mixed"
-	oneMBSizeBytes                = 1 << (10 * 2)
 )
 
 var (
@@ -1569,9 +1569,23 @@ func (a *ApplicationBackupController) backupResources(
 			log.ApplicationBackupLog(backup).Errorf("Failed to calculate size of resource info array for backup %v", backup.GetName())
 			return err
 		}
-		if backupCrSize > oneMBSizeBytes {
-			logrus.Infof("The size of application backup CR obtained %v bytes", backupCrSize)
-			logrus.Infof("Stripping all the resource info from Application backup-cr %v in namespace %v", backup.GetName(), backup.GetNamespace())
+		var largeResourceSizeLimit int64
+		largeResourceSizeLimit = k8sutils.LargeResourceSizeLimitDefault
+		configData, err := core.Instance().GetConfigMap(k8sutils.StorkControllerConfigMapName, coreapi.NamespaceSystem)
+		if err != nil {
+			log.ApplicationBackupLog(backup).Errorf("failed to read config map %v for large resource size limit", k8sutils.StorkControllerConfigMapName)
+		}
+		if configData.Data[k8sutils.LargeResourceSizeLimitName] != "" {
+			largeResourceSizeLimit, err = strconv.ParseInt(configData.Data[k8sutils.LargeResourceSizeLimitName], 0, 64)
+			if err != nil {
+				log.ApplicationBackupLog(backup).Errorf("failed to read config map %v's key %v, setting default value of 1MB", k8sutils.StorkControllerConfigMapName,
+					k8sutils.LargeResourceSizeLimitName)
+			}
+		}
+
+		log.ApplicationBackupLog(backup).Infof("The size of application backup CR obtained %v bytes", backupCrSize)
+		if backupCrSize > int(largeResourceSizeLimit) {
+			log.ApplicationBackupLog(backup).Infof("Stripping all the resource info from Application backup-cr %v in namespace %v", backup.GetName(), backup.GetNamespace())
 			// update the flag and resource-count.
 			// Strip off the resource info it contributes to bigger size of AB CR in case of large number of resource
 			backup.Status.Resources = make([]*stork_api.ApplicationBackupResourceInfo, 0)

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -43,6 +43,10 @@ const (
 	ObjectLockIncrBackupCountKey = "object-lock-incr-backup-count"
 	// ObjectLockDefaultIncrementalCount defines default incremental backup count
 	ObjectLockDefaultIncrementalCount = 5
+	//LargeResourceSizeLimit defines the maximum size of CR beyond which the backup and restores will be treated as Large resource type.
+	LargeResourceSizeLimitName = "large-resource-size-limit"
+	//LargeResourceSizeLimitDefault defines the default size of CR beyond which the backup and restores will be treated as Large resource type.
+	LargeResourceSizeLimitDefault = 1 << (10 * 2)
 	//minProtectionPeriod defines minimum number of days, the backup are protected via object-lock feature
 	minProtectionPeriod = 1
 	// RestoreVolumeBatchCountKey - restore volume batch count value

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -1088,7 +1088,7 @@ func (r *ResourceCollector) DeleteResources(
 	for _, object := range objects {
 		elapsedTime := time.Since(startTime)
 		if elapsedTime > utils.FifteenMinuteWait {
-			updateTimestamp <- utils.UpdateRestoreCrTimestamp
+			updateTimestamp <- utils.UpdateRestoreCrTimestampInDeleteResourcePath
 			startTime = time.Now()
 		}
 		// Don't delete objects that support merging
@@ -1118,7 +1118,7 @@ func (r *ResourceCollector) DeleteResources(
 	for _, object := range objects {
 		elapsedTime := time.Since(startTime)
 		if elapsedTime > utils.FifteenMinuteWait {
-			updateTimestamp <- utils.UpdateRestoreCrTimestamp
+			updateTimestamp <- utils.UpdateRestoreCrTimestampInDeleteResourcePath
 			startTime = time.Now()
 		}
 		// Objects that support merging aren't deleted

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -1087,7 +1087,7 @@ func (r *ResourceCollector) DeleteResources(
 	startTime := time.Now()
 	for _, object := range objects {
 		elapsedTime := time.Since(startTime)
-		if elapsedTime > utils.FifteenMinuteWait {
+		if elapsedTime > utils.TimeoutUpdateRestoreCrTimestamp {
 			updateTimestamp <- utils.UpdateRestoreCrTimestampInDeleteResourcePath
 			startTime = time.Now()
 		}
@@ -1117,7 +1117,7 @@ func (r *ResourceCollector) DeleteResources(
 	// Then wait for them to actually be deleted
 	for _, object := range objects {
 		elapsedTime := time.Since(startTime)
-		if elapsedTime > utils.FifteenMinuteWait {
+		if elapsedTime > utils.TimeoutUpdateRestoreCrTimestamp {
 			updateTimestamp <- utils.UpdateRestoreCrTimestampInDeleteResourcePath
 			startTime = time.Now()
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -31,10 +31,10 @@ const (
 	UpdateRestoreCrTimestampInPrepareResourcePath = 17
 	// UpdateRestoreCrTimestampInApplyResourcePath is sent in channel to signify go routine to update the timestamp
 	UpdateRestoreCrTimestampInApplyResourcePath = 19
-	// duration in which the restore CR to be updated
-	FifteenMinuteWait = 5 * time.Minute
+	// duration in which the restore CR to be updated with timestamp
+	TimeoutUpdateRestoreCrTimestamp = 15 * time.Minute
 	// duration in which the restore CR to be updated for resource Count progress
-	FiveMinuteWait = 5 * time.Minute
+	TimeoutUpdateRestoreCrProgress = 5 * time.Minute
 	// sleep interval for restore time stamp update go-routine to check channel for any data
 	SleepIntervalForCheckingChannel = 10 * time.Second
 	// RestoreCrChannelBufferSize is the count of maximum signals it can hold in restore CR update related channel

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -25,10 +25,16 @@ const (
 	trimCRDGroupNameKey = "TRIM_CRD_GROUP_NAME"
 	// QuitRestoreCrTimestampUpdate is sent in the channel to informs the go routine to stop any further update
 	QuitRestoreCrTimestampUpdate = 13
-	// UpdateRestoreCrTimestamp is sent in channel to signify go routine to update the timestamp
-	UpdateRestoreCrTimestamp = 11
+	// UpdateRestoreCrTimestampInDeleteResourcePath is sent in channel to signify go routine to update the timestamp
+	UpdateRestoreCrTimestampInDeleteResourcePath = 11
+	// UpdateRestoreCrTimestampInPrepareResourcePath is sent in channel to signify go routine to update the timestamp
+	UpdateRestoreCrTimestampInPrepareResourcePath = 17
+	// UpdateRestoreCrTimestampInApplyResourcePath is sent in channel to signify go routine to update the timestamp
+	UpdateRestoreCrTimestampInApplyResourcePath = 19
 	// duration in which the restore CR to be updated
-	FifteenMinuteWait = 15 * time.Minute
+	FifteenMinuteWait = 5 * time.Minute
+	// duration in which the restore CR to be updated for resource Count progress
+	FiveMinuteWait = 5 * time.Minute
 	// sleep interval for restore time stamp update go-routine to check channel for any data
 	SleepIntervalForCheckingChannel = 10 * time.Second
 	// RestoreCrChannelBufferSize is the count of maximum signals it can hold in restore CR update related channel


### PR DESCRIPTION
- Added two field to restore CR one signifies number of already applied resource
- The other is the phase in which resource restoration process operating. It has three phases
	- preparing resource
	- deleting resource( only if replace is selected)
	- verifying the deleted resource
	- applied resource


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: We need to showcase of a progress bar for large resource restore. Hence we need some additional field to be updated in certain interval  in restore CR. Additionally a restore resource state is also added to signify in what state the resource process is operating.


**Does this PR change a user-facing CRD or CLI?**: No, it adds values to only status field
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Unit test:
Verified a multi namespace and a large resource based restore and  large resource based resource which has a volume as well as resources present in it.
![image](https://user-images.githubusercontent.com/15273500/231050016-b8c63672-bc81-469e-a4bd-bc208df597ed.png)


![image](https://user-images.githubusercontent.com/15273500/231050060-d5d51e28-ee91-4d94-8a05-ae2fd3a4d7b0.png)

