### PR TITLE
PWX-31372: storkctl to support backing up specific resource types and restoring specific objects.

### DIFF
--- a/pkg/storkctl/applicationbackup.go
+++ b/pkg/storkctl/applicationbackup.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"strings"
 	"time"
 
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
@@ -33,6 +34,7 @@ func newCreateApplicationBackupCommand(cmdFactory Factory, ioStreams genericclio
 	var postExecRule string
 	var waitForCompletion bool
 	var backupLocation string
+	var resourceTypes string
 
 	createApplicationBackupCommand := &cobra.Command{
 		Use:     applicationBackupSubcommand,
@@ -52,6 +54,7 @@ func newCreateApplicationBackupCommand(cmdFactory Factory, ioStreams genericclio
 				util.CheckErr(fmt.Errorf("need to provide BackupLocation to use for backup"))
 				return
 			}
+
 			applicationBackup := &storkv1.ApplicationBackup{
 				Spec: storkv1.ApplicationBackupSpec{
 					Namespaces:     namespaceList,
@@ -60,6 +63,16 @@ func newCreateApplicationBackupCommand(cmdFactory Factory, ioStreams genericclio
 					BackupLocation: backupLocation,
 				},
 			}
+
+			if len(resourceTypes) > 0 {
+				resourceList, err := getResourceTypes(resourceTypes, ioStreams)
+				if err != nil {
+					util.CheckErr(err)
+					return
+				}
+				applicationBackup.Spec.ResourceTypes = resourceList
+			}
+
 			applicationBackup.Name = applicationBackupName
 			applicationBackup.Namespace = cmdFactory.GetNamespace()
 			_, err := storkops.Instance().CreateApplicationBackup(applicationBackup)
@@ -86,6 +99,7 @@ func newCreateApplicationBackupCommand(cmdFactory Factory, ioStreams genericclio
 	createApplicationBackupCommand.Flags().StringVarP(&preExecRule, "preExecRule", "", "", "Rule to run before executing applicationbackup")
 	createApplicationBackupCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Rule to run after executing applicationbackup")
 	createApplicationBackupCommand.Flags().StringVarP(&backupLocation, "backupLocation", "b", "", "BackupLocation to use for the backup")
+	createApplicationBackupCommand.Flags().StringVarP(&resourceTypes, "resourceTypes", "", "", "List of specific resource types which need to be backed up, ex: \"Deployment,PersistentVolumeClaim\"")
 
 	return createApplicationBackupCommand
 }
@@ -271,4 +285,40 @@ func waitForApplicationBackup(name, namespace string, ioStreams genericclioption
 	}
 
 	return msg, err
+}
+
+func getResourceTypes(resourceType string, ioStreams genericclioptions.IOStreams) ([]string, error) {
+	resourceList := make([]string, 0)
+	resourceTypes := strings.Split(resourceType, ",")
+
+	discoveryClient, err := getDiscoveryClientForApiResources()
+	if err != nil {
+		return resourceList, fmt.Errorf("error getting discoveryclient: %v", err)
+	}
+	// List the available API resources
+	apiResourceList, err := discoveryClient.ServerPreferredResources()
+	if err != nil {
+		return resourceList, fmt.Errorf("error getting API resources: %v", err)
+	}
+
+	for _, resourceType := range resourceTypes {
+		found := false
+		for _, group := range apiResourceList {
+			for _, apiResource := range group.APIResources {
+				if isValidResourceType(resourceType, apiResource) {
+					resourceList = append(resourceList, apiResource.Kind)
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			return resourceList, fmt.Errorf("error getting k8s resource type for input resourcetype: %s", resourceType)
+		}
+	}
+
+	return resourceList, nil
 }

--- a/pkg/storkctl/applicationrestore_test.go
+++ b/pkg/storkctl/applicationrestore_test.go
@@ -4,6 +4,7 @@
 package storkctl
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,25 @@ func TestGetRestoresNoRestore(t *testing.T) {
 	testCommon(t, cmdArgs, &restoreList, expected, false)
 }
 
+func createBackupLocationAndVerify(
+	t *testing.T,
+	name string,
+	namespace string,
+) {
+	bl := &storkv1.BackupLocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Location: storkv1.BackupLocationItem{Type: storkv1.BackupLocationS3},
+	}
+	_, err := storkops.Instance().CreateBackupLocation(bl)
+	require.NoError(t, err, "Error creating backuplocation")
+
+	_, err = storkops.Instance().GetBackupLocation(name, namespace)
+	require.NoError(t, err, "Error getting backuplocation")
+}
+
 func createApplicationRestoreAndVerify(
 	t *testing.T,
 	name string,
@@ -30,8 +50,23 @@ func createApplicationRestoreAndVerify(
 	namespaces []string,
 	backupLocation string,
 	backupName string,
+	resources string,
+	createBackup bool,
+	createBackupLocation bool,
 ) {
+
+	if createBackupLocation {
+		createBackupLocationAndVerify(t, backupLocation, namespace)
+	}
+	if createBackup {
+		createApplicationBackupAndVerify(t, backupName, namespace, namespaces, backupLocation, "", "", "")
+	}
+
 	cmdArgs := []string{"create", "apprestores", "-n", namespace, name, "--backupLocation", backupLocation, "--backupName", backupName}
+
+	if len(resources) > 0 {
+		cmdArgs = append(cmdArgs, "--resources", resources)
+	}
 
 	expected := "ApplicationRestore " + name + " started successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
@@ -47,7 +82,7 @@ func createApplicationRestoreAndVerify(
 
 func TestGetApplicationRestoresOneApplicationRestore(t *testing.T) {
 	defer resetTest()
-	createApplicationRestoreAndVerify(t, "getrestoretest", "test", []string{"namespace1"}, "backuplocation", "backupname")
+	createApplicationRestoreAndVerify(t, "getrestoretest", "test", []string{"namespace1"}, "backuplocation", "backupname", "", true, true)
 
 	expected := "NAME             STAGE   STATUS   VOLUMES   RESOURCES   CREATED   ELAPSED\n" +
 		"getrestoretest                    0/0       0                     \n"
@@ -61,8 +96,8 @@ func TestGetApplicationRestoresMultiple(t *testing.T) {
 	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}})
 	require.NoError(t, err, "Error creating default namespace")
 
-	createApplicationRestoreAndVerify(t, "getrestoretest1", "default", []string{"namespace1"}, "backuplocation", "backupname")
-	createApplicationRestoreAndVerify(t, "getrestoretest2", "default", []string{"namespace1"}, "backuplocation", "backupname")
+	createApplicationRestoreAndVerify(t, "getrestoretest1", "default", []string{"namespace1"}, "backuplocation", "backupname", "", true, true)
+	createApplicationRestoreAndVerify(t, "getrestoretest2", "default", []string{"namespace1"}, "backuplocation", "backupname", "", false, false)
 
 	expected := "NAME              STAGE   STATUS   VOLUMES   RESOURCES   CREATED   ELAPSED\n" +
 		"getrestoretest1                    0/0       0                     \n" +
@@ -83,7 +118,7 @@ func TestGetApplicationRestoresMultiple(t *testing.T) {
 
 	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}})
 	require.NoError(t, err, "Error creating ns1 namespace")
-	createApplicationRestoreAndVerify(t, "getrestoretest21", "ns1", []string{"namespace1"}, "backuplocation", "backupname")
+	createApplicationRestoreAndVerify(t, "getrestoretest21", "ns1", []string{"namespace1"}, "backuplocation", "backupname", "", true, true)
 	cmdArgs = []string{"get", "apprestores", "--all-namespaces"}
 	expected = "NAMESPACE   NAME               STAGE   STATUS   VOLUMES   RESOURCES   CREATED   ELAPSED\n" +
 		"default     getrestoretest1                     0/0       0                     \n" +
@@ -94,7 +129,7 @@ func TestGetApplicationRestoresMultiple(t *testing.T) {
 
 func TestGetApplicationRestoresWithStatusAndProgress(t *testing.T) {
 	defer resetTest()
-	createApplicationRestoreAndVerify(t, "getrestorestatustest", "default", []string{"namespace1"}, "backuplocation", "backupname")
+	createApplicationRestoreAndVerify(t, "getrestorestatustest", "default", []string{"namespace1"}, "backuplocation", "backupname", "", true, true)
 	restore, err := storkops.Instance().GetApplicationRestore("getrestorestatustest", "default")
 	require.NoError(t, err, "Error getting restore")
 
@@ -113,6 +148,116 @@ func TestGetApplicationRestoresWithStatusAndProgress(t *testing.T) {
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 
+func TestSpecificObjectRestore(t *testing.T) {
+	defer resetTest()
+	// Create a backup and update with resources
+	createApplicationBackupAndVerify(t, "backupname", "test", []string{"namespace1"}, "backupname", "", "", "")
+	backup, err := storkops.Instance().GetApplicationBackup("backupname", "test")
+	require.NoError(t, err, "Error getting backup")
+	// Update the status of the backup
+	backup.Status.FinishTimestamp = metav1.Now()
+	backup.CreationTimestamp = metav1.NewTime(backup.Status.FinishTimestamp.Add(-5 * time.Minute))
+	backup.Status.TriggerTimestamp = metav1.NewTime(backup.Status.FinishTimestamp.Add(-5 * time.Minute))
+	backup.Status.Stage = storkv1.ApplicationBackupStageFinal
+	backup.Status.Status = storkv1.ApplicationBackupStatusSuccessful
+	backup.Status.Volumes = []*storkv1.ApplicationBackupVolumeInfo{}
+	backupResources := make([]*storkv1.ApplicationBackupResourceInfo, 3)
+	backupResources[0] = &storkv1.ApplicationBackupResourceInfo{
+		ObjectInfo: storkv1.ObjectInfo{
+			Name:      "deploy1",
+			Namespace: "ns1",
+			GroupVersionKind: metav1.GroupVersionKind{
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+		},
+	}
+	backupResources[1] = &storkv1.ApplicationBackupResourceInfo{
+		ObjectInfo: storkv1.ObjectInfo{
+			Name:      "pvc1",
+			Namespace: "ns1",
+			GroupVersionKind: metav1.GroupVersionKind{
+				Group:   "core",
+				Version: "v1",
+				Kind:    "PersistentVolumeClaim",
+			},
+		},
+	}
+	backupResources[2] = &storkv1.ApplicationBackupResourceInfo{
+		ObjectInfo: storkv1.ObjectInfo{
+			Name:      "pv1",
+			Namespace: "",
+			GroupVersionKind: metav1.GroupVersionKind{
+				Group:   "core",
+				Version: "v1",
+				Kind:    "PersistentVolume",
+			},
+		},
+	}
+	backup.Status.Resources = backupResources
+	_, err = storkops.Instance().UpdateApplicationBackup(backup)
+	require.NoError(t, err, "Error updating backup")
+
+	// Update the status of the backup
+	backup.Status.FinishTimestamp = metav1.Now()
+	backup.CreationTimestamp = metav1.NewTime(backup.Status.FinishTimestamp.Add(-5 * time.Minute))
+	backup.Status.TriggerTimestamp = metav1.NewTime(backup.Status.FinishTimestamp.Add(-5 * time.Minute))
+	backup.Status.Stage = storkv1.ApplicationBackupStageFinal
+	backup.Status.Status = storkv1.ApplicationBackupStatusSuccessful
+	backup.Status.Volumes = []*storkv1.ApplicationBackupVolumeInfo{}
+	_, err = storkops.Instance().UpdateApplicationBackup(backup)
+	require.NoError(t, err, "Error updating backup")
+
+	createApplicationRestoreAndVerify(t, "specificrestoretest1", "test", []string{"ns1"}, "backuplocation", "backupname", "PersistentVolumeClaim/ns1/pvc1", false, true)
+
+	expected := "NAME                   STAGE   STATUS   VOLUMES   RESOURCES   CREATED   ELAPSED\n" +
+		"specificrestoretest1                    0/0       0                     \n"
+
+	cmdArgs := []string{"get", "apprestores", "-n", "test"}
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	restore, err := storkops.Instance().GetApplicationRestore("specificrestoretest1", "test")
+	require.NoError(t, err, "Error getting restore specificrestoretest1")
+	require.Equal(t, "PersistentVolumeClaim", restore.Spec.IncludeResources[0].Kind, "ApplicationRestore Resource Kind Mismatch")
+	require.Equal(t, "pvc1", restore.Spec.IncludeResources[0].Name, "ApplicationRestore Resource Name Mismatch")
+	require.Equal(t, "ns1", restore.Spec.IncludeResources[0].Namespace, "ApplicationRestore Resource Namespace Mismatch")
+	require.Equal(t, "core", restore.Spec.IncludeResources[0].Group, "ApplicationRestore Resource Group Mismatch")
+	require.Equal(t, "v1", restore.Spec.IncludeResources[0].Version, "ApplicationRestore Resource Version Mismatch")
+
+	resourceList := []string{
+		"Deployment/ns1/deploy1",
+		"persistentvolumeclaim/ns1/pvc1",
+	}
+	resources := strings.Join(resourceList, ",")
+	createApplicationRestoreAndVerify(t, "specificrestoretest2", "test", []string{"ns1"}, "backuplocation", "backupname", resources, false, false)
+
+	expected = "NAME                   STAGE   STATUS   VOLUMES   RESOURCES   CREATED   ELAPSED\n" +
+		"specificrestoretest1                    0/0       0                     \n" +
+		"specificrestoretest2                    0/0       0                     \n"
+
+	cmdArgs = []string{"get", "apprestores", "-n", "test"}
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	cmdArgs = []string{"create", "apprestores", "-n", "test", "restoreName", "--backupLocation", "backuplocation", "--backupName", "backupname", "--resources", "ConfigMap/ns1/cm1"}
+	expected = "error: error in creating applicationrestore: error getting resource ConfigMap with name cm1 in applicationbackup"
+	testCommon(t, cmdArgs, nil, expected, true)
+
+}
+
+func TestCreateApplicationRestoreNoBackuplocation(t *testing.T) {
+	cmdArgs := []string{"create", "apprestores", "-n", "test", "restoreName", "--backupLocation", "backupLocation", "--backupName", "backupName"}
+	expected := "error: backuplocation backupLocation does not exist in namespace test"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestCreateApplicationRestoreNoBackup(t *testing.T) {
+	createBackupLocationAndVerify(t, "backupLocation", "test")
+	cmdArgs := []string{"create", "apprestores", "-n", "test", "restoreName", "--backupLocation", "backupLocation", "--backupName", "backupName"}
+	expected := "error: applicationbackup backupName does not exist in namespace test"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
 func TestCreateApplicationRestoresNoName(t *testing.T) {
 	cmdArgs := []string{"create", "apprestores"}
 
@@ -122,7 +267,7 @@ func TestCreateApplicationRestoresNoName(t *testing.T) {
 
 func TestCreateApplicationRestores(t *testing.T) {
 	defer resetTest()
-	createApplicationRestoreAndVerify(t, "createrestore", "default", []string{"namespace1"}, "backuplocation", "backupname")
+	createApplicationRestoreAndVerify(t, "createrestore", "default", []string{"namespace1"}, "backuplocation", "backupname", "", true, true)
 }
 
 func TestCreateApplicationRestoresMissingParameters(t *testing.T) {
@@ -131,6 +276,7 @@ func TestCreateApplicationRestoresMissingParameters(t *testing.T) {
 	expected := "error: need to provide BackupLocation to use for restore"
 	testCommon(t, cmdArgs, nil, expected, true)
 
+	createBackupLocationAndVerify(t, "backuplocation", "default")
 	cmdArgs = []string{"create", "apprestores", "createrestore", "--backupLocation", "backuplocation"}
 	expected = "error: need to provide BackupName to restore"
 	testCommon(t, cmdArgs, nil, expected, true)
@@ -138,7 +284,7 @@ func TestCreateApplicationRestoresMissingParameters(t *testing.T) {
 
 func TestCreateDuplicateApplicationRestores(t *testing.T) {
 	defer resetTest()
-	createApplicationRestoreAndVerify(t, "createrestore", "default", []string{"namespace1"}, "backuplocation", "backupname")
+	createApplicationRestoreAndVerify(t, "createrestore", "default", []string{"namespace1"}, "backuplocation", "backupname", "", true, true)
 	cmdArgs := []string{"create", "apprestores", "createrestore", "--backupLocation", "backuplocation", "--backupName", "backupname"}
 
 	expected := "Error from server (AlreadyExists): applicationrestores.stork.libopenstorage.org \"createrestore\" already exists"
@@ -155,7 +301,7 @@ func TestDeleteApplicationRestoresNoApplicationRestoreName(t *testing.T) {
 
 func TestDeleteApplicationRestores(t *testing.T) {
 	defer resetTest()
-	createApplicationRestoreAndVerify(t, "deleterestore", "default", []string{"namespace1"}, "backuplocation", "backupname")
+	createApplicationRestoreAndVerify(t, "deleterestore", "default", []string{"namespace1"}, "backuplocation", "backupname", "", true, true)
 
 	cmdArgs := []string{"delete", "apprestores", "deleterestore"}
 	expected := "ApplicationRestore deleterestore deleted successfully\n"
@@ -165,16 +311,16 @@ func TestDeleteApplicationRestores(t *testing.T) {
 	expected = "Error from server (NotFound): applicationrestores.stork.libopenstorage.org \"deleterestore\" not found"
 	testCommon(t, cmdArgs, nil, expected, true)
 
-	createApplicationRestoreAndVerify(t, "deleterestore1", "default", []string{"namespace1"}, "backuplocation", "backupname1")
-	createApplicationRestoreAndVerify(t, "deleterestore2", "default", []string{"namespace1"}, "backuplocation", "backupname2")
+	createApplicationRestoreAndVerify(t, "deleterestore1", "default", []string{"namespace1"}, "backuplocation", "backupname1", "", true, false)
+	createApplicationRestoreAndVerify(t, "deleterestore2", "default", []string{"namespace1"}, "backuplocation", "backupname2", "", true, false)
 
 	cmdArgs = []string{"delete", "apprestores", "deleterestore1", "deleterestore2"}
 	expected = "ApplicationRestore deleterestore1 deleted successfully\n"
 	expected += "ApplicationRestore deleterestore2 deleted successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
-	createApplicationRestoreAndVerify(t, "deleterestore1", "default", []string{"namespace1"}, "backuplocation", "backupname1")
-	createApplicationRestoreAndVerify(t, "deleterestore2", "default", []string{"namespace1"}, "backuplocation", "backupname2")
+	createApplicationRestoreAndVerify(t, "deleterestore1", "default", []string{"namespace1"}, "backuplocation", "backupname1", "", false, false)
+	createApplicationRestoreAndVerify(t, "deleterestore2", "default", []string{"namespace1"}, "backuplocation", "backupname2", "", false, false)
 }
 
 func TestCreateApplicationRestoreWaitSuccess(t *testing.T) {
@@ -183,6 +329,10 @@ func TestCreateApplicationRestoreWaitSuccess(t *testing.T) {
 
 	namespace := "dummy-namespace"
 	name := "dummy-name"
+
+	createBackupLocationAndVerify(t, "backuplocation", "dummy-namespace")
+	createApplicationBackupAndVerify(t, "backupname", namespace, []string{namespace}, "backuplocation", "", "", "")
+
 	cmdArgs := []string{"create", "apprestores", "-n", namespace, name, "--backupLocation", "backuplocation", "--backupName", "backupname", "--wait"}
 
 	expected := "ApplicationRestore dummy-name started successfully\n" +
@@ -200,6 +350,10 @@ func TestCreateApplicationRestoreWaitFailed(t *testing.T) {
 
 	namespace := "dummy-namespace"
 	name := "dummy-name"
+
+	createBackupLocationAndVerify(t, "backuplocation", "dummy-namespace")
+	createApplicationBackupAndVerify(t, "backupname", namespace, []string{namespace}, "backuplocation", "", "", "")
+
 	cmdArgs := []string{"create", "applicationrestore", "-n", namespace, name, "--backupLocation", "backuplocation", "--backupName", "backupname", "--wait"}
 
 	expected := "ApplicationRestore dummy-name started successfully\n" +

--- a/pkg/storkctl/common.go
+++ b/pkg/storkctl/common.go
@@ -3,7 +3,13 @@ package storkctl
 import (
 	"fmt"
 	"io"
+	"strings"
 	"time"
+
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	discovery "k8s.io/client-go/discovery"
+	"k8s.io/utils/strings/slices"
 )
 
 func toTimeString(t time.Time) string {
@@ -22,4 +28,30 @@ func printMsg(msg string, out io.Writer) {
 	if _, printErr := fmt.Fprintln(out, msg); printErr != nil {
 		fmt.Println(msg)
 	}
+}
+
+func getDiscoveryClientForApiResources() (discovery.DiscoveryInterface, error) {
+	tempFactory := NewFactory()
+	config, err := tempFactory.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	aeclient, err := apiextensionsclient.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("error getting apiextension client, %v", err)
+	}
+
+	return aeclient.Discovery(), nil
+}
+
+func isValidResourceType(resourceType string, apiResource metav1.APIResource) bool {
+	resourceType = strings.ToLower(resourceType)
+	// comparing all small cases
+	if resourceType == strings.ToLower(apiResource.Name) ||
+		resourceType == strings.ToLower(apiResource.Kind) ||
+		resourceType == strings.ToLower(apiResource.SingularName) ||
+		slices.Contains(apiResource.ShortNames, resourceType) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Signed-Off-By: Diptiranjan


**What type of PR is this?**
improvement

**What this PR does / why we need it**:
1. Support for backing up resources with particular resource types
2. Support for restoring a particular object

**Does this PR change a user-facing CRD or CLI?**:
<!--
yes,

1.   ./storkctl create backup back-test1 --resourceTypes "pvc" --namespaces mysql -n kube-system -b bl1
ApplicationBackup back-test1 started successfully

2.  ./storkctl create backup back-test2 --resourceTypes "deployments,PersistentVolumeClaim" --namespaces mysql -n kube-system -b bl1
ApplicationBackup back-test2 started successfully

3. ./storkctl create applicationrestores test-restore1 -l bl1 -b back-test2 -r Retain --resources "pvc/mysql/mysql-data" -n kube-system
ApplicationRestore test-restore1 started successfully

4. ./storkctl create applicationrestores test-restore2 -l bl1 -b back-test2 -r Delete --resources "Deployment/mysql/mysql,pvc/mysql/mysql-data" -n kube-system
ApplicationRestore test-restore2 started successfully

-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: storkctl was not supporting creating of backup for specific resource types and resources for specific resources.
User Impact: Manually it was required to add the backup and restore CRs. 
Resolution : Support for specific resource types backup and specific resource restore through storkctl is now supported.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.8.0
-->

**Test**
More test results have been updated in PWX-31372
