### PR TITLE
PWX-28210: Disable filter and prioritize for Windows Pods

### DIFF
--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -155,6 +155,7 @@ func (m *Driver) ProvisionVolume(
 	size uint64,
 	labels map[string]string,
 	needsAntiHyperconvergence bool,
+	windowsVolume bool,
 ) error {
 	if _, ok := m.volumes[volumeName]; ok {
 		return fmt.Errorf("volume %v already exists", volumeName)
@@ -166,6 +167,7 @@ func (m *Driver) ProvisionVolume(
 		Size:                      size,
 		Labels:                    labels,
 		NeedsAntiHyperconvergence: needsAntiHyperconvergence,
+		WindowsVolume:             windowsVolume,
 	}
 
 	for i := 0; i < len(replicaIndexes); i++ {

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -283,6 +283,8 @@ type Info struct {
 	VolumeSourceRef interface{}
 	// NeedsAntiHyperconvergence is a flag for figuring if Pod needs anti-hyperconvergence
 	NeedsAntiHyperconvergence bool
+	// WindowsVolume is a flag to indicate if the volume is being used by a windows Pod
+	WindowsVolume bool
 }
 
 // NodeStatus Status of driver on a node

--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -45,8 +45,10 @@ const (
 	schedulingFailureEventReason                  = "FailedScheduling"
 	// Pod annotation to check if only local nodes should be used to schedule a pod
 	preferLocalNodeOnlyAnnotation = "stork.libopenstorage.org/preferLocalNodeOnly"
-	// StorageCluster parameter to check if only remote nodes should be used to schedule a pod
+	// StorageClass parameter to check if only remote nodes should be used to schedule a pod
 	preferRemoteNodeOnlyParameter = "stork.libopenstorage.org/preferRemoteNodeOnly"
+	// StorageClass parameter to check if the Pod is using a volume labeled for Windows
+	windowsStorageClassLabel = "winshare"
 	// annotation to skip a volume and its local node replicas for scoring while
 	// scheduling a pod
 	skipScoringLabel = "stork.libopenstorage.org/skipSchedulerScoring"
@@ -228,6 +230,15 @@ func (e *Extender) processFilterRequest(w http.ResponseWriter, req *http.Request
 			storklog.PodLog(pod).Errorf("Error getting list of driver nodes, returning all nodes, err: %v", err)
 		} else {
 			for _, volumeInfo := range driverVolumes {
+				// Pod is using a volume that is labeled for Windows
+				// This Pod needs to run only on Windows node
+				// Stork will return all nodes in the filter request
+				if e.volumePrefersWindowsNodes(volumeInfo) {
+					e.encodeFilterResponse(encoder,
+						pod,
+						args.Nodes.Items)
+					return
+				}
 				onlineNodeFound := false
 				for _, volumeNode := range volumeInfo.DataNodes {
 					for _, driverNode := range driverNodes {
@@ -324,6 +335,13 @@ func (e *Extender) processFilterRequest(w http.ResponseWriter, req *http.Request
 		filteredNodes = args.Nodes.Items
 	}
 
+	e.encodeFilterResponse(encoder, pod, filteredNodes)
+}
+
+func (e *Extender) encodeFilterResponse(encoder *json.Encoder,
+	pod *v1.Pod,
+	filteredNodes []v1.Node) {
+
 	storklog.PodLog(pod).Debugf("Nodes in filter response:")
 	for _, node := range filteredNodes {
 		log.Debugf("%v %+v", node.Name, node.Status.Addresses)
@@ -338,12 +356,24 @@ func (e *Extender) processFilterRequest(w http.ResponseWriter, req *http.Request
 	}
 }
 
-// volumePrefersRemoteOnly checks if preferRemoteNodeOnly label is applied to the label
+// volumePrefersRemoteOnly checks if preferRemoteNodeOnly label is applied to the volume
 func (e *Extender) volumePrefersRemoteOnly(volumeInfo *volume.Info) bool {
 	if volumeInfo.Labels != nil {
 		if value, ok := volumeInfo.Labels[preferRemoteNodeOnlyParameter]; ok {
 			if preferRemoteOnlyExists, err := strconv.ParseBool(value); err == nil {
 				return preferRemoteOnlyExists
+			}
+		}
+	}
+	return false
+}
+
+// volumePrefersWindowsNodes checks if "winshare" label is applied to the volume
+func (e *Extender) volumePrefersWindowsNodes(volumeInfo *volume.Info) bool {
+	if volumeInfo.Labels != nil {
+		if value, ok := volumeInfo.Labels[windowsStorageClassLabel]; ok {
+			if preferWindowsNodesExists, err := strconv.ParseBool(value); err == nil {
+				return preferWindowsNodesExists
 			}
 		}
 	}
@@ -631,6 +661,11 @@ func (e *Extender) processPrioritizeRequest(w http.ResponseWriter, req *http.Req
 						skipVolumeScoring = false
 					}
 				}
+
+				if e.volumePrefersWindowsNodes(volume) {
+					skipVolumeScoring = true
+				}
+
 				if skipVolumeScoring {
 					storklog.PodLog(pod).Debugf("Skipping volume %v from scoring", volume.VolumeName)
 					continue
@@ -764,18 +799,7 @@ func (e *Extender) processCSIExtPodFilterRequest(
 		filteredNodes = args.Nodes.Items
 	}
 
-	storklog.PodLog(pod).Debugf("Nodes in filter response:")
-	for _, node := range filteredNodes {
-		log.Debugf("%v %+v", node.Name, node.Status.Addresses)
-	}
-	response := &schedulerapi.ExtenderFilterResult{
-		Nodes: &v1.NodeList{
-			Items: filteredNodes,
-		},
-	}
-	if err := encoder.Encode(response); err != nil {
-		storklog.PodLog(pod).Errorf("Error encoding filter response: %+v : %v", response, err)
-	}
+	e.encodeFilterResponse(encoder, pod, filteredNodes)
 }
 
 func (e *Extender) processCSIExtPodPrioritizeRequest(

--- a/pkg/extender/extender_test.go
+++ b/pkg/extender/extender_test.go
@@ -598,7 +598,7 @@ func WFFCVolumeTest(t *testing.T) {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, podVolume)
 	driver.AddPVC(pvcClaim)
 	provNodes := []int{}
-	if err := driver.ProvisionVolume("WFFCVol", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("WFFCVol", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -650,7 +650,7 @@ func WFFCMultiVolumeTest(t *testing.T) {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, podVolume1)
 	driver.AddPVC(pvcClaim1)
 	provNodes := []int{}
-	if err := driver.ProvisionVolume("WFFCVol1", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("WFFCVol1", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -670,7 +670,7 @@ func WFFCMultiVolumeTest(t *testing.T) {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, podVolume2)
 	driver.AddPVC(pvcClaim2)
 	provNodes = []int{1}
-	if err := driver.ProvisionVolume("normalVol", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("normalVol", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -712,7 +712,7 @@ func noVolumeNodeTest(t *testing.T) {
 	pod := newPod("noVolumeNode", map[string]bool{"noVolumeNode": false})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("noVolumeNode", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("noVolumeNode", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	filterResponse, err := sendFilterRequest(pod, requestNodes)
@@ -754,7 +754,7 @@ func noDriverNodeTest(t *testing.T) {
 	pod := newPod("noDriverNode", map[string]bool{"noDriverNode": false})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("noDriverNode", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("noDriverNode", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	filterResponse, err := sendFilterRequest(pod, requestNodes)
@@ -783,7 +783,7 @@ func singleVolumeTest(t *testing.T) {
 
 	pod := newPod("singleVolume", map[string]bool{"singleVolume": false})
 
-	if err := driver.ProvisionVolume("singleVolume", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("singleVolume", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	filterResponse, err := sendFilterRequest(pod, nodes)
@@ -829,11 +829,11 @@ func multipleVolumeTest(t *testing.T) {
 	pod := newPod("doubleVolumePod", map[string]bool{"volume1": false, "volume2": false})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("volume1", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("volume1", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("volume2", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("volume2", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -881,11 +881,11 @@ func multipleVolumeSkipTest(t *testing.T) {
 	pod := newPod("doubleVolumeSkipPod", map[string]bool{"included-volume": false, "excluded-volume": true})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("included-volume", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("included-volume", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("excluded-volume", provNodes, 1, map[string]string{skipScoringLabel: "true"}, false); err != nil {
+	if err := driver.ProvisionVolume("excluded-volume", provNodes, 1, map[string]string{skipScoringLabel: "true"}, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -934,11 +934,11 @@ func multipleVolumeStorageDownTest(t *testing.T) {
 	pod := newPod("doubleVolumeSkipPod", map[string]bool{"vol1": false, "vol2": true})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("vol1", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("vol1", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("vol2", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("vol2", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -985,7 +985,7 @@ func driverErrorTest(t *testing.T) {
 
 	pod := newPod("driverErrorPod", map[string]bool{"driverErrorTest": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("volume1", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("volume1", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1030,7 +1030,7 @@ func driverNodeErrorStateTest(t *testing.T) {
 
 	pod := newPod("driverErrorPod", map[string]bool{"driverNodeErrorTest": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("driverNodeErrorTest", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("driverNodeErrorTest", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1080,11 +1080,11 @@ func zoneTest(t *testing.T) {
 
 	pod := newPod("zoneTest", map[string]bool{"zoneVolume1": false, "zoneVolume2": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("zoneVolume1", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("zoneVolume1", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("zoneVolume2", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("zoneVolume2", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1132,11 +1132,11 @@ func zoneStorageDownNodeTest(t *testing.T) {
 
 	pod := newPod("zoneStorageDownNodeTest", map[string]bool{"zoneVol1": false, "zoneVol2": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("zoneVol1", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("zoneVol1", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("zoneVol2", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("zoneVol2", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	if err := driver.UpdateNodeStatus(0, volume.NodeStorageDown); err != nil {
@@ -1187,11 +1187,11 @@ func regionTest(t *testing.T) {
 
 	pod := newPod("regionTest", map[string]bool{"regionVolume1": false, "regionVolume2": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("regionVolume1", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("regionVolume1", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("regionVolume2", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("regionVolume2", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1238,11 +1238,11 @@ func regionStorageDownNodeTest(t *testing.T) {
 
 	pod := newPod("regionStorageDownNodeTest", map[string]bool{"regionVol1": false, "regionVol2": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("regionVol1", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("regionVol1", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("regionVol2", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("regionVol2", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1288,7 +1288,7 @@ func nodeNameTest(t *testing.T) {
 
 	pod := newPod("nodeNameTest", map[string]bool{"nodeNameTest": false})
 
-	if err := driver.ProvisionVolume("nodeNameTest", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("nodeNameTest", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	filterResponse, err := sendFilterRequest(pod, nodes)
@@ -1329,7 +1329,7 @@ func ipTest(t *testing.T) {
 
 	pod := newPod("ipTest", map[string]bool{"ipTest": false})
 
-	if err := driver.ProvisionVolume("ipTest", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("ipTest", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	filterResponse, err := sendFilterRequest(pod, nodes)
@@ -1388,7 +1388,7 @@ func noReplicasTest(t *testing.T) {
 	pod := newPod("noReplicasTest", map[string]bool{"noReplicasTest": false})
 
 	provNodes := []int{0}
-	if err := driver.ProvisionVolume("noReplicasTest", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("noReplicasTest", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	if err := driver.UpdateNodeStatus(0, volume.NodeOffline); err != nil {
@@ -1480,7 +1480,7 @@ func preferLocalNodeTest(t *testing.T) {
 	pod := newPod("preferLocalNodeTest", map[string]bool{"preferLocalNodeTest": false})
 
 	provNodes := []int{0}
-	if err := driver.ProvisionVolume("preferLocalNodeTest", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("preferLocalNodeTest", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1507,7 +1507,7 @@ func extenderMetricsTest(t *testing.T) {
 		t.Fatalf("Error creating cluster: %v", err)
 	}
 	// check if pod is hyper-Converged
-	if err := driver.ProvisionVolume("metric-vol-1", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("metric-vol-1", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	pod := newPod("HyperPodTest", map[string]bool{"metric-vol-1": false})
@@ -1522,11 +1522,11 @@ func extenderMetricsTest(t *testing.T) {
 	require.Equal(t, testutil.ToFloat64(HyperConvergedPodsCounter), float64(1), "hyperConverged_pods_total not matched")
 
 	// Semi-Hyper converged pod metrics
-	if err := driver.ProvisionVolume("metric-vol-2", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("metric-vol-2", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes2 := []int{1, 2}
-	if err := driver.ProvisionVolume("metric-vol-3", provNodes2, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("metric-vol-3", provNodes2, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	semiHyperPod := newPod("SemiPodTest", map[string]bool{"metric-vol-2": false, "metric-vol-3": false})
@@ -1541,7 +1541,7 @@ func extenderMetricsTest(t *testing.T) {
 	require.Equal(t, testutil.ToFloat64(SemiHyperConvergePodsCounter), float64(1), "semi_hyperConverged_pods_total not matched")
 
 	// non-hyper converged pod metrics
-	if err := driver.ProvisionVolume("non-metric-vol", provNodes, 1, nil, false); err != nil {
+	if err := driver.ProvisionVolume("non-metric-vol", provNodes, 1, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	nonHyperPod := newPod("NonHyperPodTest", map[string]bool{"non-metric-vol": false})
@@ -1573,7 +1573,7 @@ func preferRemoteNodeOnlyIgnoredForHyperConvergedVolumesTest(t *testing.T) {
 	pod := newPod("preferRemoteNodeOnlyIgnoredForHyperConvergedVolumesTest", map[string]bool{"preferRemoteNodeOnlyIgnoredForHyperConvergedVolumesTest": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferRemoteNodeOnlyIgnoredForHyperConvergedVolumesTest", provNodes, 6, map[string]string{preferRemoteNodeOnlyParameter: "true"}, false); err != nil {
+	if err := driver.ProvisionVolume("preferRemoteNodeOnlyIgnoredForHyperConvergedVolumesTest", provNodes, 6, map[string]string{preferRemoteNodeOnlyParameter: "true"}, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1598,7 +1598,7 @@ func preferRemoteNodeOnlyFailedSchedulingTest(t *testing.T) {
 	pod := newPod("preferRemoteNodeOnlyFailedSchedulingTest", map[string]bool{"preferRemoteNodeOnlyFailedSchedulingTest": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferRemoteNodeOnlyFailedSchedulingTest", provNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true); err != nil {
+	if err := driver.ProvisionVolume("preferRemoteNodeOnlyFailedSchedulingTest", provNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1623,7 +1623,7 @@ func preferRemoteNodeOnlyAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("preferRemoteNodeOnlyAntiHyperConvergenceTest", map[string]bool{"preferRemoteNodeOnlyAntiHyperConvergenceTest": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferRemoteNodeOnlyAntiHyperConvergenceTest", provNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true); err != nil {
+	if err := driver.ProvisionVolume("preferRemoteNodeOnlyAntiHyperConvergenceTest", provNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1672,7 +1672,7 @@ func antiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("sharedV4ServiceAntiHyperConverged", map[string]bool{"sharedV4ServiceAntiHyperConverged": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("sharedV4ServiceAntiHyperConverged", provNodes, 3, nil, true); err != nil {
+	if err := driver.ProvisionVolume("sharedV4ServiceAntiHyperConverged", provNodes, 3, nil, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1714,7 +1714,7 @@ func offlineNodesAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("offlineNodesAntiHyperConvergenceTest", map[string]bool{"offlineNodesAntiHyperConvergenceTest": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("offlineNodesAntiHyperConvergenceTest", provNodes, 3, nil, true); err != nil {
+	if err := driver.ProvisionVolume("offlineNodesAntiHyperConvergenceTest", provNodes, 3, nil, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1750,12 +1750,12 @@ func multiVolumeAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("multiVolumeAntiHyperConvergenceTest", map[string]bool{"HyperConvergedVolumes": false, "sharedV4Svc": false})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumes", regularVolumeProvNodes, 3, nil, false); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumes", regularVolumeProvNodes, 3, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{3, 4, 5}
-	if err := driver.ProvisionVolume("sharedV4Svc", sharedV4SvcProvNodes, 3, nil, true); err != nil {
+	if err := driver.ProvisionVolume("sharedV4Svc", sharedV4SvcProvNodes, 3, nil, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1798,12 +1798,12 @@ func multiVolume2AntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("multiVolumeAntiHyperConvergenceTest", map[string]bool{"HyperConvergedVolumes2": false, "sharedV4Svc2": false})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumes2", regularVolumeProvNodes, 3, nil, false); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumes2", regularVolumeProvNodes, 3, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{2, 3, 4}
-	if err := driver.ProvisionVolume("sharedV4Svc2", sharedV4SvcProvNodes, 3, nil, true); err != nil {
+	if err := driver.ProvisionVolume("sharedV4Svc2", sharedV4SvcProvNodes, 3, nil, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1852,12 +1852,12 @@ func multiVolume3PreferRemoteOnlyAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("multiVolumeAntiHyperConvergenceTest", map[string]bool{"HyperConvergedVolumes3": false, "sharedV4Svc3": false})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumes3", regularVolumeProvNodes, 3, nil, false); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumes3", regularVolumeProvNodes, 3, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("sharedV4Svc3", sharedV4SvcProvNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true); err != nil {
+	if err := driver.ProvisionVolume("sharedV4Svc3", sharedV4SvcProvNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1897,12 +1897,12 @@ func multiVolumeSkipHyperConvergedVolumesScoringTest(t *testing.T) {
 	pod := newPod("multiVolumeSkipHyperConvergedVolumesScoringTest", map[string]bool{"HyperConvergedVolumesMultiSkip": true, "sharedV4SvcMultiSkip": true})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumesMultiSkip", regularVolumeProvNodes, 3, map[string]string{skipScoringLabel: "true"}, false); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumesMultiSkip", regularVolumeProvNodes, 3, map[string]string{skipScoringLabel: "true"}, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{3, 4, 5}
-	if err := driver.ProvisionVolume("sharedV4SvcMultiSkip", sharedV4SvcProvNodes, 3, nil, true); err != nil {
+	if err := driver.ProvisionVolume("sharedV4SvcMultiSkip", sharedV4SvcProvNodes, 3, nil, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1945,12 +1945,12 @@ func multiVolumeSkipAllVolumeScoringTest(t *testing.T) {
 	pod := newPod("multiVolumeSkipAllVolumeScoringTest", map[string]bool{"HyperConvergedVolumesSkip": true, "sharedV4SvcMultiVolumeSkip": true})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumesSkip", regularVolumeProvNodes, 3, map[string]string{skipScoringLabel: "true"}, false); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumesSkip", regularVolumeProvNodes, 3, map[string]string{skipScoringLabel: "true"}, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{3, 4, 5}
-	if err := driver.ProvisionVolume("sharedV4SvcMultiVolumeSkip", sharedV4SvcProvNodes, 3, map[string]string{skipScoringLabel: "true"}, true); err != nil {
+	if err := driver.ProvisionVolume("sharedV4SvcMultiVolumeSkip", sharedV4SvcProvNodes, 3, map[string]string{skipScoringLabel: "true"}, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1993,12 +1993,12 @@ func multiVolumeWithStorageDownNodesAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("multiVolumeWithStorageDownNodesAntiHyperConvergenceTest", map[string]bool{"StorageDownNodesHyperConvergedVolumes": false, "StorageDownNodeSharedV4Svc": false})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("StorageDownNodesHyperConvergedVolumes", regularVolumeProvNodes, 3, nil, false); err != nil {
+	if err := driver.ProvisionVolume("StorageDownNodesHyperConvergedVolumes", regularVolumeProvNodes, 3, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{3, 4, 5}
-	if err := driver.ProvisionVolume("StorageDownNodeSharedV4Svc", sharedV4SvcProvNodes, 3, nil, true); err != nil {
+	if err := driver.ProvisionVolume("StorageDownNodeSharedV4Svc", sharedV4SvcProvNodes, 3, nil, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2046,7 +2046,7 @@ func disableHyperConvergenceTest(t *testing.T) {
 	pod.Annotations[disableHyperconvergenceAnnotation] = "true"
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("multiVolumeDisableHyperConvergedTest", provNodes, 3, nil, true); err != nil {
+	if err := driver.ProvisionVolume("multiVolumeDisableHyperConvergedTest", provNodes, 3, nil, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2090,7 +2090,7 @@ func preferLocalNodeWithHyperConvergedVolumesTest(t *testing.T) {
 	pod.Annotations[preferLocalNodeOnlyAnnotation] = "true"
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferLocalNodeWithHyperConvergedVolumesTest", provNodes, 3, nil, false); err != nil {
+	if err := driver.ProvisionVolume("preferLocalNodeWithHyperConvergedVolumesTest", provNodes, 3, nil, false, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2118,7 +2118,7 @@ func preferLocalNodeIgnoredWithAntiHyperConvergenceTest(t *testing.T) {
 	pod.Annotations[preferLocalNodeOnlyAnnotation] = "true"
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferLocalNodeIgnoredWithAntiHyperConvergenceTest", provNodes, 3, nil, true); err != nil {
+	if err := driver.ProvisionVolume("preferLocalNodeIgnoredWithAntiHyperConvergenceTest", provNodes, 3, nil, true, false); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2145,7 +2145,7 @@ func skipScoringForWindowsPods(t *testing.T) {
 	pod := newPod("windowsVolumeSkipScoring", map[string]bool{"WindowsVolume": true})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("WindowsVolume", regularVolumeProvNodes, 3, map[string]string{windowsStorageClassLabel: "true"}, false); err != nil {
+	if err := driver.ProvisionVolume("WindowsVolume", regularVolumeProvNodes, 3, map[string]string{"winshare": "true"}, false, true); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -107,13 +107,13 @@ func setup(t *testing.T) {
 	err = driver.UpdateNodeStatus(5, volume.NodeOffline)
 	require.NoError(t, err, "Error setting node status to Offline")
 
-	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil, false)
+	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil, false, false)
 	require.NoError(t, err, "Error provisioning volume")
 
-	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil, false)
+	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil, false, false)
 	require.NoError(t, err, "Error provisioning volume")
 
-	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil, false)
+	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil, false, false)
 	require.NoError(t, err, "Error provisioning volume")
 
 	eventBroadcaster := record.NewBroadcaster()


### PR DESCRIPTION
**What type of PR is this?**
>feature

**What this PR does / why we need it**:
* In a mixed node cluster i.e. having both Linux and Windows nodes, if scheduling request comes for a Pod which uses a volume with [winshare: true] Stork will skip scoring for those Pods(https://portworx.atlassian.net/wiki/spaces/PE/pages/2702016513/Windows+container+support#:~:text=px%2Dcsi%2Dwin%20storageclass%20%3A%20Storage%20class%20with%20%22winshare%22%3A%20%22true%22%20attribute%20to%20distinguish%20Windows%20export%20volumes)
**Note**: 
* Node affinity or taints must be set for the Windows Pod so we don't receive Linux nodes in the filter request for a Windows Pod. 
* As per confirmation on https://purestorage.slack.com/archives/G01NEU80BSA/p1690866080451719?thread_ts=1690611028.265749&cid=G01NEU80BSA   [kubernetes.io/os](http://kubernetes.io/os): "windows" will be set for Windows Pods to ensure this. 

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note - Feature
* Disable node scoring for scheduling pods which are using volumes with label 'winshare: "true"'

```

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.7.1

**Notes**:
* Beta drop notes :  https://docs.google.com/document/d/1E2nsTDzKuJ6GM8VEBLODa754HM53bYjT3wtjkKfCxDg/edit
* Functional Spec: https://portworx.atlassian.net/wiki/spaces/PE/pages/2702016513/Windows+container+support
* Operator PR: https://github.com/libopenstorage/operator/pull/1176
* Stork Scheduler Integration test for regression: https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2023.7-dev/job/extender-op-k8s-1-25-0/57/ 
* Updated Stork Scheduler Integration test for regression: after addressing review concerns https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2023.7-dev/job/extender-op-k8s-1-25-0/60/

**Manual Testing**:
```
Scenario 1: Windows Pod. Filtering returns same windows node as received in request and Pod gets scheduled on Windows node.
[u/ppandey/spec]$ kp get pods -owide
NAME                              READY   STATUS    RESTARTS   AGE    IP            NODE               NOMINATED NODE   READINESS GATES
win-demo-run11-696ff75b49-q64fl   2/2     Running   0          117m   10.132.0.26   pnookalawindows1   <none>           <none>
[u/ppandey/spec]$ 
time="2023-08-10T02:35:41Z" level=debug msg="Updating scheduler to stork for Resource:Pod, Name: win-demo-run11-696ff75b49-, Namespace:portworx"
time="2023-08-10T02:35:44Z" level=debug msg="Nodes in filter request:" Namespace=portworx Owner=ReplicaSet/win-demo-run11-696ff75b49 PodName=win-demo-run11-696ff75b49-q64fl
time="2023-08-10T02:35:44Z" level=debug msg="pnookalawindows1 [{Type:ExternalIP Address:10.13.114.159} {Type:InternalIP Address:10.13.114.159} {Type:Hostname Address:pnookalawindows1}]" Namespace=portworx Owner=ReplicaSet/win-demo-run11-696ff75b49 PodName=win-demo-run11-696ff75b49-q64fl
time="2023-08-10T02:35:44Z" level=debug msg="Nodes in filter response:" Namespace=portworx Owner=ReplicaSet/win-demo-run11-696ff75b49 PodName=win-demo-run11-696ff75b49-q64fl
time="2023-08-10T02:35:44Z" level=debug msg="pnookalawindows1 [{Type:ExternalIP Address:10.13.114.159} {Type:InternalIP Address:10.13.114.159} {Type:Hostname Address:pnookalawindows1}]"

Scenario 2:  For a mysql deployment updated StorageClass to use winshare: true. Prioritize give equal scores to all nodes. 
time="2023-08-10T04:41:20Z" level=debug msg="Updating scheduler to stork for Resource:Pod, Name: mysql-64c674cb5c-, Namespace:portworx"
time="2023-08-10T04:41:29Z" level=debug msg="Nodes in prioritize request:" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw
time="2023-08-10T04:41:29Z" level=debug msg="[{Type:ExternalIP Address:10.13.114.156} {Type:InternalIP Address:10.13.114.156} {Type:Hostname Address:ocp-pnookalacluster1-m6cd6-worker-q5n9n}]" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw
time="2023-08-10T04:41:29Z" level=debug msg="[{Type:ExternalIP Address:10.13.114.157} {Type:InternalIP Address:10.13.114.157} {Type:Hostname Address:ocp-pnookalacluster1-m6cd6-worker-q9668}]" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw
time="2023-08-10T04:41:29Z" level=debug msg="[{Type:ExternalIP Address:10.13.114.159} {Type:InternalIP Address:10.13.114.159} {Type:Hostname Address:pnookalawindows1}]" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw
time="2023-08-10T04:41:29Z" level=debug msg="[{Type:ExternalIP Address:10.13.114.125} {Type:InternalIP Address:10.13.114.125} {Type:Hostname Address:ocp-pnookalacluster1-m6cd6-worker-sqrzp}]" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw


time="2023-08-10T04:41:29Z" level=debug msg="Skipping volume pvc-1742a4bb-ccb1-413c-aa48-53108d38a7cd from scoring" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw
time="2023-08-10T04:41:29Z" level=debug msg="Nodes in response:" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw
time="2023-08-10T04:41:29Z" level=debug msg="{Host:ocp-pnookalacluster1-m6cd6-worker-q5n9n Score:5}" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw
time="2023-08-10T04:41:29Z" level=debug msg="{Host:ocp-pnookalacluster1-m6cd6-worker-q9668 Score:5}" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw
time="2023-08-10T04:41:29Z" level=debug msg="{Host:pnookalawindows1 Score:5}" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw
time="2023-08-10T04:41:29Z" level=debug msg="{Host:ocp-pnookalacluster1-m6cd6-worker-sqrzp Score:5}" Namespace=portworx Owner=ReplicaSet/mysql-64c674cb5c PodName=mysql-64c674cb5c-htrhw





