### PR TITLE
pb-4365: Added already exist error for the dataexport CR creation in kdmp driver

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -307,6 +307,11 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		}
 		_, err = kdmpShedOps.Instance().CreateDataExport(dataExport)
 		if err != nil {
+			// If the dataexport CR already exists, continue to next PVC
+			if k8serror.IsAlreadyExists(err) {
+				logrus.Infof("dataexport [%v/%v] already exists, ignore and continue", dataExport.Namespace, dataExport.Name)
+				continue
+			}
 			logrus.Errorf("failed to create DataExport CR: %v", err)
 			return volumeInfos, err
 		}
@@ -781,6 +786,11 @@ func (k *kdmp) StartRestore(
 		}
 		logrus.Tracef("%s de cr name [%v/%v]", funct, dataExport.Namespace, dataExport.Name)
 		if _, err := kdmpShedOps.Instance().CreateDataExport(dataExport); err != nil {
+			// If the dataexport CR already exists, continue to next PVC
+			if k8serror.IsAlreadyExists(err) {
+				logrus.Infof("dataexport [%v/%v] already exists, ignore and continue", dataExport.Namespace, dataExport.Name)
+				continue
+			}
 			logrus.Errorf("failed to create DataExport CR: %v", err)
 			return volumeInfos, err
 		}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
 pb-4365: Added already exist error for the dataexport CR creation in kdmp driver
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
Issue: Sometime the backup and restore fails, if the Dataexport CR already exists.
User Impact: Backup and restore fails, if the reconciler exists rentry again with "Dataexport CR already exists"
Resolution: Added check for "Dataexport CR already exists" and continue with other volumes.

```

**Does this change need to be cherry-picked to a release branch?**:
Yet to be decide.
Testing:
Will ask the QA team to run the failing system test again.
