### PR TITLE
pb-4278: Adding sse (s3 server side encryption) field in the s3config of backuplocation CR.

### DIFF
--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -108,6 +108,9 @@ type S3Config struct {
 	// UseIam when set stork will use the instance IAM role associated with the nodes
 	// on which stork pods run
 	UseIam bool `json:"useIam"`
+	// SSE (Server Side Encryption) type for the S3 bucket.
+	// supported option: "AES256", "aws:kms"
+	sse string `json:"sse"`
 }
 
 // AzureConfig specifies the config required to connect to Azure Blob Storage


### PR DESCRIPTION



**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>feature


**What this PR does / why we need it**:
```
  pb-4278: Adding sse (s3 server side encryption) field in the s3config of
    backuplocation CR.
```

**Does this PR change a user-facing CRD or CLI?**:
It changes backuplocation CR, But do not want to call till complete implementation is available.

**Is a release note needed?**:
NA. As not pubically calling out till complete implementation is available.


**Does this change need to be cherry-picked to a release branch?**:
23.7.2 and 23.8.0
