### PR TITLE
PWX-29422: Providing option to specify namespaces selector in migrati…

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2458,7 +2458,7 @@ func (p *portworx) DeletePair(pair *storkapi.ClusterPair) error {
 	return nil
 }
 
-func (p *portworx) StartMigration(migration *storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error) {
+func (p *portworx) StartMigration(migration *storkapi.Migration, migrationNamespaces []string) ([]*storkapi.MigrationVolumeInfo, error) {
 	if !p.initDone {
 		if err := p.initPortworxClients(); err != nil {
 			return nil, err
@@ -2482,7 +2482,7 @@ func (p *portworx) StartMigration(migration *storkapi.Migration) ([]*storkapi.Mi
 		return nil, err
 	}
 
-	if len(migration.Spec.Namespaces) == 0 {
+	if len(migrationNamespaces) == 0 {
 		return nil, fmt.Errorf("namespaces for migration cannot be empty")
 	}
 
@@ -2491,7 +2491,7 @@ func (p *portworx) StartMigration(migration *storkapi.Migration) ([]*storkapi.Mi
 		return nil, fmt.Errorf("error getting clusterpair: %v", err)
 	}
 	volumeInfos := make([]*storkapi.MigrationVolumeInfo, 0)
-	for _, namespace := range migration.Spec.Namespaces {
+	for _, namespace := range migrationNamespaces {
 		pvcList, err := core.Instance().GetPersistentVolumeClaims(namespace, migration.Spec.Selectors)
 		if err != nil {
 			return nil, fmt.Errorf("error getting list of volumes to migrate: %v", err)

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -190,7 +190,7 @@ type ClusterPairPluginInterface interface {
 type MigratePluginInterface interface {
 	// Start migration of volumes specified by the spec. Should only migrate
 	// volumes, not the specs associated with them
-	StartMigration(*storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error)
+	StartMigration(*storkapi.Migration, []string) ([]*storkapi.MigrationVolumeInfo, error)
 	// Get the status of migration of the volumes specified in the status
 	// for the migration spec
 	GetMigrationStatus(*storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error)
@@ -421,7 +421,7 @@ func (c *ClusterPairNotSupported) DeletePair(*storkapi.ClusterPair) error {
 type MigrationNotSupported struct{}
 
 // StartMigration returns ErrNotSupported
-func (m *MigrationNotSupported) StartMigration(*storkapi.Migration) ([]*storkapi.MigrationVolumeInfo, error) {
+func (m *MigrationNotSupported) StartMigration(*storkapi.Migration, []string) ([]*storkapi.MigrationVolumeInfo, error) {
 	return nil, &errors.ErrNotSupported{}
 }
 

--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -16,6 +16,7 @@ type MigrationSpec struct {
 	ClusterPair                  string            `json:"clusterPair"`
 	AdminClusterPair             string            `json:"adminClusterPair"`
 	Namespaces                   []string          `json:"namespaces"`
+	NamespaceSelectors           map[string]string `json:"namespaceSelectors"`
 	IncludeResources             *bool             `json:"includeResources"`
 	IncludeVolumes               *bool             `json:"includeVolumes"`
 	StartApplications            *bool             `json:"startApplications"`

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -1872,6 +1872,13 @@ func (in *MigrationSpec) DeepCopyInto(out *MigrationSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NamespaceSelectors != nil {
+		in, out := &in.NamespaceSelectors, &out.NamespaceSelectors
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.IncludeResources != nil {
 		in, out := &in.IncludeResources, &out.IncludeResources
 		*out = new(bool)

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//	import (
-//	  "k8s.io/client-go/kubernetes"
-//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//	)
+//   import (
+//     "k8s.io/client-go/kubernetes"
+//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//   )
 //
-//	kclientset, _ := kubernetes.NewForConfig(c)
-//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   kclientset, _ := kubernetes.NewForConfig(c)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//	import (
-//	  "k8s.io/client-go/kubernetes"
-//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//	)
+//   import (
+//     "k8s.io/client-go/kubernetes"
+//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//   )
 //
-//	kclientset, _ := kubernetes.NewForConfig(c)
-//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   kclientset, _ := kubernetes.NewForConfig(c)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -548,11 +548,9 @@ func (m *MigrationController) getMigrationNamespaces(ctx context.Context, migrat
 	uniqueNamespaces := make(map[string]bool)
 
 	for _, ns := range migration.Spec.Namespaces {
-		if _, ok := uniqueNamespaces[ns]; !ok {
-			migrationNamespaces = append(migrationNamespaces, ns)
-		}
 		uniqueNamespaces[ns] = true
 	}
+
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
@@ -561,7 +559,6 @@ func (m *MigrationController) getMigrationNamespaces(ctx context.Context, migrat
 	if err != nil {
 		return nil, err
 	}
-
 	for key, val := range migration.Spec.NamespaceSelectors {
 		label := key + "=" + val
 		namespaces, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: label})
@@ -569,11 +566,12 @@ func (m *MigrationController) getMigrationNamespaces(ctx context.Context, migrat
 			return nil, err
 		}
 		for _, namespace := range namespaces.Items {
-			if _, ok := uniqueNamespaces[namespace.GetName()]; !ok {
-				migrationNamespaces = append(migrationNamespaces, namespace.GetName())
-			}
 			uniqueNamespaces[namespace.GetName()] = true
 		}
+	}
+
+	for namespace := range uniqueNamespaces {
+		migrationNamespaces = append(migrationNamespaces, namespace)
 	}
 	return migrationNamespaces, nil
 }

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -310,12 +310,21 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 			err.Error())
 		return nil
 	}
-
+	migrationNamespaces, err := m.getMigrationNamespaces(ctx, migration)
+	if err != nil {
+		err := fmt.Errorf("unable to extract migration namespaces")
+		log.MigrationLog(migration).Errorf(err.Error())
+		m.recorder.Event(migration,
+			v1.EventTypeWarning,
+			string(stork_api.MigrationStatusFailed),
+			err.Error())
+		return nil
+	}
 	// Check whether namespace is allowed to be migrated before each stage
 	// Restrict migration to only the namespace that the object belongs
 	// except for the namespace designated by the admin
-	if !m.namespaceMigrationAllowed(migration) {
-		err := fmt.Errorf("Spec.Namespaces should only contain the current namespace")
+	if !m.namespaceMigrationAllowed(migration, migrationNamespaces) {
+		err := fmt.Errorf("migration namespaces should only contain the current namespace")
 		log.MigrationLog(migration).Errorf(err.Error())
 		m.recorder.Event(migration,
 			v1.EventTypeWarning,
@@ -324,7 +333,6 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 		return nil
 	}
 	var terminationChannels []chan bool
-	var err error
 	var clusterDomains *stork_api.ClusterDomains
 	if !*migration.Spec.IncludeVolumes {
 		for i := 0; i < domainsMaxRetries; i++ {
@@ -360,7 +368,7 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 	switch migration.Status.Stage {
 	case stork_api.MigrationStageInitial:
 		// Make sure the namespaces exist
-		for _, ns := range migration.Spec.Namespaces {
+		for _, ns := range migrationNamespaces {
 			_, err := core.Instance().GetNamespace(ns)
 			if err != nil {
 				if migration.Spec.SkipDeletedNamespaces != nil && *migration.Spec.SkipDeletedNamespaces {
@@ -465,7 +473,7 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 		}
 		fallthrough
 	case stork_api.MigrationStagePreExecRule:
-		terminationChannels, err = m.runPreExecRule(migration)
+		terminationChannels, err = m.runPreExecRule(migration, migrationNamespaces)
 		if err != nil {
 			message := fmt.Sprintf("Error running PreExecRule: %v", err)
 			log.MigrationLog(migration).Errorf(message)
@@ -484,7 +492,7 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 		fallthrough
 	case stork_api.MigrationStageVolumes:
 		if *migration.Spec.IncludeVolumes {
-			err := m.migrateVolumes(migration, terminationChannels)
+			err := m.migrateVolumes(migration, migrationNamespaces, terminationChannels)
 			if err != nil {
 				message := fmt.Sprintf("Error migrating volumes: %v", err)
 				log.MigrationLog(migration).Errorf(message)
@@ -513,7 +521,7 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 			// This is a volumeOnly migration
 			volumesOnly = true
 		}
-		err := m.migrateResources(migration, volumesOnly)
+		err := m.migrateResources(migration, migrationNamespaces, volumesOnly)
 		if err != nil {
 			message := fmt.Sprintf("Error migrating resources: %v", err)
 			log.MigrationLog(migration).Errorf(message)
@@ -535,8 +543,44 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 	return nil
 }
 
+func (m *MigrationController) getMigrationNamespaces(ctx context.Context, migration *stork_api.Migration) ([]string, error) {
+	var migrationNamespaces []string
+	uniqueNamespaces := make(map[string]bool)
+
+	for _, ns := range migration.Spec.Namespaces {
+		if _, ok := uniqueNamespaces[ns]; !ok {
+			migrationNamespaces = append(migrationNamespaces, ns)
+		}
+		uniqueNamespaces[ns] = true
+	}
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	for key, val := range migration.Spec.NamespaceSelectors {
+		label := key + "=" + val
+		namespaces, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{LabelSelector: label})
+		if err != nil {
+			return nil, err
+		}
+		for _, namespace := range namespaces.Items {
+			if _, ok := uniqueNamespaces[namespace.GetName()]; !ok {
+				migrationNamespaces = append(migrationNamespaces, namespace.GetName())
+			}
+			uniqueNamespaces[namespace.GetName()] = true
+		}
+	}
+	return migrationNamespaces, nil
+}
+
 func (m *MigrationController) purgeMigratedResources(
 	migration *stork_api.Migration,
+	migrationNamespaces []string,
 	resourceCollectorOpts resourcecollector.Options,
 ) error {
 	remoteConfig, err := getClusterPairSchedulerConfig(migration.Spec.ClusterPair, migration.Namespace)
@@ -556,7 +600,7 @@ func (m *MigrationController) purgeMigratedResources(
 		return err
 	}
 	destObjects, _, err := rc.GetResources(
-		migration.Spec.Namespaces,
+		migrationNamespaces,
 		migration.Spec.Selectors,
 		migration.Spec.ExcludeSelectors,
 		nil,
@@ -573,7 +617,7 @@ func (m *MigrationController) purgeMigratedResources(
 		return err
 	}
 	srcObjects, _, err := m.resourceCollector.GetResources(
-		migration.Spec.Namespaces,
+		migrationNamespaces,
 		migration.Spec.Selectors,
 		migration.Spec.ExcludeSelectors,
 		nil,
@@ -641,11 +685,11 @@ func objectToCollect(destObject []runtime.Unstructured) ([]runtime.Unstructured,
 	return objects, nil
 }
 
-func (m *MigrationController) namespaceMigrationAllowed(migration *stork_api.Migration) bool {
+func (m *MigrationController) namespaceMigrationAllowed(migration *stork_api.Migration, migrationNamespaces []string) bool {
 	// Restrict migration to only the namespace that the object belongs
 	// except for the namespace designated by the admin
 	if migration.Namespace != m.migrationAdminNamespace {
-		for _, ns := range migration.Spec.Namespaces {
+		for _, ns := range migrationNamespaces {
 			if ns != migration.Namespace {
 				return false
 			}
@@ -654,7 +698,7 @@ func (m *MigrationController) namespaceMigrationAllowed(migration *stork_api.Mig
 	return true
 }
 
-func (m *MigrationController) migrateVolumes(migration *stork_api.Migration, terminationChannels []chan bool) error {
+func (m *MigrationController) migrateVolumes(migration *stork_api.Migration, migrationNamespaces []string, terminationChannels []chan bool) error {
 	defer func() {
 		for _, channel := range terminationChannels {
 			channel <- true
@@ -682,7 +726,7 @@ func (m *MigrationController) migrateVolumes(migration *stork_api.Migration, ter
 				storageStatus, err)
 		}
 
-		volumeInfos, err := m.volDriver.StartMigration(migration)
+		volumeInfos, err := m.volDriver.StartMigration(migration, migrationNamespaces)
 		if err != nil {
 			return err
 		}
@@ -704,7 +748,7 @@ func (m *MigrationController) migrateVolumes(migration *stork_api.Migration, ter
 
 		// Run any post exec rules once migration is triggered
 		if migration.Spec.PostExecRule != "" {
-			err = m.runPostExecRule(migration)
+			err = m.runPostExecRule(migration, migrationNamespaces)
 			if err != nil {
 				message := fmt.Sprintf("Error running PostExecRule: %v", err)
 				log.MigrationLog(migration).Errorf(message)
@@ -788,13 +832,13 @@ func (m *MigrationController) migrateVolumes(migration *stork_api.Migration, ter
 			if err != nil {
 				return err
 			}
-			err = m.migrateResources(migration, false)
+			err = m.migrateResources(migration, migrationNamespaces, false)
 			if err != nil {
 				log.MigrationLog(migration).Errorf("Error migrating resources: %v", err)
 				return err
 			}
 		} else {
-			err := m.migrateResources(migration, true)
+			err := m.migrateResources(migration, migrationNamespaces, true)
 			if err != nil {
 				log.MigrationLog(migration).Errorf("Error migrating resources: %v", err)
 				return err
@@ -808,7 +852,7 @@ func (m *MigrationController) migrateVolumes(migration *stork_api.Migration, ter
 	return m.updateMigrationCR(context.TODO(), migration)
 }
 
-func (m *MigrationController) runPreExecRule(migration *stork_api.Migration) ([]chan bool, error) {
+func (m *MigrationController) runPreExecRule(migration *stork_api.Migration, migrationNamespaces []string) ([]chan bool, error) {
 	if migration.Spec.PreExecRule == "" {
 		migration.Status.Stage = stork_api.MigrationStageVolumes
 		migration.Status.Status = stork_api.MigrationStatusPending
@@ -838,7 +882,7 @@ func (m *MigrationController) runPreExecRule(migration *stork_api.Migration) ([]
 		}
 	}
 	terminationChannels := make([]chan bool, 0)
-	for _, ns := range migration.Spec.Namespaces {
+	for _, ns := range migrationNamespaces {
 		r, err := storkops.Instance().GetRule(migration.Spec.PreExecRule, ns)
 		if err != nil {
 			for _, channel := range terminationChannels {
@@ -861,8 +905,8 @@ func (m *MigrationController) runPreExecRule(migration *stork_api.Migration) ([]
 	return terminationChannels, nil
 }
 
-func (m *MigrationController) runPostExecRule(migration *stork_api.Migration) error {
-	for _, ns := range migration.Spec.Namespaces {
+func (m *MigrationController) runPostExecRule(migration *stork_api.Migration, migrationNamespaces []string) error {
+	for _, ns := range migrationNamespaces {
 		r, err := storkops.Instance().GetRule(migration.Spec.PostExecRule, ns)
 		if err != nil {
 			return err
@@ -876,7 +920,7 @@ func (m *MigrationController) runPostExecRule(migration *stork_api.Migration) er
 	return nil
 }
 
-func (m *MigrationController) migrateResources(migration *stork_api.Migration, volumesOnly bool) error {
+func (m *MigrationController) migrateResources(migration *stork_api.Migration, migrationNamespaces []string, volumesOnly bool) error {
 	clusterPair, err := storkops.Instance().GetClusterPair(migration.Spec.ClusterPair, migration.Namespace)
 	if err != nil {
 		return err
@@ -915,14 +959,14 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration, v
 		resourceCollectorOpts.IncludeAllNetworkPolicies = true
 	}
 	if volumesOnly {
-		allObjects, pvcsWithOwnerRef, err = m.getVolumeOnlyMigrationResources(migration, resourceCollectorOpts)
+		allObjects, pvcsWithOwnerRef, err = m.getVolumeOnlyMigrationResources(migration, migrationNamespaces, resourceCollectorOpts)
 		if err != nil {
 			// already raised event in getVolumeOnlyMigrationResources()
 			return err
 		}
 	} else {
 		allObjects, pvcsWithOwnerRef, err = m.resourceCollector.GetResources(
-			migration.Spec.Namespaces,
+			migrationNamespaces,
 			migration.Spec.Selectors,
 			migration.Spec.ExcludeSelectors,
 			nil,
@@ -1000,7 +1044,7 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration, v
 		return err
 	}
 
-	err = m.applyResources(migration, updateObjects, resGroups, clusterPair, crdList)
+	err = m.applyResources(migration, migrationNamespaces, updateObjects, resGroups, clusterPair, crdList)
 	if err != nil {
 		m.recorder.Event(migration,
 			v1.EventTypeWarning,
@@ -1040,7 +1084,7 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration, v
 	}
 
 	if *migration.Spec.PurgeDeletedResources {
-		if err := m.purgeMigratedResources(migration, resourceCollectorOpts); err != nil {
+		if err := m.purgeMigratedResources(migration, migrationNamespaces, resourceCollectorOpts); err != nil {
 			message := fmt.Sprintf("Error cleaning up resources: %v", err)
 			log.MigrationLog(migration).Errorf(message)
 			m.recorder.Event(migration,
@@ -1697,6 +1741,7 @@ func (m *MigrationController) updateOwnerReferenceOnPVC(
 
 func (m *MigrationController) applyResources(
 	migration *stork_api.Migration,
+	migrationNamespaces []string,
 	objects []runtime.Unstructured,
 	resGroups map[string]string,
 	clusterPair *stork_api.ClusterPair,
@@ -1794,7 +1839,7 @@ func (m *MigrationController) applyResources(
 
 	// First make sure all the namespaces are created on the
 	// remote cluster
-	for _, ns := range migration.Spec.Namespaces {
+	for _, ns := range migrationNamespaces {
 		namespace, err := core.Instance().GetNamespace(ns)
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -2427,6 +2472,7 @@ func (m *MigrationController) createCRD() error {
 
 func (m *MigrationController) getVolumeOnlyMigrationResources(
 	migration *stork_api.Migration,
+	migrationNamespaces []string,
 	resourceCollectorOpts resourcecollector.Options,
 ) ([]runtime.Unstructured, []v1.PersistentVolumeClaim, error) {
 	var resources []runtime.Unstructured
@@ -2441,7 +2487,7 @@ func (m *MigrationController) getVolumeOnlyMigrationResources(
 	objects, _, err := m.resourceCollector.GetResourcesForType(
 		resource,
 		nil,
-		migration.Spec.Namespaces,
+		migrationNamespaces,
 		migration.Spec.Selectors,
 		migration.Spec.ExcludeSelectors,
 		nil,
@@ -2467,7 +2513,7 @@ func (m *MigrationController) getVolumeOnlyMigrationResources(
 	objects, pvcWithOwnerRef, err = m.resourceCollector.GetResourcesForType(
 		resource,
 		nil,
-		migration.Spec.Namespaces,
+		migrationNamespaces,
 		migration.Spec.Selectors,
 		migration.Spec.ExcludeSelectors,
 		nil,

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -87,6 +87,7 @@ func testMigration(t *testing.T) {
 	t.Run("operatorMigrationRabbitmqTest", operatorMigrationRabbitmqTest)
 	t.Run("bidirectionalClusterPairTest", bidirectionalClusterPairTest)
 	t.Run("serviceAndServiceAccountUpdate", serviceAndServiceAccountUpdate)
+	t.Run("namespaceLabelSelectorTest", namespaceLabelSelectorTest)
 
 	err = setRemoteConfig("")
 	require.NoError(t, err, "setting kubeconfig to default failed")
@@ -452,6 +453,19 @@ func migrationLabelExcludeSelectorTest(t *testing.T) {
 		"label-exclude-selector-migration",
 		true,
 		false,
+		true,
+	)
+}
+
+func namespaceLabelSelectorTest(t *testing.T) {
+	triggerMigrationTest(
+		t,
+		"ns-selector-test",
+		"cassandra",
+		[]string{"mysql-1-pvc"},
+		"namespace-selector-migration",
+		true,
+		true,
 		true,
 	)
 }

--- a/test/integration_test/specs/namespace-selector-migration/migration.yaml
+++ b/test/integration_test/specs/namespace-selector-migration/migration.yaml
@@ -1,0 +1,14 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: Migration
+metadata:
+  name: ns-selector-migration
+spec:
+  # This should be the name of the cluster pair
+  clusterPair: remoteclusterpair
+  # If set to false this will migrate only the volumes. No PVCs, apps, etc will be migrated
+  includeResources: true
+  # If set to false, the deployments and stateful set replicas will be set to 0 on the destination. There will be an annotation with "stork.openstorage.org/migrationReplicas" to store the replica count from the source
+  startApplications: true
+  # List of namespaces to migrate
+  namespaceSelectors:
+    kubernetes.io/metadata.name: cassandra-ns-selector-test  


### PR DESCRIPTION
…on spec.

**What type of PR is this?**
>feature

**What this PR does / why we need it**:
https://portworx.atlassian.net/browse/PWX-29422
Allow users to specify namespace selectors in migration spec.

**Does this PR change a user-facing CRD or CLI?**:
yes, 

**Is a release note needed?**:
Yes
* You can now provide namespace labels in MigrationSchedule spec to specify namespaces for migration.

**Does this change need to be cherry-picked to a release branch?**:
yes 23.5.0


**Notes**:
* I have added one function getMigrationNamespaces to get all unique namespaces for migration and referencing this list throughout our migration flow.
* 
 ```
MigrationSchedule ->
spec:
  template:
    spec:
        namespaceSelectors:
          ns: migrate

Namespace ->
kind: Namespace
metadata:
  labels:
    kubernetes.io/metadata.name: mysql
    ns: migrate
```
* Triggered  migration Jenkins job https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2023.4-dev/job/23-4-dev-migration-k8s-1-24-0/463/ to make sure there are no regressions
