### PR TITLE
pb-4241: Added ErrCodeBucketAlreadyExists check in CreateBucket to avoid logging confusing warning event in the applicationbackup CR.

### DIFF
--- a/pkg/objectstore/s3/s3.go
+++ b/pkg/objectstore/s3/s3.go
@@ -71,6 +71,8 @@ func CreateBucket(backupLocation *stork_api.BackupLocation) error {
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() == s3.ErrCodeBucketAlreadyOwnedByYou {
 				return nil
+			} else if awsErr.Code() == s3.ErrCodeBucketAlreadyExists {
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
pb-4241: Added ErrCodeBucketAlreadyExists check in CreateBucket to avoid logging confusing warning event in the applicationbackup CR.
```

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
```release-note
Issue: Warning event is logged in the applicaitonbackup CR, if the S3 bucket was already exists.
User Impact: The warning event was confusing to the user.
Resolution: Avoiding warning event if S3 objectstore gives ErrCodeBucketAlreadyExists code.

```

**Does this change need to be cherry-picked to a release branch?**:
23.7.2 branch

**Testing:**
Before fix:

<img width="2056" alt="Screenshot 2023-08-20 at 1 32 55 PM" src="https://github.com/libopenstorage/stork/assets/52188641/a7570464-99cd-465f-8277-278d5e3dbb2b">
After fix the warning event is visible in applicationbackup CR.
