### PR TITLE
Fixed deletion of clusterPair on destination, so that we avoid backuplocation Not found issue on source

### DIFF
--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -373,7 +373,7 @@ func deploymentMigrationReverseTest(t *testing.T) {
 	//validateAndDestroyMigration(t, []*scheduler.Context{preMigrationCtx}, preMigrationCtx, true, true, true, true, false)
 
 	destroyAndWait(t, []*scheduler.Context{postMigrationCtx})
-	validateAndDestroyMigration(t, []*scheduler.Context{preMigrationCtx}, instanceID, appKey, preMigrationCtx, false, false, false, true, true, true)
+	validateAndDestroyMigration(t, []*scheduler.Context{preMigrationCtx}, instanceID, appKey, preMigrationCtx, false, false, false, true, false, true)
 
 	// If we are here then the test has passed
 	testResult = testResultPass


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
Fixed deletion of clusterPair on destination, so that we avoid backuplocation Not found issue on source

Source deletion is working but as we skip destination deletion the clusterPair exist on destination and it complains about Backuplocation not found on source