### PR TITLE
pb-3798: The progress bar to show total count correctly

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1331,7 +1331,6 @@ func (a *ApplicationRestoreController) applyResources(
 			continue
 		}
 		restore.Status.LastUpdateTimestamp = metav1.Now()
-		restore.Status.ResourceCount = len(objects)
 		restore.Status.RestoredResourceCount = 0
 		err = a.client.Update(context.TODO(), restore)
 		if err != nil {
@@ -1386,6 +1385,8 @@ func (a *ApplicationRestoreController) applyResources(
 			return err
 		}
 	}
+
+	restore.Status.ResourceCount = len(objects)
 	tempResourceList := make([]*storkapi.ApplicationRestoreResourceInfo, 0)
 	for _, o := range objects {
 		// every five minutes once, we need to update the restore CR timestamp


### PR DESCRIPTION
- In case of multi namespace scenario the show status picking the total resource count before the filteration when we restore only selective namesapces
- Hence updated the total resource count at the appropriate place so that multi namespace backup's restore with a iselective namespaces to show correct count


**What type of PR is this?** Bug
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: 


**Does this PR change a user-facing CRD or CLI?**: - In case of multi namespace scenario the show status picking the total resource count before the filteration when we restore only selective namesapces
- Hence updated the total resource count at the appropriate place so that multi namespace backup's restore with a iselective namespaces to show correct count

<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: no
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: 23.3.1
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Unit tested details are shown in pb-3798 bug report
