### PR TITLE
PWX-32617: Update google sdk.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN asdf install kubelogin latest
 RUN asdf global kubelogin latest
 
 #Install Google Cloud SDK
-ARG GCLOUD_SDK=google-cloud-cli-439.0.0-linux-x86_64.tar.gz
+ARG GCLOUD_SDK=google-cloud-cli-444.0.0-linux-x86_64.tar.gz
 ARG GCLOUD_INSTALL_DIR="/usr/lib"
 RUN curl -q -o $GCLOUD_SDK https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
     tar xf $GCLOUD_SDK -C $GCLOUD_INSTALL_DIR && rm -rf $GCLOUD_SDK && \


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Update GCloud SDK.
Without this change: Vulnerability count = 327 https://aetos.pwx.purestorage.com/security/Stork/23-8-0-dev/2023-08-17-19-37-03-746232
With this change: Vulnerability count = 259 https://aetos.pwx.purestorage.com/security/Stork/23-8-0-dev/2023-08-24-21-21-00-059221

**Does this PR change a user-facing CRD or CLI?**:
na

**Is a release note needed?**:
```Improvement
Update google cloud sdk to to v444.0.0 to fix vulnerabilities.
```

**Does this change need to be cherry-picked to a release branch?**:
yes, 23.8.0


