### PR TITLE
skip namespace deletion during blowup, for negative cases

### DIFF
--- a/test/integration_test/clusterdomain_test.go
+++ b/test/integration_test/clusterdomain_test.go
@@ -70,12 +70,12 @@ func triggerClusterDomainUpdate(
 ) {
 	// run the command on the remote cluster as currently
 	// we do not stop/deactivate the remote cluster
-	err := setRemoteConfig(remoteFilePath)
-	require.NoError(t, err, "Error resetting remote config")
+	err := setDestinationKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
 
 	defer func() {
-		err = setRemoteConfig("")
-		require.NoError(t, err, "Error resetting remote config")
+		err := setSourceKubeConfig()
+		require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
 	}()
 
 	updateName := name + uuid.New()
@@ -182,8 +182,8 @@ func testClusterDomainsFailover(
 	require.NoError(t, err, "Unexpected error on scaling down application.")
 
 	// start the app on cluster 2
-	err = setRemoteConfig(remoteFilePath)
-	require.NoError(t, err, "Error setting remote config")
+	err = setDestinationKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
 
 	// Set scale factor to it's orignal values on cluster 1
 	err = schedulerDriver.ScaleApplication(preMigrationCtx, oldScaleFactor)
@@ -226,8 +226,8 @@ func testClusterDomainsFailback(
 	require.NoError(t, err, "validation of cluster domain status for %v failed", cdsName)
 
 	// start the app on cluster 1
-	err = setRemoteConfig("")
-	require.NoError(t, err, "Error resetting remote config")
+	err = setSourceKubeConfig()
+	require.NoError(t, err, "failed to set kubeconfig to source cluster: %v", err)
 
 	err = schedulerDriver.ScaleApplication(ctxs[0], oldScaleFactor)
 	require.NoError(t, err, "Unexpected error on ScaleApplication")

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -793,7 +793,8 @@ func scheduleBidirectionalClusterPair(cpName, cpNamespace, projectMappings strin
 	}
 
 	if projectMappings != "" {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--project-mappings %s", projectMappings))
+		cmdArgs = append(cmdArgs, "--project-mappings")
+		cmdArgs = append(cmdArgs, projectMappings)
 	}
 
 	// Get external object store details and append to the command accordingily

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -105,6 +105,7 @@ func triggerMigrationTest(
 	migrationSuccessExpected bool,
 	migrateAllAppsExpected bool,
 	startAppsOnMigration bool,
+	skipDestDeletion bool,
 ) {
 	var err error
 	// Reset config in case of error
@@ -115,7 +116,7 @@ func triggerMigrationTest(
 
 	ctxs, preMigrationCtx := triggerMigration(t, instanceID, appKey, additionalAppKeys, []string{migrationAppKey}, migrateAllAppsExpected, false, startAppsOnMigration, false, "", nil)
 
-	validateAndDestroyMigration(t, ctxs, instanceID, appKey, preMigrationCtx, migrationSuccessExpected, startAppsOnMigration, migrateAllAppsExpected, false, false, true)
+	validateAndDestroyMigration(t, ctxs, instanceID, appKey, preMigrationCtx, migrationSuccessExpected, startAppsOnMigration, migrateAllAppsExpected, false, skipDestDeletion, true)
 }
 
 func triggerMigration(
@@ -215,7 +216,7 @@ func validateAndDestroyMigration(
 	var err error
 	timeout := defaultWaitTimeout
 	if !migrationSuccessExpected {
-		timeout = timeout / 2
+		timeout = timeout / 5
 	}
 
 	allAppsCtx := ctxs[0].DeepCopy()
@@ -281,6 +282,7 @@ func deploymentMigrationTest(t *testing.T) {
 		true,
 		true,
 		true,
+		false,
 	)
 
 	// If we are here then the test has passed
@@ -377,6 +379,7 @@ func statefulsetMigrationTest(t *testing.T) {
 		true,
 		true,
 		true,
+		false,
 	)
 
 	// If we are here then the test has passed
@@ -399,6 +402,7 @@ func statefulsetMigrationStartAppFalseTest(t *testing.T) {
 		"cassandra-migration-startapps-false",
 		true,
 		true,
+		false,
 		false,
 	)
 
@@ -423,6 +427,7 @@ func statefulsetMigrationRuleTest(t *testing.T) {
 		true,
 		true,
 		true,
+		false,
 	)
 
 	// If we are here then the test has passed
@@ -446,6 +451,7 @@ func statefulsetMigrationRulePreExecMissingTest(t *testing.T) {
 		false,
 		true,
 		true,
+		true,
 	)
 
 	// If we are here then the test has passed
@@ -466,6 +472,7 @@ func statefulsetMigrationRulePostExecMissingTest(t *testing.T) {
 		nil,
 		"mysql-migration-post-exec-missing",
 		false,
+		true,
 		true,
 		true,
 	)
@@ -491,6 +498,7 @@ func migrationDisallowedNamespaceTest(t *testing.T) {
 		false,
 		true,
 		true,
+		true,
 	)
 
 	// If we are here then the test has passed
@@ -512,6 +520,7 @@ func migrationFailingPreExecRuleTest(t *testing.T) {
 		nil,
 		"mysql-migration-failing-pre-exec",
 		false,
+		true,
 		true,
 		true,
 	)
@@ -537,6 +546,7 @@ func migrationFailingPostExecRuleTest(t *testing.T) {
 		false,
 		true,
 		true,
+		true,
 	)
 
 	// If we are here then the test has passed
@@ -560,6 +570,7 @@ func migrationLabelSelectorTest(t *testing.T) {
 		true,
 		false,
 		true,
+		false,
 	)
 
 	// If we are here then the test has passed
@@ -583,6 +594,7 @@ func migrationLabelExcludeSelectorTest(t *testing.T) {
 		true,
 		false,
 		true,
+		false,
 	)
 
 	// If we are here then the test has passed
@@ -1378,6 +1390,7 @@ func operatorMigrationMongoTest(t *testing.T) {
 		true,
 		true,
 		true,
+		false,
 	)
 
 	// If we are here then the test has passed
@@ -1413,6 +1426,7 @@ func operatorMigrationRabbitmqTest(t *testing.T) {
 		true,
 		true,
 		true,
+		false,
 	)
 
 	// If we are here then the test has passed


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
* During namespace deletion that happens as part of blowup method, for negative case destination namespace does not exist so we need to skip that deletion of namespace on destination
* Fix projectID mappings in bidirectional cluster pairing in stork integration tests
* Fix cluster switching in cluster domain tests


**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no


**Does this change need to be cherry-picked to a release branch?**:
no

