### PR TITLE
pb-3801: DeletResource should handle nil channel argument

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -1120,11 +1120,14 @@ func (r *ResourceCollector) DeleteResources(
 	deleteStart := metav1.Now()
 	startTime := time.Now()
 	for _, object := range objects {
-		elapsedTime := time.Since(startTime)
-		if elapsedTime > utils.TimeoutUpdateRestoreCrTimestamp {
-			updateTimestamp <- utils.UpdateRestoreCrTimestampInDeleteResourcePath
-			startTime = time.Now()
+		if updateTimestamp != nil {
+			elapsedTime := time.Since(startTime)
+			if elapsedTime > utils.TimeoutUpdateRestoreCrTimestamp {
+				updateTimestamp <- utils.UpdateRestoreCrTimestampInDeleteResourcePath
+				startTime = time.Now()
+			}
 		}
+
 		// Don't delete objects that support merging
 		if r.mergeSupportedForResource(object) {
 			continue
@@ -1150,10 +1153,12 @@ func (r *ResourceCollector) DeleteResources(
 
 	// Then wait for them to actually be deleted
 	for _, object := range objects {
-		elapsedTime := time.Since(startTime)
-		if elapsedTime > utils.TimeoutUpdateRestoreCrTimestamp {
-			updateTimestamp <- utils.UpdateRestoreCrTimestampInDeleteResourcePath
-			startTime = time.Now()
+		if updateTimestamp != nil {
+			elapsedTime := time.Since(startTime)
+			if elapsedTime > utils.TimeoutUpdateRestoreCrTimestamp {
+				updateTimestamp <- utils.UpdateRestoreCrTimestampInDeleteResourcePath
+				startTime = time.Now()
+			}
 		}
 		// Objects that support merging aren't deleted
 		if r.mergeSupportedForResource(object) {


### PR DESCRIPTION
- In volume restore stage we restore resources early for kdmp driver Hence a proper channel need to be passed for the restore CR updation process.

- The path where DeletResource doesn't need CR update logic, therein the nil channel argument  should be handled gracefully.


**What type of PR is this?** Bug

>bug

**What this PR does / why we need it**: We need to handle the nil channel pointer in the deleteResource API. Additionally in kdmp driver we need to pass the proper channel so that restore CR can be updated timely.


**Does this PR change a user-facing CRD or CLI?**: NO
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: NO
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: 23.3.1
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Unit testing
![Screenshot from 2023-04-20 18-15-43](https://user-images.githubusercontent.com/15273500/233378356-0ce5f8ba-0318-4c35-a874-8d8f219c4710.png)
![Screenshot from 2023-04-20 18-16-10](https://user-images.githubusercontent.com/15273500/233378366-0e478a48-ca8c-4d98-8074-a42b451bee19.png)
![Screenshot from 2023-04-20 18-46-57](https://user-images.githubusercontent.com/15273500/233378368-eb373b7f-5752-4a29-90ee-1233727b7970.png)
![image](https://user-images.githubusercontent.com/15273500/233589134-71c0f817-75d9-44c9-94b9-563d992545c6.png)
![image](https://user-images.githubusercontent.com/15273500/233589338-a0ac225f-7428-4987-b9cd-43954cf38bdb.png)
