### PR TITLE
PB-3882 - handle resource export status when its nil

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1875,6 +1875,11 @@ func (a *ApplicationRestoreController) restoreResources(
 					string(resourceExport.Status.ResourceExportResourceApplyStage))
 				restore.Status.LastUpdateTimestamp = metav1.Now()
 				doCleanup = false
+			default:
+				doCleanup = false
+				if len(resourceExport.Status.Status) != 0 {
+					log.ApplicationRestoreLog(restore).Errorf("%v: invalid status for resource export: %s, status: %s", fn, resourceExport.Name, resourceExport.Status.Status)
+				}
 			}
 			restore.Status.LastUpdateTimestamp = metav1.Now()
 			err = a.client.Update(context.TODO(), restore)


### PR DESCRIPTION
**What type of PR is this?** bug

**What this PR does / why we need it**: handle resource export estatus when its nil , so cleanup will not be made when its empty. Usually the status update happens in the initial block of resource export reconciler. (i.e status to "initial"). When status update fails due to network crunch , the RE CR may hold an empty string


![Screenshot from 2023-05-29 19-36-07](https://github.com/libopenstorage/stork/assets/101168875/58a2d7cf-54b8-4003-9b49-57906d61099d)
