### PR TITLE
PWX-30765: Updating golang, aws and gcloud sdk to fix vulnerabilities.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: go
 go:
-  - 1.19.1
+  - 1.19.10
 before_install:
   - sudo apt-get update -yq || true
   - sudo apt-get install go-md2man -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN microdnf clean all && microdnf install -y python3.9 ca-certificates tar gzip
 RUN python3 -m pip install awscli && python3 -m pip install oci-cli && python3 -m pip install rsa --upgrade
 
 
-RUN curl -q -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
+RUN curl -q -o /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_linux_amd64 && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
 #Install asdf
@@ -31,7 +31,7 @@ RUN asdf install kubelogin latest
 RUN asdf global kubelogin latest
 
 #Install Google Cloud SDK
-ARG GCLOUD_SDK=google-cloud-sdk-418.0.0-linux-x86_64.tar.gz
+ARG GCLOUD_SDK=google-cloud-cli-439.0.0-linux-x86_64.tar.gz
 ARG GCLOUD_INSTALL_DIR="/usr/lib"
 RUN curl -q -o $GCLOUD_SDK https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
     tar xf $GCLOUD_SDK -C $GCLOUD_INSTALL_DIR && rm -rf $GCLOUD_SDK && \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ STORK_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_IMAGE):$(DOCKER_HUB_STORK_TAG)
 CMD_EXECUTOR_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_CMD_EXECUTOR_IMAGE):$(DOCKER_HUB_CMD_EXECUTOR_TAG)
 STORK_TEST_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_TEST_IMAGE):$(DOCKER_HUB_STORK_TEST_TAG)
 
-DOCK_BUILD_CNT  := golang:1.19.1
+DOCK_BUILD_CNT  := golang:1.19.10
 
 ifndef PKGS
 PKGS := $(shell go list ./... 2>&1 | grep -v 'github.com/libopenstorage/stork/vendor' | grep -v 'pkg/client/informers/externalversions' | grep -v versioned | grep -v 'pkg/apis/stork' | grep -v 'hack')
@@ -39,7 +39,7 @@ BIN         :=$(BASE_DIR)/bin
 VERSION = $(RELEASE_VER)-$(GIT_SHA)
 
 LDFLAGS += "-s -w -X github.com/libopenstorage/stork/pkg/version.Version=$(VERSION)"
-BUILD_OPTIONS := -ldflags=$(LDFLAGS)
+BUILD_OPTIONS := -ldflags=$(LDFLAGS) -buildvcs=false
 
 .DEFAULT_GOAL=all
 .PHONY: test clean vendor vendor-update px-statfs

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ VERSION = $(RELEASE_VER)-$(GIT_SHA)
 LDFLAGS += "-s -w -X github.com/libopenstorage/stork/pkg/version.Version=$(VERSION)"
 BUILD_OPTIONS := -ldflags=$(LDFLAGS) -buildvcs=false
 
+SECCOMP_OPTIONS := --security-opt seccomp=unconfined
+
 .DEFAULT_GOAL=all
 .PHONY: test clean vendor vendor-update px-statfs
 
@@ -66,21 +68,21 @@ lint:
 	done
 
 vet:
-	  docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
+	  docker run --rm $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
 		      /bin/bash -c "cd /go/src/github.com/libopenstorage/stork; \
 	          go vet $(PKGS); \
 	          go vet -tags unittest $(PKGS); \
 	          go vet -tags integrationtest github.com/libopenstorage/stork/test/integration_test"
 
 staticcheck:
-	  docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork $(DOCK_BUILD_CNT) \
+	  docker run --rm  $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork $(DOCK_BUILD_CNT) \
 		      /bin/bash -c "cd /go/src/github.com/libopenstorage/stork; \
 			  go install honnef.co/go/tools/cmd/staticcheck@v0.3.3; \
 			  staticcheck $(PKGS); \
 			  staticcheck -tags integrationtest test/integration_test/*.go;staticcheck -tags unittest $(PKGS)"
 
 errcheck:
-	  docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
+	  docker run --rm  $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
 		      /bin/bash -c "cd /go/src/github.com/libopenstorage/stork; \
 	          GO111MODULE=off go get -u github.com/kisielk/errcheck; \
 	          errcheck -verbose -blank $(PKGS); \
@@ -88,7 +90,7 @@ errcheck:
 	          errcheck -verbose -blank -tags integrationtest /go/src/github.com/libopenstorage/stork/test/integration_test"
 
 check-fmt:
-	  docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork $(DOCK_BUILD_CNT) \
+	  docker run --rm  $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork $(DOCK_BUILD_CNT) \
 		      /bin/bash -c "cd /go/src/github.com/libopenstorage/stork; \
 			  diff -u <(echo -n) <(gofmt -l -d -s -e $(GO_FILES));"
 
@@ -113,7 +115,7 @@ test:
 
 integration-test:
 	@echo "Building stork integration tests"
-	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
+	docker run --rm $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
 		   /bin/bash -c 'cd /go/src/github.com/libopenstorage/stork/test/integration_test && \
 		   GOOS=linux go test -tags integrationtest $(BUILD_OPTIONS) -v -c -o stork.test;'
 
@@ -132,19 +134,19 @@ codegen:
 
 stork:
 	@echo "Building the stork binary"
-	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
+	docker run --rm $(SECCOMP_OPTIONS)  -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
            /bin/bash -c 'cd /go/src/github.com/libopenstorage/stork/cmd/stork && \
 		   CGO_ENABLED=0 GOOS=linux go build $(BUILD_OPTIONS) -o /go/src/github.com/libopenstorage/stork/bin/stork;'
 
 cmdexecutor:
 	@echo "Building command executor binary"
-	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
+	docker run --rm $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
 		/bin/bash -c 'cd /go/src/github.com/libopenstorage/stork/cmd/cmdexecutor && \
 		GOOS=linux go build $(BUILD_OPTIONS) -o /go/src/github.com/libopenstorage/stork/bin/cmdexecutor;'
 
 storkctl:
 	@echo "Building storkctl"
-	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
+	docker run --rm $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
 		/bin/bash -c 'cd /go/src/github.com/libopenstorage/stork/cmd/storkctl; \
 		CGO_ENABLED=0 GOOS=linux go build $(BUILD_OPTIONS) -o /go/src/github.com/libopenstorage/stork/bin/linux/storkctl; \
 		CGO_ENABLED=0 GOOS=darwin go build $(BUILD_OPTIONS) -o /go/src/github.com/libopenstorage/stork/bin/darwin/storkctl; \
@@ -152,7 +154,7 @@ storkctl:
 
 px-statfs:
 	@echo "Building px_statfs.so"
-	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
+	docker run --rm  $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
 		   /bin/bash -c 'cd /go/src/github.com/libopenstorage/stork/drivers/volume/portworx/px-statfs &&  \
            gcc -g -shared -fPIC -o /go/src/github.com/libopenstorage/stork/bin/px_statfs.so px_statfs.c -ldl -D__USE_LARGEFILE64;'
 
@@ -166,7 +168,7 @@ container: help
 
 help:
 	@echo "Updating help file"
-	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/stork $(DOCK_BUILD_CNT) \
+	docker run --rm $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork $(DOCK_BUILD_CNT) \
            /bin/bash -c "cd /go/src/github.com/libopenstorage/stork; \
                 apt-get update -y && apt-get install -y go-md2man; \
                 go-md2man -in help.md -out help.1; \

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ integration-test:
 	@echo "Building stork integration tests"
 	docker run --rm $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
 		   /bin/bash -c 'cd /go/src/github.com/libopenstorage/stork/test/integration_test && \
-		   GOOS=linux go test -tags integrationtest $(BUILD_OPTIONS) -v -c -o stork.test;'
+		   CGO_ENABLED=0 GOOS=linux go test -tags integrationtest $(BUILD_OPTIONS) -v -c -o stork.test;'
 
 integration-test-container:
 	@echo "Building container: docker build --tag $(STORK_TEST_IMG) -f Dockerfile ."


### PR DESCRIPTION
**What type of PR is this?**
>Improvement


**What this PR does / why we need it**:
Update golang, aws-iam-authenticator and google-cloud-sdk versions to address golang vulnerabilities.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
Fixed several vulnerabilities resulting from 

**Does this change need to be cherry-picked to a release branch?**:
yes 23.7

**Notes**:
* Changes will be tested as part of 23.7.0 System tests
* There is some issue in our github repo due to which following error is observed when updating to any golang version > 1.19.1. To bypass this error -buildvcs=false  has been added.
```
 error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```
This is probably being caused due to some issue with out github repo but I have not been able to figure this out yet. 
Consequence of doing this change is that vcs information will not be embedded in the container image. 
```
go version -m bin/stork 
        build	-ldflags="-s -w -X github.com/libopenstorage/stork/pkg/version.Version=23.7.0-eb657dcdc"
	build	vcs=git
	build	vcs.revision=eb657dcdc5d17934b4f048b94d0080d1c7e5e266
	build	vcs.time=2023-07-20T08:48:30Z
	build	vcs.modified=true

```
However we are already passing the version info using ldflag so we should be good.

* Another issue observed after updating to 1.19.10 was following error during Travis build
[Travis](https://app.travis-ci.com/github/libopenstorage/stork/builds/264737415)
```
runtime/cgo: pthread_create failed: Operation not permitted
478SIGABRT: abort
```
It appears that default seccomp rules are not allowing us to build and resulting in a crash. As a workaround, I have updated it to unconfined.

* Added CGO_ENABLED=0 in stork.test build. https://github.com/golang/go/issues/57328 due to following error 
`stork.test: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.34 not found (required by /stork.test)`
