### PR TITLE
pb-3807: Restored Resource count should match with total resource Count

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1399,6 +1399,8 @@ func (a *ApplicationRestoreController) applyResources(
 		}
 	}
 	objects = tempObjects
+	// Total resource count will include the PV PVC as a resource too.
+	restore.Status.ResourceCount = len(objects)
 
 	// skip CSI PV/PVCs before applying
 	objects, err = a.removeCSIVolumesBeforeApply(restore, objects)
@@ -1614,6 +1616,9 @@ func (a *ApplicationRestoreController) restoreResources(
 		// Strip off the resource info it contributes to bigger size of application restore CR in case of large number of resource
 		restore.Status.Resources = make([]*storkapi.ApplicationRestoreResourceInfo, 0)
 		restore.Status.ResourceCount = resourceCount
+		// For csi & kdmp we have updated the restore object after applyResources() completed,
+		// we need to update the restored resource count once again.
+		restore.Status.RestoredResourceCount = resourceCount
 		restore.Status.LargeResourceEnabled = true
 	}
 	err = a.client.Update(context.TODO(), restore)


### PR DESCRIPTION
In case of CSI or KDMP the PV & PVC are updated to restore object late. Hence RestoredResource count should be updated again after aforementioned action completes.


**What type of PR is this?** Bug
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: Restored Resource Count should match with that of total resource count in case of CSI & KDMP scenario


**Does this PR change a user-facing CRD or CLI?**:No 
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
 
**Is a release note needed?**:No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:23.3.1 
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

