### PR TITLE
PWX-30356: Storkctl create clusterpair doesn't honor port from cli

### DIFF
--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -500,7 +500,7 @@ func getClusterPairParams(config, endpoint string, customPort string) (string, s
 		ip = svc.Spec.LoadBalancerIP
 	}
 	pxToken := os.Getenv("PX_AUTH_TOKEN")
-	if customPort != "" {
+	if len(customPort) > 0 {
 		port = customPort
 	} else {
 		for _, svcPort := range svc.Spec.Ports {
@@ -510,7 +510,6 @@ func getClusterPairParams(config, endpoint string, customPort string) (string, s
 			}
 		}
 	}
-
 	pxEndpoint := net.JoinHostPort(ip, port)
 	// TODO: support https as well
 	clnt, err := clusterclient.NewAuthClusterClient("http://"+pxEndpoint, "v1", pxToken, "")

--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -259,7 +259,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 				return
 			}
 			printMsg("Using PX-Service Endpoint of DR cluster to create clusterpair...\n", ioStreams.Out)
-			ip, port, token, err := getClusterPairParams(dFile, dIP)
+			ip, port, token, err := getClusterPairParams(dFile, dIP, dPort)
 			if err != nil {
 				err := fmt.Errorf("unable to create clusterpair from source to DR cluster. Err: %v", err)
 				util.CheckErr(err)
@@ -296,7 +296,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 				return
 			}
 			printMsg("Using PX-Service endpoints of source cluster to create clusterpair...\n", ioStreams.Out)
-			ip, port, token, err = getClusterPairParams(sFile, sIP)
+			ip, port, token, err = getClusterPairParams(sFile, sIP, sPort)
 			if err != nil {
 				err := fmt.Errorf("unable to create clusterpair from DR to source cluster. Err: %v", err)
 				util.CheckErr(err)
@@ -476,7 +476,7 @@ func getConfig(configFile string) clientcmd.ClientConfig {
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(configLoadingRules, configOverrides)
 }
 
-func getClusterPairParams(config, endpoint string) (string, string, string, error) {
+func getClusterPairParams(config, endpoint string, customPort string) (string, string, string, error) {
 	var ip, port, token string
 	client, err := core.NewInstanceFromConfigFile(config)
 	if err != nil {
@@ -500,12 +500,17 @@ func getClusterPairParams(config, endpoint string) (string, string, string, erro
 		ip = svc.Spec.LoadBalancerIP
 	}
 	pxToken := os.Getenv("PX_AUTH_TOKEN")
-	for _, svcPort := range svc.Spec.Ports {
-		if svcPort.Name == "px-api" {
-			port = strconv.Itoa(int(svcPort.Port))
-			break
+	if customPort != "" {
+		port = customPort
+	} else {
+		for _, svcPort := range svc.Spec.Ports {
+			if svcPort.Name == "px-api" {
+				port = strconv.Itoa(int(svcPort.Port))
+				break
+			}
 		}
 	}
+
 	pxEndpoint := net.JoinHostPort(ip, port)
 	// TODO: support https as well
 	clnt, err := clusterclient.NewAuthClusterClient("http://"+pxEndpoint, "v1", pxToken, "")


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
Storkctl create clusterpair doesn't honor port from cli
https://portworx.atlassian.net/browse/PWX-30356


**Does this PR change a user-facing CRD or CLI?**:
yes

**Is a release note needed?**:
```release-note
Issue: Storkctl create clusterpair doesn't honor the port provided from CLI
User Impact: Users unable to create bi-directional clusterpairs
Resolution: Passing the port provided from CLI in the endpoints for creating cluster pair.

```

**Does this change need to be cherry-picked to a release branch?**:
yes 23.5
