### PR TITLE
PWX-33787: Ignore backuplocation not found error during clusterpair deletion.

### DIFF
--- a/pkg/migration/controllers/clusterpair.go
+++ b/pkg/migration/controllers/clusterpair.go
@@ -233,13 +233,11 @@ func (c *ClusterPairController) cleanup(clusterPair *stork_api.ClusterPair) erro
 	// Delete the backuplocation and secret associated with clusterpair as part of the delete
 	if backuplocationName, ok := clusterPair.Spec.Options["backuplocation"]; ok {
 		bl, err := storkops.Instance().GetBackupLocation(backuplocationName, clusterPair.Namespace)
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				logrus.Errorf("fetching backuplocation %s in ns %s failed: %v", backuplocationName, clusterPair.Namespace, err)
-			}
-			return nil
+		if err != nil && !errors.IsNotFound(err) {
+			logrus.Errorf("fetching backuplocation %s in ns %s failed: %v", backuplocationName, clusterPair.Namespace, err)
+			return err
 		}
-		if bl.Annotations[storkCreatedAnnotation] == "true" {
+		if err == nil && bl.Annotations[storkCreatedAnnotation] == "true" {
 			secret, err := core.Instance().GetSecret(bl.Location.SecretConfig, bl.Namespace)
 			if err != nil && errors.IsNotFound(err) {
 				logrus.Errorf("fetching secret %s in ns %s failed: %v", bl.Location.SecretConfig, bl.Namespace, err)


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug

**What this PR does / why we need it**:
Deleting a namespace can make backuplocation to delete first and it should not block the clusterpair deletion from px.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes. 23.7.3, 23.8.0
-->

**Test**
➜  stork git:(23.7.3) ✗ kubectl delete ns test1
namespace "test1" deleted
➜  stork git:(23.7.3) ✗ kubectl get clusterpair -A
No resources found
➜  stork git:(23.7.3) ✗ kubectl get backuplocations -ntest1
No resources found in test1 namespace.
➜  stork git:(23.7.3) ✗ kubectl get secret -ntest1
No resources found in test1 namespace.

[root@dipti5-k8s-pxc-8d21-0 ~]# docker run --rm -e ETCDCTL_API=3 sens/etcdctl --endpoints http://*******:9019 get --prefix=true pwx/dipti5/cluster/pair
[root@dipti5-k8s-pxc-8d21-0 ~]#

Complete result has been updated in PWX-33787,
