### PR TITLE
PB-3827 - Fix loop in cleanupSnapshotsForRestore to avoid assignment of the last entry to all keys

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -653,7 +653,8 @@ func (c *csi) cleanupSnapshotsForRestore(
 			if err != nil {
 				return err
 			}
-			for _, vs := range vsList.Items {
+			for _, val := range vsList.Items {
+				vs := val
 				vsMap[vs.Name] = &vs
 			}
 
@@ -666,7 +667,8 @@ func (c *csi) cleanupSnapshotsForRestore(
 		if err != nil {
 			return err
 		}
-		for _, vsContent := range vsContentList.Items {
+		for _, val := range vsContentList.Items {
+			vsContent := val
 			vsContentMap[vsContent.Name] = &vsContent
 		}
 		log.ApplicationRestoreLog(restore).Debugf("collected %v snapshots and %v snapshotcontents to clean", len(vsMap), len(vsContentMap))
@@ -684,7 +686,8 @@ func (c *csi) cleanupSnapshotsForRestore(
 		if err != nil {
 			return err
 		}
-		for _, vs := range vsList.Items {
+		for _, val := range vsList.Items {
+			vs := val
 			vsMap[vs.Name] = &vs
 		}
 
@@ -697,7 +700,8 @@ func (c *csi) cleanupSnapshotsForRestore(
 	if err != nil {
 		return err
 	}
-	for _, vsContent := range vsContentList.Items {
+	for _, val := range vsContentList.Items {
+		vsContent := val
 		vsContentMap[vsContent.Name] = &vsContent
 	}
 	log.ApplicationRestoreLog(restore).Debugf("collected %v snapshots and %v snapshotcontents to clean", len(vsMap), len(vsContentMap))


### PR DESCRIPTION

**What type of PR is this?**
>bug

**What this PR does / why we need it**: Fixes the for loop in cleanupSnapshotsForRestore to avoid assignment of the last entry to all keys


**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

