### PR TITLE
PWX-30276: Do not delete pods running on storage down nodes.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -530,9 +530,12 @@ func (p *portworx) inspectVolume(volDriver volume.VolumeDriver, volumeID string)
 
 	return info, nil
 }
-
 func (p *portworx) mapNodeStatus(status api.Status) storkvolume.NodeStatus {
 	switch status {
+	case api.Status_STATUS_POOLMAINTENANCE:
+		fallthrough
+	case api.Status_STATUS_STORAGE_DOWN:
+		return storkvolume.NodeStorageDown
 	case api.Status_STATUS_INIT:
 		fallthrough
 	case api.Status_STATUS_OFFLINE:
@@ -551,8 +554,6 @@ func (p *portworx) mapNodeStatus(status api.Status) storkvolume.NodeStatus {
 		fallthrough
 	case api.Status_STATUS_OK:
 		return storkvolume.NodeOnline
-	case api.Status_STATUS_STORAGE_DOWN:
-		fallthrough
 	case api.Status_STATUS_STORAGE_DEGRADED:
 		fallthrough
 	case api.Status_STATUS_STORAGE_REBALANCE:

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -288,6 +288,10 @@ const (
 	NodeOnline NodeStatus = "Online"
 	// NodeOffline Node is Offline
 	NodeOffline NodeStatus = "Offline"
+	// NodeStorageDown Node is Online but storage is down.
+	// The expection from the driver is applications can continue their IO
+	// since the data is replicated to other nodes.
+	NodeStorageDown NodeStatus = "StorageDown"
 	// NodeDegraded Node is in degraded state
 	NodeDegraded NodeStatus = "Degraded"
 )

--- a/pkg/extender/extender_test.go
+++ b/pkg/extender/extender_test.go
@@ -365,12 +365,6 @@ func pxCSIExtPodNoDriverTest(t *testing.T) {
 	nodes.Items = append(nodes.Items, *newNode("node1", "node1", "192.168.0.1", "rack1", "a", "us-east-1"))
 	nodes.Items = append(nodes.Items, *newNode("node2", "node2", "192.168.0.2", "rack1", "a", "us-east-1"))
 	nodes.Items = append(nodes.Items, *newNode("node3", "node3", "192.168.0.3", "rack1", "a", "us-east-1"))
-	nodes.Items = append(nodes.Items, *newNode("node4", "node4", "192.168.0.4", "rack1", "a", "us-east-1"))
-
-	if err := driver.UpdateNodeStatus(3, volume.NodeDegraded); err != nil {
-		t.Fatalf("Error setting node status to StorageDown: %v", err)
-	}
-
 	filterResponse, err := sendFilterRequest(pod, nodes)
 	if err != nil {
 		t.Fatalf("Error sending filter request: %v", err)
@@ -400,13 +394,13 @@ func pxCSIExtPodDriverTest(t *testing.T) {
 	nodes.Items = append(nodes.Items, *newNode("node5", "node5", "192.168.0.5", "rack1", "", ""))
 	nodes.Items = append(nodes.Items, *newNode("node6", "node6", "192.168.0.6", "rack1", "", ""))
 
-	if err := driver.CreateCluster(5, nodes); err != nil {
+	if err := driver.CreateCluster(6, nodes); err != nil {
 		t.Fatalf("Error creating cluster: %v", err)
 	}
 	pod := newPod("px-csi-ext-foo", nil)
 
 	if err := driver.UpdateNodeStatus(5, volume.NodeDegraded); err != nil {
-		t.Fatalf("Error setting node status to StorageDown: %v", err)
+		t.Fatalf("Error setting node status to Degraded: %v", err)
 	}
 
 	filterResponse, err := sendFilterRequest(pod, nodes)
@@ -415,6 +409,8 @@ func pxCSIExtPodDriverTest(t *testing.T) {
 	}
 	verifyFilterResponse(t, nodes, []int{0, 1, 2, 3, 4}, filterResponse)
 
+	// Remove the degraded node from the list
+	nodes.Items = nodes.Items[:5]
 	prioritizeResponse, err := sendPrioritizeRequest(pod, nodes)
 	if err != nil {
 		t.Fatalf("Error sending prioritize request: %v", err)
@@ -480,7 +476,7 @@ func pxCSIExtPodOfflinePxNodesTest(t *testing.T) {
 	pod := newPod("px-csi-ext-foo", nil)
 
 	if err := driver.UpdateNodeStatus(2, volume.NodeOffline); err != nil {
-		t.Fatalf("Error setting node status to StorageDown: %v", err)
+		t.Fatalf("Error setting node status to Offline: %v", err)
 	}
 
 	filterResponse, err := sendFilterRequest(pod, nodes)

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -206,10 +206,11 @@ func (m *Monitor) driverMonitor() {
 			}
 			nodes = volume.RemoveDuplicateOfflineNodes(nodes)
 			for _, node := range nodes {
-				// Check if nodes are reported online by the storage driver
-				// If not online, look at all the pods on that node
+				// Check if nodes are reported as offline or degraded by the storage driver
+				// If offline or degraded, look at all the pods on that node
 				// For any Running pod on that node using volume by the driver, kill the pod
-				if node.Status != volume.NodeOnline {
+				// Degraded nodes are not considered offline and pods are not deleted from them.
+				if node.Status == volume.NodeOffline || node.Status == volume.NodeDegraded {
 					m.wg.Add(1)
 					// wait for 1 min if node is upgrading
 					go m.cleanupDriverNodePods(node)

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -235,7 +235,7 @@ func (m *Monitor) cleanupDriverNodePods(node *volume.NodeInfo) {
 		if err != nil {
 			return false, nil
 		}
-		if n.Status != volume.NodeOnline {
+		if node.Status == volume.NodeOffline || node.Status == volume.NodeDegraded {
 			log.Infof("Volume driver on node %v (%v) is still offline (%v)", node.Hostname, node.StorageID, n.RawStatus)
 			return false, nil
 		}

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -316,7 +316,7 @@ func testStorageDownNode(t *testing.T) {
 	require.NoError(t, err, "failed to create pod")
 
 	err = driver.UpdateNodeStatus(node2Index, volume.NodeStorageDown)
-	require.NoError(t, err, "Error setting node status to Degraded")
+	require.NoError(t, err, "Error setting node status to StorageDown")
 	defer func() {
 		err = driver.UpdateNodeStatus(node2Index, volume.NodeOnline)
 		require.NoError(t, err, "Error setting node status to Online")

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -1165,6 +1165,28 @@ func addRunToMilestone(testrailID int, testResult *string) (int, error) {
 	return runID, nil
 }
 
+func getPodsForApp(ctx *scheduler.Context) ([]v1.Pod, error) {
+	var pods []v1.Pod
+
+	for _, specObj := range ctx.App.SpecList {
+		if obj, ok := specObj.(*appsapi.Deployment); ok {
+			depPods, err := apps.Instance().GetDeploymentPods(obj)
+			if err != nil {
+				return nil, err
+			}
+			pods = append(pods, depPods...)
+		} else if obj, ok := specObj.(*appsapi.StatefulSet); ok {
+			ssPods, err := apps.Instance().GetStatefulSetPods(obj)
+			if err != nil {
+				return nil, err
+			}
+			pods = append(pods, ssPods...)
+		}
+	}
+
+	return pods, nil
+}
+
 func TestMain(m *testing.M) {
 	flag.IntVar(&snapshotScaleCount,
 		"snapshot-scale-count",


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
- Introduce a new state in Stork for storage down nodes.
- Remap portworx StorageDown state to Stork's StorageDown state
- For degraded node state:
  - filter out the nodes from extender requests.
  - monitor should delete the pods running on them
- For storage down state:
  - do not filter out such nodes.
  - give a low score to nodes which are storage down.
  - monitor should not delete pods running on them

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
Issue: Stork would delete pods running on Degraded or Portworx StorageDown nodes.
User Impact: Applications would face disruption even though drivers like Portworx supported applications running on StorageDown nodes.
Resolution: Stork will not delete pods running on StorageDown nodes.

```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 23.4

**Testing Notes**
- Added a UT to ensure pods are not deleted on StorageDown nodes.
- Modified existing UTs to use StorageDown state instead of NodeDegraded state. 
- Added a UT in extender to not schedule pods on Degraded nodes.
- Currently working on adding integration tests.

