### PR TITLE
PWX-30577: Changes for getting px-auth-token for getting clusterpair token call.

### DIFF
--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -12,13 +12,11 @@ import (
 	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
-	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -166,13 +164,6 @@ func (c *ClusterPairController) handle(ctx context.Context, clusterPair *stork_a
 				err.Error())
 			return c.client.Update(context.TODO(), clusterPair)
 		}
-		if err := c.createBackupLocationOnRemote(remoteConfig, clusterPair); err != nil {
-			c.recorder.Event(clusterPair,
-				v1.EventTypeWarning,
-				string(clusterPair.Status.SchedulerStatus),
-				err.Error())
-			return c.client.Update(context.TODO(), clusterPair)
-		}
 		clusterPair.Status.SchedulerStatus = stork_api.ClusterPairStatusReady
 		c.recorder.Event(clusterPair,
 			v1.EventTypeNormal,
@@ -266,46 +257,4 @@ func (c *ClusterPairController) createCRD() error {
 		return err
 	}
 	return apiextensions.Instance().ValidateCRDV1beta1(resource, validateCRDTimeout, validateCRDInterval)
-}
-
-func (c *ClusterPairController) createBackupLocationOnRemote(remoteConfig *restclient.Config, clusterPair *stork_api.ClusterPair) error {
-	if bkpl, ok := clusterPair.Spec.Options[stork_api.BackupLocationResourceName]; ok {
-		remoteClient, err := storkops.NewForConfig(remoteConfig)
-		if err != nil {
-			return err
-		}
-		client, err := kubernetes.NewForConfig(remoteConfig)
-		if err != nil {
-			return err
-		}
-		ns, err := core.Instance().GetNamespace(clusterPair.Namespace)
-		if err != nil {
-			return err
-		}
-		// Don't create if the namespace already exists on the remote cluster
-		_, err = client.CoreV1().Namespaces().Get(context.TODO(), clusterPair.Namespace, metav1.GetOptions{})
-		if err != nil {
-			// create namespace on destination cluster
-			_, err = client.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        ns.Name,
-					Labels:      ns.Labels,
-					Annotations: ns.Annotations,
-				},
-			}, metav1.CreateOptions{})
-			if err != nil && !errors.IsAlreadyExists(err) {
-				return err
-			}
-		}
-		// create backuplocation on destination cluster
-		resp, err := storkops.Instance().GetBackupLocation(bkpl, clusterPair.GetNamespace())
-		if err != nil {
-			return err
-		}
-		resp.ResourceVersion = ""
-		if _, err := remoteClient.CreateBackupLocation(resp); err != nil && !errors.IsAlreadyExists(err) {
-			return err
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
1. Getting px-auth-token for auth enabled clusters.
2. Removing backuplocations creation in destination as this will be done as part of bidirectional clusterpair with storkctl.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.6.1
-->

**Test**
Test results have been updated in the ticket.
