### PR TITLE
PB-4193: Portworx volume size issue

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3408,7 +3408,10 @@ func (p *portworx) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*stork
 					// return nil, err
 				}
 			} else {
-				vInfo.TotalSize = resp.GetCompressedObjectBytes()
+				// For Portworx version lessthan v3.0.0 GetCompressedObjectBytes method will result empty.
+				if vInfo.TotalSize = resp.GetCompressedObjectBytes(); vInfo.TotalSize == 0 {
+					vInfo.TotalSize = resp.GetSize()
+				}
 			}
 		}
 		volumeInfos = append(volumeInfos, vInfo)


### PR DESCRIPTION
   - Use SdkCloudBackupSizeResponse.GetSize() for portworx volumes if SdkCloudBackupSizeResponse.GetCompressedObjectBytes() is empty
Signed-off-by: Santosh Kumar Gajawada <sgajawada@purestorage.com>


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
Using the latest stork with portworx volumes lessthan v3.0.0 will result an empty size due to unsupported response from the portworx SdkCloudBackupSizeResponse

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: ApplicationBackupVolumeInfo size is empty.
User Impact: For the portworx volumes with version lessthan v3.0.0
Resolution: By using the portworx api to get size.

```
**Does this change need to be cherry-picked to a release branch?**:
yes, 23.7.1

**Unit Test**
![Screenshot from 2023-08-16 11-32-12](https://github.com/libopenstorage/stork/assets/116876049/a688e676-ebf9-4b54-abcc-28693f48b13c)
![Screenshot from 2023-08-16 11-21-34](https://github.com/libopenstorage/stork/assets/116876049/9beb4781-d27a-45b8-b9d9-be56b3cde7b4)
![Screenshot from 2023-08-14 18-55-05](https://github.com/libopenstorage/stork/assets/116876049/bb3988ad-5bd7-486f-a906-28c760b7b1bb)
![Screenshot from 2023-08-14 18-54-46](https://github.com/libopenstorage/stork/assets/116876049/d5674e62-457d-48b9-b04c-e8c826226bee)
![Screenshot from 2023-08-14 18-54-16](https://github.com/libopenstorage/stork/assets/116876049/e38d0cfe-fdd7-44bf-80ec-0ba0bb7deccd)
![Screenshot from 2023-08-14 18-54-08](https://github.com/libopenstorage/stork/assets/116876049/d257e70c-c66b-41ea-ae1a-a2b21b22449c)
![Screenshot from 2023-08-16 12-20-21](https://github.com/libopenstorage/stork/assets/116876049/bdc8ecf1-9a8e-4aa3-bd3c-5b22ebce76d2)

