### PR TITLE
pb-4467: Added support for passing sse type in the native CSI backup path

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	kSnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	kSnapshotv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
 	kSnapshotClient "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
@@ -27,6 +28,7 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/sirupsen/logrus"
+	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -576,8 +578,23 @@ func (c *csi) uploadObject(
 		}
 	}
 
+	var options blob.WriterOptions
+	if backupLocation.Location.S3Config != nil {
+		sseType := backupLocation.Location.S3Config.SSE
+		if len(sseType) != 0 {
+			beforeWrite := func(asFunc func(interface{}) bool) error {
+				var input *s3manager.UploadInput
+				if asFunc(&input) {
+					input.ServerSideEncryption = &sseType
+				}
+				return nil
+			}
+			options = blob.WriterOptions{BeforeWrite: beforeWrite}
+		}
+	}
+
 	objectPath := controllers.GetObjectPath(backup)
-	writer, err := bucket.NewWriter(context.TODO(), filepath.Join(objectPath, objectName), nil)
+	writer, err := bucket.NewWriter(context.TODO(), filepath.Join(objectPath, objectName), &options)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
```
pb-4467: Added support for passing sse type in the native CSI backup path.
```

**Does this PR change a user-facing CRD or CLI?**:
N.A

**Is a release note needed?**:
N.A

**Does this change need to be cherry-picked to a release branch?**:
2.9.0

Testing:
- Tested native csi backup on the IBM c
<img width="1477" alt="Screenshot 2023-09-28 at 9 18 52 PM" src="https://github.com/libopenstorage/stork/assets/52188641/aa141ceb-b928-4908-bec2-bc3cb558d241">
<img width="2049" alt="Screenshot 2023-09-28 at 9 18 33 PM" src="https://github.com/libopenstorage/stork/assets/52188641/e84867b0-2abc-4b5c-9bdb-9b607ad2008b">
<img width="634" alt="Screenshot 2023-09-28 at 9 18 16 PM" src="https://github.com/libopenstorage/stork/assets/52188641/e4ec7c92-e91b-427e-b87c-afdc424c5f2f">
<img width="653" alt="Screenshot 2023-09-28 at 9 18 06 PM" src="https://github.com/libopenstorage/stork/assets/52188641/ec93bebc-1a20-4f28-8bc8-47d6d6a092e9">
<img width="1975" alt="Screenshot 2023-09-28 at 9 17 56 PM" src="https://github.com/libopenstorage/stork/assets/52188641/32664a7f-f481-419f-9b3c-36dca53c9132">
luster.

