### PR TITLE
PB-4245 :: Restrict backup of "kube-system" ns

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -221,7 +221,9 @@ func (a *ApplicationBackupController) updateWithAllNamespaces(backup *stork_api.
 	}
 	namespacesToBackup := make([]string, 0)
 	for _, ns := range namespaces.Items {
-		namespacesToBackup = append(namespacesToBackup, ns.Name)
+		if ns.Name != "kube-system" {
+			namespacesToBackup = append(namespacesToBackup, ns.Name)
+		}
 	}
 	backup.Spec.Namespaces = namespacesToBackup
 	err = a.client.Update(context.TODO(), backup)
@@ -292,7 +294,9 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		}
 		var selectedNamespaces []string
 		for _, namespace := range namespaces.Items {
-			selectedNamespaces = append(selectedNamespaces, namespace.Name)
+			if namespace.Name != "kube-system" {
+				selectedNamespaces = append(selectedNamespaces, namespace.Name)
+			}
 		}
 		backup.Spec.Namespaces = selectedNamespaces
 	}


### PR DESCRIPTION
- Restrict backup of "kube-system" in case of all namespaces i.e. *
- Restrict backup of "kube-system" in case of label-selector
- Allow backup of "kube-system" in case API is specifically passing it i.e. namsespace=kube-system in API call


**What type of PR is this?**
>feature

**What this PR does / why we need it**:
This PR restricts kube-system ns backup in below scenarios.
- Restrict backup of "kube-system" in case of all namespaces i.e. *
- Restrict backup of "kube-system" in case of label-selector

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->yes
```release-note
Issue: #PB-4245
User Impact: User will not be able to backup kube-system namespace if tried with label-selector or all namespace
Resolution: If user wants to backup kube-system namespace the one needs to pass it specifically as namsespace=kube-system in API calls

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->yes, 23.9

**Testing Screenshot**

Before fix

![Screenshot 2023-09-14 at 8 16 16 PM](https://github.com/libopenstorage/stork/assets/54888022/6cc8119d-e798-482a-8cae-2b05eaec1ce9)
<img width="1703" alt="Screenshot 2023-09-14 at 8 17 46 PM" src="https://github.com/libopenstorage/stork/assets/54888022/bcf02128-8562-4971-8953-d08cc3cff3ef">
![Screenshot 2023-09-14 at 8 24 21 PM](https://github.com/libopenstorage/stork/assets/54888022/c18dffc9-ef7a-4ffc-9d2b-8535814ea19f)
<img width="1710" alt="Screenshot 2023-09-14 at 8 25 20 PM" src="https://github.com/libopenstorage/stork/assets/54888022/cfdb88c2-24a6-49b5-85b2-728a56c42c8a">
<img width="1708" alt="Screenshot 2023-09-14 at 8 26 00 PM" src="https://github.com/libopenstorage/stork/assets/54888022/325be6d3-e288-4e5a-988e-85a6361e2281">
![Screenshot 2023-09-14 at 8 58 30 PM](https://github.com/libopenstorage/stork/assets/54888022/1f09ef56-dc7e-4151-bfa3-7baf81312519)
<img width="1717" alt="Screenshot 2023-09-14 at 8 58 55 PM" src="https://github.com/libopenstorage/stork/assets/54888022/d73e78e6-0742-4eda-ac35-80e2f87c3c25">
<img width="1707" alt="Screenshot 2023-09-14 at 8 59 28 PM" src="https://github.com/libopenstorage/stork/assets/54888022/4742048d-5dfa-4b21-be93-ee240b8a2d3f">

After Fix

![Screenshot 2023-09-15 at 1 30 56 PM](https://github.com/libopenstorage/stork/assets/54888022/d9eb27da-eb65-40b9-a402-a5bccedabfda)
![Screenshot 2023-09-15 at 1 31 55 PM](https://github.com/libopenstorage/stork/assets/54888022/3165c0cb-dd94-4bcc-8ec3-41e02de9132b)
![Screenshot 2023-09-15 at 1 32 36 PM](https://github.com/libopenstorage/stork/assets/54888022/66a604b4-edb9-4467-a909-359e362c4ae1)
![Screenshot 2023-09-15 at 1 34 22 PM](https://github.com/libopenstorage/stork/assets/54888022/318a4aa8-6549-437b-8dd0-105dd0d63484)
![Screenshot 2023-09-15 at 1 35 45 PM](https://github.com/libopenstorage/stork/assets/54888022/d1334403-df63-4e5f-8376-10de9078bd7a)
![Screenshot 2023-09-15 at 1 36 05 PM](https://github.com/libopenstorage/stork/assets/54888022/4f739d30-23a2-450b-a16a-cfe52389f896)
![Screenshot 2023-09-15 at 6 01 43 PM](https://github.com/libopenstorage/stork/assets/54888022/a4886445-7743-4076-a4ca-41df587ad026)
![Screenshot 2023-09-15 at 6 02 14 PM](https://github.com/libopenstorage/stork/assets/54888022/42ca4555-6392-4392-82d4-43d7eecb7c47)
![Screenshot 2023-09-15 at 6 02 34 PM](https://github.com/libopenstorage/stork/assets/54888022/9561d031-17fc-431b-b91d-838026ca2c89)


