### PR TITLE
Siva nfs final

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -421,6 +421,7 @@ func (a *aws) GetPreRestoreResources(
 	*storkapi.ApplicationBackup,
 	*storkapi.ApplicationRestore,
 	[]runtime.Unstructured,
+	[]byte,
 ) ([]runtime.Unstructured, error) {
 	return nil, nil
 }

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -471,6 +471,7 @@ func (a *azure) GetPreRestoreResources(
 	*storkapi.ApplicationBackup,
 	*storkapi.ApplicationRestore,
 	[]runtime.Unstructured,
+	[]byte,
 ) ([]runtime.Unstructured, error) {
 	return nil, nil
 }

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -410,6 +410,7 @@ func (g *gcp) GetPreRestoreResources(
 	*storkapi.ApplicationBackup,
 	*storkapi.ApplicationRestore,
 	[]runtime.Unstructured,
+	[]byte,
 ) ([]runtime.Unstructured, error) {
 	return nil, nil
 }

--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -570,6 +570,7 @@ func (k *kdmp) GetPreRestoreResources(
 	backup *storkapi.ApplicationBackup,
 	restore *storkapi.ApplicationRestore,
 	objects []runtime.Unstructured,
+	storageClassBytes []byte,
 ) ([]runtime.Unstructured, error) {
 	return k.getRestorePVCs(backup, restore, objects)
 }

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -64,6 +64,15 @@ func (l *linstor) linstorClient() (*lclient.Client, error) {
 	return l.cli, nil
 }
 
+func (l *linstor) GetPreRestoreResources(
+	*storkapi.ApplicationBackup,
+	*storkapi.ApplicationRestore,
+	[]runtime.Unstructured,
+	[]byte,
+) ([]runtime.Unstructured, error) {
+	return nil, nil
+}
+
 func (l *linstor) Init(_ interface{}) error {
 	// Configuration of linstor client happens via environment variables:
 	// * LS_CONTROLLERS

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -15,6 +15,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8shelper "k8s.io/component-helpers/storage/volume"
 )
 
@@ -63,6 +64,15 @@ func (m Driver) Init(_ interface{}) error {
 // Stop Stops the mock driver
 func (m Driver) Stop() error {
 	return nil
+}
+
+func (m *Driver) GetPreRestoreResources(
+	*storkapi.ApplicationBackup,
+	*storkapi.ApplicationRestore,
+	[]runtime.Unstructured,
+	[]byte,
+) ([]runtime.Unstructured, error) {
+	return nil, nil
 }
 
 // CreateCluster Creates a cluster with specified number of nodes

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2655,7 +2655,13 @@ func (p *portworx) UpdateMigratedPersistentVolumeSpec(
 ) (*v1.PersistentVolume, error) {
 	// Get the pv storageclass and get the provision detail and decide on csi section.
 	if len(pv.Spec.StorageClassName) != 0 {
-		sc, err := storkcache.Instance().GetStorageClass(pv.Spec.StorageClassName)
+		var sc *storagev1.StorageClass
+		var err error
+		if !reflect.ValueOf(storkcache.Instance()).IsNil() {
+			sc, err = storkcache.Instance().GetStorageClass(pv.Spec.StorageClassName)
+		} else {
+			sc, err = storage.Instance().GetStorageClass(pv.Spec.StorageClassName)
+		}
 		if err != nil {
 			logrus.Warnf("failed in getting the storage class [%v]: %v", pv.Spec.StorageClassName, err)
 		}
@@ -3415,6 +3421,7 @@ func (p *portworx) GetPreRestoreResources(
 	backup *storkapi.ApplicationBackup,
 	restore *storkapi.ApplicationRestore,
 	objects []runtime.Unstructured,
+	storageClassByte []byte,
 ) ([]runtime.Unstructured, error) {
 	secretsToRestore := make(map[string]bool)
 	objectsToRestore := make([]runtime.Unstructured, 0)
@@ -3593,7 +3600,13 @@ func (p *portworx) getCloudBackupRestoreSpec(
 		// No mapping provided
 		return locator, restoreSpec, nil
 	}
-	sc, err := storkcache.Instance().GetStorageClass(destStorageClass)
+	var sc *storagev1.StorageClass
+	var err error
+	if !reflect.ValueOf(storkcache.Instance()).IsNil() {
+		sc, err = storkcache.Instance().GetStorageClass(destStorageClass)
+	} else {
+		sc, err = storage.Instance().GetStorageClass(destStorageClass)
+	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch storage class %v: %v", destStorageClass, err)
 	}

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -223,7 +223,7 @@ type BackupRestorePluginInterface interface {
 	// Delete the backups specified in the status
 	DeleteBackup(*storkapi.ApplicationBackup) (bool, error)
 	// Get any resources that should be created before the restore is started
-	GetPreRestoreResources(*storkapi.ApplicationBackup, *storkapi.ApplicationRestore, []runtime.Unstructured) ([]runtime.Unstructured, error)
+	GetPreRestoreResources(*storkapi.ApplicationBackup, *storkapi.ApplicationRestore, []runtime.Unstructured, []byte) ([]runtime.Unstructured, error)
 	// Start restore of volumes specified by the spec. Should only restore
 	// volumes, not the specs associated with them
 	StartRestore(*storkapi.ApplicationRestore, []*storkapi.ApplicationBackupVolumeInfo, []runtime.Unstructured) ([]*storkapi.ApplicationRestoreVolumeInfo, error)

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
 )
 
-require github.com/portworx/kdmp v0.4.1-0.20230320064430-aad8b8b5f8ea
+require github.com/portworx/kdmp v0.4.1-0.20230424204103-0511288bf033
 
 require (
 	cloud.google.com/go v0.107.0 // indirect
@@ -298,7 +298,7 @@ replace (
 	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc10 => github.com/kubernetes-incubator/external-storage v0.25.1-openstorage-rc1
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20230324214216-7f88436db3de
-	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20230320064430-aad8b8b5f8ea
+	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20230424204103-0511288bf033
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230228105744-505c1a2d8203
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20230216213348-6ba0e5494ad5
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -1798,7 +1798,7 @@ github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9 h1:pZQ5uaWk
 github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9/go.mod h1:gE8rSd6lwLNXNbiW3DrRZjFMs+y4fDHy/6uiOO9cdzY=
 github.com/libopenstorage/stork v1.4.1-0.20220414104250-3c18fd21ed95/go.mod h1:yE94X0xBFSBQ9LvvJ/zppc4+XeiCAXtsHfYHm15dlcA=
 github.com/libopenstorage/stork v1.4.1-0.20230207013129-a31284f0e973/go.mod h1:/EFTTQyBxNzul96urrYPdjNEYeDzVgZzK88gRQjoVmk=
-github.com/libopenstorage/stork v1.4.1-0.20230310131740-6799188e7fac/go.mod h1:sE83yimgTrJAJCKKF1Y9k+6T2d6uflx4FXdi6mVVUJg=
+github.com/libopenstorage/stork v1.4.1-0.20230424175842-dc27ab228a6e/go.mod h1:R8QFEl+G89q0eOJuMYObW6vSX1gI+BtV/oIzdWgwgz4=
 github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1 h1:5vqfYYWm4b+lbkMtvvWtWBiqLbmLN6dNvWaa7wVsz/Q=
 github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1/go.mod h1:xwNGC7xiz/BQ/wbMkvHujL8Gjgseg+x41xMek7sKRRQ=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
@@ -2171,8 +2171,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v1.0.5/go.mod h1:APVvOesVSAnne5SClsPxPdfvZTVDojXh1/G3qb5wjGI=
 github.com/portworx/dcos-secrets v0.0.0-20180616013705-8e8ec3f66611/go.mod h1:4hklRW/4DQpLqkcXcjtNprbH2tz/sJaNtqinfPWl/LA=
-github.com/portworx/kdmp v0.4.1-0.20230320064430-aad8b8b5f8ea h1:Lv/9N+kgTqsZWo27ZhL+Py9sTDF2OmoO5TNHArBY18U=
-github.com/portworx/kdmp v0.4.1-0.20230320064430-aad8b8b5f8ea/go.mod h1:3PNTzDtuJawHpdFQPE5+YFgoNgvTNU9L3K8rPgq1FDE=
+github.com/portworx/kdmp v0.4.1-0.20230424204103-0511288bf033 h1:cMfvXHmi2fttAU8HuA29XNf+kUupe9Z2hCJBDWBlr5s=
+github.com/portworx/kdmp v0.4.1-0.20230424204103-0511288bf033/go.mod h1:1uA/EgvW3zgsBrma08hrix8V2G+mJ6BNcRrfBFctcQw=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200929023115-b312c7519467 h1:jkqzdbOnejgSN5HG/FLt4enNrozWT/K+nlmaRm3P1II=

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -62,6 +62,12 @@ const (
 	DefaultRestoreVolumeBatchSleepInterval = "20s"
 	// RestoreVolumeBatchSleepIntervalKey - restore volume batch sleep interval key
 	RestoreVolumeBatchSleepIntervalKey = "restore-volume-sleep-interval"
+	// RestoreVolumeBatchSleepInterval - restore volume batch sleep interval
+	RestoreVolumeBatchSleepInterval = 20 * time.Second
+	// PxServiceEnvName - PX service ENV name
+	PxServiceEnvName = "PX_SERVICE_NAME"
+	// PxNamespaceEnvName - PX namespace ENV name
+	PxNamespaceEnvName = "PX_NAMESPACE"
 )
 
 // JSONPatchOp is a single json mutation done by a k8s mutating webhook
@@ -339,4 +345,22 @@ func IsValidBucketRetentionPeriod(bucketRetentionPeriod int64) (bool, int64, err
 	// user should set.
 	minRetentionDays := minProtectionPeriod + incrBkpCnt + 1
 	return (bucketRetentionPeriod >= minRetentionDays), minRetentionDays, nil
+}
+
+// GetPxNamespaceFromStorkDeploy - will return the px namespace env from stork deploy
+func GetPxNamespaceFromStorkDeploy(storkDeployName, storkDeployNamespace string) (string, string, error) {
+	deploy, err := apps.Instance().GetDeployment(storkDeployName, storkDeployNamespace)
+	if err != nil {
+		return "", "", err
+	}
+	var service, namespace string
+	for _, envVar := range deploy.Spec.Template.Spec.Containers[0].Env {
+		if envVar.Name == PxServiceEnvName {
+			service = envVar.Value
+		}
+		if envVar.Name == PxNamespaceEnvName {
+			namespace = envVar.Value
+		}
+	}
+	return namespace, service, nil
 }

--- a/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/resourcebackup.go
+++ b/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/resourcebackup.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -57,10 +58,8 @@ type ResourceBackup struct {
 	Type ResourceBackupType `json:"type,omitempty"`
 	// Status Overall status
 	Status ResourceBackupProgressStatus `json:"status,omitempty"`
-	// VolumesInfo Contains list of vols to be restored. Filled in by nfs executor job
-	VolumesInfo []*ResourceBackupVolumeInfo `json:"volumesInfo,omitempty"`
-	// ExistingVolumesInfo existing vols which are not be restored
-	ExistingVolumesInfo []*ResourceRestoreVolumeInfo `json:"existingVolumesInfo,omitempty"`
+	// RestoreCompleteList - restore complete volumeInfo
+	RestoreCompleteList []*storkapi.ApplicationRestoreVolumeInfo `json:"restoreCompleteList,omitempty"`
 }
 
 // ResourceBackupSpec configuration parameters for ResourceBackup

--- a/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/resourceexport.go
+++ b/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/resourceexport.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -92,10 +93,8 @@ type ResourceExport struct {
 	Spec              ResourceExportSpec `json:"spec"`
 	// Status Overall status
 	Status ResourceStatus `json:"status,omitempty"`
-	// VolumesInfo Contains list of vols to be restored. Filled in by nfs executor job
-	VolumesInfo []*ResourceBackupVolumeInfo `json:"volumesInfo"`
-	// ExistingVolumesInfo existing vols which are not be restored
-	ExistingVolumesInfo []*ResourceRestoreVolumeInfo `json:"existingVolumesInfo,omitempty"`
+	// RestoreCompleteList - restore complete volumeInfo
+	RestoreCompleteList []*storkapi.ApplicationRestoreVolumeInfo `json:"restoreCompleteList,omitempty"`
 }
 
 // ResourceExportSpec configuration parameters for ResourceExport

--- a/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1/zz_generated.deepcopy.go
@@ -12,6 +12,7 @@ LICENSE
 package v1alpha1
 
 import (
+	storkv1alpha1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -280,24 +281,13 @@ func (in *ResourceBackup) DeepCopyInto(out *ResourceBackup) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	out.Spec = in.Spec
 	in.Status.DeepCopyInto(&out.Status)
-	if in.VolumesInfo != nil {
-		in, out := &in.VolumesInfo, &out.VolumesInfo
-		*out = make([]*ResourceBackupVolumeInfo, len(*in))
+	if in.RestoreCompleteList != nil {
+		in, out := &in.RestoreCompleteList, &out.RestoreCompleteList
+		*out = make([]*storkv1alpha1.ApplicationRestoreVolumeInfo, len(*in))
 		for i := range *in {
 			if (*in)[i] != nil {
 				in, out := &(*in)[i], &(*out)[i]
-				*out = new(ResourceBackupVolumeInfo)
-				(*in).DeepCopyInto(*out)
-			}
-		}
-	}
-	if in.ExistingVolumesInfo != nil {
-		in, out := &in.ExistingVolumesInfo, &out.ExistingVolumesInfo
-		*out = make([]*ResourceRestoreVolumeInfo, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(ResourceRestoreVolumeInfo)
+				*out = new(storkv1alpha1.ApplicationRestoreVolumeInfo)
 				(*in).DeepCopyInto(*out)
 			}
 		}
@@ -452,24 +442,13 @@ func (in *ResourceExport) DeepCopyInto(out *ResourceExport) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	out.Spec = in.Spec
 	in.Status.DeepCopyInto(&out.Status)
-	if in.VolumesInfo != nil {
-		in, out := &in.VolumesInfo, &out.VolumesInfo
-		*out = make([]*ResourceBackupVolumeInfo, len(*in))
+	if in.RestoreCompleteList != nil {
+		in, out := &in.RestoreCompleteList, &out.RestoreCompleteList
+		*out = make([]*storkv1alpha1.ApplicationRestoreVolumeInfo, len(*in))
 		for i := range *in {
 			if (*in)[i] != nil {
 				in, out := &(*in)[i], &(*out)[i]
-				*out = new(ResourceBackupVolumeInfo)
-				(*in).DeepCopyInto(*out)
-			}
-		}
-	}
-	if in.ExistingVolumesInfo != nil {
-		in, out := &in.ExistingVolumesInfo, &out.ExistingVolumesInfo
-		*out = make([]*ResourceRestoreVolumeInfo, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(ResourceRestoreVolumeInfo)
+				*out = new(storkv1alpha1.ApplicationRestoreVolumeInfo)
 				(*in).DeepCopyInto(*out)
 			}
 		}

--- a/vendor/github.com/portworx/kdmp/pkg/client/clientset/versioned/clientset.go
+++ b/vendor/github.com/portworx/kdmp/pkg/client/clientset/versioned/clientset.go
@@ -10,6 +10,7 @@ package versioned
 
 import (
 	"fmt"
+	"net/http"
 
 	kdmpv1alpha1 "github.com/portworx/kdmp/pkg/client/clientset/versioned/typed/kdmp/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
@@ -45,7 +46,29 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 // If config's RateLimiter is not set and QPS and Burst are acceptable,
 // NewForConfig will generate a rate-limiter in configShallowCopy.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	configShallowCopy := *c
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	// share the transport between all clients
+	httpClient, err := rest.HTTPClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewForConfigAndClient(&configShallowCopy, httpClient)
+}
+
+// NewForConfigAndClient creates a new Clientset for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+// If config's RateLimiter is not set and QPS and Burst are acceptable,
+// NewForConfigAndClient will generate a rate-limiter in configShallowCopy.
+func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		if configShallowCopy.Burst <= 0 {
@@ -53,14 +76,15 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+
 	var cs Clientset
 	var err error
-	cs.kdmpV1alpha1, err = kdmpv1alpha1.NewForConfig(&configShallowCopy)
+	cs.kdmpV1alpha1, err = kdmpv1alpha1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
+	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -70,11 +94,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.kdmpV1alpha1 = kdmpv1alpha1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/vendor/github.com/portworx/kdmp/pkg/client/clientset/versioned/scheme/register.go
+++ b/vendor/github.com/portworx/kdmp/pkg/client/clientset/versioned/scheme/register.go
@@ -27,14 +27,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/vendor/github.com/portworx/kdmp/pkg/client/clientset/versioned/typed/kdmp/v1alpha1/kdmp_client.go
+++ b/vendor/github.com/portworx/kdmp/pkg/client/clientset/versioned/typed/kdmp/v1alpha1/kdmp_client.go
@@ -9,6 +9,8 @@ LICENSE
 package v1alpha1
 
 import (
+	"net/http"
+
 	v1alpha1 "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
 	"github.com/portworx/kdmp/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
@@ -54,12 +56,28 @@ func (c *KdmpV1alpha1Client) VolumeBackupDeletes(namespace string) VolumeBackupD
 }
 
 // NewForConfig creates a new KdmpV1alpha1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*KdmpV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new KdmpV1alpha1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*KdmpV1alpha1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
@@ -305,8 +305,9 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 			utils.KdmpConfigmapName,
 			utils.KdmpConfigmapNamespace,
 			backupLocation.Location.NFSConfig.ServerAddr,
-			backupLocation.Location.Path,
+			backupLocation.Location.NFSConfig.SubPath,
 			backupLocation.Location.NFSConfig.MountOptions,
+			backupLocation.Location.NFSConfig.SubPath,
 		)
 		if err != nil && err != utils.ErrJobAlreadyRunning && err != utils.ErrOutOfJobResources {
 			msg := fmt.Sprintf("failed to start a data transfer job, dataexport [%v]: %v", dataExport.Name, err)
@@ -1649,6 +1650,7 @@ func startTransferJob(
 	nfsServerAddr string,
 	nfsExportPath string,
 	nfsMountOption string,
+	nfsSubPath string,
 ) (string, error) {
 	if drv == nil {
 		return "", fmt.Errorf("data transfer driver is not set")
@@ -1700,6 +1702,7 @@ func startTransferJob(
 			drivers.WithNfsServer(nfsServerAddr),
 			drivers.WithNfsExportDir(nfsExportPath),
 			drivers.WithNfsMountOption(nfsMountOption),
+			drivers.WithNfsSubPath(nfsSubPath),
 		)
 	case drivers.KopiaRestore:
 		return drv.StartJob(
@@ -1718,6 +1721,7 @@ func startTransferJob(
 			drivers.WithJobConfigMapNs(jobConfigMapNs),
 			drivers.WithNfsServer(nfsServerAddr),
 			drivers.WithNfsExportDir(nfsExportPath),
+			drivers.WithNfsSubPath(nfsSubPath),
 		)
 	}
 

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/utils/utils.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/utils/utils.go
@@ -743,7 +743,7 @@ func CreateNfsPvc(pvcName string, pvName string, namespace string) error {
 func CreateNFSPvPvcForJob(jobName string, namespace string, o drivers.JobOpts) error {
 	// create PV before creating job
 	nfsPvName := GetPvNameForJob(jobName)
-	if err := CreateNfsPv(nfsPvName, o.NfsServer, o.NfsExportDir, o.NfsMountOption); err != nil {
+	if err := CreateNfsPv(nfsPvName, o.NfsServer, o.NfsSubPath, o.NfsMountOption); err != nil {
 		return err
 	}
 	logrus.Debugf("Created NFS PV successfully %s", nfsPvName)

--- a/vendor/github.com/portworx/kdmp/pkg/executor/common.go
+++ b/vendor/github.com/portworx/kdmp/pkg/executor/common.go
@@ -1,0 +1,782 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"time"
+
+	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/crypto"
+	"github.com/libopenstorage/stork/pkg/log"
+	kdmpapi "github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1"
+	"github.com/portworx/kdmp/pkg/drivers"
+	"github.com/portworx/kdmp/pkg/drivers/utils"
+	kdmpops "github.com/portworx/kdmp/pkg/util/ops"
+	"github.com/portworx/sched-ops/k8s/core"
+	kdmpschedops "github.com/portworx/sched-ops/k8s/kdmp"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/kubectl/pkg/cmd/util"
+)
+
+const (
+	amazonS3Endpoint      = "s3.amazonaws.com"
+	googleAccountFilePath = "/root/.gce_credentials"
+	accessKeypath         = "/etc/cred-secret/accessKey"
+	secretAccessKeyPath   = "/etc/cred-secret/secretAccessKey"
+	bucketPath            = "/etc/cred-secret/path"
+	endpointPath          = "/etc/cred-secret/endpoint"
+	passwordPath          = "/etc/cred-secret/password"
+	regionPath            = "/etc/cred-secret/region"
+	disableSslPath        = "/etc/cred-secret/disablessl"
+	// AccountKeyPath gce account key path
+	AccountKeyPath         = "/etc/cred-secret/accountkey"
+	projectIDKeypath       = "/etc/cred-secret/projectid"
+	storageAccountNamePath = "/etc/cred-secret/storageaccountname"
+	storageAccountKeyPath  = "/etc/cred-secret/storageaccountkey"
+	// ServerAddr & SubPath needed for NFS based backuplocation
+	serverAddr = "/etc/cred-secret/serverAddr"
+	subPath    = "/etc/cred-secret/subPath"
+
+	// DefaultTimeout Max time a command will be retired before failing
+	DefaultTimeout = 1 * time.Minute
+	// BackupUID backup UID annotation
+	BackupUID  = "portworx.io/backup-uid"
+	retrySleep = 10 * time.Second
+	maxRetry   = 10
+)
+
+// BackupTool backup tool
+type BackupTool int
+
+const (
+	// ResticType for restic tool
+	ResticType BackupTool = 0
+	// KopiaType for kopia tool
+	KopiaType BackupTool = 1
+)
+
+const (
+	// MetadataObjectName metadat resource file
+	MetadataObjectName = "metadata.json"
+	// NamespacesFile ns file
+	NamespacesFile = "namespaces.json"
+	// CrdFile crd file
+	CrdFile = "crds.json"
+	// ResourcesFile resources file
+	ResourcesFile = "resources.json"
+	// BackupResourcesBatchCount backup processing batch count
+	BackupResourcesBatchCount = 15
+)
+
+// S3Config specifies the config required to connect to an S3-compliant
+// objectstore
+type S3Config struct {
+	Endpoint        string
+	AccessKeyID     string
+	SecretAccessKey string
+	// Region will be defaulted to us-east-1 if not provided
+	Region     string
+	DisableSSL bool
+}
+
+// AzureConfig specifies the config required to connect to Azure Blob Storage
+type AzureConfig struct {
+	StorageAccountName string
+	StorageAccountKey  string
+}
+
+// GoogleConfig specifies the config required to connect to Google Cloud Storage
+type GoogleConfig struct {
+	ProjectID  string
+	AccountKey string
+}
+
+// NfsConfig specifies the config required to connect to NFS Baqckuplocation
+type NfsConfig struct {
+	ServerAddr string
+	SubPath    string
+}
+
+// Repository contains information used to connect the repository.
+type Repository struct {
+	// Name is a repository name without an url address.
+	Name string
+	// Path is bucket name.
+	Path string
+	// AuthEnv is a set of environment variables used for authentication.
+	AuthEnv []string
+	// S3Config s3config details
+	S3Config *S3Config
+	// AzureConfig azure config details
+	AzureConfig *AzureConfig
+	// GoogleConfig goole config details
+	GoogleConfig *GoogleConfig
+	// NfsConfig NFS config details
+	NfsConfig *NfsConfig
+	// Password repository password
+	Password string
+	// Type objectstore type
+	Type storkapi.BackupLocationType
+}
+
+// Status is the current status of the command being executed
+type Status struct {
+	// ProgressPercentage is the progress of the command in percentage
+	ProgressPercentage float64
+	// TotalBytesProcessed is the no. of bytes processed
+	TotalBytesProcessed uint64
+	// TotalBytes is the total no. of bytes to be backed up
+	TotalBytes uint64
+	// SnapshotID is the snapshot ID of the backup being handled
+	SnapshotID string
+	// Done indicates if the operation has completed
+	Done bool
+	// LastKnownError is the last known error of the command
+	LastKnownError error
+}
+
+// Error is the error returned by the command
+type Error struct {
+	// CmdOutput is the stdout received from the command
+	CmdOutput string
+	// CmdErr is the stderr received from the command
+	CmdErr string
+	// Reason is the actual reason describing the error
+	Reason string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%v: Cmd Output [%v] Cmd Error [%v]", e.Reason, e.CmdOutput, e.CmdErr)
+}
+
+// ParseBackupLocation parses the provided backup location and returns the repository name
+func ParseBackupLocation(repoName, name, namespace, filePath string) (*Repository, error) {
+	backupLocation, err := readBackupLocation(name, namespace, filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	switch backupLocation.Location.Type {
+	case storkapi.BackupLocationS3:
+		return parseS3(repoName, backupLocation.Location)
+	case storkapi.BackupLocationAzure:
+		return parseAzure(repoName, backupLocation.Location)
+	case storkapi.BackupLocationGoogle:
+		return parseGce(repoName, backupLocation.Location)
+	}
+	return nil, fmt.Errorf("unsupported backup location: %v", backupLocation.Location.Type)
+}
+
+func readBackupLocation(name, namespace, filePath string) (*storkapi.BackupLocation, error) {
+	if name != "" {
+		if namespace == "" {
+			namespace = "default"
+		}
+		return storkops.Instance().GetBackupLocation(name, namespace)
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &storkapi.BackupLocation{}
+	if err = yaml.NewYAMLOrJSONDecoder(f, 1024).Decode(out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func parseS3(repoName string, backupLocation storkapi.BackupLocationItem) (*Repository, error) {
+	if backupLocation.S3Config == nil {
+		return nil, fmt.Errorf("failed to parse s3 config from BackupLocation")
+	}
+
+	envs := make([]string, 0)
+	envs = append(envs, fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", backupLocation.S3Config.AccessKeyID))
+	envs = append(envs, fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", backupLocation.S3Config.SecretAccessKey))
+	if backupLocation.S3Config.Region != "" {
+		envs = append(envs, fmt.Sprintf("AWS_REGION=%s", backupLocation.S3Config.Region))
+	}
+
+	if repoName == "" {
+		repoName = backupLocation.Path
+	}
+	return &Repository{
+		Name:    repoName,
+		Path:    fmt.Sprintf("s3:%s/%s", backupLocation.S3Config.Endpoint, repoName),
+		AuthEnv: envs,
+	}, nil
+}
+
+func parseAzure(repoName string, backupLocation storkapi.BackupLocationItem) (*Repository, error) {
+	if backupLocation.AzureConfig == nil {
+		return nil, fmt.Errorf("failed to parse azure config from BackupLocation")
+	}
+	envs := make([]string, 0)
+	envs = append(envs, fmt.Sprintf("AZURE_ACCOUNT_NAME=%s", backupLocation.AzureConfig.StorageAccountName))
+	envs = append(envs, fmt.Sprintf("AZURE_ACCOUNT_KEY=%s", backupLocation.AzureConfig.StorageAccountKey))
+
+	if repoName == "" {
+		repoName = backupLocation.Path
+	}
+	return &Repository{
+		Name:    repoName,
+		Path:    "azure:" + repoName + "/",
+		AuthEnv: envs,
+	}, nil
+}
+
+func parseGce(repoName string, backupLocation storkapi.BackupLocationItem) (*Repository, error) {
+	if backupLocation.GoogleConfig == nil {
+		return nil, fmt.Errorf("failed to parse google config from BackupLocation")
+	}
+
+	if err := os.WriteFile(
+		googleAccountFilePath,
+		[]byte(backupLocation.GoogleConfig.AccountKey),
+		0644,
+	); err != nil {
+		return nil, fmt.Errorf("failed to parse google account key: %v", err)
+	}
+
+	envs := make([]string, 0)
+	envs = append(envs, fmt.Sprintf("GOOGLE_PROJECT_ID=%s", backupLocation.GoogleConfig.ProjectID))
+	envs = append(envs, fmt.Sprintf("GOOGLE_APPLICATION_CREDENTIALS=%s", googleAccountFilePath))
+
+	if repoName == "" {
+		repoName = backupLocation.Path
+	}
+	return &Repository{
+		Name:    repoName,
+		Path:    "gs:" + repoName + "/",
+		AuthEnv: envs,
+	}, nil
+}
+
+// ParseCloudCred parsing cloud credentials
+func ParseCloudCred() (*Repository, error) {
+	// Read the BL type
+	fPath := drivers.KopiaCredSecretMount + "/" + "type"
+	blType, err := os.ReadFile(fPath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", fPath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+	logrus.Infof("type: %v", string(blType))
+	repository := &Repository{}
+	var rErr error
+	switch storkapi.BackupLocationType(blType) {
+	case storkapi.BackupLocationS3:
+		repository, rErr = parseS3Creds()
+	case storkapi.BackupLocationGoogle:
+		repository, rErr = parseGoogleCreds()
+	case storkapi.BackupLocationAzure:
+		repository, rErr = parseAzureCreds()
+	case storkapi.BackupLocationNFS:
+		repository, rErr = parseNfsCreds()
+	}
+	if rErr != nil {
+		return nil, rErr
+	}
+
+	password, err := os.ReadFile(passwordPath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", passwordPath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+	repository.Password = string(password)
+	bucket, err := os.ReadFile(bucketPath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", bucketPath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+	if storkapi.BackupLocationType(blType) == storkapi.BackupLocationNFS {
+		// For NFS this path need to be absolute path not just a bucket name anymore.
+		repository.Path = drivers.NfsMount + string(bucket) + "/"
+	} else {
+		repository.Path = string(bucket)
+	}
+
+	return repository, rErr
+}
+
+func parseS3Creds() (*Repository, error) {
+	repository := &Repository{
+		S3Config: &S3Config{},
+	}
+	accessKey, err := os.ReadFile(accessKeypath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", accessKeypath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	secretAccessKey, err := os.ReadFile(secretAccessKeyPath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", secretAccessKeyPath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	endpoint, err := os.ReadFile(endpointPath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", endpointPath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	disableSsl, err := os.ReadFile(disableSslPath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", disableSslPath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	isSsl, err := strconv.ParseBool(string(disableSsl))
+	if err != nil {
+		errMsg := fmt.Sprintf("failed converting ssl value %v to bool: %s", disableSsl, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+	repository.S3Config.AccessKeyID = string(accessKey)
+	repository.S3Config.SecretAccessKey = string(secretAccessKey)
+	repository.S3Config.Endpoint = string(endpoint)
+	repository.S3Config.DisableSSL = isSsl
+	repository.Type = storkapi.BackupLocationS3
+	region, err := os.ReadFile(regionPath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", regionPath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+	repository.S3Config.Region = string(region)
+
+	return repository, nil
+}
+
+func parseNfsCreds() (*Repository, error) {
+	repository := &Repository{
+		NfsConfig: &NfsConfig{},
+	}
+	repository.Type = storkapi.BackupLocationNFS
+	sa, err := os.ReadFile(serverAddr)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", serverAddr, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+	bucket, err := os.ReadFile(bucketPath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", subPath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	repository.NfsConfig.ServerAddr = string(sa)
+	repository.NfsConfig.SubPath = string(bucket)
+	return repository, nil
+}
+
+func parseGoogleCreds() (*Repository, error) {
+	repository := &Repository{
+		GoogleConfig: &GoogleConfig{},
+	}
+
+	projectID, err := os.ReadFile(projectIDKeypath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", projectIDKeypath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+	accountKey, err := os.ReadFile(AccountKeyPath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", AccountKeyPath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	repository.Type = storkapi.BackupLocationGoogle
+	repository.GoogleConfig.AccountKey = string(accountKey)
+	repository.GoogleConfig.ProjectID = string(projectID)
+
+	return repository, nil
+}
+
+func parseAzureCreds() (*Repository, error) {
+	repository := &Repository{
+		AzureConfig: &AzureConfig{},
+	}
+
+	storageAccountName, err := os.ReadFile(storageAccountNamePath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", storageAccountNamePath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	storageAccountKey, err := os.ReadFile(storageAccountKeyPath)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed reading data from file %s : %s", storageAccountKeyPath, err)
+		logrus.Errorf("%v", errMsg)
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	repository.Type = storkapi.BackupLocationAzure
+	repository.AzureConfig.StorageAccountName = string(storageAccountName)
+	repository.AzureConfig.StorageAccountKey = string(storageAccountKey)
+
+	return repository, nil
+}
+
+// WriteVolumeBackupDeleteStatus writes a delete status to the Volumedelete cr.
+func WriteVolumeBackupDeleteStatus(
+	statusType kdmpapi.VolumeBackupDeleteStatusType,
+	errMsg string,
+	volumeBackupDeleteName,
+	volumeBackupDeleteNamespace string,
+) error {
+	vd, err := kdmpschedops.Instance().GetVolumeBackupDelete(volumeBackupDeleteName, volumeBackupDeleteNamespace)
+	if err != nil {
+		return fmt.Errorf("failed in getting VolumeBackupDelete CR  [%s/%s]: %v", volumeBackupDeleteName, volumeBackupDeleteNamespace, err)
+	}
+	vd.Status.Status = statusType
+	vd.Status.Reason = errMsg
+
+	if _, err = kdmpschedops.Instance().UpdateVolumeBackupDelete(vd); err != nil {
+		return fmt.Errorf("failed in updating VolumeBackupDelete CR %s/%s VolumeDelete: %v", volumeBackupDeleteName, volumeBackupDeleteNamespace, err)
+	}
+	return nil
+}
+
+// WriteVolumeBackupStatus writes a backup status to the VolumeBackup crd.
+func WriteVolumeBackupStatus(
+	status *Status,
+	volumeBackupName,
+	namespace string,
+) error {
+	if volumeBackupName == "" {
+		return nil
+	}
+
+	vb, err := kdmpops.Instance().GetVolumeBackup(context.Background(), volumeBackupName, namespace)
+	if err != nil {
+		return fmt.Errorf("get %s/%s VolumeBackup: %v", volumeBackupName, namespace, err)
+	}
+
+	vb.Status.ProgressPercentage = status.ProgressPercentage
+	vb.Status.TotalBytes = status.TotalBytes
+	vb.Status.TotalBytesProcessed = status.TotalBytesProcessed
+	vb.Status.SnapshotID = status.SnapshotID
+	if status.LastKnownError != nil {
+		vb.Status.LastKnownError = status.LastKnownError.Error()
+	} else {
+		vb.Status.LastKnownError = ""
+	}
+
+	if _, err = kdmpops.Instance().UpdateVolumeBackup(context.Background(), vb); err != nil {
+		return fmt.Errorf("update %s/%s VolumeBackup: %v", volumeBackupName, namespace, err)
+	}
+	return nil
+}
+
+// UpdateStatusInResourceBackup -- Updating resourceBackup status
+func UpdateStatusInResourceBackup(
+	status kdmpapi.ResourceBackupStatus,
+	reason string,
+	progress float64,
+	rbName string,
+	rbNamespace string,
+) error {
+	for i := 0; i < maxRetry; i++ {
+		rb, err := kdmpschedops.Instance().GetResourceBackup(rbName, rbNamespace)
+		if err != nil {
+			errMsg := fmt.Sprintf("error reading ResourceBackup CR[%v/%v]: %v", rbNamespace, rbName, err)
+			time.Sleep(retrySleep)
+			return fmt.Errorf(errMsg)
+		}
+		rb.Status.Status = status
+		rb.Status.Reason = reason
+		rb.Status.ProgressPercentage = progress
+		_, err = kdmpschedops.Instance().UpdateResourceBackup(rb)
+		if err != nil {
+			errMsg := fmt.Sprintf("error updating ResourceBackup CR[%v/%v]: %v", rbNamespace, rbName, err)
+			time.Sleep(retrySleep)
+			return fmt.Errorf(errMsg)
+		}
+	}
+
+	return nil
+}
+
+// UpdateResourceBackupStatus  -- Updating resourceBackup status
+func UpdateResourceBackupStatus(
+	status kdmpapi.ResourceBackupProgressStatus,
+	rbName string,
+	rbNamespace string,
+) error {
+	rb, err := kdmpschedops.Instance().GetResourceBackup(rbName, rbNamespace)
+	if err != nil {
+		errMsg := fmt.Sprintf("error reading ResourceBackup CR[%v/%v]: %v", rbNamespace, rbName, err)
+		return fmt.Errorf(errMsg)
+	}
+	rb.Status.Status = status.Status
+	rb.Status.Reason = status.Reason
+	rb.Status.ProgressPercentage = status.ProgressPercentage
+	_, err = kdmpschedops.Instance().UpdateResourceBackup(rb)
+	if err != nil {
+		errMsg := fmt.Sprintf("error updating ResourceBackup CR[%v/%v]: %v", rbNamespace, rbName, err)
+		return fmt.Errorf(errMsg)
+	}
+
+	return nil
+}
+
+// CreateVolumeBackup creates volumebackup CRD
+func CreateVolumeBackup(name, namespace, repository, blName, blNamespace string) error {
+	new := &kdmpapi.VolumeBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				utils.SkipResourceAnnotation: "true",
+			},
+		},
+		Spec: kdmpapi.VolumeBackupSpec{
+			Repository: repository,
+			BackupLocation: kdmpapi.DataExportObjectReference{
+				Name:      blName,
+				Namespace: blNamespace,
+			},
+		},
+	}
+
+	vb, err := kdmpops.Instance().GetVolumeBackup(context.Background(), name, namespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			_, err = kdmpops.Instance().CreateVolumeBackup(context.Background(), new)
+		}
+		return err
+	}
+
+	if !reflect.DeepEqual(vb.Spec, new.Spec) {
+		return fmt.Errorf("volumebackup %s/%s with different spec already exists", namespace, name)
+	}
+
+	if vb.Status.SnapshotID != "" {
+		return fmt.Errorf("volumebackup %s/%s with snapshot id already exists", namespace, name)
+	}
+
+	return nil
+}
+
+// GetSourcePath data source path
+func GetSourcePath(path, glob string) (string, error) {
+	if len(path) == 0 && len(glob) == 0 {
+		return "", fmt.Errorf("source-path argument is required for backups")
+	}
+
+	if len(path) > 0 {
+		return path, nil
+	}
+
+	matches, err := filepath.Glob(glob)
+	if err != nil {
+		return "", fmt.Errorf("parse source-path-glob: %s", err)
+	}
+
+	if len(matches) != 1 {
+		return "", fmt.Errorf("parse source-path-glob: invalid amount of matches: %v", matches)
+	}
+
+	return matches[0], nil
+}
+
+// HandleErr handle errors
+func HandleErr(err error) {
+	if err != nil {
+		util.CheckErr(err)
+	}
+}
+
+// GetCrNameWithUID - returns Cr name by appending the object name with UID
+func GetCrNameWithUID(name, uid string) string {
+	return name + "-" + getShortUID(uid)
+}
+
+// getShortUID returns the first part of the UID. If an empty UID is provided, this function will return an empty string.
+func getShortUID(uid string) string {
+	if len(uid) < 8 {
+		return ""
+	}
+	return uid[0:7]
+}
+
+// CreateNamespacesFromMapping creates namespace if it's not present
+func CreateNamespacesFromMapping(
+	applicationCRName string,
+	restoreNamespace string) error {
+	funct := "createNamespacesFromMapping"
+	restore, err := storkops.Instance().GetApplicationRestore(applicationCRName, restoreNamespace)
+	if err != nil {
+		logrus.Errorf("%s: Error getting restore cr: %v", funct, err)
+		return err
+	}
+	backup, err := storkops.Instance().GetApplicationBackup(restore.Spec.BackupName, restore.Namespace)
+	if err != nil {
+		log.ApplicationRestoreLog(restore).Errorf("Error getting backup: %v", err)
+		return err
+	}
+	return createNamespaces(backup, restore.Spec.BackupLocation, restore.Namespace, restore)
+}
+
+func createNamespaces(backup *storkapi.ApplicationBackup,
+	backupLocation string,
+	backupLocationNamespace string,
+	restore *storkapi.ApplicationRestore) error {
+	var namespaces []*v1.Namespace
+	funct := "create namespaces"
+
+	repo, err := ParseCloudCred()
+	if err != nil {
+		logrus.Errorf("%s: error parsing cloud cred: %v", funct, err)
+		return err
+	}
+	bkpDir := filepath.Join(repo.Path, backup.Status.BackupPath)
+	restoreLocation, err := storkops.Instance().GetBackupLocation(backup.Spec.BackupLocation, backupLocationNamespace)
+	if err != nil {
+		return err
+	}
+
+	nsData, err := DownloadObject(bkpDir, NamespacesFile, restoreLocation.Location.EncryptionV2Key)
+	if err != nil {
+		return err
+	}
+	if nsData != nil {
+		if err = json.Unmarshal(nsData, &namespaces); err != nil {
+			return err
+		}
+		for _, ns := range namespaces {
+			if restoreNS, ok := restore.Spec.NamespaceMapping[ns.Name]; ok {
+				ns.Name = restoreNS
+			} else {
+				// Skip namespaces we aren't restoring
+				continue
+			}
+			// create mapped restore namespace with metadata of backed up
+			// namespace
+			_, err := core.Instance().CreateNamespace(&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        ns.Name,
+					Labels:      ns.Labels,
+					Annotations: ns.GetAnnotations(),
+				},
+			})
+			log.ApplicationRestoreLog(restore).Tracef("Creating dest namespace %v", ns.Name)
+			if err != nil {
+				if errors.IsAlreadyExists(err) {
+					oldNS, err := core.Instance().GetNamespace(ns.GetName())
+					if err != nil {
+						return err
+					}
+					annotations := make(map[string]string)
+					labels := make(map[string]string)
+					if restore.Spec.ReplacePolicy == storkapi.ApplicationRestoreReplacePolicyDelete {
+						// overwrite all annotation in case of replace policy set to delete
+						annotations = ns.GetAnnotations()
+						labels = ns.GetLabels()
+					} else if restore.Spec.ReplacePolicy == storkapi.ApplicationRestoreReplacePolicyRetain {
+						// only add new annotation,labels in case of replace policy is set to retain
+						annotations = oldNS.GetAnnotations()
+						if annotations == nil {
+							annotations = make(map[string]string)
+						}
+						for k, v := range ns.GetAnnotations() {
+							if _, ok := annotations[k]; !ok {
+								annotations[k] = v
+							}
+						}
+						labels = oldNS.GetLabels()
+						if labels == nil {
+							labels = make(map[string]string)
+						}
+						for k, v := range ns.GetLabels() {
+							if _, ok := labels[k]; !ok {
+								labels[k] = v
+							}
+						}
+					}
+					log.ApplicationRestoreLog(restore).Tracef("Namespace already exists, updating dest namespace %v", ns.Name)
+					_, err = core.Instance().UpdateNamespace(&v1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        ns.Name,
+							Labels:      labels,
+							Annotations: annotations,
+						},
+					})
+					if err != nil {
+						return err
+					}
+					continue
+				}
+				return err
+			}
+		}
+		return nil
+	}
+	for _, namespace := range restore.Spec.NamespaceMapping {
+		if ns, err := core.Instance().GetNamespace(namespace); err != nil {
+			if errors.IsNotFound(err) {
+				if _, err := core.Instance().CreateNamespace(&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        ns.Name,
+						Labels:      ns.Labels,
+						Annotations: ns.GetAnnotations(),
+					},
+				}); err != nil {
+					return err
+				}
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// DownloadObject download nfs resource object
+func DownloadObject(
+	resourcePath string,
+	resourceFileName string,
+	encryptionKey string,
+) ([]byte, error) {
+	logrus.Debugf("downloadObject resourcePath: %s, resourceFileName: %s", resourcePath, resourceFileName)
+	filePath := filepath.Join(resourcePath, resourceFileName)
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("getting file content of %s failed: %v", filePath, err)
+	}
+
+	if len(encryptionKey) > 0 {
+		var decryptData []byte
+		if decryptData, err = crypto.Decrypt(data, encryptionKey); err != nil {
+			logrus.Errorf("nfs downloadObject: decrypt failed :%v, returning data direclty", err)
+			return data, nil
+		}
+		return decryptData, nil
+	}
+	return data, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -894,7 +894,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20230320064430-aad8b8b5f8ea => github.com/portworx/kdmp v0.4.1-0.20230320064430-aad8b8b5f8ea
+# github.com/portworx/kdmp v0.4.1-0.20230424204103-0511288bf033 => github.com/portworx/kdmp v0.4.1-0.20230424204103-0511288bf033
 ## explicit; go 1.19
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1
@@ -917,6 +917,7 @@ github.com/portworx/kdmp/pkg/drivers/resticbackup
 github.com/portworx/kdmp/pkg/drivers/resticrestore
 github.com/portworx/kdmp/pkg/drivers/rsync
 github.com/portworx/kdmp/pkg/drivers/utils
+github.com/portworx/kdmp/pkg/executor
 github.com/portworx/kdmp/pkg/jobratelimit
 github.com/portworx/kdmp/pkg/util/ops
 github.com/portworx/kdmp/pkg/utils
@@ -2244,7 +2245,7 @@ sigs.k8s.io/yaml
 # github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc10 => github.com/kubernetes-incubator/external-storage v0.25.1-openstorage-rc1
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20230324214216-7f88436db3de
-# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20230320064430-aad8b8b5f8ea
+# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20230424204103-0511288bf033
 # github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230228105744-505c1a2d8203
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20230216213348-6ba0e5494ad5
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7


### PR DESCRIPTION
What type of PR is this?

feature
NFS backuplocation support.

What this PR does / why we need it:

 pb-3448: Support for restore with NFS backuplocation

            - In restoreVolume cleaned up the cases to have only nfs and non nfs for
              calling driver.startRestore
            - changed getRestoreStorageClasses and downloadObject to get the
              storageclass.json in the case of NFS backuplocation directly from mount NFS pvc
            - Removed some of the conversion function, which is not required.
                      - convertResourceVolInfoToAppBkpVolInfo
                      - convertResourceVolInfoToAppBkpVolInfo
Does this PR change a user-facing CRD or CLI?:
No

Is a release note needed?:
N.A
Does this change need to be cherry-picked to a release branch?:
N.A

Testing:
Basic testing of Native CSI, Direct KDMP and PX backup/restore was done with NFS backuplocation.