### PR TITLE
PWX-33569: Creating objectstore locations in destination cluster in unidirectional clusterpair creation with storkctl

### DIFF
--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -229,9 +229,6 @@ func (c *ClusterPairController) cleanup(clusterPair *stork_api.ClusterPair) erro
 			}
 		}
 	}
-	if !skipDelete && clusterPair.Status.RemoteStorageID != "" {
-		return c.volDriver.DeletePair(clusterPair)
-	}
 
 	// Delete the backuplocation and secret associated with clusterpair as part of the delete
 	if backuplocationName, ok := clusterPair.Spec.Options["backuplocation"]; ok {
@@ -259,6 +256,11 @@ func (c *ClusterPairController) cleanup(clusterPair *stork_api.ClusterPair) erro
 			}
 		}
 	}
+
+	if !skipDelete && clusterPair.Status.RemoteStorageID != "" {
+		return c.volDriver.DeletePair(clusterPair)
+	}
+
 	return nil
 }
 

--- a/pkg/storkctl/clusterpair_test.go
+++ b/pkg/storkctl/clusterpair_test.go
@@ -133,24 +133,22 @@ func TestCreateUniDirectionalClusterPairMissingParameters(t *testing.T) {
 	expected := "error: missing parameter \"src-kube-file\" - Kubeconfig file missing for source cluster"
 	testCommon(t, cmdArgs, nil, expected, true)
 
-	srcConfig := createTempFile(t, "src.config", "source configuration")
-	destConfig := createTempFile(t, "dest.config", "destination configuration")
+	srcConfig := createTempFile(t, "src.config", "source")
+	destConfig := createTempFile(t, "dest.config", "destination")
 	defer os.Remove(srcConfig.Name())
 	defer os.Remove(destConfig.Name())
+
 	cmdArgs = []string{"create", "clusterpair", "uni-pair1", "-n", "test", "--src-kube-file", srcConfig.Name(), "--unidirectional"}
 	expected = "error: missing parameter \"dest-kube-file\" - Kubeconfig file missing for destination cluster"
-	testCommon(t, cmdArgs, nil, expected, true)
-
-	cmdArgs = []string{"create", "clusterpair", "uni-pair1", "-n", "test", "--src-kube-file", srcConfig.Name(), "--dest-kube-file", destConfig.Name(), "-u"}
-	expected = "error: missing parameter \"provider\" - External objectstore provider needs to be either of azure, google, s3"
 	testCommon(t, cmdArgs, nil, expected, true)
 
 	cmdArgs = []string{"create", "clusterpair", "uni-pair1", "-n", "test", "--src-kube-file", srcConfig.Name(), "--dest-kube-file", srcConfig.Name(), "-u"}
 	expected = "error: source kubeconfig file and destination kubeconfig file should be different"
 	testCommon(t, cmdArgs, nil, expected, true)
 
-	srcConfigDuplicate := createTempFile(t, "srcDup.config", "source configuration")
+	srcConfigDuplicate := createTempFile(t, "srcDup.config", "source")
 	defer os.Remove(srcConfigDuplicate.Name())
+
 	cmdArgs = []string{"create", "clusterpair", "uni-pair1", "-n", "test", "--src-kube-file", srcConfig.Name(), "--dest-kube-file", srcConfigDuplicate.Name(), "-u"}
 	expected = "error: source kubeconfig and destination kubeconfig file should be different"
 	testCommon(t, cmdArgs, nil, expected, true)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
yes,


-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Creating clusterpair with --unidirectional fails as objectstore info was missing in destination cluster.
User Impact: Migration using the above clusterpair will fail.
Resolution: Creating objectstore info in destination cluster for migration to succeed.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.7.3 .
-->

**Test**
`
1. Creating clusterpair with unidirectional option.

➜  stork git:(PWX-33569) ✗ ./storkctl create clusterpair uni-cp-fw -n mongodb --src-kube-file /tmp/dipti5.config --dest-kube-file /tmp/dipti7.config --s3-access-key admin --s3-secret-key Password1 --s3-endpoint minio.pwx.dev.purestorage.com --s3-region us-east1 -p s3 -u
Destination portworx endpoint is 10.13.194.128:9001

Creating Secret and ObjectstoreLocation in source cluster in namespace mongodb...
ObjectstoreLocation uni-cp-fw created on source cluster in namespace mongodb

Creating Secret and ObjectstoreLocation in destination cluster in namespace mongodb...
ObjectstoreLocation uni-cp-fw created on destination cluster in namespace mongodb

Creating a cluster pair. Direction: Source -> Destination
ClusterPair uni-cp-fw created successfully. Direction Source -> Destination


In source:

➜  stork git:(PWX-33569) ✗ ./storkctl get clusterpair -n mongodb
NAME        STORAGE-STATUS   SCHEDULER-STATUS   CREATED
uni-cp-fw   Ready            Ready              10 Sep 23 18:43 UTC
➜  stork git:(PWX-33569) ✗ km get backuplocations
NAME        AGE
uni-cp-fw   74s
➜  stork git:(PWX-33569) ✗ km get secret uni-cp-fw
NAME        TYPE     DATA   AGE
uni-cp-fw   Opaque   8      81s


In dest:
➜  stork git:(PWX-33569) ✗ ./storkctl get clusterpair -n mongodb
No resources found.
➜  stork git:(PWX-33569) ✗  km get backuplocations
NAME        AGE
uni-cp-fw   112s
➜  stork git:(PWX-33569) ✗ km get secret uni-cp-fw
NAME        TYPE     DATA   AGE
uni-cp-fw   Opaque   8      117s


Doing migration :

➜  stork git:(PWX-33569) ✗ ./storkctl get migrationschedule -n mongodb
NAME         POLICYNAME   CLUSTERPAIR     SUSPEND   LAST-SUCCESS-TIME     LAST-SUCCESS-DURATION
mongo-rev    every-15m    dipti-mongodb   true
mongodb-fp   every-15m    uni-cp-fw       false     09 Sep 23 01:33 UTC   1m52s


➜  stork git:(PWX-33569) ✗ ./storkctl get migrations -n mongodb
NAME                                    CLUSTERPAIR   STAGE   STATUS       VOLUMES   RESOURCES   CREATED               ELAPSED                                    TOTAL BYTES TRANSFERRED
mongodb-fp-interval-2023-09-10-184626   uni-cp-fw     Final   Successful   6/6       29/29       10 Sep 23 18:46 UTC   Volumes (1m30s) Resources (32s)            734998528



2. Creating cp with same name in dest cluster
➜  stork git:(23.7.2) ✗ ./storkctl create clusterpair uni-cp-fw -n mongodb --src-kube-file /tmp/dipti7.config --dest-kube-file /tmp/dipti5.config --s3-access-key admin --s3-secret-key Password1 --s3-endpoint minio.pwx.dev.purestorage.com --s3-region us-east1 -p s3 -u
Destination portworx endpoint is 10.13.192.154:9001

Creating Secret and ObjectstoreLocation in source cluster in namespace mongodb...
Error from server (AlreadyExists): secrets "uni-cp-fw" already exists

3. Creating CP with same name in dest cluster using “use-existing-backuplocation” flag

➜  stork git:(23.7.2) ✗ ./storkctl create clusterpair uni-cp-fw -n mongodb --src-kube-file /tmp/dipti7.config --dest-kube-file /tmp/dipti5.config --s3-access-key admin --s3-secret-key Password1 --s3-endpoint minio.pwx.dev.purestorage.com --s3-region us-east1 -p s3 -u --use-existing-backuplocation uni-cp-fw
Destination portworx endpoint is 10.13.192.154:9001
Creating a cluster pair. Direction: Source -> Destination
ClusterPair uni-cp-fw created successfully. Direction Source -> Destination

➜  stork git:(23.7.2) ✗ ./storkctl get clusterpair -n mongodb
NAME        STORAGE-STATUS   SCHEDULER-STATUS   CREATED
uni-cp-fw   Ready            Ready              11 Sep 23 03:10 UTC


➜  stork git:(23.7.2) ✗ ./storkctl get migrations -n mongodb
NAME                                   CLUSTERPAIR   STAGE   STATUS       VOLUMES   RESOURCES   CREATED               ELAPSED                          TOTAL BYTES TRANSFERRED
mongo-rev-interval-2023-09-11-032632   uni-cp-fw     Final   Successful   6/6       29/29       11 Sep 23 03:26 UTC   Volumes (44s) Resources (1m2s)   842321920

4. Creating cp with different name in dest cluster
➜  stork git:(23.7.2) ✗ ./storkctl create clusterpair uni-cp-rev -n mongodb --src-kub
e-file /tmp/dipti7.config --dest-kube-file /tmp/dipti5.config --s3-access-key admin -
-s3-secret-key Password1 --s3-endpoint minio.pwx.dev.purestorage.com --s3-region us-e
ast1 -p s3 -u
Destination portworx endpoint is 10.13.192.154:9001

Creating Secret and ObjectstoreLocation in source cluster in namespace mongodb...
ObjectstoreLocation uni-cp-rev created on source cluster in namespace mongodb

Creating Secret and ObjectstoreLocation in destination cluster in namespace mongodb...
ObjectstoreLocation uni-cp-rev created on destination cluster in namespace mongodb

Creating a cluster pair. Direction: Source -> Destination
ClusterPair uni-cp-rev created successfully. Direction Source -> Destination

➜  stork git:(23.7.2) ✗ ./storkctl get migrations -n mongodb
NAME                                   CLUSTERPAIR   STAGE   STATUS       VOLUMES   RESOURCES   CREATED               ELAPSED                         TOTAL BYTES TRANSFERRED
mongo-rev-interval-2023-09-11-055359   uni-cp-rev    Final   Successful   6/6       29/29       11 Sep 23 05:53 UTC   Volumes (43s) Resources (25s)   854593536


5. Deleting clusterpair:

➜  stork git:(23.7.2) ✗ bin/linux/storkctl get clusterpair -n mongodb
NAME         STORAGE-STATUS   SCHEDULER-STATUS   CREATED
uni-cp-rev   Ready            Ready              11 Sep 23 08:26 UTC
➜  stork git:(23.7.2) ✗ km delete clusterpair uni-cp-rev
clusterpair.stork.libopenstorage.org "uni-cp-rev" deleted
➜  stork git:(23.7.2) ✗
➜  stork git:(23.7.2) ✗ km get secrets  | grep dipti
➜  stork git:(23.7.2) ✗ bin/linux/storkctl get clusterpair -n mongodb
No resources found.
➜  stork git:(23.7.2) ✗ km get backuplocations uni-cp-rev
Error from server (NotFound): backuplocations.stork.libopenstorage.org "uni-cp-rev" not found
➜  stork git:(23.7.2) ✗ km get secret uni-cp-rev
Error from server (NotFound): secrets "uni-cp-rev" not found

6. Creating a bidirectional cp:

➜  stork git:(23.7.2) ✗ bin/linux/storkctl create clusterpair bi-cp-mongo -n mongodb --src-kube-file /tmp/dipti5.config --dest-kube-file /tmp/dipti7.config --s3-access-key admin --s3-secret-key Password1 --s3-endpoint minio.pwx.dev.purestorage.com --s3-region us-east1 -p s3
Source portworx endpoint is 10.13.192.154:9001
Destination portworx endpoint is 10.13.194.128:9001

Creating Secret and ObjectstoreLocation in source cluster in namespace mongodb...
ObjectstoreLocation bi-cp-mongo created on source cluster in namespace mongodb

Creating Secret and ObjectstoreLocation in destination cluster in namespace mongodb...
ObjectstoreLocation bi-cp-mongo created on destination cluster in namespace mongodb

Creating a cluster pair. Direction: Source -> Destination
ClusterPair bi-cp-mongo created successfully. Direction Source -> Destination

Creating a cluster pair. Direction: Destination -> Source
Cluster pair bi-cp-mongo created successfully. Direction: Destination -> Source

In source:
➜  stork git:(23.7.2) ✗ km get clusterpair -A
NAMESPACE   NAME          AGE
mongodb     bi-cp-mongo   27s
➜  stork git:(23.7.2) ✗ km get backuplocations bi-cp-mongo
NAME          AGE
bi-cp-mongo   49s
➜  stork git:(23.7.2) ✗ km get secret bi-cp-mongo
NAME          TYPE     DATA   AGE
bi-cp-mongo   Opaque   8      57s

In dest:
➜  stork git:(23.7.2) ✗ km get clusterpair -A
NAMESPACE   NAME          AGE
mongodb     bi-cp-mongo   82s
➜  stork git:(23.7.2) ✗ km get backuplocations bi-cp-mongo
NAME          AGE
bi-cp-mongo   103s
➜  stork git:(23.7.2) ✗ km get secret bi-cp-mongo
NAME          TYPE     DATA   AGE
bi-cp-mongo   Opaque   8      107s

➜  stork git:(23.7.2) ✗ bin/linux/storkctl get migrations -n mongodb
NAME                                    CLUSTERPAIR   STAGE   STATUS       VOLUMES   RESOURCES   CREATED               ELAPSED                                  TOTAL BYTES TRANSFERRED
mongodb-fp-interval-2023-09-11-083836   bi-cp-mongo   Final   Successful   6/6       29/29       11 Sep 23 08:38 UTC   Volumes (1m6s) Resources (1m9s)          854593536

`

