### PR TITLE
PB-4578: Fix RT CR status with duplicate resources and RT controller with duplicate effort.

### DIFF
--- a/pkg/migration/controllers/resourcetransformation.go
+++ b/pkg/migration/controllers/resourcetransformation.go
@@ -250,57 +250,50 @@ func (r *ResourceTransformationController) validateTransformResource(ctx context
 			log.TransformLog(transform).Errorf("Error getting resources kind:%s, err: %v", kind, err)
 			return err
 		}
-		for _, path := range spec.Paths {
-			// This can be handle by CRD validation- v1 version crd support
-			if !(path.Operation == stork_api.AddResourcePath || path.Operation == stork_api.DeleteResourcePath ||
-				path.Operation == stork_api.ModifyResourcePathValue) {
-				return fmt.Errorf("unsupported operation type for given path : %s", path.Operation)
+		for _, object := range objects.Items {
+			metadata, err := meta.Accessor(object)
+			if err != nil {
+				log.TransformLog(transform).Errorf("Unable to read metadata for resource %v, err: %v", kind, err)
+				return err
 			}
-			for _, object := range objects.Items {
-				metadata, err := meta.Accessor(object)
-				if err != nil {
-					log.TransformLog(transform).Errorf("Unable to read metadata for resource %v, err: %v", kind, err)
-					return err
-				}
-				resInfo := &stork_api.TransformResourceInfo{
-					Name:             metadata.GetName(),
-					Namespace:        metadata.GetNamespace(),
-					GroupVersionKind: metav1.GroupVersionKind(object.GetObjectKind().GroupVersionKind()),
-					Specs:            spec,
-				}
-				if err := resourcecollector.TransformResources(object, []stork_api.TransformResourceInfo{*resInfo}, metadata.GetName(), metadata.GetNamespace()); err != nil {
-					log.TransformLog(transform).Errorf("Unable to apply patch path %s during validation on resource kind : %s/,%s/%s,  err: %v", path, kind, resInfo.Namespace, resInfo.Name, err)
-					resInfo.Status = stork_api.ResourceTransformationStatusFailed
-					resInfo.Reason = err.Error()
-					return err
-				}
-				unstructured, ok := object.(*unstructured.Unstructured)
-				if !ok {
-					return fmt.Errorf("unable to cast object to unstructured: %v", object)
-				}
-				resource := &metav1.APIResource{
-					Name:       strings.ToLower(ruleset.Pluralize(strings.ToLower(kind))),
-					Namespaced: len(metadata.GetNamespace()) > 0,
-				}
-				dynamicClient := localInterface.Resource(
-					object.GetObjectKind().GroupVersionKind().GroupVersion().WithResource(resource.Name)).Namespace(getTransformNamespace(transform.Namespace))
+			resInfo := &stork_api.TransformResourceInfo{
+				Name:             metadata.GetName(),
+				Namespace:        metadata.GetNamespace(),
+				GroupVersionKind: metav1.GroupVersionKind(object.GetObjectKind().GroupVersionKind()),
+				Specs:            spec,
+			}
+			if err := resourcecollector.TransformResources(object, []stork_api.TransformResourceInfo{*resInfo}, metadata.GetName(), metadata.GetNamespace()); err != nil {
+				log.TransformLog(transform).Errorf("Unable to transform resource: %s/%s having group version kind:%v with error: %v", resInfo.Namespace, resInfo.Name, resInfo.GroupVersionKind, err)
+				resInfo.Status = stork_api.ResourceTransformationStatusFailed
+				resInfo.Reason = err.Error()
+				return err
+			}
+			unstructured, ok := object.(*unstructured.Unstructured)
+			if !ok {
+				return fmt.Errorf("unable to cast object to unstructured: %v", object)
+			}
+			resource := &metav1.APIResource{
+				Name:       strings.ToLower(ruleset.Pluralize(strings.ToLower(kind))),
+				Namespaced: len(metadata.GetNamespace()) > 0,
+			}
+			dynamicClient := localInterface.Resource(
+				object.GetObjectKind().GroupVersionKind().GroupVersion().WithResource(resource.Name)).Namespace(getTransformNamespace(transform.Namespace))
 
-				unstructured.SetNamespace(getTransformNamespace(transform.Namespace))
-				log.TransformLog(transform).Infof("Applying object %s, %s",
-					object.GetObjectKind().GroupVersionKind().Kind,
-					metadata.GetName())
-				_, err = dynamicClient.Create(context.TODO(), unstructured, metav1.CreateOptions{DryRun: []string{"All"}})
-				if err != nil {
-					log.TransformLog(transform).Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, kind, resInfo.Namespace, resInfo.Name, err)
-					resInfo.Status = stork_api.ResourceTransformationStatusFailed
-					resInfo.Reason = err.Error()
-				} else {
-					log.TransformLog(transform).Infof("Applied patch path %s on resource kind: %s/,%s/%s", path, kind, resInfo.Namespace, resInfo.Name)
-					resInfo.Status = stork_api.ResourceTransformationStatusReady
-					resInfo.Reason = ""
-				}
-				transform.Status.Resources = append(transform.Status.Resources, resInfo)
+			unstructured.SetNamespace(getTransformNamespace(transform.Namespace))
+			log.TransformLog(transform).Infof("Applying object %s, %s",
+				object.GetObjectKind().GroupVersionKind().Kind,
+				metadata.GetName())
+			_, err = dynamicClient.Create(context.TODO(), unstructured, metav1.CreateOptions{DryRun: []string{"All"}})
+			if err != nil {
+				log.TransformLog(transform).Errorf("Error while DryRun of resource: %s/%s having group version kind:%v with error: %v", resInfo.Namespace, resInfo.Name, resInfo.GroupVersionKind, err)
+				resInfo.Status = stork_api.ResourceTransformationStatusFailed
+				resInfo.Reason = err.Error()
+			} else {
+				log.TransformLog(transform).Infof("DryRun is successfull for resource: %s/%s having group version kind:%v ", resInfo.Namespace, resInfo.Name, resInfo.GroupVersionKind)
+				resInfo.Status = stork_api.ResourceTransformationStatusReady
+				resInfo.Reason = ""
 			}
+			transform.Status.Resources = append(transform.Status.Resources, resInfo)
 		}
 	}
 


### PR DESCRIPTION
 - Remove loop on the paths in the validateTransformResource as this is already been doing in the resourcecollector.TransformResources
 - Because of this redandent computation issue is solved and RT CR status will not be overloded with duplicate resource information.
 - Remove path.Operation validation in validateTransformResource as this is already completed with the RT CR is in Initial Stage using the ResourceTransformationController.validateSpecPath method.


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
To fix the performance while transforming resources in rt controller by removing the redundant computations which are even occupying the RT CR status

**Does this PR change a user-facing CRD or CLI?**:
no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
no
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
Yes because it is a bug in the latest release stork release.
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
JIRA BUG: https://portworx.atlassian.net/browse/PB-4578
Unit Test Result
![Screenshot from 2023-10-12 13-26-15](https://github.com/libopenstorage/stork/assets/116876049/37abc966-0ffa-41f1-99b6-df6ccaf910e1)

