### PR TITLE
PB-4145: Mask macAddress during VM Restore

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -1034,7 +1034,9 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		return false, r.prepareRancherNetworkPolicy(object, *opts)
 	case "Deployment", "StatefulSet", "DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer", "ReplicaSet":
 		return false, r.prepareRancherApplicationResource(object, *opts)
-
+	case "VirtualMachine":
+		logrus.Debugf("Transforming kubevirt VM resource for apply")
+		return false, r.prepareVirtualMachineForApply(object, nil)
 	}
 	return false, nil
 }

--- a/pkg/resourcecollector/virtualmachine.go
+++ b/pkg/resourcecollector/virtualmachine.go
@@ -5,6 +5,70 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+/*
+ * Parsing logic to fetch the given key; Ex: "macAddress" from interface slice
+ */
+func (r *ResourceCollector) parseMap(input map[string]interface{}, output map[string]interface{}, key string, is_key_present *bool) {
+	for mKey, mVal := range input {
+		if mKey == key {
+			*is_key_present = true
+			continue
+		}
+		output[mKey] = mVal
+
+	}
+}
+
+/*
+ * This function removes macAddress element from the interface list
+ */
+func (r *ResourceCollector) removeMac(object runtime.Unstructured) error {
+
+	content := object.UnstructuredContent()
+	path := []string{"spec", "template", "spec", "domain", "devices", "interfaces"}
+	data, _, er := unstructured.NestedSlice(content, path...)
+	if er != nil {
+		return er
+	}
+	remove := false
+	interf := make([]interface{}, 0, 1)
+	for _, val := range data {
+		switch typeval := val.(type) {
+		case map[string]interface{}:
+			b := make(map[string]interface{})
+			r.parseMap(typeval, b, "macAddress", &remove)
+			interf = append(interf, b)
+		}
+	}
+
+	// We will not change if given key was not found in the content.
+	if remove {
+		unstructured.RemoveNestedField(content, path...)
+		if err := unstructured.SetNestedSlice(content, interf, path...); err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
+/*
+ * This should be called from restore workflow for any resource transform for
+ * VM resources.
+ */
+func (r *ResourceCollector) prepareVirtualMachineForApply(
+	object runtime.Unstructured,
+	namespaces []string,
+) error {
+
+	// Lets remove macAddress as it creates macAddress conflict while restore
+	// to the same cluster to different namespace while the source VM is up and
+	// running.
+	err := r.removeMac(object)
+	return err
+
+}
+
 func (r *ResourceCollector) prepareVirtualMachineForCollection(
 	object runtime.Unstructured,
 	namespaces []string,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test
Feature
**What this PR does / why we need it**:

This fixes PB-4145 to support kubevirt VM for backup and restore. 

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no
**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```
no
**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

no