### PR TITLE
adding name of resource that were not restored on applicationrestore.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bin/
 help-cmdexecutor.1
 help.1
 coverage.txt
+.idea
+

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1605,7 +1605,7 @@ func (a *ApplicationRestoreController) restoreResources(
 	for _, resource := range restore.Status.Resources {
 		if resource.Status != storkapi.ApplicationRestoreStatusSuccessful {
 			restore.Status.Status = storkapi.ApplicationRestoreStatusPartialSuccess
-			restore.Status.Reason = "Volumes were restored successfully. Some existing resources were not replaced"
+			restore.Status.Reason = fmt.Sprintf("Volumes were restored successfully. Some existing resources were not replaced, resource: %s", resource.Name)
 			break
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

improvement

**What this PR does / why we need it**:

On pkg/applicationmanager/controllers/applicationrestore.go line 1608 we need to check which resource were not successfully restored.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no

```restore.Status.Reason = fmt.Sprintf("Volumes were restored successfully. Some existing resources were not replaced, resource: %s", resource.Name)```



**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
no

