### PR TITLE
PB-4564: unmarshalling error when RT transform spec path type is int/bool

### DIFF
--- a/pkg/resourcecollector/resourcetransformation.go
+++ b/pkg/resourcecollector/resourcetransformation.go
@@ -2,6 +2,7 @@ package resourcecollector
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
@@ -54,7 +55,11 @@ func TransformResources(
 			for _, path := range patch.Specs.Paths {
 				switch path.Operation {
 				case stork_api.AddResourcePath:
-					value := getNewValueForPath(path.Value, string(path.Type))
+					value, err := getNewValueForPath(path.Value, path.Type)
+					if err != nil {
+						logrus.Errorf("Unable to parse the Value for the type %s specified, path %s on resource kind: %s/,%s/%s,  err: %v", path.Type, path, patch.Kind, patch.Namespace, patch.Name, err)
+						return err
+					}
 					if path.Type == stork_api.KeyPairResourceType {
 						updateMap := value.(map[string]string)
 						err := unstructured.SetNestedStringMap(content, updateMap, strings.Split(path.Path, ".")...)
@@ -107,7 +112,12 @@ func TransformResources(
 						}
 						value = currList
 					} else {
-						value = path.Value
+						var err error
+						value, err = getNewValueForPath(path.Value, path.Type)
+						if err != nil {
+							logrus.Errorf("Unable to parse the Value for the type %s specified, path %s on resource kind: %s/,%s/%s,  err: %v", path.Type, path, patch.Kind, patch.Namespace, patch.Name, err)
+							return err
+						}
 					}
 					err := unstructured.SetNestedField(content, value, strings.Split(path.Path, ".")...)
 					if err != nil {
@@ -137,9 +147,13 @@ func TransformResources(
 	return nil
 }
 
-func getNewValueForPath(oldVal, valType string) interface{} {
+func getNewValueForPath(oldVal string, valType stork_api.ResourceTransformationValueType) (interface{}, error) {
 	var updatedValue interface{}
-	if valType == string(stork_api.KeyPairResourceType) {
+	var err error
+
+	switch valType {
+	case stork_api.KeyPairResourceType:
+		//TODO: here we can accept map[string]interface{}, so we can use SetNestedField instead of SetNestedStringMap
 		newVal := make(map[string]string)
 		mapList := strings.Split(oldVal, ",")
 		for _, val := range mapList {
@@ -147,13 +161,18 @@ func getNewValueForPath(oldVal, valType string) interface{} {
 			newVal[keyPair[0]] = keyPair[1]
 		}
 		updatedValue = newVal
-	} else if valType == string(stork_api.SliceResourceType) {
+	case stork_api.SliceResourceType:
+		// TODO: here we can accept []interface{}{}, so we can use SetNestedField instead of SetNestedStringSlice
 		newVal := []string{}
 		arrList := strings.Split(oldVal, ",")
 		newVal = append(newVal, arrList...)
 		updatedValue = newVal
-	} else {
+	case stork_api.IntResourceType:
+		updatedValue, err = strconv.ParseInt(oldVal, 10, 64)
+	case stork_api.BoolResourceType:
+		updatedValue, err = strconv.ParseBool(oldVal)
+	default:
 		updatedValue = oldVal
 	}
-	return updatedValue
+	return updatedValue, err
 }


### PR DESCRIPTION
      - Modify getNewValueForPath function to parse the value based on the type.
      - To solve the unmarshalling error while doing the dry-run as int/bool were also parsed as string.

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
To solve the unmarshalling error while doing the dry-run as int/bool were also parsed as string.

**Does this PR change a user-facing CRD or CLI?**:
no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
no
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
 Yes because it is a bug in the latest release stork release.
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

JIRA BUG: https://portworx.atlassian.net/browse/PB-4564
Unit Test Result:
![Screenshot from 2023-10-13 11-04-58](https://github.com/libopenstorage/stork/assets/116876049/33a195d6-6c8a-423c-b278-389271d656d0)



