### PR TITLE
PWX-32230: Supporting unidirectional clusterpair creation with storkctl create command.

### DIFF
--- a/pkg/storkctl/generate.go
+++ b/pkg/storkctl/generate.go
@@ -7,8 +7,9 @@ import (
 
 func newGenerateCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	generateCommands := &cobra.Command{
-		Use:   "generate",
-		Short: "Generate stork specs",
+		Use:        "generate",
+		Short:      "Generate stork specs",
+		Deprecated: "use command \"create\" instead.",
 	}
 
 	generateCommands.AddCommand(


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
improvement

**What this PR does / why we need it**:
With storkctl create option, we can create unidirectional cluster pair.

**Does this PR change a user-facing CRD or CLI?**:
<!--
yes
-->
```
git:(PWX-32230) ✗ bin/linux/storkctl create clusterpair uni-cp -p s3 -n kube-system --src-kube-file /tmp/dipti5.config --dest-kube-file /tmp/dipti7.config --s3-access-key ***** --s3-secret-key ****** --s3-endpoint ********* --s3-region us-east1 --uni-directional
Destination portworx endpoint is 10.10.100.100:9001
Fetching px token with auth token in destination cluster

Creating Secret and Backuplocation in source cluster in namespace kube-system...
Backuplocation uni-cp created on source cluster in namespace kube-system

Creating a cluster pair. Direction: Source -> Destination
ClusterPair uni-cp created successfully. Direction Source -> Destination

```

**Is a release note needed?**:
<!--
yes
-->

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.7.0
-->

**Test**
Test result has been updated in PWX-32230.
