### PR TITLE
pb-4093 Deleting the volumesnapshotcontent in the case of failed native CSI backup.

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -1906,14 +1906,12 @@ func (c *csi) CleanupBackupResources(backup *storkapi.ApplicationBackup) error {
 				continue
 			}
 			vsMap.(map[string]*kSnapshotv1.VolumeSnapshot)[vInfo.BackupID] = snapshot
-			if snapshotInfo.Status == snapshotter.StatusReady {
-				snapshotContent, ok := snapshotInfo.Content.(*kSnapshotv1.VolumeSnapshotContent)
-				if !ok {
-					logrus.Warnf("failed to map volumesnapshotcontent object")
-					continue
-				}
-				vsContentMap.(map[string]*kSnapshotv1.VolumeSnapshotContent)[vInfo.BackupID] = snapshotContent
+			snapshotContent, ok := snapshotInfo.Content.(*kSnapshotv1.VolumeSnapshotContent)
+			if !ok {
+				logrus.Warnf("failed to map volumesnapshotcontent object")
+				continue
 			}
+			vsContentMap.(map[string]*kSnapshotv1.VolumeSnapshotContent)[vInfo.BackupID] = snapshotContent
 		} else {
 			snapshot, ok := snapshotInfo.SnapshotRequest.(*kSnapshotv1beta1.VolumeSnapshot)
 			if !ok {
@@ -1921,14 +1919,12 @@ func (c *csi) CleanupBackupResources(backup *storkapi.ApplicationBackup) error {
 				continue
 			}
 			vsMap.(map[string]*kSnapshotv1beta1.VolumeSnapshot)[vInfo.BackupID] = snapshot
-			if snapshotInfo.Status == snapshotter.StatusReady {
-				snapshotContent, ok := snapshotInfo.Content.(*kSnapshotv1beta1.VolumeSnapshotContent)
-				if !ok {
-					logrus.Warnf("failed to map volumesnapshotcontent object")
-					continue
-				}
-				vsContentMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)[vInfo.BackupID] = snapshotContent
+			snapshotContent, ok := snapshotInfo.Content.(*kSnapshotv1beta1.VolumeSnapshotContent)
+			if !ok {
+				logrus.Warnf("failed to map volumesnapshotcontent object")
+				continue
 			}
+			vsContentMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)[vInfo.BackupID] = snapshotContent
 		}
 	}
 	// cleanup after a successful object upload
@@ -1937,9 +1933,9 @@ func (c *csi) CleanupBackupResources(backup *storkapi.ApplicationBackup) error {
 		logrus.Tracef("failed to cleanup snapshots: %v", err)
 	}
 	if c.v1SnapshotRequired {
-		log.ApplicationBackupLog(backup).Tracef("started clean up of %v snapshots and %v snapshotcontents", len(vsMap.(map[string]*kSnapshotv1.VolumeSnapshot)), len(vsContentMap.(map[string]*kSnapshotv1.VolumeSnapshotContent)))
+		log.ApplicationBackupLog(backup).Infof("started clean up of %v snapshots and %v snapshotcontents", len(vsMap.(map[string]*kSnapshotv1.VolumeSnapshot)), len(vsContentMap.(map[string]*kSnapshotv1.VolumeSnapshotContent)))
 	} else {
-		log.ApplicationBackupLog(backup).Tracef("started clean up of %v snapshots and %v snapshotcontents", len(vsMap.(map[string]*kSnapshotv1beta1.VolumeSnapshot)), len(vsContentMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)))
+		log.ApplicationBackupLog(backup).Infof("started clean up of %v snapshots and %v snapshotcontents", len(vsMap.(map[string]*kSnapshotv1beta1.VolumeSnapshot)), len(vsContentMap.(map[string]*kSnapshotv1beta1.VolumeSnapshotContent)))
 	}
 	return nil
 }

--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -383,7 +383,7 @@ func (c *csiDriver) SnapshotStatus(name, namespace string) (SnapshotInfo, error)
 		var snapshotContent *kSnapshotv1.VolumeSnapshotContent
 		var volumeSnapshotContentReady bool
 		var contentName string
-		if volumeSnapshotReady && snapshot.Status.BoundVolumeSnapshotContentName != nil {
+		if snapshot.Status.BoundVolumeSnapshotContentName != nil {
 			snapshotContentName := *snapshot.Status.BoundVolumeSnapshotContentName
 			snapshotContent, err = c.snapshotClient.SnapshotV1().VolumeSnapshotContents().Get(context.TODO(), snapshotContentName, metav1.GetOptions{})
 			if err != nil {
@@ -474,7 +474,7 @@ func (c *csiDriver) SnapshotStatus(name, namespace string) (SnapshotInfo, error)
 		var snapshotContent *kSnapshotv1beta1.VolumeSnapshotContent
 		var volumeSnapshotContentReady bool
 		var contentName string
-		if volumeSnapshotReady && snapshot.Status.BoundVolumeSnapshotContentName != nil {
+		if snapshot.Status.BoundVolumeSnapshotContentName != nil {
 			snapshotContentName := *snapshot.Status.BoundVolumeSnapshotContentName
 			snapshotContent, err = c.snapshotClient.SnapshotV1beta1().VolumeSnapshotContents().Get(context.TODO(), snapshotContentName, metav1.GetOptions{})
 			if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
```
     pb-4093 Deleting the volumesnapshotcontent in the case of failed native
    CSI backup

            - Adding the vsc name in the map in CleanupBackupResources with
              out any status check ( success/failure/in-progress)
            - In SnapshotStatus() also removed the check for ready state to
              add the volumesnapshotcontent name in the snapshotInfo. If the status
              volumesnapshotcontent is present, we will add the VSC name in the snapshotInfo.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: The volumesnapshotcontent are not getting deleted when the native CSI backup fails with the timeout error.
User Impact: The volumesnapshotcontent will get accumulated in the case of native CSI backup failures
Resolution: Taking care of deleting the volumesnapshotcontent in the case of failure as well.

```

**Does this change need to be cherry-picked to a release branch?**:
Yes. 
23.7 branch and 23.7.1 branch.

**Testing:
Vaidated the fix on IBM setup with timeout error.**