### PR TITLE
PB-4302: Implement automatic resource transformation for Kubevirt

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -1034,7 +1034,9 @@ func (r *ResourceCollector) PrepareResourceForApply(
 		return false, r.prepareRancherNetworkPolicy(object, *opts)
 	case "Deployment", "StatefulSet", "DeploymentConfig", "IBPPeer", "IBPCA", "IBPConsole", "IBPOrderer", "ReplicaSet":
 		return false, r.prepareRancherApplicationResource(object, *opts)
-
+	case "VirtualMachine":
+		logrus.Tracef("Transforming kubevirt VM resource for apply")
+		return false, r.prepareVirtualMachineForApply(object, nil)
 	}
 	return false, nil
 }

--- a/pkg/resourcecollector/virtualmachine.go
+++ b/pkg/resourcecollector/virtualmachine.go
@@ -1,9 +1,99 @@
 package resourcecollector
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+// Transform dataVolume: to persistentVolumeClaim:
+func transformDataVolume(input map[string]interface{}, name string) map[string]interface{} {
+
+	output := make(map[string]interface{})
+
+	for key, val := range input {
+		if key == name {
+			output["claimName"] = val
+			continue
+		}
+		output[key] = val
+	}
+	return output
+}
+
+// Utility function for virtualMachine template parsing logic
+func parseMap(input map[string]interface{}, output map[string]interface{}, is_key_present *bool) {
+
+	for mKey, mVal := range input {
+		switch mKey {
+		case "macAddress":
+			*is_key_present = true
+			continue
+		case "dataVolume":
+			*is_key_present = true
+			switch typeval := mVal.(type) {
+			case map[string]interface{}:
+				output["persistentVolumeClaim"] = transformDataVolume(typeval, "name")
+				continue
+			}
+		}
+		output[mKey] = mVal
+	}
+}
+
+// Path parsing function for virtualMachine template.
+func transformPath(object runtime.Unstructured, path []string) error {
+
+	content := object.UnstructuredContent()
+	data, _, err := unstructured.NestedSlice(content, path...)
+	if err != nil {
+		return err
+	}
+	found := false
+	newDeviceFields := make([]interface{}, 0, 1)
+	for _, val := range data {
+		switch typeval := val.(type) {
+		case map[string]interface{}:
+			newMap := make(map[string]interface{})
+			parseMap(typeval, newMap, &found)
+			newDeviceFields = append(newDeviceFields, newMap)
+		}
+	}
+	// Update only if the desired path,value is found in the template for transformation
+	// Ignore otherwise.
+	if found {
+		unstructured.RemoveNestedField(content, path...)
+		if err := unstructured.SetNestedSlice(content, newDeviceFields, path...); err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
+// This should be called from restore workflow for any resource transform for
+// VM resources.
+func (r *ResourceCollector) prepareVirtualMachineForApply(
+	object runtime.Unstructured,
+	namespaces []string,
+) error {
+
+	// Remove macAddress as it creates macAddress conflict while restore
+	// to the same cluster to different namespace while the source VM is
+	// up and running.
+	path := "spec.template.spec.domain.devices.interfaces"
+	if err := transformPath(object, strings.Split(path, ".")); err != nil {
+		return err
+	}
+
+	// Transform dataVolume to associated PVC for dataVolumeTemplate configurations
+	path = "spec.template.spec.volumes"
+	err := transformPath(object, strings.Split(path, "."))
+
+	return err
+
+}
 
 func (r *ResourceCollector) prepareVirtualMachineForCollection(
 	object runtime.Unstructured,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test



**What this PR does / why we need it**:
This changes fixes the issue while restoring kubevirt VMs with networking configurations and also with DatavolumeTemplates.

More details in https://portworx.atlassian.net/browse/PB-4302


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
NO
**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: https://portworx.atlassian.net/browse/PB-4302
User Impact: None
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
NO
