### PR TITLE
pb-4208: Retaining the values of user editable parameter of stork-controller-config configmap during pod restart.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1980,7 +1980,7 @@ func (a *ApplicationRestoreController) restoreResources(
 		}
 	}
 
-	log.ApplicationRestoreLog(restore).Infof("The size of application restore CR obtained %v bytes", restoreCrSize)
+	log.ApplicationRestoreLog(restore).Infof("The size of application restore CR obtained %v bytes - largeResourceSizeLimit: %v", restoreCrSize, largeResourceSizeLimit)
 	if restoreCrSize > int(largeResourceSizeLimit) {
 		log.ApplicationRestoreLog(restore).Infof("Stripping all the resource info from restore cr as it is a large resource based restore")
 		resourceCount := len(restore.Status.Resources)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
 pb-4208: Retaining the values of user editable parameter of stork-controller-config configmap during pod restart.
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Yes
```release-note
Issue: The value of large-resource related parameter, updated by user  in the stork-controller-config configmap are no retained across the stork pod restarts.
User Impact: User need to update large-resource related parameter in stork-controller-config configmap, every time when stork pods restarts.
Resolution: Retaining the user updated value of large-resource related parameter in stork-controller-config cofigmap across the stork pod restarts.

```

**Does this change need to be cherry-picked to a release branch?**:
23.7.1, 23.7.2 branches.

**Testing:**

Tested that   large-resource-size-limit parameter value is retained across the stork pods restarts.

```
[root@ssubramani-aug14-k8s-pxc-48e2-0 ~]# kubectl  get cm stork-controller-config -n kube-system
NAME                      DATA   AGE
stork-controller-config   4      34h
[root@ssubramani-aug14-k8s-pxc-48e2-0 ~]# kubectl  get cm stork-controller-config -n kube-system -o yaml
apiVersion: v1
data:
  admin-ns: kube-system
  large-resource-size-limit: "819200"
  service-account: stork
  stork-deploy-ns: portworx
kind: ConfigMap
metadata:
  creationTimestamp: "2023-08-14T04:39:27Z"
  name: stork-controller-config
  namespace: kube-system
  resourceVersion: "694896"
  uid: 034b03e4-2bdf-4ab1-bd87-a46d9adf5575
[root@ssubramani-aug14-k8s-pxc-48e2-0 ~]# kubectl  get pods -n portworx | grep stork
stork-645bc7ddc5-cnbrs                                  1/1     Running   0          3m14s
stork-645bc7ddc5-pf4md                                  1/1     Running   0          3m29s
stork-645bc7ddc5-th6dg                                  1/1     Running   0          3m29s
stork-scheduler-7648fbb7d7-d8fgt                        1/1     Running   0          34h
stork-scheduler-7648fbb7d7-t74bt                        1/1     Running   0          34h
stork-scheduler-7648fbb7d7-xvp5x                        1/1     Running   0          34h
[root@ssubramani-aug14-k8s-pxc-48e2-0 ~]# kubectl  delete pods stork-645bc7ddc5-cnbrs stork-645bc7ddc5-pf4md stork-645bc7ddc5-th6dg -n portworx
pod "stork-645bc7ddc5-cnbrs" deleted
pod "stork-645bc7ddc5-pf4md" deleted
pod "stork-645bc7ddc5-th6dg" deleted
[root@ssubramani-aug14-k8s-pxc-48e2-0 ~]# kubectl  get pods -n portworx | grep stork
stork-645bc7ddc5-c6hj7                                  1/1     Running   0          3m13s
stork-645bc7ddc5-nhlbw                                  1/1     Running   0          3m13s
stork-645bc7ddc5-pw828                                  1/1     Running   0          3m13s
stork-scheduler-7648fbb7d7-d8fgt                        1/1     Running   0          34h
stork-scheduler-7648fbb7d7-t74bt                        1/1     Running   0          34h
stork-scheduler-7648fbb7d7-xvp5x                        1/1     Running   0          34h
[root@ssubramani-aug14-k8s-pxc-48e2-0 ~]# kubectl  get cm stork-controller-config -n kube-system -o yaml
apiVersion: v1
data:
  admin-ns: kube-system
  large-resource-size-limit: "819200"
  service-account: stork
  stork-deploy-ns: portworx
kind: ConfigMap
metadata:
  creationTimestamp: "2023-08-14T04:39:27Z"
  name: stork-controller-config
  namespace: kube-system
  resourceVersion: "694896"
  uid: 034b03e4-2bdf-4ab1-bd87-a46d9adf5575
[root@ssubramani-aug14-k8s-pxc-48e2-0 ~]#
```

https://backup.docs.portworx.com/reference/large-res-config/