### PR TITLE
pb-3878: updated both the datasource and datasourcRef of pvc during restore.

### DIFF
--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -635,6 +635,9 @@ func (c *csiDriver) RestoreVolumeClaim(opts ...Option) (*v1.PersistentVolumeClai
 		Kind:     "VolumeSnapshot",
 		Name:     o.RestoreSnapshotName,
 	}
+	// Overwritting the pvc.Spec.DataSourceRef to point same volumesnapshot name as that of pvc.Spec.DataSource
+	// Otherwise the pvc creation fails if pvc.Spec.DataSourceRef was poiinting to some stale vs name.
+	pvc.Spec.DataSourceRef = pvc.Spec.DataSource
 	pvc.Status = v1.PersistentVolumeClaimStatus{
 		Phase: v1.ClaimPending,
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
If the backed up PVC spec has both the dataSource and dataSourceRef referring to the volumensnapshot, during restore, we need to update both of them point to the same volumesnapshot. If the dataSourceRef is point to the stale volumesnapshot entry that is different from dataSource, the creation of PVC fails with below error:

error:
time="2023-05-17T09:24:37Z" level=info msg="sivakumar --- .CreatePersistentVolumeClaim failed PersistentVolumeClaim \"mysql-data\" is invalid: spec: Invalid value: field.Path{name:\"dataSource\", index:\"\", parent:(*field.Path)(0xc011eec6f0)}: must match dataSourceRef"
time="2023-05-17T09:24:37Z" level=info msg="sivakumar -- c.snapshotter.RestoreVolumeClaim --- failed to create PVC : PersistentVolumeClaim \"mysql-data\" is invalid: spec: Invalid value: field.Path{name:\"dataSource\", index:\"\", parent:(*field.Path)(0xc011eec6f0)}: must match dataSourceRef"
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: CSI restoring from a backup taken from already restore PVC was failing
User Impact: User were not able to restore the backup taken from already restored CSI PVC
Resolution: The issue is fixed such that user can do CSI restore  from a backup taken from already restore PVC.

```

**Does this change need to be cherry-picked to a release branch?**:
23.5 branch

https://kubernetes.io/docs/concepts/storage/persistent-volumes/