### PR TITLE
pb-4570: Added support to pass SSE type in UploadSnapshotObjects(), csi snapshotter flow.

### DIFF
--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	kSnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	kSnapshotv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1beta1"
 	kSnapshotClient "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
@@ -1047,8 +1048,21 @@ func (c *csiDriver) UploadSnapshotObjects(
 			return err
 		}
 	}
-
-	writer, err := bucket.NewWriter(context.TODO(), filepath.Join(objectPath, objectName), nil)
+	var options blob.WriterOptions
+	if backupLocation.Location.S3Config != nil {
+		sseType := backupLocation.Location.S3Config.SSE
+		if len(sseType) != 0 {
+			beforeWrite := func(asFunc func(interface{}) bool) error {
+				var input *s3manager.UploadInput
+				if asFunc(&input) {
+					input.ServerSideEncryption = &sseType
+				}
+				return nil
+			}
+			options = blob.WriterOptions{BeforeWrite: beforeWrite}
+		}
+	}
+	writer, err := bucket.NewWriter(context.TODO(), filepath.Join(objectPath, objectName), &options)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>improvement ( Adding SSE support)


**What this PR does / why we need it**:
```
pb-4570: Added support to pass SSE type in UploadSnapshotObjects(), csi snapshotter flow.
```

**Does this PR change a user-facing CRD or CLI?**:
No, Will add a generic Release note for SSE support.

**Does this change need to be cherry-picked to a release branch?**:
2.9 branch

**Testing:**

Validated the KDMP+Localsnapshot on IBM cluster with SS3 enabled bucket.
![Screenshot 2023-10-08 at 9 55 44 PM](https://github.com/libopenstorage/stork/assets/52188641/46b303fd-c43a-468a-81ab-1b909d89c5e1)
![Screenshot 2023-10-08 at 9 55 29 PM](https://github.com/libopenstorage/stork/assets/52188641/911d08dd-3a76-4dc5-af44-9465c6fe542e)
![Screenshot 2023-10-09 at 9 08 17 AM](https://github.com/libopenstorage/stork/assets/52188641/03174fdc-b8bf-48b7-8b65-83c0386e8530)
![Screenshot 2023-10-09 at 9 08 06 AM](https://github.com/libopenstorage/stork/assets/52188641/b794f048-838d-4018-acaa-0194339fcab3)
![Screenshot 2023-10-09 at 9 07 50 AM](https://github.com/libopenstorage/stork/assets/52188641/d07af100-d8f2-4afd-b78e-ead255e612e4)
