### PR TITLE
 PWX-33267: update px-statfs configmap if needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,3 +54,4 @@ COPY ./bin/windows/storkctl.exe /storkctl/windows/
 COPY ./LICENSE /licenses
 COPY ./bin/stork /
 COPY ./bin/px_statfs.so /
+COPY ./bin/px_statfs.so.sha256 /

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ DOCK_BUILD_CNT := golang:1.19.10
 # px_statfs.so can be loaded on OCP 4.12 which uses RHEL8. Use "ldd -r -v ./bin/px_statfs.so" to
 # see which glibc will be needed to be present on the host where the .so gets loaded.
 DOCK_GCC_BUILD_CNT := gcc:10.5.0
+PX_STATFS_SRC_DIR := /go/src/github.com/libopenstorage/stork/drivers/volume/portworx/px-statfs
+PX_STATFS_DEST_DIR := /go/src/github.com/libopenstorage/stork/bin
 
 ifndef PKGS
 PKGS := $(shell go list ./... 2>&1 | grep -v 'github.com/libopenstorage/stork/vendor' | grep -v 'pkg/client/informers/externalversions' | grep -v versioned | grep -v 'pkg/apis/stork' | grep -v 'hack')
@@ -160,8 +162,9 @@ storkctl:
 px-statfs:
 	@echo "Building px_statfs.so"
 	docker run --rm  $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_GCC_BUILD_CNT) \
-		   /bin/bash -c 'cd /go/src/github.com/libopenstorage/stork/drivers/volume/portworx/px-statfs &&  \
-           gcc -g -shared -fPIC -o /go/src/github.com/libopenstorage/stork/bin/px_statfs.so px_statfs.c -ldl -D__USE_LARGEFILE64;'
+		   /bin/bash -c 'cd $(PX_STATFS_SRC_DIR) &&  \
+           gcc -g -shared -fPIC -o $(PX_STATFS_DEST_DIR)/px_statfs.so px_statfs.c -ldl -D__USE_LARGEFILE64 && \
+           sha256sum $(PX_STATFS_DEST_DIR)/px_statfs.so | cut -d " " -f 1 > $(PX_STATFS_DEST_DIR)/px_statfs.so.sha256;'
 
 
 container: help


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
When a new virt-launcher pod is starting, update the existing px-statfs configMap, if needed.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
no

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
no
