### PR TITLE
pb-3807: Update resource count properly in large resource restore

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1854,6 +1854,10 @@ func (a *ApplicationRestoreController) restoreResources(
 						resource.Reason)
 				}
 				restore.Status.LargeResourceEnabled = resourceExport.Status.LargeResourceEnabled
+				restore.Status.ResourceCount = int(resourceExport.Status.TotalResourceCount)
+				restore.Status.RestoredResourceCount = int(resourceExport.Status.RestoredResourceCount)
+				log.ApplicationRestoreLog(restore).Tracef("%v: resource export CR successful with total resource count %v and restored resource count %v",
+					fn, restore.Status.ResourceCount, restore.Status.RestoredResourceCount)
 			case kdmpapi.ResourceExportStatusInitial:
 				doCleanup = false
 			case kdmpapi.ResourceExportStatusPending:
@@ -1900,7 +1904,14 @@ func (a *ApplicationRestoreController) restoreResources(
 		return err
 	}
 
-	restore.Status.ResourceCount = len(restore.Status.Resources)
+	if nfs && restore.Status.LargeResourceEnabled {
+		// For NFS & large Resource Enabled we would have got resource count from RE CR in success path
+		// just add PV & PVC count which is copied to restore CR in the addCSIVolumeResources() function.
+		restore.Status.ResourceCount += len(restore.Status.Resources)
+	} else {
+		restore.Status.ResourceCount = len(restore.Status.Resources)
+	}
+
 	restore.Status.Stage = storkapi.ApplicationRestoreStageFinal
 	restore.Status.FinishTimestamp = metav1.Now()
 	restore.Status.Status = storkapi.ApplicationRestoreStatusSuccessful


### PR DESCRIPTION
- During restore, specifically for the CSI and kdmp, the PV & PVC count is considered in total resource count
- Other than CSI, the total resource count should be obtained from resourceexport CR rather than application restore CR.


**What type of PR is this?** bug
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: Updates the total resource count properly in case of restore when backup contains CSI  volumes. 


**Does this PR change a user-facing CRD or CLI?**: NO
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: No
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Unit test :
![image](https://github.com/libopenstorage/stork/assets/15273500/c5dec7e0-1b86-4704-b5bd-8cd59a7e6d60)

Backup the checked one are used for restore.
![image](https://github.com/libopenstorage/stork/assets/15273500/3a04a4ca-3602-4032-886b-61fd63e350c8)
