### PR TITLE
PWX-32496: Modifying input param "google-json-key" to "google-json-key-file" for creating clusterpair with google objectstore.

### DIFF
--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -412,7 +412,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 					return
 				}
 				if len(googleJSONKey) == 0 {
-					util.CheckErr(getMissingParameterError("google-json-key", "Json key file missing for Google"))
+					util.CheckErr(getMissingParameterError("google-key-file-path", "Json key file missing for Google"))
 					return
 				}
 				// Read the jsonkey file
@@ -594,13 +594,13 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 	createClusterPairCommand.Flags().MarkDeprecated("src-ip", "instead provide --src-ep")
 	createClusterPairCommand.Flags().StringVarP(&sPort, "src-port", "", "", "Port of storage node from source cluster")
 	createClusterPairCommand.Flags().MarkDeprecated("src-port", "instead provide --src-ep")
-	createClusterPairCommand.Flags().StringVarP(&sEP, "src-ep", "", "", "Endpoint of portworx-api service in source cluster")
+	createClusterPairCommand.Flags().StringVarP(&sEP, "src-ep", "", "", "(Optional)Endpoint of portworx-api service in source cluster")
 	createClusterPairCommand.Flags().StringVarP(&sFile, "src-kube-file", "", "", "Path to the kubeconfig of source cluster")
 	createClusterPairCommand.Flags().StringVarP(&dIP, "dest-ip", "", "", "IP of storage node from destination cluster")
 	createClusterPairCommand.Flags().MarkDeprecated("dest-ip", "instead provide --dest-ep")
 	createClusterPairCommand.Flags().StringVarP(&dPort, "dest-port", "", "", "Port of storage node from destination cluster")
 	createClusterPairCommand.Flags().MarkDeprecated("dest-port", "instead provide --dest-ep")
-	createClusterPairCommand.Flags().StringVarP(&dEP, "dest-ep", "", "", "Endpoint of portworx-api service in destination cluster")
+	createClusterPairCommand.Flags().StringVarP(&dEP, "dest-ep", "", "", "(Optional)Endpoint of portworx-api service in destination cluster")
 	createClusterPairCommand.Flags().StringVarP(&dFile, "dest-kube-file", "", "", "Path to the kubeconfig of destination cluster")
 	createClusterPairCommand.Flags().StringVarP(&srcToken, "src-token", "", "", "(Optional)Source cluster token for cluster pairing")
 	createClusterPairCommand.Flags().StringVarP(&destToken, "dest-token", "", "", "(Optional)Destination cluster token for cluster pairing")
@@ -623,7 +623,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 	createClusterPairCommand.Flags().StringVar(&azureAccountKey, "azure-account-key", "", "Account key for Azure")
 	// Google
 	createClusterPairCommand.Flags().StringVar(&googleProjectID, "google-project-id", "", "Project ID for Google")
-	createClusterPairCommand.Flags().StringVar(&googleJSONKey, "google-json-key", "", "Json key for Google")
+	createClusterPairCommand.Flags().StringVar(&googleJSONKey, "google-key-file-path", "", "Json key for Google")
 
 	return createClusterPairCommand
 }

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -843,7 +843,7 @@ func getObjectStoreArgs(objectStoreType storkv1.BackupLocationType, secretName s
 		}
 	} else if objectStoreType == storkv1.BackupLocationGoogle {
 		objectStoreArgs = append(objectStoreArgs,
-			[]string{"--provider", "google", "--google-project-id", string(secretData.Data["projectID"]), "--azure-account-key", string(secretData.Data["accountKey"])}...)
+			[]string{"--provider", "google", "--google-project-id", string(secretData.Data["projectID"]), "--google-key-file-path", string(secretData.Data["accountKey"])}...)
 		if val, ok := secretData.Data["encryptionKey"]; ok && len(val) > 0 {
 			objectStoreArgs = append(objectStoreArgs, "--encryption-key")
 			objectStoreArgs = append(objectStoreArgs, string(val))


### PR DESCRIPTION
Signed-Off-By: Diptiranjan


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
improvement

**What this PR does / why we need it**:
Modifying "google-json-key" to "google-json-key-file" to have better understanding for the input parameter that it requires a file path for input.

**Does this PR change a user-facing CRD or CLI?**:
<!--
yes
-->

**Is a release note needed?**:
<!--
no
-->


**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.7.0
-->

