### PR TITLE
Revert "PWX-33267: use gcc 10.5.0 container to build px_statfs.so 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,7 @@ STORK_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_IMAGE):$(DOCKER_HUB_STORK_TAG)
 CMD_EXECUTOR_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_CMD_EXECUTOR_IMAGE):$(DOCKER_HUB_CMD_EXECUTOR_TAG)
 STORK_TEST_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_TEST_IMAGE):$(DOCKER_HUB_STORK_TEST_TAG)
 
-DOCK_BUILD_CNT := golang:1.19.10
-
-# DO NOT update this to the latest version. We need to keep this old enough so that
-# px_statfs.so can be loaded on OCP 4.12 which uses RHEL8. Use "ldd -r -v ./bin/px_statfs.so" to
-# see which glibc will be needed to be present on the host where the .so gets loaded.
-DOCK_GCC_BUILD_CNT := gcc:10.5.0
+DOCK_BUILD_CNT  := golang:1.19.10
 
 ifndef PKGS
 PKGS := $(shell go list ./... 2>&1 | grep -v 'github.com/libopenstorage/stork/vendor' | grep -v 'pkg/client/informers/externalversions' | grep -v versioned | grep -v 'pkg/apis/stork' | grep -v 'hack')
@@ -159,7 +154,7 @@ storkctl:
 
 px-statfs:
 	@echo "Building px_statfs.so"
-	docker run --rm  $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_GCC_BUILD_CNT) \
+	docker run --rm  $(SECCOMP_OPTIONS) -v $(shell pwd):/go/src/github.com/libopenstorage/stork  $(DOCK_BUILD_CNT) \
 		   /bin/bash -c 'cd /go/src/github.com/libopenstorage/stork/drivers/volume/portworx/px-statfs &&  \
            gcc -g -shared -fPIC -o /go/src/github.com/libopenstorage/stork/bin/px_statfs.so px_statfs.c -ldl -D__USE_LARGEFILE64;'
 


### PR DESCRIPTION


This reverts commit ed2e76b9a86b844dbdb5f73e1d2cec5aff99bd74.


**What type of PR is this?**
Reverting the kubevirt changes from 23.7.3.

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes - 23.7.3

