### PR TITLE
PWX-32901: Update aws-iam-authenticator in Stork container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN microdnf clean all && microdnf install -y python3.9 ca-certificates tar gzip
 RUN python3 -m pip install awscli && python3 -m pip install oci-cli && python3 -m pip install rsa --upgrade
 
 
-RUN curl -q -o /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_linux_amd64 && \
+RUN curl -Lo /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.11/aws-iam-authenticator_0.6.11_linux_amd64 && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
 #Install asdf


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Update aws-iam-authenticator binary to the latest version and use -Lo option.

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: aws-iam-authenticator binary size was 0 in the Stork container.
User Impact: Users using Kubeconfig with aws-iam-authenticator will fail to create cluster pair on EKS
Resolution: Updated the aws-iam-authenticator and updating the curl options to make sure binary gets downloaded

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 23.7.1

