### PR TITLE
Using ubi8-minimal base image for cmdexecutor.

### DIFF
--- a/Dockerfile.cmdexecutor
+++ b/Dockerfile.cmdexecutor
@@ -1,11 +1,13 @@
-FROM registry.access.redhat.com/rhel7-atomic
+FROM registry.access.redhat.com/ubi8-minimal:latest
 MAINTAINER Portworx Inc. <support@portworx.com>
 
+ARG VERSION=master
+ARG RELEASE=latest
 LABEL name="openstorage/cmdexecutor" \
       maintainer="support@portworx.com" \
       vendor="Portworx Inc." \
-      version="1.1" \
-      release="1" \
+      version=${VERSION} \
+      release=${RELEASE} \
       summary="STORK Command executor" \
       description="CLI to execute async commands for Kubernetes Pods" \
       url="https://github.com/libopenstorage/stork" \


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
Unable to pull registry.access.redhat.com/ubi8-minimal   image.
Looks like redhat started enforcing authenticated pulls for redhat registry
https://catalog.redhat.com/software/containers/rhel-atomic/58b9d66e4b339a07cca53596?container-tabs=gti&gti-tabs=unauthenticated

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
na
```

**Does this change need to be cherry-picked to a release branch?**:
yes 23.5.0

