### PR TITLE
PWX-33267: use gcc 10.5.0 container to build px_statfs.so (#1489)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,12 @@ STORK_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_IMAGE):$(DOCKER_HUB_STORK_TAG)
 CMD_EXECUTOR_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_CMD_EXECUTOR_IMAGE):$(DOCKER_HUB_CMD_EXECUTOR_TAG)
 STORK_TEST_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_TEST_IMAGE):$(DOCKER_HUB_STORK_TEST_TAG)
 
-DOCK_BUILD_CNT  := golang:1.19.10
+DOCK_BUILD_CNT := golang:1.19.10
+
+# DO NOT update this to the latest version. We need to keep this old enough so that
+# px_statfs.so can be loaded on OCP 4.12 which uses RHEL8. Use "ldd -r -v ./bin/px_statfs.so" to
+# see which glibc will be needed to be present on the host where the .so gets loaded.
+DOCK_GCC_BUILD_CNT := gcc:10.5.0
 
 ifndef PKGS
 PKGS := $(shell go list ./... 2>&1 | grep -v 'github.com/libopenstorage/stork/vendor' | grep -v 'pkg/client/informers/externalversions' | grep -v versioned | grep -v 'pkg/apis/stork' | grep -v 'hack')
@@ -154,7 +159,7 @@ storkctl:
 
 px-statfs:
 	@echo "Building px_statfs.so"
-	docker run --rm  $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
+	docker run --rm  $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_GCC_BUILD_CNT) \
 		   /bin/bash -c 'cd /go/src/github.com/libopenstorage/stork/drivers/volume/portworx/px-statfs &&  \
            gcc -g -shared -fPIC -o /go/src/github.com/libopenstorage/stork/bin/px_statfs.so px_statfs.c -ldl -D__USE_LARGEFILE64;'
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
Cherry-pick fix for PWX-33267 to 23.7.2 release

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: See the main PR.
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

