### PR TITLE
pb-3831: In csi driver CancelRestore, cleaning up dangling PVC, if restore is not succeed and retain as well

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -1683,7 +1683,10 @@ func (c *csi) CancelRestore(restore *storkapi.ApplicationRestore) error {
 		if vrInfo.DriverName != storkvolume.CSIDriverName {
 			continue
 		}
-		pvcRestoreSucceeded := (vrInfo.Status == storkapi.ApplicationRestoreStatusPartialSuccess || vrInfo.Status == storkapi.ApplicationRestoreStatusSuccessful)
+		// For existing volume, the status will be retained.
+		pvcRestoreSucceeded := (vrInfo.Status == storkapi.ApplicationRestoreStatusPartialSuccess ||
+			vrInfo.Status == storkapi.ApplicationRestoreStatusSuccessful ||
+			vrInfo.Status == storkapi.ApplicationRestoreStatusRetained)
 
 		// Only clean up dangling PVC if it's restore did not succeed
 		if !pvcRestoreSucceeded {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
pb-3831: In csi driver CancelRestore, cleaning up dangling PVC, if restore is not succeed and retain as well
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: In CSI, in-place restore, the retained PVC are getting deleted after restore.
User Impact: After in-place CSI restore, the PVC stork in Terminating state and app is not usable.
Resolution: With the fix, the in-place CSI restore, the existing PVC will not deleted and remain unchanged.

```

**Does this change need to be cherry-picked to a release branch?**:
Need decide.

Tested on NFS setup.

