### PR TITLE
PWX-30712: Initializing shared informer cache for all stork Pods

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -356,11 +356,10 @@ func run(c *cli.Context) {
 	}
 	// Registering application registration CRDs explicitly to use
 	// shared informer cache for caching application-controller CRs
-	if c.Bool("application-controller") {
-		if err := applicationmanager.CreateCRD(); err != nil {
-			log.Fatalf("Error creating CRDs for application manager: %v", err)
-		}
+	if err := applicationmanager.CreateCRD(); err != nil {
+		log.Fatalf("Error creating CRDs for application manager: %v", err)
 	}
+
 	// Setup stork cache. We setup this cache for all the stork pods instead of just the leader pod.
 	// In this way, even the stork extender code can use this cache, since the extender filter/process
 	// requests can land on any stork pod.

--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -354,6 +354,20 @@ func run(c *cli.Context) {
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Fatalf("Setup scheme failed for stork resources: %v", err)
 	}
+	// Registering application registration CRDs explicitly to use
+	// shared informer cache for caching application-controller CRs
+	if c.Bool("application-controller") {
+		if err := applicationmanager.CreateCRD(); err != nil {
+			log.Fatalf("Error creating CRDs for application manager: %v", err)
+		}
+	}
+	// Setup stork cache. We setup this cache for all the stork pods instead of just the leader pod.
+	// In this way, even the stork extender code can use this cache, since the extender filter/process
+	// requests can land on any stork pod.
+	if err := cache.CreateSharedInformerCache(mgr); err != nil {
+		log.Fatalf("failed to setup shared informer cache: %v", err)
+	}
+	log.Infof("shared informer cache has been intialized")
 
 	var d volume.Driver
 	if driverName != "" {
@@ -581,14 +595,6 @@ func runStork(mgr manager.Manager, ctx context.Context, d volume.Driver, recorde
 			log.Fatalf("Error initializing kdmp controller: %v", err)
 		}
 	}
-
-	// Setup stork cache. We setup this cache for all the stork pods instead of just the leader pod.
-	// In this way, even the stork extender code can use this cache, since the extender filter/process
-	// requests can land on any stork pod.
-	if err := cache.CreateSharedInformerCache(mgr); err != nil {
-		log.Fatalf("failed to setup shared informer cache: %v", err)
-	}
-	log.Infof("shared informer cache has been intialized")
 
 	go func() {
 		for {

--- a/pkg/applicationmanager/applicationmanager.go
+++ b/pkg/applicationmanager/applicationmanager.go
@@ -34,9 +34,6 @@ type ApplicationManager struct {
 
 // Init Initializes the ApplicationManager and any children controller
 func (a *ApplicationManager) Init(mgr manager.Manager, adminNamespace string, stopChannel chan os.Signal) error {
-	if err := a.createCRD(); err != nil {
-		return err
-	}
 	backupController := controllers.NewApplicationBackup(mgr, a.Recorder, a.ResourceCollector)
 	if err := backupController.Init(mgr, adminNamespace, a.RsyncTime); err != nil {
 		return err
@@ -70,7 +67,7 @@ func (a *ApplicationManager) Init(mgr manager.Manager, adminNamespace string, st
 	return nil
 }
 
-func (a *ApplicationManager) createCRD() error {
+func CreateCRD() error {
 	resource := apiextensions.CustomResource{
 		Name:    stork_api.BackupLocationResourceName,
 		Plural:  stork_api.BackupLocationResourcePlural,


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Shared informer cache should be initialized for all Stork Pods.
We need to register applciation controller CRDs explicitly before initializing Cache.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes 23.4

**Test**:
Migration Jenkins Job: https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2023.4-dev/job/23-4-dev-migration-k8s-1-24-0/

