### PR TITLE
Cherry-pick PWX-30765: Updating golang, aws and gcloud sdk to fix vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: go
 go:
-  - 1.19.1
+  - 1.19.10
 before_install:
   - sudo apt-get update -yq || true
   - sudo apt-get install go-md2man -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN microdnf clean all && microdnf install -y python3.9 ca-certificates tar gzip
 RUN python3 -m pip install awscli && python3 -m pip install oci-cli && python3 -m pip install rsa --upgrade
 
 
-RUN curl -q -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
+RUN curl -q -o /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_linux_amd64 && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
 #Install asdf
@@ -31,7 +31,7 @@ RUN asdf install kubelogin latest
 RUN asdf global kubelogin latest
 
 #Install Google Cloud SDK
-ARG GCLOUD_SDK=google-cloud-sdk-418.0.0-linux-x86_64.tar.gz
+ARG GCLOUD_SDK=google-cloud-cli-439.0.0-linux-x86_64.tar.gz
 ARG GCLOUD_INSTALL_DIR="/usr/lib"
 RUN curl -q -o $GCLOUD_SDK https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
     tar xf $GCLOUD_SDK -C $GCLOUD_INSTALL_DIR && rm -rf $GCLOUD_SDK && \


### PR DESCRIPTION
**What type of PR is this?**
>Improvement


**What this PR does / why we need it**:
Update golang, aws-iam-authenticator and google-cloud-sdk versions to address golang vulnerabilities.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
Fixed several vulnerabilities resulting from 

**Does this change need to be cherry-picked to a release branch?**:
yes 23.7

**Notes**:
* Changes will be tested as part of 23.7.0 System tests
* There is some issue in our github repo due to which following error is observed when updating to any golang version > 1.19.1. To bypass this error -buildvcs=false  has been added.
```
 error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```
This is probably being caused due to some issue with out github repo but I have not been able to figure this out yet. 
Consequence of doing this change is that vcs information will not be embedded in the container image. 
```
go version -m bin/stork 
        build	-ldflags="-s -w -X github.com/libopenstorage/stork/pkg/version.Version=23.7.0-eb657dcdc"
	build	vcs=git
	build	vcs.revision=eb657dcdc5d17934b4f048b94d0080d1c7e5e266
	build	vcs.time=2023-07-20T08:48:30Z
	build	vcs.modified=true

```
However we are already passing the version info using ldflag so we should be good.

* Another issue observed after updating to 1.19.10 was following error during Travis build
[Travis](https://app.travis-ci.com/github/libopenstorage/stork/builds/264737415)
```
runtime/cgo: pthread_create failed: Operation not permitted
478SIGABRT: abort
```
It appears that default seccomp rules are not allowing us to build and resulting in a crash. As a workaround, I have updated it to unconfined.

* Added CGO_ENABLED=0 in stork.test build. https://github.com/golang/go/issues/57328 due to following error 
`stork.test: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.34 not found (required by /stork.test)`
