### PR TITLE
DS-4808: Include stdout output in cmdexecutor logs

### DIFF
--- a/cmd/cmdexecutor/cmdexecutor.go
+++ b/cmd/cmdexecutor/cmdexecutor.go
@@ -163,13 +163,15 @@ func main() {
 		podKey := createPodStringFromNameAndNamespace(ns, name)
 		go func(errChan chan error, stdoutChan chan string, doneChan chan bool, execInst cmdexecutor.Executor) {
 			err := execInst.Wait(time.Duration(statusCheckTimeout) * time.Second)
-			// log the output of command execution before returning/marking it done
-			for stdout := range stdoutChan {
-				logrus.Infof("[%s] :: %s", podKey, stdout)
-			}
+
 			if err != nil {
 				errChan <- err
 				return
+			}
+			// log the output of command execution before marking it done
+			// note: if wait is returning err, it won't log output
+			for stdout := range stdoutChan {
+				logrus.Infof("[%s] :: %s", podKey, stdout)
 			}
 
 			doneChan <- true

--- a/cmd/cmdexecutor/cmdexecutor.go
+++ b/cmd/cmdexecutor/cmdexecutor.go
@@ -161,10 +161,10 @@ func main() {
 	for _, executor := range executors {
 		ns, name := executor.GetPod()
 		podKey := createPodStringFromNameAndNamespace(ns, name)
-		go func(errChan chan error, stdoutChans map[string]chan string, doneChan chan bool, execInst cmdexecutor.Executor) {
+		go func(errChan chan error, stdoutChan chan string, doneChan chan bool, execInst cmdexecutor.Executor) {
 			err := execInst.Wait(time.Duration(statusCheckTimeout) * time.Second)
 			// log the output of command execution before returning/marking it done
-			for stdout := range stdoutChans[podKey] {
+			for stdout := range stdoutChan {
 				logrus.Infof("[%s] :: %s", podKey, stdout)
 			}
 			if err != nil {
@@ -173,7 +173,7 @@ func main() {
 			}
 
 			doneChan <- true
-		}(errChans[podKey], stdoutChans, done, executor)
+		}(errChans[podKey], stdoutChans[podKey], done, executor)
 	}
 
 	// Now go into a wait loop which will exit if either of the 2 things happen

--- a/pkg/cmdexecutor/cmdexecutor.go
+++ b/pkg/cmdexecutor/cmdexecutor.go
@@ -29,7 +29,7 @@ const (
 // Executor is an interface to start and wait for async commands in pods
 type Executor interface {
 	// Start starts the command in the pod asynchronously
-	Start(chan error) error
+	Start(chan string, chan error) error
 	// Wait checks if the command started in pod completed successfully
 	//	timeout is the time after which the check should timeout.
 	Wait(timeout time.Duration) error
@@ -61,7 +61,7 @@ func Init(podNamespace, podName, container, command, taskID string) Executor {
 	}
 }
 
-func (c *cmdExecutor) Start(errChan chan error) error {
+func (c *cmdExecutor) Start(stdoutChan chan string, errChan chan error) error {
 	if !strings.Contains(c.command, waitCmdPlaceholder) {
 		return fmt.Errorf("given command: %s needs to have ${WAIT_CMD} placeholder", c.command)
 	}
@@ -73,7 +73,7 @@ func (c *cmdExecutor) Start(errChan chan error) error {
 	waitScriptCreateCmd := fmt.Sprintf("rm -rf %s %s && echo 'touch %s && while [ ! -f %s ]; do sleep 2; done' > %s && chmod +x %s",
 		c.statusFile, killFile, c.statusFile, killFile, waitScriptLocation, waitScriptLocation)
 	cmdSplit := []string{"/bin/sh", "-c", waitScriptCreateCmd}
-	_, err := core.Instance().RunCommandInPod(cmdSplit, c.podName, c.container, c.podNamespace)
+	stdout, err := core.Instance().RunCommandInPod(cmdSplit, c.podName, c.container, c.podNamespace)
 	if err != nil {
 		err = fmt.Errorf("failed to create wait script in pod: [%s] %s using command: %s due to err: %v",
 			c.podNamespace, c.podName, waitScriptCreateCmd, err)
@@ -85,13 +85,14 @@ func (c *cmdExecutor) Start(errChan chan error) error {
 	go func() {
 		logrus.Infof("Running command: %s on pod: [%s] %s", command, c.podNamespace, c.podName)
 		cmdSplit = []string{"/bin/sh", "-c", command}
-		_, err = core.Instance().RunCommandInPod(cmdSplit, c.podName, c.container, c.podNamespace)
+		stdout, err = core.Instance().RunCommandInPod(cmdSplit, c.podName, c.container, c.podNamespace)
 		if err != nil {
 			err = fmt.Errorf("failed to run command: %s in pod: [%s] %s due to err: %v",
 				command, c.podNamespace, c.podName, err)
 			logrus.Errorf(err.Error())
 		}
 
+		stdoutChan <- stdout
 		errChan <- err
 	}()
 

--- a/pkg/cmdexecutor/cmdexecutor.go
+++ b/pkg/cmdexecutor/cmdexecutor.go
@@ -94,6 +94,7 @@ func (c *cmdExecutor) Start(stdoutChan chan string, errChan chan error) error {
 
 		stdoutChan <- stdout
 		errChan <- err
+		close(stdoutChan)
 	}()
 
 	return nil

--- a/test/integration_test/cmdexecutor_test.go
+++ b/test/integration_test/cmdexecutor_test.go
@@ -62,8 +62,9 @@ func TestCommandExecutor(t *testing.T) {
 		// Negative test cases
 		for _, pod := range pods {
 			executor := cmdexecutor.Init(pod.GetNamespace(), pod.GetName(), "", noWaitPlaceholderCmd, string(pod.GetUID()))
+			stdoutChan := make(chan string)
 			errChan := make(chan error)
-			err = executor.Start(errChan)
+			err = executor.Start(stdoutChan, errChan)
 			require.Error(t, err, "expected error from the start command API")
 		}
 
@@ -89,8 +90,9 @@ func startCommandInPods(t *testing.T, command string, pods []v1.Pod) []cmdexecut
 	executors := make([]cmdexecutor.Executor, 0)
 	for _, pod := range pods {
 		executor := cmdexecutor.Init(pod.GetNamespace(), pod.GetName(), "", command, string(pod.GetUID()))
+		stdoutChan := make(chan string)
 		errChan := make(chan error)
-		err := executor.Start(errChan)
+		err := executor.Start(stdoutChan, errChan)
 		require.NoError(t, err, "failed to start async command")
 		executors = append(executors, executor)
 	}


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
This PR logs the stdout of command run by cmdexecutor on different pods to cmdexecutor logs. 
Required for [DS-4808](https://portworx.atlassian.net/browse/DS-4808)

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
No

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
No

