### PR TITLE
PWX-30752: storkctl to use higher qps and burst default values.

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -188,12 +188,12 @@ func main() {
 		cli.IntFlag{
 			Name:  "k8s-api-qps",
 			Value: 1000,
-			Usage: "Restrict number of k8s API requests from stork (default: 100 QPS)",
+			Usage: "Restrict number of k8s API requests from stork (default: 1000 QPS)",
 		},
 		cli.IntFlag{
 			Name:  "k8s-api-burst",
 			Value: 2000,
-			Usage: "Restrict number of k8s API requests from stork (default: 100 Burst)",
+			Usage: "Restrict number of k8s API requests from stork (default: 2000 Burst)",
 		},
 		cli.BoolTFlag{
 			Name:  "kdmp-controller",

--- a/pkg/storkctl/factory.go
+++ b/pkg/storkctl/factory.go
@@ -77,8 +77,8 @@ func (f *factory) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&f.context, "context", "", "name of the kubeconfig context to use")
 	flags.StringVarP(&f.outputFormat, "output", "o", outputFormatTable, "output format. One of: table|json|yaml")
 	flags.BoolVarP(&f.watch, "watch", "w", false, "watch stork resources")
-	flags.IntVarP(&f.qps, "qps", "", 100, "restrict number of k8s API requests from stork")
-	flags.IntVarP(&f.burst, "burst", "", 100, "restrict number of k8s API requests from stork")
+	flags.IntVarP(&f.qps, "qps", "", 1000, "restrict number of k8s API requests from stork")
+	flags.IntVarP(&f.burst, "burst", "", 2000, "restrict number of k8s API requests from stork")
 }
 
 func (f *factory) BindGetFlags(flags *pflag.FlagSet) {


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
storkctl uses higher qps and burst 

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.4.0
-->

