### PR TITLE
pb-3891: updating the resourcount of restore CR in updateResourceStatus.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1900,6 +1900,7 @@ func (a *ApplicationRestoreController) restoreResources(
 		return err
 	}
 
+	restore.Status.ResourceCount = len(restore.Status.Resources)
 	restore.Status.Stage = storkapi.ApplicationRestoreStageFinal
 	restore.Status.FinishTimestamp = metav1.Now()
 	restore.Status.Status = storkapi.ApplicationRestoreStatusSuccessful


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
pb-3891: updating the resourcount of restore CR in updateResourceStatus.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
Currently the PV and PVC counts of CSI and kdmp resources are not getting updated in the final count. 

