### PR TITLE
update stork integration test container to Go 1.17.0

### DIFF
--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.16.1
+FROM golang:1.17.0
 
 # Install dependancies
 RUN apt-get update && \ 
-    /usr/local/go/bin/go install gotest.tools/gotestsum@latest
+    /usr/local/go/bin/go install -v  gotest.tools/gotestsum@latest
 
 RUN apt-get update && apt-get install -y python3-pip && apt-get install -y jq
 


### PR DESCRIPTION
integration-test

**What this PR does / why we need it**:
https://portworx.atlassian.net/browse/PTX-20175

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
