### PR TITLE
PWX-29789: Implementation of crd plural map for dynamically getting crd's plurals

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -33,6 +33,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/migration/controllers"
 	"github.com/libopenstorage/stork/pkg/monitor"
 	"github.com/libopenstorage/stork/pkg/objectcontroller"
+	"github.com/libopenstorage/stork/pkg/pluralmap"
 	"github.com/libopenstorage/stork/pkg/pvcwatcher"
 	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	"github.com/libopenstorage/stork/pkg/rule"
@@ -475,6 +476,12 @@ func runStork(mgr manager.Manager, ctx context.Context, d volume.Driver, recorde
 	if adminNamespace == "" {
 		adminNamespace = c.String("migration-admin-namespace")
 	}
+
+	// Setting up the pluralmap. It has the right plural for a crd kind installed in the cluster.
+	if err := pluralmap.CreateCRDPlurals(); err != nil {
+		log.Fatalf("failed to setup crd plural map: %v", err)
+	}
+	log.Infof("crd plural map has been intialized")
 
 	monitor := &monitor.Monitor{
 		Driver:      d,

--- a/pkg/applicationmanager/controllers/applicationregistration.go
+++ b/pkg/applicationmanager/controllers/applicationregistration.go
@@ -8,6 +8,7 @@ import (
 
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/appregistration"
+	"github.com/libopenstorage/stork/pkg/pluralmap"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
 	"github.com/portworx/sched-ops/k8s/stork"
 	"github.com/portworx/sched-ops/task"
@@ -170,12 +171,24 @@ func RegisterDefaultCRDs() error {
 			if err := registerCRDV1(*crd); err != nil {
 				logrus.WithError(err).Error("unable to create appreg for v1 crd")
 			}
+			if len(crd.Spec.Names.Kind) > 0 {
+				if _, ok := pluralmap.Instance().GetCRDKindToPluralMap()[strings.ToLower(crd.Spec.Names.Kind)]; !ok {
+					pluralmap.Instance().SetPluralForCRDKind(crd.Spec.Names.Kind, crd.Spec.Names.Plural)
+					logrus.Infof("Adding new crd to plural map %s/%s", crd.Spec.Names.Kind, crd.Spec.Names.Plural)
+				}
+			}
 		} else if crd, ok := object.(*apiextensionsv1beta1.CustomResourceDefinition); ok {
 			if _, ok := skipCrds[crd.Spec.Group]; ok {
 				return
 			}
 			if err := registerCRD(*crd); err != nil {
 				logrus.WithError(err).Error("unable to create appreg for v1beta1 crd")
+			}
+			if len(crd.Spec.Names.Kind) > 0 {
+				if _, ok := pluralmap.Instance().GetCRDKindToPluralMap()[strings.ToLower(crd.Spec.Names.Kind)]; !ok {
+					pluralmap.Instance().SetPluralForCRDKind(crd.Spec.Names.Kind, crd.Spec.Names.Plural)
+					logrus.Infof("Adding new crd to plural map %s/%s", crd.Spec.Names.Kind, crd.Spec.Names.Plural)
+				}
 			}
 
 		} else {

--- a/pkg/pluralmap/pluralmap.go
+++ b/pkg/pluralmap/pluralmap.go
@@ -1,0 +1,94 @@
+package pluralmap
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/portworx/sched-ops/k8s/apiextensions"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+type pluralMap struct {
+	crdPluralLock      sync.Mutex
+	crdKindToPluralMap map[string]string
+}
+
+// PluralMap has getters and setters for crdKindToPluralMap.
+type PluralMap interface {
+	// GetCRDKindToPluralMap returns the crdKindToPluralMap from pluralmap singleton.
+	GetCRDKindToPluralMap() map[string]string
+
+	// SetPluralForCRDKind will set a new CRD's plural in the map
+	SetPluralForCRDKind(kind, plural string)
+}
+
+var (
+	crdPluralMap        *pluralMap
+	crdPluralGlobalLock sync.Mutex
+)
+
+func Instance() *pluralMap {
+	if crdPluralMap == nil {
+		CreateCRDPlurals()
+	}
+	crdPluralGlobalLock.Lock()
+	defer crdPluralGlobalLock.Unlock()
+	return crdPluralMap
+}
+
+func getCRDKindToPluralMap() map[string]string {
+	kindToPluralMap := make(map[string]string)
+	crdv1List, err := apiextensions.Instance().ListCRDs()
+	if err == nil {
+		for _, crd := range crdv1List.Items {
+			kindToPluralMap[strings.ToLower(crd.Spec.Names.Kind)] = crd.Spec.Names.Plural
+		}
+	} else if apierrors.IsNotFound(err) {
+		// list and register crds via v1beta1 apis
+		crdv1beta1List, err := apiextensions.Instance().ListCRDsV1beta1()
+		if err != nil {
+			logrus.Warnf("unable to list v1beta1 crds: %v", err)
+			return kindToPluralMap
+		}
+		for _, crd := range crdv1beta1List.Items {
+			if len(crd.Spec.Names.Kind) > 0 {
+				kindToPluralMap[strings.ToLower(crd.Spec.Names.Kind)] = crd.Spec.Names.Plural
+			}
+		}
+	}
+	return kindToPluralMap
+}
+
+func CreateCRDPlurals() error {
+	crdPluralGlobalLock.Lock()
+	defer crdPluralGlobalLock.Unlock()
+
+	if crdPluralMap != nil {
+		return fmt.Errorf("plural map has already been initialized")
+	}
+	crdPluralMap = &pluralMap{}
+	crdPluralMap.crdKindToPluralMap = getCRDKindToPluralMap()
+	logrus.Debugf("Current crd plural map: %v", crdPluralMap.crdKindToPluralMap)
+
+	return nil
+}
+
+func (p *pluralMap) GetCRDKindToPluralMap() map[string]string {
+	p.crdPluralLock.Lock()
+	defer p.crdPluralLock.Unlock()
+	// Making a new copy of map and returning it to avoid concurrent map read and map write
+	crdKindToPluralMapCopy := make(map[string]string, len(p.crdKindToPluralMap))
+	for k, v := range p.crdKindToPluralMap {
+		crdKindToPluralMapCopy[k] = v
+	}
+	return crdKindToPluralMapCopy
+}
+
+func (p *pluralMap) SetPluralForCRDKind(kind, plural string) {
+	p.crdPluralLock.Lock()
+	defer p.crdPluralLock.Unlock()
+
+	p.crdKindToPluralMap[strings.ToLower(kind)] = plural
+}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libopenstorage/stork/drivers/volume"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	storkcache "github.com/libopenstorage/stork/pkg/cache"
+	"github.com/libopenstorage/stork/pkg/pluralmap"
 	"github.com/libopenstorage/stork/pkg/utils"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/rbac"
@@ -1244,6 +1245,7 @@ func (r *ResourceCollector) prepareRancherApplicationResource(
 }
 
 func GetDefaultRuleSet() *inflect.Ruleset {
+
 	// TODO: we should use k8s code generator logic to pluralize
 	// crd resources instead of depending on inflect lib
 	ruleset := inflect.NewDefaultRuleset()
@@ -1264,5 +1266,8 @@ func GetDefaultRuleSet() *inflect.Ruleset {
 	ruleset.AddPlural("scheduling", "scheduling")
 	ruleset.AddPlural("spss", "spss")
 
+	for kind, group := range pluralmap.Instance().GetCRDKindToPluralMap() {
+		ruleset.AddPlural(kind, group)
+	}
 	return ruleset
 }


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
For finding crd's plural for querying,  currently inflect ruleset was used.
Sometimes the crd's plural does not align with the library's rules and in that case every time a stork release is required with added exceptions. 
The current fix will find the existing crd's plurals and keep it in a global cache for further use. 

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->


**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.4
-->

**Test**
Tested following 2 cases with migration for confluent kafka application.
1. App was installed first and stork gets installed later.
2. Stork was installed first and app gets installed later.

Details of test results have been updated in PWX-29789.