### PR TITLE
PWX-31470: Clusterwide operator CR migration support.

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationregistration.go
+++ b/pkg/apis/stork/v1alpha1/applicationregistration.go
@@ -37,6 +37,10 @@ type ApplicationResource struct {
 	// in addition to parent server
 	// NestedSuspendOptions allow way to suspend such CR server
 	NestedSuspendOptions []SuspendOptions `json:"customSuspendOptions"`
+	// Clusterwide Operators will control the CRs in all namespaces
+	// StashStrategy option if enabled will make sure as part of migration the CR does not get applied
+	// if StashCR is enabled. The CR will be applied as part of app activation
+	StashStrategy StashStrategy `json:"stashStrategy"`
 }
 
 // SuspendOptions to disable CRD upon migration/restore/clone
@@ -44,6 +48,11 @@ type SuspendOptions struct {
 	Path  string `json:"path"`
 	Type  string `json:"type"`
 	Value string `json:"value"`
+}
+
+// StashStrategy to restrict applying CR during migration
+type StashStrategy struct {
+	StashCR bool `json:"stashCR"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -30,6 +30,7 @@ import (
 const (
 	validateCRDInterval    time.Duration = 5 * time.Second
 	validateCRDTimeout     time.Duration = 1 * time.Minute
+	skipResourceAnnotation               = "stork.libopenstorage.org/skip-resource"
 	storkCreatedAnnotation               = "stork.libopenstorage.org/created-by-stork"
 )
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -254,3 +254,11 @@ func CompareFiles(filePath1 string, filePath2 string) (bool, error) {
 	// Compare the byte content of the files
 	return string(content1) == string(content2), nil
 }
+
+func GetStashedConfigMapName(objKind string, group string, objName string) string {
+	cmName := fmt.Sprintf("%s-%s-%s", objKind, group, objName)
+	if len(cmName) > 253 {
+		cmName = cmName[:253]
+	}
+	return cmName
+}


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Stashing strategy for the CR content to a configmap so that after migration with `startApplication: False` the application automatically does not get started when it is managed by a clusterwide operator.

Avoid recreating the resources during migration if there is no change to the resource content.

**Does this PR change a user-facing CRD or CLI?**:
<!--
yes

CRD change for applicationregistration's resources
  stashStratergy:
    stashCR: true
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Applications controlled by CR automatically gets started after migration if the operator is already up and running in a different namespace.
User Impact: Apps in destination cluster gets started which is not as per expectation with startApplication: false
Resolution: Stashing strategy for the CR content to a configmap has been added so that only after activate migration the CR spec gets applied and app will start then only.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.7.0
-->

**Test**
Have been updated in PWX-31470 & PWX-32807.