### PR TITLE
pb-3917: Added correct k8s resource version V1 for volumesnapshotcontent delete in CSI cleanupSnapshots

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -758,7 +758,7 @@ func (c *csi) cleanupSnapshots(
 			}
 		}
 		for _, vsc := range vsContentMap.(map[string]*kSnapshotv1.VolumeSnapshotContent) {
-			err := c.snapshotClient.SnapshotV1beta1().VolumeSnapshotContents().Delete(context.TODO(), vsc.Name, metav1.DeleteOptions{})
+			err := c.snapshotClient.SnapshotV1().VolumeSnapshotContents().Delete(context.TODO(), vsc.Name, metav1.DeleteOptions{})
 			if k8s_errors.IsNotFound(err) {
 				continue
 			} else if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
 pb-3917: Added correct k8s resource version V1 for volumesnapshotcontent delete in CSI cleanupSnapshots
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

