### PR TITLE
PWX-31999: Deleting backuplocation and secret reference as part of clusterpair deletion.

### DIFF
--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
+	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -27,8 +28,9 @@ import (
 )
 
 const (
-	validateCRDInterval time.Duration = 5 * time.Second
-	validateCRDTimeout  time.Duration = 1 * time.Minute
+	validateCRDInterval    time.Duration = 5 * time.Second
+	validateCRDTimeout     time.Duration = 1 * time.Minute
+	storkCreatedAnnotation               = "stork.libopenstorage.org/created-by-stork"
 )
 
 // NewClusterPair creates a new instance of ClusterPairController.
@@ -228,6 +230,33 @@ func (c *ClusterPairController) cleanup(clusterPair *stork_api.ClusterPair) erro
 	}
 	if !skipDelete && clusterPair.Status.RemoteStorageID != "" {
 		return c.volDriver.DeletePair(clusterPair)
+	}
+
+	// Delete the backuplocation and secret associated with clusterpair as part of the delete
+	if backuplocationName, ok := clusterPair.Spec.Options["backuplocation"]; ok {
+		bl, err := storkops.Instance().GetBackupLocation(backuplocationName, clusterPair.Namespace)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				logrus.Errorf("fetching backuplocation %s in ns %s failed: %v", backuplocationName, clusterPair.Namespace, err)
+			}
+			return nil
+		}
+		if bl.Annotations[storkCreatedAnnotation] == "true" {
+			secret, err := core.Instance().GetSecret(bl.Location.SecretConfig, bl.Namespace)
+			if err != nil && errors.IsNotFound(err) {
+				logrus.Errorf("fetching secret %s in ns %s failed: %v", bl.Location.SecretConfig, bl.Namespace, err)
+			}
+			if err == nil && secret.Annotations[storkCreatedAnnotation] == "true" {
+				err := core.Instance().DeleteSecret(bl.Location.SecretConfig, bl.Namespace)
+				if err != nil && !errors.IsNotFound(err) {
+					logrus.Errorf("deleting secret %s in ns %s failed: %v", bl.Location.SecretConfig, bl.Namespace, err)
+				}
+			}
+			err = storkops.Instance().DeleteBackupLocation(bl.Name, bl.Namespace)
+			if err != nil && !errors.IsNotFound(err) {
+				logrus.Errorf("deleting backuplocation %s in ns %s failed: %v", backuplocationName, bl.Namespace, err)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -33,6 +33,7 @@ const (
 	gcloudPath             = "./google-cloud-sdk/bin/gcloud"
 	gcloudBinaryName       = "gcloud"
 	skipResourceAnnotation = "stork.libopenstorage.org/skip-resource"
+	storkCreatedAnnotation = "stork.libopenstorage.org/created-by-stork"
 	pxAdminTokenSecret     = "px-admin-token"
 	secretNamespace        = "openstorage.io/auth-secret-namespace"
 	secretName             = "openstorage.io/auth-secret-name"
@@ -346,6 +347,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 					Namespace: cmdFactory.GetNamespace(),
 					Annotations: map[string]string{
 						skipResourceAnnotation: "true",
+						storkCreatedAnnotation: "true",
 					},
 				},
 				Location: storkv1.BackupLocationItem{},
@@ -481,6 +483,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 					Namespace: cmdFactory.GetNamespace(),
 					Annotations: map[string]string{
 						skipResourceAnnotation: "true",
+						storkCreatedAnnotation: "true",
 					},
 				},
 				Data: credentialData,


### PR DESCRIPTION
Signed-Off-By: Diptiranjan


**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Deletes backuplocation and secret those are created as part of clusterpair creation.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.7.0
-->

**Test**
```
➜  stork git:(PWX-31999) ✗ bin/linux/storkctl create clusterpair cp-s3-del-bl -p s3 -n kube-system --src-kube-file /tmp/dipti5.config --dest-kube-file /tmp/dipti7.config --s3-access-key ***** --s3-secret-key ****** --s3-endpoint ******  --s3-region us-east-1
Source portworx endpoint is 10.13.192.154:9001
Destination portworx endpoint is 10.13.194.128:9001

Creating Secret and Backuplocation in source cluster in namespace kube-system...
Backuplocation cp-s3-del-bl created on source cluster in namespace kube-system

Creating a cluster pair. Direction: Source -> Destination
ClusterPair cp-s3-del-bl created successfully. Direction Source -> Destination

Creating Secret and Backuplocation in destination cluster in namespace kube-system...
Backuplocation cp-s3-del-bl created on destination cluster in namespace kube-system

Creating a cluster pair. Direction: Destination -> Source
Cluster pair cp-s3-del-bl created successfully. Direction: Destination -> Source

source:

➜  stork git:(PWX-31999) ✗ ks get backuplocation cp-s3-del-bl -o yaml
apiVersion: stork.libopenstorage.org/v1alpha1
cluster:
  encryptionKey: ""
  secretConfig: ""
  sync: false
  type: ""
kind: BackupLocation
location:
  encryptionKey: ""
  encryptionV2Key: ""
  path: ""
  repositoryPassword: ""
  secretConfig: cp-s3-del-bl
  sync: false
  type: s3
metadata:
  annotations:
    stork.libopenstorage.org/created-by-stork: "true"
    stork.libopenstorage.org/skip-resource: "true"
  creationTimestamp: "2023-06-28T11:06:21Z"
  generation: 1
  name: cp-s3-del-bl
  namespace: kube-system
  resourceVersion: "46589005"
  uid: f7fb25f1-4814-4ebb-8e97-407f6c450332
➜  stork git:(PWX-31999) ✗ ks get secret cp-s3-del-bl -o yaml
apiVersion: v1
data:
  accessKeyID: YWRtaW4=
  disableSSL: ZmFsc2U=
  encryptionKey: ""
  endpoint: bWluaW8ucHd4LmRldi5wdXJlc3RvcmFnZS5jb20=
  path: ""
  region: dXMtZWFzdC0x
  secretAccessKey: UGFzc3dvcmQx
  type: czM=
kind: Secret
metadata:
  annotations:
    stork.libopenstorage.org/created-by-stork: "true"
    stork.libopenstorage.org/skip-resource: "true"
  creationTimestamp: "2023-06-28T11:06:21Z"
  name: cp-s3-del-bl
  namespace: kube-system
  resourceVersion: "46589004"
  uid: 7aee3e2b-00e5-4a11-86bf-06281ca776ce
type: Opaque

Dest:
➜  ~ ks get backuplocation cp-s3-del-bl -o yaml
apiVersion: stork.libopenstorage.org/v1alpha1
cluster:
  encryptionKey: ""
  secretConfig: ""
  sync: false
  type: ""
kind: BackupLocation
location:
  encryptionKey: ""
  encryptionV2Key: ""
  path: ""
  repositoryPassword: ""
  secretConfig: cp-s3-del-bl
  sync: false
  type: s3
metadata:
  annotations:
    stork.libopenstorage.org/created-by-stork: "true"
    stork.libopenstorage.org/skip-resource: "true"
  creationTimestamp: "2023-06-28T11:06:21Z"
  generation: 1
  name: cp-s3-del-bl
  namespace: kube-system
  resourceVersion: "17684643"
  uid: 316b45c7-9a7b-42cb-8cd2-f5bf2e5b801d
➜  ~ ks get secret cp-s3-del-bl
NAME           TYPE     DATA   AGE
cp-s3-del-bl   Opaque   8      88s
➜  ~ ks get secret cp-s3-del-bl -o yaml
apiVersion: v1
data:
  accessKeyID: YWRtaW4=
  disableSSL: ZmFsc2U=
  encryptionKey: ""
  endpoint: bWluaW8ucHd4LmRldi5wdXJlc3RvcmFnZS5jb20=
  path: ""
  region: dXMtZWFzdC0x
  secretAccessKey: UGFzc3dvcmQx
  type: czM=
kind: Secret
metadata:
  annotations:
    stork.libopenstorage.org/created-by-stork: "true"
    stork.libopenstorage.org/skip-resource: "true"
  creationTimestamp: "2023-06-28T11:06:21Z"
  name: cp-s3-del-bl
  namespace: kube-system
  resourceVersion: "17684642"
  uid: 355b294a-57aa-4665-a7fb-5d9e125ae2ad
type: Opaque


Deleting cp on source:
=================

➜  stork git:(PWX-31999) ✗ ks delete clusterpair cp-s3-del-bl
clusterpair.stork.libopenstorage.org "cp-s3-del-bl" deleted

➜  stork git:(PWX-31999) ✗ ks get backuplocation cp-s3-del-bl -o yaml
Error from server (NotFound): backuplocations.stork.libopenstorage.org "cp-s3-del-bl" not found
➜  stork git:(PWX-31999) ✗
➜  stork git:(PWX-31999) ✗ ks get backuplocation secret -o yaml
Error from server (NotFound): backuplocations.stork.libopenstorage.org "secret" not found


Deleting cp on destination:
====================
➜  ~ storkctl get clusterpair  -n kube-system
NAME                 STORAGE-STATUS   SCHEDULER-STATUS   CREATED
cp-s3-del-bl         Ready            Ready              28 Jun 23 11:06 UTC
➜  ~ ks get backuplocation cp-s3-del-bl
NAME           AGE
cp-s3-del-bl   93m
➜  ~ ks get secret cp-s3-del-bl
NAME           TYPE     DATA   AGE
cp-s3-del-bl   Opaque   8      93m
➜  ~ ks delete clusterpair cp-s3-del-bl
clusterpair.stork.libopenstorage.org "cp-s3-del-bl" deleted
➜  ~ ks get backuplocation cp-s3-del-bl
Error from server (NotFound): backuplocations.stork.libopenstorage.org "cp-s3-del-bl" not found
➜  ~ ks get secret cp-s3-del-bl
Error from server (NotFound): secrets "cp-s3-del-bl" not found

```
