### PR TITLE
pb-3876: Fixed invalid access of pvc struct, when pvc creation fails in RestoreFromLocalSnapshot.

### DIFF
--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -1592,13 +1592,14 @@ func (c *csiDriver) RestoreFromLocalSnapshot(backupLocation *storkapi.BackupLoca
 	}
 
 	// create a new pvc for restore from the snapshot
+	pvcName := pvc.Name
 	pvc, err = c.RestoreVolumeClaim(
 		RestoreSnapshotName(vsName),
 		RestoreNamespace(namespace),
 		PVC(*pvc),
 	)
 	if err != nil {
-		return status, fmt.Errorf("failed to restore pvc %s/%s from csi local snapshot: %v", namespace, pvc.Name, err)
+		return status, fmt.Errorf("failed to restore pvc %s/%s from csi local snapshot: %v", namespace, pvcName, err)
 	}
 	logrus.Debugf("created pvc: %s/%s", pvc.Namespace, pvc.Name)
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
pb-3876: Fixed invalid access of pvc struct, when pvc creation fails in RestoreFromLocalSnapshot.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: stork pod was crashing when pvc creation fails during local snapshots.
User Impact: The backups using local snapshot was failing.
Resolution: Fixed the invalid access during the pvc creation failure as part of local snapshot creation

```

**Does this change need to be cherry-picked to a release branch?**:
23.5 branch.

