### PR TITLE
PWX-33454: storkctl deactivate should not create CR from stashed configmap.

### DIFF
--- a/pkg/resourceutils/updatereplicas.go
+++ b/pkg/resourceutils/updatereplicas.go
@@ -375,7 +375,9 @@ func getUpdatedReplicaCount(annotations map[string]string, activate bool, printF
 }
 
 func updateStashedCMObjects(namespace string, activate bool, printFunc func(string, string), config *rest.Config) {
-
+	if !activate {
+		return
+	}
 	pvcToPVCOwnerMapping := make(map[string][]metav1.OwnerReference)
 	// List the configmaps with label "stash-cr" enabled
 	configMaps, err := core.Instance().ListConfigMap(namespace, metav1.ListOptions{LabelSelector: StashCRLabel})


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
bug

**What this PR does / why we need it**:
storkctl activate should try to create the CR from stashed configmap, not deactivate.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->


**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.8.0
-->

**Test**
Without Fix:
➜  stork git:(PWX-30292) ✗ bin/linux/storkctl deactivate migrations -n mongodb
Updated replicas for deployment mongodb/mongodb-kubernetes-operator to 0

Updated CR for mongodbcommunity mongodb/example-mongodb
W0903 18:55:05.406178    9248 warnings.go:70] snapshot.storage.k8s.io/v1beta1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot
**Successfully created the CRs from the stashed configmaps MongoDBCommunity/example-mongodb** -> this should have been avoided
Set the ApplicationActivated status in the MigrationSchedule mongodb/mongodb-fp to false

With Fix:
➜  stork git:(PWX-30292) ✗ bin/linux/storkctl deactivate migrations -n mongodb
Updated replicas for deployment mongodb/mongodb-kubernetes-operator to 0
Updated CR for mongodbcommunity mongodb/example-mongodb
W0903 19:07:24.987788   29631 warnings.go:70] snapshot.storage.k8s.io/v1beta1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot
Set the ApplicationActivated status in the MigrationSchedule mongodb/mongodb-fp to false
