### PR TITLE
PWX-30291: Removing sts and deployments from stork webhook

### DIFF
--- a/pkg/webhookadmission/utils.go
+++ b/pkg/webhookadmission/utils.go
@@ -64,7 +64,7 @@ func CreateMutateWebhook(caBundle []byte, ns string) error {
 				Rule: admissionv1beta1.Rule{
 					APIGroups:   []string{"apps", ""},
 					APIVersions: []string{"v1"},
-					Resources:   []string{"deployments", "statefulsets", "pods"},
+					Resources:   []string{"pods"},
 				},
 			},
 		},
@@ -189,7 +189,7 @@ func createWebhookV1(caBundle []byte, ns string) error {
 				Rule: admissionv1.Rule{
 					APIGroups:   []string{"apps", ""},
 					APIVersions: []string{"v1"},
-					Resources:   []string{"deployments", "statefulsets", "pods"},
+					Resources:   []string{"pods"},
 				},
 			},
 		},

--- a/pkg/webhookadmission/webhook.go
+++ b/pkg/webhookadmission/webhook.go
@@ -19,7 +19,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/admission/v1beta1"
 	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	appv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,81 +93,45 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 	arReq := admissionReview.Request
 	resourceName := arReq.Name
 
-	switch arReq.Kind.Kind {
-	case "StatefulSet":
-		var ss appv1.StatefulSet
-		if err = json.Unmarshal(arReq.Object.Raw, &ss); err != nil {
-			log.Errorf("Could not unmarshal admission review object: %v", err)
-			c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "could not unmarshal ar object", err.Error())
-			http.Error(w, "Decode error", http.StatusBadRequest)
-			return
-		}
-		if resourceName == "" {
-			resourceName = ss.GenerateName
-		}
-		log.Debugf("Received admission review request for sts %s,%s", resourceName, arReq.Namespace)
-		if !skipSchedulerUpdate(skipHookAnnotation, ss.ObjectMeta.Annotations) {
-			isStorkResource, err = c.checkVolumeOwner(ss.Spec.Template.Spec.Volumes, arReq.Namespace)
-			if err != nil {
-				c.Recorder.Event(&ss, v1.EventTypeWarning, "Could not get volume owner info for ss: %v", err.Error())
-				http.Error(w, "Could not get volume owner info", http.StatusInternalServerError)
-				return
-			}
-			schedPath = appSchedPrefix + podSpecSchedPath
-		}
-	case "Deployment":
-		var deployment appv1.Deployment
-		if err := json.Unmarshal(arReq.Object.Raw, &deployment); err != nil {
-			log.Errorf("Could not unmarshal admission review object: %v", err)
-			c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "could not unmarshal ar object", err.Error())
-			http.Error(w, "Decode error", http.StatusBadRequest)
-			return
-		}
-		if resourceName == "" {
-			resourceName = deployment.GenerateName
-		}
-		log.Debugf("Received admission review request for deployment %s,%s", resourceName, arReq.Namespace)
-		if !skipSchedulerUpdate(skipHookAnnotation, deployment.ObjectMeta.Annotations) {
-			isStorkResource, err = c.checkVolumeOwner(deployment.Spec.Template.Spec.Volumes, arReq.Namespace)
-			if err != nil {
-				c.Recorder.Event(&deployment, v1.EventTypeWarning, "Could not get volume owner info deployment: %v", err.Error())
-				http.Error(w, "Could not get volume owner info", http.StatusInternalServerError)
-				return
-			}
-			schedPath = appSchedPrefix + podSpecSchedPath
-		}
-	case "Pod":
-		var pod v1.Pod
-		if err := json.Unmarshal(arReq.Object.Raw, &pod); err != nil {
-			log.Errorf("Could not unmarshal admission review object: %v", err)
-			c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "could not unmarshal ar object", err.Error())
-			http.Error(w, "Decode error", http.StatusBadRequest)
-			return
-		}
-		if resourceName == "" {
-			resourceName = pod.GenerateName
-		}
-		log.Debugf("Received admission review request for pod %s,%s", resourceName, arReq.Namespace)
-		if !skipSchedulerUpdate(skipHookAnnotation, pod.ObjectMeta.Annotations) {
-			isStorkResource, err = c.checkVolumeOwner(pod.Spec.Volumes, arReq.Namespace)
-			if err != nil {
-				c.Recorder.Event(&pod, v1.EventTypeWarning, "Could not get volume owner info for pod: %v", err.Error())
-				http.Error(w, "Could not get volume owner info", http.StatusInternalServerError)
-				return
-			}
-			schedPath = podSpecSchedPath
+	if arReq.Kind.Kind != "Pod" {
+		errMsg := fmt.Errorf("kind=%s not supported", arReq.Kind.Kind)
+		log.Errorf("Failed to serve admission review request: %v", err)
+		c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "invalid admission review request", errMsg.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
-			// get extra patches for pods
-			if isStorkResource {
-				// pod object does not have name and namespace populated, so we pass them separately. Also,
-				// if the pod is using generateName, arReq.Name is empty.
-				patches, err = c.Driver.GetPodPatches(arReq.Namespace, &pod)
-				if err != nil {
-					log.Errorf("Failed to get pod patches for pod %s/%s: %v", arReq.Namespace, resourceName, err)
-					c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "could not get pod patches", err.Error())
-					http.Error(w, "Could not get pod patches", http.StatusInternalServerError)
-					return
-				}
+	var pod v1.Pod
+	if err := json.Unmarshal(arReq.Object.Raw, &pod); err != nil {
+		log.Errorf("Could not unmarshal admission review object: %v", err)
+		c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "could not unmarshal ar object", err.Error())
+		http.Error(w, "Decode error", http.StatusBadRequest)
+		return
+	}
+	if resourceName == "" {
+		resourceName = pod.GenerateName
+	}
+	log.Debugf("Received admission review request for pod %s,%s", resourceName, arReq.Namespace)
+	if !skipSchedulerUpdate(skipHookAnnotation, pod.ObjectMeta.Annotations) {
+		isStorkResource, err = c.checkVolumeOwner(pod.Spec.Volumes, arReq.Namespace)
+		if err != nil {
+			log.Errorf("Failed to serve admission review request %v", err)
+			c.Recorder.Event(&pod, v1.EventTypeWarning, "Could not get volume owner info for pod", err.Error())
+			http.Error(w, "Could not get volume owner info : "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		schedPath = podSpecSchedPath
+
+		// get extra patches for pods
+		if isStorkResource {
+			// pod object does not have name and namespace populated, so we pass them separately. Also,
+			// if the pod is using generateName, arReq.Name is empty.
+			patches, err = c.Driver.GetPodPatches(arReq.Namespace, &pod)
+			if err != nil {
+				log.Errorf("Failed to get pod patches for pod %s/%s: %v", arReq.Namespace, resourceName, err)
+				c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "could not get pod patches", err.Error())
+				http.Error(w, "Could not get pod patches", http.StatusInternalServerError)
+				return
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Remove Stork as the scheduler from Statefulsets and Deployments.

Currently we are not able to set Stork as the scheduler for Statefulsets because we rely on the PVC to be owned by Portworx. STS uses volumeClaimTemplates where PVC is not created when the webhook admission request comes to stork and schedulerName is not updated. Later when webhook admission request arrives for Pods, Stork does update the Schedulername and it works.

I believe there is no reason to update Stork as the scheduler for StatefulSets and Deployments when we have the webhook enabled for Pods. This PR is removing these webhook for Deployments and Statefulsets.

Please note that any annotation set on the Deployment or STS is not passed onto the Pods. To be able to specify stork.libopenstorage.org/disable-admission-controller that disables webhook for the specific STS /Deployment, we need to update it on  spec.templace.metadata.annotations. 


**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: Webhook errors observed when trying to mutate statefulsets to update Stork as the scheduler.
User Impact: Customers can not understand this error and gets the impression that Stork webhook is not working
Resolution: Removing wtbhookd for statefulsets and deployments as Stork already has a webhook for Pods that manages setting Stork as the default scheduler.

```

**Does this change need to be cherry-picked to a release branch?**:
yes 23.5

