### PR TITLE
PWX-30319: Fix incorrect migration status with service account deletion

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -1155,6 +1155,40 @@ func (r *ResourceCollector) DeleteResources(
 	return nil
 }
 
+// ObjectTobeDeleted returns list of objects present on destination but not on source
+func (r *ResourceCollector) ObjectTobeDeleted(srcObjects, destObjects []runtime.Unstructured) []runtime.Unstructured {
+	var deleteObjects []runtime.Unstructured
+	for _, o := range destObjects {
+		name, namespace, kind, err := utils.GetObjectDetails(o)
+		if err != nil {
+			// skip purging if we are not able to get object details
+			logrus.Errorf("Unable to get object details %v", err)
+			continue
+		}
+		// Don't return objects that support merging
+		if r.mergeSupportedForResource(o) {
+			continue
+		}
+		isPresent := false
+		for _, s := range srcObjects {
+			sname, snamespace, skind, err := utils.GetObjectDetails(s)
+			if err != nil {
+				// skip purging if we are not able to get object details
+				continue
+			}
+			if skind == kind && snamespace == namespace && sname == name {
+				isPresent = true
+				break
+			}
+		}
+		if !isPresent {
+			logrus.Infof("Deleting object from destination(%v:%v:%v)", name, namespace, kind)
+			deleteObjects = append(deleteObjects, o)
+		}
+	}
+	return deleteObjects
+}
+
 func (r *ResourceCollector) getDynamicClient(
 	dynamicInterface dynamic.Interface,
 	object runtime.Unstructured,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -11,6 +11,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 const (
@@ -127,4 +128,17 @@ func GetSizeOfObject(object interface{}) (int, error) {
 		return 0, err
 	}
 	return buf.Len(), nil
+}
+
+// Get ObjectDetails returns name, namespace, kind of the given object
+func GetObjectDetails(o interface{}) (name, namespace, kind string, err error) {
+	metadata, err := meta.Accessor(o)
+	if err != nil {
+		return "", "", "", err
+	}
+	objType, err := meta.TypeAccessor(o)
+	if err != nil {
+		return "", "", "", err
+	}
+	return metadata.GetName(), metadata.GetNamespace(), objType.GetKind(), nil
 }


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
SA deletion is not reflected on the destination cluster during migration. Migration status should also not be showing status as Purged.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: Incorrect migration status for service account deletion on source cluster 
User Impact: User expects service account to be deleted on destination cluster based on status while it is not supported
Resolution: Do not show purged status for resources for which merging is supported on desintation cluster

```

**Does this change need to be cherry-picked to a release branch?**:
yes 23.5.0

**Notes**:
* Only changes required to fix this is following
```
if r.mergeSupportedForResource(o) {
			continue
		}
```
* ObjectTobeDeleted() has been moved to resource collector package: Reason 1: Needed to check mergeSupportedForResource which is pkg scoped 2. This is where it should logically belong
* GetObjectDetails() is moved to utils package

