### PR TITLE
PWX-24657: Bidirectional clusterpair improvements

### DIFF
--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -12,13 +12,11 @@ import (
 	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
-	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -166,13 +164,6 @@ func (c *ClusterPairController) handle(ctx context.Context, clusterPair *stork_a
 				err.Error())
 			return c.client.Update(context.TODO(), clusterPair)
 		}
-		if err := c.createBackupLocationOnRemote(remoteConfig, clusterPair); err != nil {
-			c.recorder.Event(clusterPair,
-				v1.EventTypeWarning,
-				string(clusterPair.Status.SchedulerStatus),
-				err.Error())
-			return c.client.Update(context.TODO(), clusterPair)
-		}
 		clusterPair.Status.SchedulerStatus = stork_api.ClusterPairStatusReady
 		c.recorder.Event(clusterPair,
 			v1.EventTypeNormal,
@@ -266,46 +257,4 @@ func (c *ClusterPairController) createCRD() error {
 		return err
 	}
 	return apiextensions.Instance().ValidateCRDV1beta1(resource, validateCRDTimeout, validateCRDInterval)
-}
-
-func (c *ClusterPairController) createBackupLocationOnRemote(remoteConfig *restclient.Config, clusterPair *stork_api.ClusterPair) error {
-	if bkpl, ok := clusterPair.Spec.Options[stork_api.BackupLocationResourceName]; ok {
-		remoteClient, err := storkops.NewForConfig(remoteConfig)
-		if err != nil {
-			return err
-		}
-		client, err := kubernetes.NewForConfig(remoteConfig)
-		if err != nil {
-			return err
-		}
-		ns, err := core.Instance().GetNamespace(clusterPair.Namespace)
-		if err != nil {
-			return err
-		}
-		// Don't create if the namespace already exists on the remote cluster
-		_, err = client.CoreV1().Namespaces().Get(context.TODO(), clusterPair.Namespace, metav1.GetOptions{})
-		if err != nil {
-			// create namespace on destination cluster
-			_, err = client.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        ns.Name,
-					Labels:      ns.Labels,
-					Annotations: ns.Annotations,
-				},
-			}, metav1.CreateOptions{})
-			if err != nil && !errors.IsAlreadyExists(err) {
-				return err
-			}
-		}
-		// create backuplocation on destination cluster
-		resp, err := storkops.Instance().GetBackupLocation(bkpl, clusterPair.GetNamespace())
-		if err != nil {
-			return err
-		}
-		resp.ResourceVersion = ""
-		if _, err := remoteClient.CreateBackupLocation(resp); err != nil && !errors.IsAlreadyExists(err) {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/apiextensions"
+	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -27,8 +28,9 @@ import (
 )
 
 const (
-	validateCRDInterval time.Duration = 5 * time.Second
-	validateCRDTimeout  time.Duration = 1 * time.Minute
+	validateCRDInterval    time.Duration = 5 * time.Second
+	validateCRDTimeout     time.Duration = 1 * time.Minute
+	storkCreatedAnnotation               = "stork.libopenstorage.org/created-by-stork"
 )
 
 // NewClusterPair creates a new instance of ClusterPairController.
@@ -228,6 +230,33 @@ func (c *ClusterPairController) cleanup(clusterPair *stork_api.ClusterPair) erro
 	}
 	if !skipDelete && clusterPair.Status.RemoteStorageID != "" {
 		return c.volDriver.DeletePair(clusterPair)
+	}
+
+	// Delete the backuplocation and secret associated with clusterpair as part of the delete
+	if backuplocationName, ok := clusterPair.Spec.Options["backuplocation"]; ok {
+		bl, err := storkops.Instance().GetBackupLocation(backuplocationName, clusterPair.Namespace)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				logrus.Errorf("fetching backuplocation %s in ns %s failed: %v", backuplocationName, clusterPair.Namespace, err)
+			}
+			return nil
+		}
+		if bl.Annotations[storkCreatedAnnotation] == "true" {
+			secret, err := core.Instance().GetSecret(bl.Location.SecretConfig, bl.Namespace)
+			if err != nil && errors.IsNotFound(err) {
+				logrus.Errorf("fetching secret %s in ns %s failed: %v", bl.Location.SecretConfig, bl.Namespace, err)
+			}
+			if err == nil && secret.Annotations[storkCreatedAnnotation] == "true" {
+				err := core.Instance().DeleteSecret(bl.Location.SecretConfig, bl.Namespace)
+				if err != nil && !errors.IsNotFound(err) {
+					logrus.Errorf("deleting secret %s in ns %s failed: %v", bl.Location.SecretConfig, bl.Namespace, err)
+				}
+			}
+			err = storkops.Instance().DeleteBackupLocation(bl.Name, bl.Namespace)
+			if err != nil && !errors.IsNotFound(err) {
+				logrus.Errorf("deleting backuplocation %s in ns %s failed: %v", backuplocationName, bl.Namespace, err)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -33,6 +33,7 @@ const (
 	gcloudPath             = "./google-cloud-sdk/bin/gcloud"
 	gcloudBinaryName       = "gcloud"
 	skipResourceAnnotation = "stork.libopenstorage.org/skip-resource"
+	storkCreatedAnnotation = "stork.libopenstorage.org/created-by-stork"
 	pxAdminTokenSecret     = "px-admin-token"
 	secretNamespace        = "openstorage.io/auth-secret-namespace"
 	secretName             = "openstorage.io/auth-secret-name"
@@ -346,6 +347,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 					Namespace: cmdFactory.GetNamespace(),
 					Annotations: map[string]string{
 						skipResourceAnnotation: "true",
+						storkCreatedAnnotation: "true",
 					},
 				},
 				Location: storkv1.BackupLocationItem{},
@@ -481,6 +483,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 					Namespace: cmdFactory.GetNamespace(),
 					Annotations: map[string]string{
 						skipResourceAnnotation: "true",
+						storkCreatedAnnotation: "true",
 					},
 				},
 				Data: credentialData,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -237,4 +238,19 @@ func GetUIDLastSection(uid types.UID) string {
 		uidLastSection = string(uid)
 	}
 	return uidLastSection
+}
+
+func CompareFiles(filePath1 string, filePath2 string) (bool, error) {
+	content1, err := os.ReadFile(filePath1)
+	if err != nil {
+		return false, err
+	}
+
+	content2, err := os.ReadFile(filePath2)
+	if err != nil {
+		return false, err
+	}
+
+	// Compare the byte content of the files
+	return string(content1) == string(content2), nil
 }


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Bidirectional cluster pair improvements.

**Does this PR change a user-facing CRD or CLI?**:
<!--
yes

bin/linux/storkctl create clusterpair cp-nonauth2 -p s3 -n kube-system --s3-access-key ***** --s3-secret-key ****** --s3-region us-east-1 --s3-endpoint abc.com --src-kube-file /tmp/dipti5.config --dest-kube-file /tmp/dipti7.config

Source portworx endpoint is 10.13.192.154:9001
Destination portworx endpoint is 10.13.194.128:9001

Creating Secret and Backuplocation in source cluster in namespace kube-system...
Backuplocation cp-nonauth2 created on source cluster in namespace kube-system

Creating a cluster pair. Direction: Source -> Destination
ClusterPair cp-nonauth2 created successfully. Direction Source -> Destination

Creating Secret and Backuplocation in destination cluster in namespace kube-system...
Backuplocation cp-nonauth2 created on destination cluster in namespace kube-system

Creating a cluster pair. Direction: Destination -> Source
Cluster pair cp-nonauth2 created successfully. Direction: Destination -> Source

-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Bidirectional clusterpair improvements with auto detecting px endpoints and px token.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.7.0
-->

