### PR TITLE
pb-3807: RestoredResourceCount to reflect pv pvc count too

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1921,6 +1921,9 @@ func (a *ApplicationRestoreController) restoreResources(
 		restore.Status.ResourceCount = len(restore.Status.Resources)
 	}
 
+	// Let's accomodate the PV-PVC counts in RestoredResourceCount, specifically for CSI & kdmp case.
+	restore.Status.RestoredResourceCount = restore.Status.ResourceCount
+
 	restore.Status.Stage = storkapi.ApplicationRestoreStageFinal
 	restore.Status.FinishTimestamp = metav1.Now()
 	restore.Status.Status = storkapi.ApplicationRestoreStatusSuccessful


### PR DESCRIPTION
In case of CSI and KDMP, the volumes entries are added later. Hence the restoredResourceCount and TotalResourceCount aare updated at the end of resource restore process.


**What type of PR is this?** BUG
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: This makes the restoredResource Count and Total resource count to reflect the right value upon success. ealier it shos the count without PV-PVC counts.


**Does this PR change a user-facing CRD or CLI?**: NO
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: NO
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: NO
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Unit Test :
Before Fix : In case of KDMP & CSI based volumes. 
![Screenshot from 2023-06-06 12-13-40](https://github.com/libopenstorage/stork/assets/15273500/1483ed8d-2309-4503-8ceb-9dd70e72c621)


After Fix:
![image](https://github.com/libopenstorage/stork/assets/15273500/bb1715d4-1ed1-41bc-b8ce-c5f2ba28d716)




