### PR TITLE
PWX-31012: Provide the PVC namespace and name labels while restoring Portworx backup.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3604,7 +3604,13 @@ func (p *portworx) StartRestore(
 
 		taskID := p.getBackupRestoreTaskID(restore.UID, volumeInfo.SourceNamespace, volumeInfo.PersistentVolumeClaim)
 		credID := p.getCredID(restore.Spec.BackupLocation, restore.Namespace)
-		locator, restoreSpec, err := p.getCloudBackupRestoreSpec(restore.Spec.StorageClassMapping, backupVolumeInfo.StorageClass, taskID)
+		locator, restoreSpec, err := p.getCloudBackupRestoreSpec(
+			restore.Spec.StorageClassMapping,
+			backupVolumeInfo.StorageClass,
+			taskID,
+			destinationNamespace,
+			volumeInfo.PersistentVolumeClaim,
+		)
 		if err != nil {
 			return volumeInfos, fmt.Errorf("failed to parse restore volume spec: %v ", err)
 		}
@@ -3648,7 +3654,8 @@ func (p *portworx) getCloudBackupRestoreSpec(
 	storageClassMapping map[string]string,
 	sourceStorageClass string,
 	taskID string,
-
+	destinationNamespace string,
+	pvcName string,
 ) (*api.VolumeLocator, *api.RestoreVolumeSpec, error) {
 	locator := &api.VolumeLocator{
 		Name: taskID, // always override name with taskID
@@ -3677,6 +3684,11 @@ func (p *portworx) getCloudBackupRestoreSpec(
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse storage class %v: %v", destStorageClass, err)
 	}
+	if locator.VolumeLabels == nil {
+		locator.VolumeLabels = make(map[string]string)
+	}
+	locator.VolumeLabels[pvcNameLabel] = pvcName
+	locator.VolumeLabels[namespaceLabel] = destinationNamespace
 	// Special handling for io_profile
 	// The default volumeSpec.IoProfile is set to sequential
 	// Check in storage class if an io profile is set. If not set use


### PR DESCRIPTION



**What type of PR is this?**
>improvement


**What this PR does / why we need it**:

- The name and namespace labels are provided as part of the Portworx Cloudsnap Restore request.
- The name of the PVC stays the same as it was when the backup was taken. However the namespace can change if the user decides to restore in a different namespace.
- These labels ensure Portworx driver knows which namespace the volume is getting restored to.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Yes
```release-note
Portworx driver will ensure the correct pvc and namespace labels are applied on the Portworx volume while restoring from an ApplicationBackup.

```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 23.8

