### PR TITLE
pb-3907: Modified UpdateMigratedPersistentVolumeSpec() to get the azure

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -399,6 +399,8 @@ func (a *aws) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 	if pv.Spec.CSI != nil {
 		pv.Spec.CSI.VolumeHandle = pv.Name

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -410,8 +410,15 @@ func (a *azure) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
-	disk, err := a.diskClient.Get(context.TODO(), a.resourceGroup, pv.Name)
+	azureSession, err := a.getAzureSession(backuplocationName, backuplocationNamespace)
+	if err != nil {
+		return nil, err
+	}
+	diskClient := azureSession.diskClient
+	disk, err := diskClient.Get(context.TODO(), a.resourceGroup, pv.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -1201,6 +1201,8 @@ func (c *csi) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 	return pv, nil
 }

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -364,6 +364,8 @@ func (g *gcp) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 	if pv.Spec.CSI != nil {
 		key, err := common.VolumeIDToKey(pv.Spec.CSI.VolumeHandle)

--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -543,6 +543,8 @@ func (k *kdmp) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 	return pv, nil
 }

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -406,6 +406,8 @@ func (l *linstor) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 
 	return pv, nil

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -323,6 +323,8 @@ func (m *Driver) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 
 	return pv, nil

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2712,6 +2712,8 @@ func (p *portworx) UpdateMigratedPersistentVolumeSpec(
 	pv *v1.PersistentVolume,
 	vInfo *storkapi.ApplicationRestoreVolumeInfo,
 	namespaceMapping map[string]string,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (*v1.PersistentVolume, error) {
 	// Get the pv storageclass and get the provision detail and decide on csi section.
 	if len(pv.Spec.StorageClassName) != 0 {

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -199,7 +199,7 @@ type MigratePluginInterface interface {
 	CancelMigration(*storkapi.Migration) error
 	// Update the PVC spec to point to the migrated volume on the destination
 	// cluster
-	UpdateMigratedPersistentVolumeSpec(*v1.PersistentVolume, *storkapi.ApplicationRestoreVolumeInfo, map[string]string) (*v1.PersistentVolume, error)
+	UpdateMigratedPersistentVolumeSpec(*v1.PersistentVolume, *storkapi.ApplicationRestoreVolumeInfo, map[string]string, string, string) (*v1.PersistentVolume, error)
 }
 
 type ActionPluginInterface interface {

--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -547,6 +547,7 @@ func (a *ApplicationCloneController) prepareResources(
 			clone.Spec.IncludeOptionalResourceTypes,
 			nil,
 			&opts,
+			"", "",
 		)
 		if err != nil {
 			return nil, err
@@ -590,7 +591,7 @@ func (a *ApplicationCloneController) preparePVResource(
 		return err
 	}
 
-	_, err := a.volDriver.UpdateMigratedPersistentVolumeSpec(&pv, nil, nil)
+	_, err := a.volDriver.UpdateMigratedPersistentVolumeSpec(&pv, nil, nil, "", "")
 	if err != nil {
 		return err
 	}

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -668,6 +668,8 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 							restore.Spec.IncludeOptionalResourceTypes,
 							nil,
 							&opts,
+							restore.Spec.BackupLocation,
+							restore.Namespace,
 						)
 						if err != nil {
 							return err
@@ -1576,6 +1578,8 @@ func (a *ApplicationRestoreController) applyResources(
 			restore.Spec.IncludeOptionalResourceTypes,
 			restore.Status.Volumes,
 			&opts,
+			restore.Spec.BackupLocation,
+			restore.Namespace,
 		)
 		if err != nil {
 			return err

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -1394,7 +1394,7 @@ func (m *MigrationController) preparePVResource(
 	}
 	pv.Annotations[PVReclaimAnnotation] = string(pv.Spec.PersistentVolumeReclaimPolicy)
 	pv.Spec.PersistentVolumeReclaimPolicy = v1.PersistentVolumeReclaimRetain
-	_, err := m.volDriver.UpdateMigratedPersistentVolumeSpec(&pv, nil, nil)
+	_, err := m.volDriver.UpdateMigratedPersistentVolumeSpec(&pv, nil, nil, "", "")
 	if err != nil {
 		return err
 	}

--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -144,6 +144,8 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	storageClassMappings map[string]string,
 	namespaceMappings map[string]string,
 	opts Options,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (bool, error) {
 	var updatedName string
 	var present bool
@@ -215,7 +217,7 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	if err != nil {
 		return false, err
 	}
-	_, err = driver.UpdateMigratedPersistentVolumeSpec(&pv, volumeInfo, namespaceMappings)
+	_, err = driver.UpdateMigratedPersistentVolumeSpec(&pv, volumeInfo, namespaceMappings, backuplocationName, backuplocationNamespace)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -980,6 +980,8 @@ func (r *ResourceCollector) PrepareResourceForApply(
 	optionalResourceTypes []string,
 	vInfo []*stork_api.ApplicationRestoreVolumeInfo,
 	opts *Options,
+	backuplocationName string,
+	backuplocationNamespace string,
 ) (bool, error) {
 	objectType, err := meta.TypeAccessor(object)
 	if err != nil {
@@ -1015,7 +1017,7 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		}
 		return true, nil
 	case "PersistentVolume":
-		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings, namespaceMappings, *opts)
+		return r.preparePVResourceForApply(object, pvNameMappings, vInfo, storageClassMappings, namespaceMappings, *opts, backuplocationName, backuplocationNamespace)
 	case "PersistentVolumeClaim":
 		return r.preparePVCResourceForApply(object, allObjects, pvNameMappings, storageClassMappings, vInfo, *opts)
 	case "ClusterRoleBinding":


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
    pb-3907: Modified UpdateMigratedPersistentVolumeSpec() to get the azure
    session from the backuplocation cluster cred.

            - Modified the UpdateMigratedPersistentVolumeSpec interface to
              take the backuplocation name and namespace.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
n.a

**Does this change need to be cherry-picked to a release branch?**:
No
Test result, I will add it in KDMP PR, where this changes need to be vendored.

