### PR TITLE
pb-3791: Add a config-map for batch volume restore sleep interval

### DIFF
--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -53,13 +53,15 @@ const (
 	RestoreVolumeBatchCountKey = "restore-volume-backup-count"
 	// DefaultRestoreVolumeBatchCount - default value for restore volume batch count
 	DefaultRestoreVolumeBatchCount = 25
-	// RestoreVolumeBatchSleepInterval - restore volume batch sleep interval
-	RestoreVolumeBatchSleepInterval = 20 * time.Second
 	// ResourceCountLimitKeyName defines the number of resources to be read via one List API call.
 	// It is assigned to Limit field of ListOption structure
 	ResourceCountLimitKeyName = "resource-count-limit"
 	// DefaultResourceCountLimit defines the default value for resource count for list api
 	DefaultResourceCountLimit = int64(500)
+	// DefaultRestoreVolumeBatchSleepInterval - restore volume batch sleep interval
+	DefaultRestoreVolumeBatchSleepInterval = "20s"
+	// RestoreVolumeBatchSleepIntervalKey - restore volume batch sleep interval key
+	RestoreVolumeBatchSleepIntervalKey = "restore-volume-sleep-interval"
 )
 
 // JSONPatchOp is a single json mutation done by a k8s mutating webhook


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: This adds a configMap to alter the existing batch restore volume sleep interval


**Does this PR change a user-facing CRD or CLI?**: no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: no
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: 23.3.1
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

