### PR TITLE
pb-3966: Updating the restore PVC size only when the volumesnapshot size is greater than PVC size

### DIFF
--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -583,15 +583,18 @@ func (c *csiDriver) RestoreVolumeClaim(opts ...Option) (*v1.PersistentVolumeClai
 			// Exhausted all retries, return error
 			return nil, fmt.Errorf("%v", errMsg)
 		}
-
 		// Make the pvc size  same as the restore size from the volumesnapshot
 		if snapshot.Status != nil && snapshot.Status.RestoreSize != nil && !snapshot.Status.RestoreSize.IsZero() {
-			quantity, err := resource.ParseQuantity(snapshot.Status.RestoreSize.String())
-			if err != nil {
-				return nil, err
+			// Update the pvc size only when the volumesnapshot size is greater than PVC size
+			if snapshot.Status.RestoreSize.Cmp(pvc.Spec.Resources.Requests[v1.ResourceStorage]) == 1 {
+				quantity, err := resource.ParseQuantity(snapshot.Status.RestoreSize.String())
+				if err != nil {
+					return nil, err
+				}
+				logrus.Debugf("setting size of pvc %s/%s same as snapshot size %s", pvc.Namespace, pvc.Name, quantity.String())
+				pvc.Spec.Resources.Requests[v1.ResourceStorage] = quantity
 			}
-			logrus.Debugf("setting size of pvc %s/%s same as snapshot size %s", pvc.Namespace, pvc.Name, quantity.String())
-			pvc.Spec.Resources.Requests[v1.ResourceStorage] = quantity
+
 		}
 	} else {
 		snapshot, err := c.snapshotClient.SnapshotV1beta1().VolumeSnapshots(o.RestoreNamespace).Get(context.TODO(), o.RestoreSnapshotName, metav1.GetOptions{})
@@ -617,15 +620,18 @@ func (c *csiDriver) RestoreVolumeClaim(opts ...Option) (*v1.PersistentVolumeClai
 			// Exhausted all retries, return error
 			return nil, fmt.Errorf("%v", errMsg)
 		}
-
 		// Make the pvc size  same as the restore size from the volumesnapshot
 		if snapshot.Status != nil && snapshot.Status.RestoreSize != nil && !snapshot.Status.RestoreSize.IsZero() {
-			quantity, err := resource.ParseQuantity(snapshot.Status.RestoreSize.String())
-			if err != nil {
-				return nil, err
+			// Update the pvc size only when the volumesnapshot size is greater than PVC size
+			if snapshot.Status.RestoreSize.Cmp(pvc.Spec.Resources.Requests[v1.ResourceStorage]) == 1 {
+				quantity, err := resource.ParseQuantity(snapshot.Status.RestoreSize.String())
+				if err != nil {
+					return nil, err
+				}
+				logrus.Debugf("setting size of pvc %s/%s same as snapshot size %s", pvc.Namespace, pvc.Name, quantity.String())
+				pvc.Spec.Resources.Requests[v1.ResourceStorage] = quantity
 			}
-			logrus.Debugf("setting size of pvc %s/%s same as snapshot size %s", pvc.Namespace, pvc.Name, quantity.String())
-			pvc.Spec.Resources.Requests[v1.ResourceStorage] = quantity
+
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
pb-3966: Updating the restore PVC size only when the volumesnapshot size is greater than PVC size
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```release-note
Issue: CSI restore fails for some of the storage provider, when the volumesnapshot size is less the PVC size
User Impact: User will not able to do CSI restore with some storage provider.
Resolution: Fixed such the restore PVC size will be always equal to source volume size or greater then source volume size, if the volumesnapshot size is greater then the source volume size

```

**Does this change need to be cherry-picked to a release branch?**:
23.6 branch.

Tested:
1) Tested kdmp+localsnapshot backup and restore on QA IBM setup.

