### PR TITLE
PWX-30712: Initializing shared informer cache for all stork Pods (#1390)

### DIFF
--- a/pkg/applicationmanager/applicationmanager.go
+++ b/pkg/applicationmanager/applicationmanager.go
@@ -34,9 +34,6 @@ type ApplicationManager struct {
 
 // Init Initializes the ApplicationManager and any children controller
 func (a *ApplicationManager) Init(mgr manager.Manager, adminNamespace string, stopChannel chan os.Signal) error {
-	if err := a.createCRD(); err != nil {
-		return err
-	}
 	backupController := controllers.NewApplicationBackup(mgr, a.Recorder, a.ResourceCollector)
 	if err := backupController.Init(mgr, adminNamespace, a.RsyncTime); err != nil {
 		return err
@@ -70,7 +67,7 @@ func (a *ApplicationManager) Init(mgr manager.Manager, adminNamespace string, st
 	return nil
 }
 
-func (a *ApplicationManager) createCRD() error {
+func CreateCRD() error {
 	resource := apiextensions.CustomResource{
 		Name:    stork_api.BackupLocationResourceName,
 		Plural:  stork_api.BackupLocationResourcePlural,


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Shared informer cache should be initialized for all Stork Pods.
We need to register applciation controller CRDs explicitly before initializing Cache.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes 23.4
