### PR TITLE
pb-3789: Add limit value for ListOption while getting resources

### DIFF
--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -55,6 +55,11 @@ const (
 	DefaultRestoreVolumeBatchCount = 25
 	// RestoreVolumeBatchSleepInterval - restore volume batch sleep interval
 	RestoreVolumeBatchSleepInterval = 20 * time.Second
+	// ResourceCountLimitKeyName defines the number of resources to be read via one List API call.
+	// It is assigned to Limit field of ListOption structure
+	ResourceCountLimitKeyName = "resource-count-limit"
+	// DefaultResourceCountLimit defines the default value for resource count for list api
+	DefaultResourceCountLimit = int64(500)
 )
 
 // JSONPatchOp is a single json mutation done by a k8s mutating webhook

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -92,6 +92,11 @@ type Options struct {
 	// resource collector to perform transformations on certain k8s resources.
 	// TODO: temporary change required to handle project related transformations
 	RancherProjectMappings map[string]string
+	// limit ensures the k8s APIs will use this value in ListOption while fetching
+	// the resources from cluster. In case of Large number of resources with substantial
+	// content in them, the etcd Server times-out, hence limit will be used to reduce
+	// the number of resources fetched in a single call.
+	ResourceCountLimit int64
 }
 
 // Objects Collection of objects
@@ -306,9 +311,7 @@ func (r *ResourceCollector) GetResourcesForType(
 		default:
 			selectors = labels.Set(labelSelectors).String()
 		}
-		objectsList, err := dynamicClient.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: selectors,
-		})
+		objectsList, err := gatherResourceInChunks(dynamicClient, opts, selectors)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error listing objects for %v: %v", gvr, err)
 		}
@@ -448,9 +451,7 @@ func (r *ResourceCollector) GetResources(
 				default:
 					selectors = labels.Set(labelSelectors).String()
 				}
-				objectsList, err := dynamicClient.List(context.TODO(), metav1.ListOptions{
-					LabelSelector: selectors,
-				})
+				objectsList, err := gatherResourceInChunks(dynamicClient, opts, selectors)
 				if err != nil {
 					if apierrors.IsForbidden(err) {
 						continue
@@ -520,6 +521,38 @@ func (r *ResourceCollector) GetResources(
 	}
 
 	return allObjects, pvcsWithOwnerReference, nil
+}
+
+// gatherResourceInChunks() collects all the resources present per ns or resource types.
+// It does it in batch of 500 unless specified by user via a config-map. This function
+// primarily helps in avoiding server timeout error when the number of resource or size
+// of it large.
+func gatherResourceInChunks(dynamicClient dynamic.ResourceInterface, opts Options, selectors string) (*unstructured.UnstructuredList, error) {
+	var err error
+	fn := "gatherResourceInChunks"
+	objectsList := &unstructured.UnstructuredList{}
+	var temp *unstructured.UnstructuredList
+	listOps := metav1.ListOptions{
+		LabelSelector: selectors,
+		Limit:         opts.ResourceCountLimit,
+	}
+	for {
+		temp, err = dynamicClient.List(context.TODO(), listOps)
+		if err != nil {
+			logrus.Warnf("%v: failed to list resources", fn)
+			return nil, err
+		}
+		if len(temp.GetContinue()) != 0 {
+			listOps.Continue = temp.GetContinue()
+			objectsList.Items = append(objectsList.Items, temp.Items...)
+			continue
+		} else {
+			// Append the final set of data left...
+			objectsList.Items = append(objectsList.Items, temp.Items...)
+			break
+		}
+	}
+	return objectsList, err
 }
 
 // IsNsPresentInIncludeResource checks if a given ns is present in the IncludeResource object


### PR DESCRIPTION
- In clutsers having large count of resources the resource List API in k8s takes a lot of time and that make etcd server to timeout client call. Hence a limit is added to ListOption so that only certain number of resources will be fetched with a single call
- Currently the limit is set to 500 resources at a time.


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: With large resource count GetResource API in resource collector package used to fail. The reason getting  large amount o resource detail via k8s API timesout. Hence we have added the limit value so that only 500 resources will be fetched every List  API call.


**Does this PR change a user-facing CRD or CLI?**:No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

**Unit Test**
Currently preparing the setup and will update the PR with unit test results ... 

```

**Does this change need to be cherry-picked to a release branch?**: 23.3.1
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Unit Test:
1. Taken a 500 configmap having 60,000 data in each configmap( as it is simulated in ticket)
2.  with 500 limit it failed hence kept it to 200 by changing the config-map entry in stork-controller-config 
3. it passed with right count of resources.
4. Performed a restore it succeed by applying the resources to a new namespace.

backup of the above case:
![Screenshot from 2023-04-19 02-16-19](https://user-images.githubusercontent.com/15273500/232904669-f2facec2-b55f-4e4b-8533-20a31ba45f8e.png)

Restore with retain option
![image](https://user-images.githubusercontent.com/15273500/232905264-87591525-2d38-44f7-b2a9-87f977f63d5f.png)

Multi namespace backup:
![image](https://user-images.githubusercontent.com/15273500/232908113-b45ca62f-63ef-43e1-8f04-0d18316ee988.png)

Additional FC execution will be done post merging the PR to master. 
