### PR TITLE
PWX-30706: Use same cmdexecutor image tag as stork

### DIFF
--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -261,11 +261,11 @@ func GetServiceAccountFromDeployment(name, namespace string) (string, error) {
 	return deploy.Spec.Template.Spec.ServiceAccountName, nil
 }
 
-// GetImageRegistryFromDeployment - extract image registry and image registry secret from deployment spec
-func GetImageRegistryFromDeployment(name, namespace string) (string, string, error) {
+// GetImageInfoFromDeployment - extract image registry, image registry secret & image tag from deployment spec
+func GetImageInfoFromDeployment(name, namespace string) (string, string, string, error) {
 	deploy, err := apps.Instance().GetDeployment(name, namespace)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	imageFields := strings.Split(deploy.Spec.Template.Spec.Containers[0].Image, "/")
 	// Here the assumption is that the image format will be <registry-name>/<extra-dir-name>/<repo-name>/image:tag
@@ -274,11 +274,14 @@ func GetImageRegistryFromDeployment(name, namespace string) (string, string, err
 	// here minus 1 is for image name
 	registryFields := imageFields[0 : len(imageFields)-1]
 	registry := strings.Join(registryFields, "/")
+
+	imageTag := strings.Split(imageFields[len(imageFields)-1], ":")[1]
+
 	imageSecret := deploy.Spec.Template.Spec.ImagePullSecrets
 	if imageSecret != nil {
-		return registry, imageSecret[0].Name, nil
+		return registry, imageSecret[0].Name, imageTag, nil
 	}
-	return registry, "", nil
+	return registry, "", imageTag, nil
 }
 
 // GetStorkPodNamespace - will return the stork pod namespace.

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -40,7 +40,8 @@ const (
 	// environment variable for command executor image registry and image registry secret.
 	cmdExecutorImageRegistryEnvVar       = "CMD-EXECUTOR-IMAGE-REGISTRY"
 	cmdExecutorImageRegistrySecretEnvVar = "CMD-EXECUTOR-IMAGE-REGISTRY-SECRET"
-	defaultCmdExecutorImage              = "cmdexecutor:0.1"
+	defaultCmdExecutorImage              = "cmdexecutor"
+	defaultCmdExecutorTag                = "0.1"
 	// annotation key value for command executor image registry and image registry secret.
 	cmdExecutorImageOverrideKey          = "stork.libopenstorage.org/cmdexecutor-image"
 	cmdExecutorImageOverrideSecretKey    = "stork.libopenstorage.org/cmdexecutor-image-secret"
@@ -343,7 +344,7 @@ func executeCommandAction(
 			return err
 		}
 		// If env is not set get the values from stork deployment spec.
-		registry, registrySecret, err := k8sutils.GetImageRegistryFromDeployment(
+		registry, registrySecret, imageTag, err := k8sutils.GetImageInfoFromDeployment(
 			k8sutils.StorkDeploymentName,
 			storkPodNs,
 		)
@@ -351,14 +352,14 @@ func executeCommandAction(
 			return err
 		}
 		if len(registry) != 0 {
-			cmdExecutorImage = registry + "/" + defaultCmdExecutorImage
+			cmdExecutorImage = registry + "/" + defaultCmdExecutorImage + ":" + imageTag
 		} else {
-			cmdExecutorImage = defaultCmdExecutorImage
+			cmdExecutorImage = defaultCmdExecutorImage + ":" + defaultCmdExecutorTag
 		}
 		cmdExecutorImageSecret = registrySecret
 	} else {
 		// if env is set get it from env variable.
-		cmdExecutorImage = os.Getenv(cmdExecutorImageRegistryEnvVar) + "/" + defaultCmdExecutorImage
+		cmdExecutorImage = os.Getenv(cmdExecutorImageRegistryEnvVar) + "/" + defaultCmdExecutorImage + ":" + defaultCmdExecutorTag
 		cmdExecutorImageSecret = os.Getenv(cmdExecutorImageRegistrySecretEnvVar)
 	}
 	ruleAnnotations := rule.GetAnnotations()


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Use updated cmdExecutorImage.https://portworx.atlassian.net/browse/PWX-30706


**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: Older image of Cmdexecutor was being referenced from Stork  
User Impact: Any new improvements in cmdexecuter image were not being used in Stork.
Resolution: Stork is now updated to use the same tag of cmdexecutor

```

**Does this change need to be cherry-picked to a release branch?**:
yes 23.5
