### PR TITLE
PB-4598: Fix for Stork pods crash issue if the RT CR using the a transform of type slice and operation add

### DIFF
--- a/pkg/resourcecollector/resourcetransformation.go
+++ b/pkg/resourcecollector/resourcetransformation.go
@@ -68,7 +68,8 @@ func TransformResources(
 							return err
 						}
 					} else if path.Type == stork_api.SliceResourceType {
-						err := unstructured.SetNestedField(content, value, strings.Split(path.Path, ".")...)
+						updateSlice := value.([]string)
+						err := unstructured.SetNestedStringSlice(content, updateSlice, strings.Split(path.Path, ".")...)
 						if err != nil {
 							logrus.Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, patch.Kind, patch.Namespace, patch.Name, err)
 							return err


### PR DESCRIPTION
  - Use SetNestedStringSlice instead of SetNestedField in case of SliceResourceType to avoid stork pod crash due to a panic

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
To fix the stork pod crash issue when ever a rt cr created with slice type with add operation

**Does this PR change a user-facing CRD or CLI?**:
no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
no
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
 Yes because it is a bug in the latest release stork release.
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

issue: https://portworx.atlassian.net/browse/PB-4598
unit test result:
![Screenshot from 2023-10-12 18-54-59](https://github.com/libopenstorage/stork/assets/116876049/bb5d9639-11bb-43e3-995a-2b04a8046b88)

