### PR TITLE
pb-4106: added nil ptr check while accessing snapshot.Status in SnapshotStatus() api.

### DIFF
--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -383,7 +383,7 @@ func (c *csiDriver) SnapshotStatus(name, namespace string) (SnapshotInfo, error)
 		var snapshotContent *kSnapshotv1.VolumeSnapshotContent
 		var volumeSnapshotContentReady bool
 		var contentName string
-		if snapshot.Status.BoundVolumeSnapshotContentName != nil {
+		if snapshot.Status != nil && snapshot.Status.BoundVolumeSnapshotContentName != nil {
 			snapshotContentName := *snapshot.Status.BoundVolumeSnapshotContentName
 			snapshotContent, err = c.snapshotClient.SnapshotV1().VolumeSnapshotContents().Get(context.TODO(), snapshotContentName, metav1.GetOptions{})
 			if err != nil {
@@ -474,7 +474,7 @@ func (c *csiDriver) SnapshotStatus(name, namespace string) (SnapshotInfo, error)
 		var snapshotContent *kSnapshotv1beta1.VolumeSnapshotContent
 		var volumeSnapshotContentReady bool
 		var contentName string
-		if snapshot.Status.BoundVolumeSnapshotContentName != nil {
+		if snapshot.Status != nil && snapshot.Status.BoundVolumeSnapshotContentName != nil {
 			snapshotContentName := *snapshot.Status.BoundVolumeSnapshotContentName
 			snapshotContent, err = c.snapshotClient.SnapshotV1beta1().VolumeSnapshotContents().Get(context.TODO(), snapshotContentName, metav1.GetOptions{})
 			if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
pb-4106: added nil ptr check while accessing snapshot.Status in SnapshotStatus() api.
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No, as it is regression from previous commit.

**Does this change need to be cherry-picked to a release branch?**:
Yes to 2.7 and 2.7.1

Testing:
Validate a successful Native CSI backup with the fix.
![Screenshot 2023-07-26 at 6 21 26 PM](https://github.com/libopenstorage/stork/assets/52188641/a0f72a22-2f4c-4e2f-b98e-a36d9522edff)


