### PR TITLE
pb-3823: Make the pre-exec cmd-executor POD session alive during snapshot process

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -122,6 +122,7 @@ type ApplicationBackupController struct {
 	recorder             record.EventRecorder
 	resourceCollector    resourcecollector.ResourceCollector
 	backupAdminNamespace string
+	terminationChannels  map[string][]chan bool
 	reconcileTime        time.Duration
 }
 
@@ -138,6 +139,7 @@ func (a *ApplicationBackupController) Init(mgr manager.Manager, backupAdminNames
 		return err
 	}
 	a.reconcileTime = time.Duration(syncTime) * time.Second
+	a.terminationChannels = make(map[string][]chan bool)
 	return controllers.RegisterTo(mgr, "application-backup-controller", a, &stork_api.ApplicationBackup{})
 }
 
@@ -308,7 +310,6 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		return nil
 	}
 
-	var terminationChannels []chan bool
 	var err error
 
 	if a.setDefaults(backup) {
@@ -391,7 +392,7 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		fallthrough
 	case stork_api.ApplicationBackupStagePreExecRule:
 		var inProgress bool
-		terminationChannels, inProgress, err = a.runPreExecRule(backup)
+		a.terminationChannels[string(backup.UID)], inProgress, err = a.runPreExecRule(backup)
 		if err != nil {
 			message := fmt.Sprintf("Error running PreExecRule: %v", err)
 			log.ApplicationBackupLog(backup).Errorf(message)
@@ -419,7 +420,7 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		}
 		fallthrough
 	case stork_api.ApplicationBackupStageVolumes:
-		err := a.backupVolumes(backup, terminationChannels)
+		err := a.backupVolumes(backup, a.terminationChannels[string(backup.UID)])
 		if err != nil {
 			message := fmt.Sprintf("Error backing up volumes: %v", err)
 			log.ApplicationBackupLog(backup).Errorf(message)
@@ -537,11 +538,6 @@ func (a *ApplicationBackupController) updateBackupCRInVolumeStage(
 }
 
 func (a *ApplicationBackupController) backupVolumes(backup *stork_api.ApplicationBackup, terminationChannels []chan bool) error {
-	defer func() {
-		for _, channel := range terminationChannels {
-			channel <- true
-		}
-	}()
 	var err error
 	// Start backup of the volumes if we don't have any status stored
 	pvcMappings := make(map[string][]v1.PersistentVolumeClaim)
@@ -705,37 +701,81 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 					if err != nil {
 						return err
 					}
+					// In case Portworx if the snapshot ID is populated for every volume then the snapshot
+					// process is considered to be completed successfully.
+					// This ensures we don't execute the post-exec before all volume's snapshot is completed
+					if driverName == volume.PortworxDriverName {
+						startTime := time.Now()
+						for {
+							// In case below logic genuinely takes long time for many volumes
+							// the CR timestamp need to be updated. This prevents backup timeout error.
+							elapsedTime := time.Since(startTime)
+							if elapsedTime > utils.TimeoutUpdateBackupCrTimestamp {
+								backup, err = a.updateBackupCRInVolumeStage(
+									namespacedName,
+									stork_api.ApplicationBackupStatusInProgress,
+									backup.Status.Stage,
+									"Volume backups are in progress",
+									volumeInfos,
+								)
+								if err != nil {
+									return err
+								}
+								startTime = time.Now()
+							}
+							// Get fresh stock of the status for all volumes.
+							snapshotNotCompleted := false
+							volumeInfos, err = driver.GetBackupStatus(backup)
+							if err != nil {
+								log.ApplicationBackupLog(backup).Errorf("error getting backup status for driver %v: %v", driverName, err)
+								return fmt.Errorf("error getting backup status for driver %v: %v", driverName, err)
+							}
+							for _, volInfo := range volumeInfos {
+								if volInfo.BackupID == "" {
+									log.ApplicationBackupLog(backup).Tracef("Snapshot of volume %v is not done yet, need to loop till snapshot is done...", volInfo.PersistentVolumeClaim)
+									snapshotNotCompleted = true
+								}
+							}
+							if !snapshotNotCompleted {
+								break
+							}
+						}
+					}
 				}
 			}
-			// Terminate any background rules that were started
-			for _, channel := range terminationChannels {
-				channel <- true
-			}
-			terminationChannels = nil
 
 			// Run any post exec rules once backup is triggered
 			driverCombo := a.checkVolumeDriverCombination(backup.Status.Volumes)
 			// If the driver combination of volumes are all non-kdmp, call the post exec rule immediately
-			if driverCombo == nonKdmpDriverOnly && backup.Spec.PostExecRule != "" {
-				err = a.runPostExecRule(backup)
-				if err != nil {
-					message := fmt.Sprintf("Error running PostExecRule: %v", err)
-					log.ApplicationBackupLog(backup).Errorf(message)
-					a.recorder.Event(backup,
-						v1.EventTypeWarning,
-						string(stork_api.ApplicationBackupStatusFailed),
-						message)
-
-					backup.Status.Stage = stork_api.ApplicationBackupStageFinal
-					backup.Status.FinishTimestamp = metav1.Now()
-					backup.Status.LastUpdateTimestamp = metav1.Now()
-					backup.Status.Status = stork_api.ApplicationBackupStatusFailed
-					backup.Status.Reason = message
-					err = a.client.Update(context.TODO(), backup)
+			if driverCombo == nonKdmpDriverOnly {
+				// Let's kill the pre-exec rule pod here so that application specific
+				// data  stream freezing logic works. Certain app actually unleash the WRITE when session ends.
+				// For detail refer pb-3823
+				for _, channel := range terminationChannels {
+					logrus.Infof("Sending termination commands to kill pre-exec pod in non-kdmp driver path")
+					channel <- true
+				}
+				if backup.Spec.PostExecRule != "" {
+					err = a.runPostExecRule(backup)
 					if err != nil {
-						return err
+						message := fmt.Sprintf("Error running PostExecRule: %v", err)
+						log.ApplicationBackupLog(backup).Errorf(message)
+						a.recorder.Event(backup,
+							v1.EventTypeWarning,
+							string(stork_api.ApplicationBackupStatusFailed),
+							message)
+
+						backup.Status.Stage = stork_api.ApplicationBackupStageFinal
+						backup.Status.FinishTimestamp = metav1.Now()
+						backup.Status.LastUpdateTimestamp = metav1.Now()
+						backup.Status.Status = stork_api.ApplicationBackupStatusFailed
+						backup.Status.Reason = message
+						err = a.client.Update(context.TODO(), backup)
+						if err != nil {
+							return err
+						}
+						return fmt.Errorf("%v", message)
 					}
-					return fmt.Errorf("%v", message)
 				}
 			}
 		}
@@ -825,26 +865,38 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 	driverCombo := a.checkVolumeDriverCombination(backup.Status.Volumes)
 	// If the driver combination of volumes onlykdmp or mixed of both kdmp and non-kdmp, call post exec rule
 	// backup of volume is success.
-	if (driverCombo == kdmpDriverOnly || driverCombo == mixedDriver) && backup.Spec.PostExecRule != "" {
-		err = a.runPostExecRule(backup)
-		if err != nil {
-			message := fmt.Sprintf("Error running PostExecRule: %v", err)
-			log.ApplicationBackupLog(backup).Errorf(message)
-			a.recorder.Event(backup,
-				v1.EventTypeWarning,
-				string(stork_api.ApplicationBackupStatusFailed),
-				message)
-
-			backup.Status.Stage = stork_api.ApplicationBackupStageFinal
-			backup.Status.FinishTimestamp = metav1.Now()
-			backup.Status.LastUpdateTimestamp = metav1.Now()
-			backup.Status.Status = stork_api.ApplicationBackupStatusFailed
-			backup.Status.Reason = message
-			err = a.client.Update(context.TODO(), backup)
+	if driverCombo == kdmpDriverOnly || driverCombo == mixedDriver {
+		// Let's kill the pre-exec rule pod here so that application specific
+		// data  stream freezing logic works. Certain app actually unleash the WRITE when session ends.
+		// At this point we are dead sure that volume snapshot for all PVCs in the APP is done.. if not then
+		// there is issue...
+		// For detail refer pb-3823
+		for _, channel := range terminationChannels {
+			logrus.Infof("Sending termination commands to kill pre-exec pod in kdmp or mixed driver path")
+			channel <- true
+		}
+		//terminationChannels = nil
+		if backup.Spec.PostExecRule != "" {
+			err = a.runPostExecRule(backup)
 			if err != nil {
-				return err
+				message := fmt.Sprintf("Error running PostExecRule: %v", err)
+				log.ApplicationBackupLog(backup).Errorf(message)
+				a.recorder.Event(backup,
+					v1.EventTypeWarning,
+					string(stork_api.ApplicationBackupStatusFailed),
+					message)
+
+				backup.Status.Stage = stork_api.ApplicationBackupStageFinal
+				backup.Status.FinishTimestamp = metav1.Now()
+				backup.Status.LastUpdateTimestamp = metav1.Now()
+				backup.Status.Status = stork_api.ApplicationBackupStatusFailed
+				backup.Status.Reason = message
+				err = a.client.Update(context.TODO(), backup)
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("%v", message)
 			}
-			return fmt.Errorf("%v", message)
 		}
 	}
 	// If the backup hasn't failed move on to the next stage.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -39,6 +39,8 @@ const (
 	UpdateRestoreCrTimestampInApplyResourcePath = 19
 	// duration in which the restore CR to be updated with timestamp
 	TimeoutUpdateRestoreCrTimestamp = 15 * time.Minute
+	// duration in which the backup CR to be updated with timestamp
+	TimeoutUpdateBackupCrTimestamp = 15 * time.Minute
 	// duration in which the restore CR to be updated for resource Count progress
 	TimeoutUpdateRestoreCrProgress = 5 * time.Minute
 	// sleep interval for restore time stamp update go-routine to check channel for any data


### PR DESCRIPTION
- Certain APPs like MYSQL unlocks the tables if the session in which the DB is locked, is ended.
- We have deferred the killing of pre-exec POD till all the volume snapshot is taken thereby ensuring DB is not in inconsistent state during snapshot process


**What type of PR is this?** BUG
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: Because pre-exec pod which waits for volume backup  to get over gets killed untimely it leads to data inconsistsency.  Though it has executed the necessary commands to lock & stop the IO but POD eviction unlocks the mysql App DB which triggers the inconsistency. Hence fixed the untimely killing of pre-exec pod. 


**Does this PR change a user-facing CRD or CLI?**: NO
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:  
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: mysql app can show inconsistent data after being restored. 
User Impact: All mysql backup may fail to run mysql application after restore operation due to data inconsistency
Resolution: Fixed the data inconsistency by holding the table lock for a required interval while backup is in progress.

```

**Does this change need to be cherry-picked to a release branch?**: 23.6
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

