### PR TITLE
PWX-31401: Create the parent directory before dumping heap and memory…

### DIFF
--- a/pkg/dbg/dbg.go
+++ b/pkg/dbg/dbg.go
@@ -26,12 +26,19 @@ func Init(name string, dir string) {
 }
 
 func installSignalHandlers(name string, dir string) {
+	// Create the directory where heap and profile will be collected.
+	if err := os.MkdirAll(dir, os.ModeDir); err != nil {
+		logrus.Warnf("Failed to create dump directory %v: %v", dir, err)
+	}
+
 	dumpChannel := make(chan os.Signal, 1)
 	cpuProfChannel := make(chan os.Signal, 1)
 	signal.Notify(dumpChannel, syscall.SIGUSR1)
+
 	go func() {
 		for {
 			<-dumpChannel
+
 			dumpGoMemoryTrace()
 			dumpHeap(generateFilename(name, dir, ".heap"))
 			dumpGoProfile(generateFilename(name, dir, ".stack"))


### PR DESCRIPTION
… profiles


**What type of PR is this?**
>bug


**What this PR does / why we need it**:
Stork failed to generate heap and cpu profiles since the directory under which it tried to create them was not present. 

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
Issue: Stork diags (stack, heap & cpu profile) generation failed.
User Impact: Users were unable to generate stork diagnostics.
Resolution: The directory under which stork dumps its diagnostics is now created before diags are generated.

```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 23.7

