### PR TITLE
PB-4580: Change TransformResources resource collector code to accept the array index in the path

### DIFF
--- a/pkg/migration/controllers/resourcetransformation.go
+++ b/pkg/migration/controllers/resourcetransformation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/libopenstorage/stork/drivers/volume"
@@ -29,6 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// pathRegexp is used to validate the transform spec path using a regular expression.
+// To check whether the path is formed with valid identifiers delimeted with '.' character where each element can optionally hold an index at the end.
+var pathRegexp = regexp.MustCompile(`^([a-zA-Z_/][a-zA-Z0-9_/]*(\[[0-9]+\])?\.)*[a-zA-Z_/][a-zA-Z0-9_/]*(\[[0-9]+\])?$`)
 
 const (
 	// ResourceTransformationControllerName of resource transformation CR handler
@@ -172,6 +177,10 @@ func (r *ResourceTransformationController) validateSpecPath(transform *stork_api
 				path.Type == stork_api.StringResourceType || path.Type == stork_api.SliceResourceType ||
 				path.Type == stork_api.KeyPairResourceType) {
 				return fmt.Errorf("unsupported type for resource %s, path %s, type: %s", kind, path.Path, path.Type)
+			}
+			//Path Validation
+			if !pathRegexp.MatchString(path.Path) {
+				return fmt.Errorf("invalid path for resource %s, path %s, type: %s", kind, path.Path, path.Type)
 			}
 		}
 	}

--- a/pkg/resourcecollector/resourcetransformation.go
+++ b/pkg/resourcecollector/resourcetransformation.go
@@ -2,6 +2,7 @@ package resourcecollector
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
@@ -57,19 +58,20 @@ func TransformResources(
 					value := getNewValueForPath(path.Value, string(path.Type))
 					if path.Type == stork_api.KeyPairResourceType {
 						updateMap := value.(map[string]string)
-						err := unstructured.SetNestedStringMap(content, updateMap, strings.Split(path.Path, ".")...)
+						err := SetNestedStringMap(content, updateMap, path.Path)
 						if err != nil {
 							logrus.Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, patch.Kind, patch.Namespace, patch.Name, err)
 							return err
 						}
 					} else if path.Type == stork_api.SliceResourceType {
-						err := unstructured.SetNestedField(content, value, strings.Split(path.Path, ".")...)
+						updateSlice := value.([]string)
+						err := SetNestedStringSlice(content, updateSlice, path.Path)
 						if err != nil {
 							logrus.Errorf("Unable to apply patch path %s on resource kind: %s/,%s/%s,  err: %v", path, patch.Kind, patch.Namespace, patch.Name, err)
 							return err
 						}
 					} else {
-						err := unstructured.SetNestedField(content, value, strings.Split(path.Path, ".")...)
+						err := SetNestedField(content, value, path.Path)
 						if err != nil {
 							logrus.Errorf("Unable to perform operation %s on path %s on resource kind: %s/,%s/%s,  err: %v", path.Operation, path, patch.Kind, patch.Namespace, patch.Name, err)
 							return err
@@ -77,13 +79,13 @@ func TransformResources(
 					}
 
 				case stork_api.DeleteResourcePath:
-					unstructured.RemoveNestedField(content, strings.Split(path.Path, ".")...)
+					RemoveNestedField(content, strings.Split(path.Path, ".")...)
 					logrus.Debugf("Removed patch path %s on resource kind: %s/,%s/%s", path, patch.Kind, patch.Namespace, patch.Name)
 
 				case stork_api.ModifyResourcePathValue:
 					var value interface{}
 					if path.Type == stork_api.KeyPairResourceType {
-						currMap, _, err := unstructured.NestedMap(content, strings.Split(path.Path, ".")...)
+						currMap, _, err := NestedMap(content, strings.Split(path.Path, ".")...)
 						if err != nil || len(currMap) == 0 {
 							return fmt.Errorf("unable to find spec path, err: %v", err)
 						}
@@ -97,7 +99,7 @@ func TransformResources(
 						}
 						value = currMap
 					} else if path.Type == stork_api.SliceResourceType {
-						currList, _, err := unstructured.NestedSlice(content, strings.Split(path.Path, ".")...)
+						currList, _, err := NestedSlice(content, strings.Split(path.Path, ".")...)
 						if err != nil {
 							return fmt.Errorf("unable to find spec path, err: %v", err)
 						}
@@ -109,7 +111,7 @@ func TransformResources(
 					} else {
 						value = path.Value
 					}
-					err := unstructured.SetNestedField(content, value, strings.Split(path.Path, ".")...)
+					err := SetNestedField(content, value, path.Path)
 					if err != nil {
 						logrus.Errorf("Unable to perform operation %s on path %s on resource kind: %s/,%s/%s,  err: %v", path.Operation, path, patch.Kind, patch.Namespace, patch.Name, err)
 						return err
@@ -156,4 +158,304 @@ func getNewValueForPath(oldVal, valType string) interface{} {
 		updatedValue = oldVal
 	}
 	return updatedValue
+}
+
+// pathRegexpWithanArray is an regualr expression to validate an index exists in the path
+var pathRegexpWithanArray = regexp.MustCompile(`^.+\[[0-9]+\].*$`)
+
+func jsonPath(fields []string) string {
+	return "." + strings.Join(fields, ".")
+}
+
+// NestedSlice is wrapper around unstructured.NestedSlice function
+// if the path doesn't consists of an index the call is transferred to unstructured.NestedSlice
+// else it uses the same logic but includes changes to support the array index
+func NestedSlice(obj map[string]interface{}, fields ...string) ([]interface{}, bool, error) {
+	if !pathRegexpWithanArray.MatchString(strings.Join(fields, ".")) {
+		return unstructured.NestedSlice(obj, fields...)
+	}
+
+	val, found, err := NestedFieldNoCopy(obj, fields...)
+	if !found || err != nil {
+		return nil, found, err
+	}
+	_, ok := val.([]interface{})
+	if !ok {
+		return nil, false, fmt.Errorf("%v accessor error: %v is of the type %T, expected []interface{}", jsonPath(fields), val, val)
+	}
+	return runtime.DeepCopyJSONValue(val).([]interface{}), true, nil
+}
+
+// NestedMap is wrapper around unstructured.NestedMap function
+// if the path doesn't consists of an index the call is transferred to unstructured.NestedMap
+// else it uses the same logic but includes changes to support the array index
+func NestedMap(obj map[string]interface{}, fields ...string) (map[string]interface{}, bool, error) {
+	if !pathRegexpWithanArray.MatchString(strings.Join(fields, ".")) {
+		return unstructured.NestedMap(obj, fields...)
+	}
+
+	m, found, err := nestedMapNoCopy(obj, fields...)
+	if !found || err != nil {
+		return nil, found, err
+	}
+	return runtime.DeepCopyJSON(m), true, nil
+}
+
+func nestedMapNoCopy(obj map[string]interface{}, fields ...string) (map[string]interface{}, bool, error) {
+	val, found, err := NestedFieldNoCopy(obj, fields...)
+	if !found || err != nil {
+		return nil, found, err
+	}
+	m, ok := val.(map[string]interface{})
+	if !ok {
+		return nil, false, fmt.Errorf("%v accessor error: %v is of the type %T, expected map[string]interface{}", jsonPath(fields), val, val)
+	}
+	return m, true, nil
+}
+
+func NestedFieldNoCopy(obj map[string]interface{}, fields ...string) (interface{}, bool, error) {
+	var val interface{} = obj
+
+	for i, field := range fields {
+		if val == nil {
+			return nil, false, nil
+		}
+		if m, ok := val.(map[string]interface{}); ok {
+			var err error
+			val, ok, err = getValueFromMapKey(m, field)
+			if !ok || err != nil {
+				return nil, false, err
+			}
+		} else {
+			return nil, false, fmt.Errorf("%v accessor error: %v is of the type %T, expected map[string]interface{}", jsonPath(fields[:i+1]), val, val)
+		}
+	}
+	return val, true, nil
+}
+
+// SetNestedStringSlice is wrapper around unstructured.SetNestedStringSlice function
+// if the path doesn't consists of an index the call is transferred to unstructured.SetNestedStringSlice
+// else it uses the same logic but includes changes to support the array index
+func SetNestedStringSlice(obj map[string]interface{}, value []string, path string) error {
+	if !pathRegexpWithanArray.MatchString(path) {
+		return unstructured.SetNestedStringSlice(obj, value, strings.Split(path, ".")...)
+	}
+
+	m := make([]interface{}, 0, len(value)) // convert []string into []interface{}
+	for _, v := range value {
+		m = append(m, v)
+	}
+	return setNestedFieldNoCopy(obj, m, strings.Split(path, ".")...)
+}
+
+// SetNestedStringMap is wrapper around unstructured.SetNestedStringMap function
+// if the path doesn't consists of an index the call is transferred to unstructured.SetNestedStringMap
+// else it uses the same logic but includes changes to support the array index
+func SetNestedStringMap(obj map[string]interface{}, value map[string]string, path string) error {
+	if !pathRegexpWithanArray.MatchString(path) {
+		return unstructured.SetNestedStringMap(obj, value, strings.Split(path, ".")...)
+	}
+	m := make(map[string]interface{}, len(value)) // convert map[string]string into map[string]interface{}
+	for k, v := range value {
+		m[k] = v
+	}
+	return setNestedFieldNoCopy(obj, m, strings.Split(path, ".")...)
+}
+
+// SetNestedField is wrapper around unstructured.SetNestedField function
+// if the path doesn't consists of an index the call is transferred to unstructured.SetNestedField
+// else it uses the same logic but includes changes to support the array index
+func SetNestedField(obj map[string]interface{}, value interface{}, path string) error {
+	if !pathRegexpWithanArray.MatchString(path) {
+		return unstructured.SetNestedField(obj, value, strings.Split(path, ".")...)
+	}
+	return setNestedFieldNoCopy(obj, runtime.DeepCopyJSONValue(value), strings.Split(path, ".")...)
+}
+
+// Here instead of m[field] we were using the getValueFromMapKey in case if the field as array index.
+// while assigning a value we use setMapKeyWithValue.
+func setNestedFieldNoCopy(obj map[string]interface{}, value interface{}, fields ...string) error {
+	m := obj
+
+	for index, field := range fields[:len(fields)-1] {
+		if val, ok, err := getValueFromMapKey(m, field); err != nil {
+			return err
+		} else if ok {
+			if valMap, ok := val.(map[string]interface{}); ok {
+				m = valMap
+			} else {
+				return fmt.Errorf("value cannot be set because %v is not a map[string]interface{}", jsonPath(fields[:index+1]))
+			}
+		} else {
+			newVal := make(map[string]interface{})
+			if err := setMapKeyWithValue(m, newVal, field); err != nil {
+				return err
+			}
+			m = newVal
+		}
+	}
+	return setMapKeyWithValue(m, value, fields[len(fields)-1])
+}
+
+// RemoveNestedField is wrapper around unstructured.RemoveNestedField function
+// if the path doesn't consists of an index the call is transferred to unstructured.RemoveNestedField
+// else it uses the same logic but includes changes to support the array index
+//
+// Here instead of m[field] we were using the getValueFromMapKey in case if the field as array index
+// deleteMapKey to remove a key from the map.
+func RemoveNestedField(obj map[string]interface{}, fields ...string) error {
+	if !pathRegexpWithanArray.MatchString(strings.Join(fields, ".")) {
+		unstructured.RemoveNestedField(obj, fields...)
+		return nil
+	}
+	m := obj
+	for _, field := range fields[:len(fields)-1] {
+		if val, ok, err := getValueFromMapKey(m, field); err != nil {
+			logrus.Errorf("Error while get value from map witk key[%v] :%v", field, err)
+			return err
+		} else if ok {
+			if valMap, ok := val.(map[string]interface{}); ok {
+				m = valMap
+			} else {
+				return nil
+			}
+		} else {
+			return nil
+		}
+	}
+
+	deleteMapKey(m, fields[len(fields)-1])
+	return nil
+}
+
+var indexDelimeter = func(c rune) bool {
+	return c == '[' || c == ']'
+}
+
+// deleteMapKey is to delete the key entry from the map m.
+// if the field contains an array index then the approriate array element is deleted.
+// Example: containers[3]
+func deleteMapKey(m map[string]interface{}, field string) {
+	// check if an array index exists in the field
+	parts := strings.FieldsFunc(field, indexDelimeter)
+	// Example: Here the parts is []string{conatiners, 3}
+	// if the length of the parts is not equal to 2 then the field is not holding the index.
+	if len(parts) != 2 {
+		delete(m, field)
+		return
+	}
+
+	// Validate the first part of the field.
+	// if the parts[0] is not an array send an error.
+	// Example: containers should hold a type []interface{}
+	arr := m[parts[0]]
+	arrValue, ok := arr.([]interface{})
+	if !ok {
+		logrus.Errorf("value cannot be set because %v is not a []interface{}", arr)
+		return
+	}
+
+	// Convert the array index to int.
+	// Example: Here the second part string "3" is converted to int to use it as Index.
+	var arrIndex int
+	_, err := fmt.Sscanf(parts[1], "%d", &arrIndex)
+	if err != nil {
+		logrus.Errorf("Error while parsing the array[%v] index :%v ", parts[0], err)
+		return
+	}
+
+	// If the index exists remove the appropriate array item from the list.
+	if arrIndex < len(arrValue) {
+		arrValue = append(arrValue[:arrIndex], arrValue[arrIndex+1:]...)
+		m[parts[0]] = arrValue
+		return
+	}
+}
+
+// setMapKeyWithValue is to assign the value to the map m with key field.
+// if the field contains an array index then the approriate array element is updated.
+// Example: containers[3]
+func setMapKeyWithValue(m map[string]interface{}, value interface{}, field string) error {
+	// check if an array index exists in the field
+	parts := strings.FieldsFunc(field, indexDelimeter)
+	// Example: Here the parts is []string{conatiners, 3}
+	// if the length of the parts is not equal to 2 then the field is not holding the index.
+	if len(parts) != 2 {
+		m[field] = value
+		return nil
+	}
+
+	// Validate the first part of the field.
+	// if the parts[0] is not an array send an error.
+	// Example: containers should hold a type []interface{}
+	arr := m[parts[0]]
+	arrValue, ok := arr.([]interface{})
+	if !ok {
+		return fmt.Errorf("value cannot be set because %v is not a []interface{}", arr)
+	}
+
+	// Convert the array index to int.
+	// Example: Here the second part string "3" is converted to int to use it as Index.
+	var arrIndex int
+	_, err := fmt.Sscanf(parts[1], "%d", &arrIndex)
+	if err != nil {
+		return err
+	}
+
+	// update the approriate array element.
+	// Example: If the 3 is lessthan the length of the array appropriate array element is updated.
+	if arrIndex < len(arrValue) {
+		arrValue[arrIndex] = value
+	} else if arrIndex > len(arrValue) {
+		// Example: If the 3 is greather the length of the array an error is return for out of range in the array.
+		return fmt.Errorf("value cannot be set because index %d is out of range in array %v with length %d", arrIndex, arr, len(arrValue))
+	} else {
+		// Example: If the 3 is equal to the length of the array.
+		// append the value to the existing array
+		arrValue = append(arrValue, value)
+	}
+	// finally update the actual data structure m
+	m[parts[0]] = arrValue
+	return nil
+}
+
+// getValueFromMapKey is to retrive the value for the map m with key field. Here the field may even contain the array index.
+// Example: containers[3]
+func getValueFromMapKey(m map[string]interface{}, field string) (interface{}, bool, error) {
+	// check if an array index exists in the field.
+	parts := strings.FieldsFunc(field, indexDelimeter)
+	// Example: Here the parts is []string{conatiners, 3}
+	// if the length of the parts is not equal to 2 then the field is not holding the index.
+	if len(parts) != 2 {
+		value, ok := m[field]
+		return value, ok, nil
+	}
+
+	// Validate the first part of the field.
+	// if the parts[0] is not an array send an error.
+	// Example: containers should hold a type []interface{}
+	arr := m[parts[0]]
+	value, ok := arr.([]interface{})
+	if !ok {
+		return nil, false, fmt.Errorf("value cannot be set because %v is not a []interface{}", arr)
+	}
+
+	// Convert the array index to int.
+	// Example: Here the second part string "3" is converted to int to use it as Index.
+	var arrIndex int
+	_, err := fmt.Sscanf(parts[1], "%d", &arrIndex)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// send the approriate array element.
+	// Example: If the 3 is lessthan the length of the array appropriate array element is returned.
+	if arrIndex < len(value) {
+		return value[arrIndex], true, nil
+	} else if arrIndex > len(value) {
+		// Example: If the 3 is greather the length of the array an error is return for out of range in the array.
+		return nil, false, fmt.Errorf("value cannot be set because index %d is out of range in array %v with length %d", arrIndex, arr, len(value))
+	}
+	// Example: If the 3 is equal to the length of the array nil error and exists=false is returned.
+	return nil, false, nil
 }


### PR DESCRIPTION
   - Change TransformResources resource collector code to accept the array index in the path


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
Added a wrapper code to unstructured module to support the array index in the transform spec path 

**Does this PR change a user-facing CRD or CLI?**:
no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
YES
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: Array Index in the transform spec is not supported before
User Impact: Unable to alter the resources under a slice using the resource transform feature
Resolution:
Now if the path is supported with array index like below
spec.containers[0].image
```

**Does this change need to be cherry-picked to a release branch?**:
YES
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

Below is the spec used for testing
```yaml
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ResourceTransformation
metadata:
  name: mysql-pod-transform
  namespace: default
  specs:
  transformSpecs:
    - paths:
        - operation: modify
          path: spec.replicas
          type: int
          value: '3'
        - operation: delete
          path: spec.replicas
          type: int
          value: ''
        - operation: add
          path: spec.replicas
          type: int
          value: '1'
        - operation: modify
          path: spec.template.spec.containers[0].name
          type: string
          value: web2
        - operation: add
          path: spec.template.spec.containers[0].ports[1].name
          type: string
          value: https
        - operation: add
          path: spec.template.spec.containers[0].ports[1].containerPort
          type: int
          value: '443'
        - operation: add
          path: spec.template.spec.containers[0].ports[1].protocol
          type: string
          value: TCP
        - operation: add
          path: spec.template.spec.containers[0].command
          type: slice
          value: echo,1,2,3,4
        - operation: modify
          path: spec.template.spec.containers[0].command
          type: slice
          value: '5'
        - operation: add
          path: spec.template.spec.setHostnameAsFQDN
          type: bool
          value: 'True'
        - operation: add
          path: spec.template.spec.containers[0].securityContext
          type: keypair
          value: procMount:procMount
        - operation: modify
          path: spec.template.spec.containers[0]
          type: keypair
          value: imagePullPolicy:Always
        - operation: add
          path: spec.template.spec.containers[0].ports[2]
          type: keypair
          value: name:web,protocol:TCP
        - operation: add
          path: spec.template.spec.containers[0].ports[2].containerPort
          type: int
          value: '8080'
        - operation: delete
          path: spec.template.spec.containers[0].ports[1]
          type: keypair
          value: ''
        - operation: delete
          path: spec.template.spec.containers[0].command[1]
          type: string
          value: ''
        - operation: add
          path: spec.template.spec.containers[0].command[1]
          type: string
          value: '10'
        - operation: modify
          path: spec.template.spec.containers[0].command[2]
          type: string
          value: '9'
      resource: apps/v1/Deployment
      selectors: null
```

Unit Test Results:
![Screenshot from 2023-10-13 20-20-28](https://github.com/libopenstorage/stork/assets/116876049/06111fae-72c9-422e-9355-df39210c3ef2)
![Screenshot from 2023-10-13 20-20-17](https://github.com/libopenstorage/stork/assets/116876049/07358f5a-d4b7-4cd7-96c3-c4641b481cda)
![Screenshot from 2023-10-13 19-52-38](https://github.com/libopenstorage/stork/assets/116876049/7f66ce1d-cfa7-437d-ae6d-60cb14cfeb6c)

CR Obejct 
```yaml
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ResourceTransformation
metadata:
  creationTimestamp: '2023-10-20T08:18:08Z'
  finalizers:
    - stork.libopenstorage.org/finalizer-cleanup
  generation: 4
  managedFields:
    - apiVersion: stork.libopenstorage.org/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        f:specs:
          .: {}
          f:transformSpecs: {}
      manager: kubectl-replace
      operation: Update
      time: '2023-10-20T08:18:08Z'
    - apiVersion: stork.libopenstorage.org/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        f:metadata:
          f:finalizers:
            .: {}
            v:"stork.libopenstorage.org/finalizer-cleanup": {}
        f:status:
          .: {}
          f:resources: {}
          f:status: {}
      manager: stork
      operation: Update
      time: '2023-10-20T08:18:09Z'
  name: mysql-pod-transform
  namespace: default
  resourceVersion: '7681963'
  uid: ce10279a-4557-482e-9ddd-f93ca4abec40
  selfLink: >-
    /apis/stork.libopenstorage.org/v1alpha1/namespaces/default/resourcetransformations/mysql-pod-transform
status:
  resources:
    - group: apps
      kind: Deployment
      name: demo-deployment
      namespace: default
      reason: ''
      specs:
        paths:
          - operation: modify
            path: spec.replicas
            type: int
            value: '3'
          - operation: delete
            path: spec.replicas
            type: int
            value: ''
          - operation: add
            path: spec.replicas
            type: int
            value: '1'
          - operation: modify
            path: spec.template.spec.containers[0].name
            type: string
            value: web2
          - operation: add
            path: spec.template.spec.containers[0].ports[1].name
            type: string
            value: https
          - operation: add
            path: spec.template.spec.containers[0].ports[1].containerPort
            type: int
            value: '443'
          - operation: add
            path: spec.template.spec.containers[0].ports[1].protocol
            type: string
            value: TCP
          - operation: add
            path: spec.template.spec.containers[0].command
            type: slice
            value: echo,1,2,3,4
          - operation: modify
            path: spec.template.spec.containers[0].command
            type: slice
            value: '5'
          - operation: add
            path: spec.template.spec.setHostnameAsFQDN
            type: bool
            value: 'True'
          - operation: add
            path: spec.template.spec.containers[0].securityContext
            type: keypair
            value: procMount:procMount
          - operation: modify
            path: spec.template.spec.containers[0]
            type: keypair
            value: imagePullPolicy:Always
          - operation: add
            path: spec.template.spec.containers[0].ports[2]
            type: keypair
            value: name:web,protocol:TCP
          - operation: add
            path: spec.template.spec.containers[0].ports[2].containerPort
            type: int
            value: '8080'
          - operation: delete
            path: spec.template.spec.containers[0].ports[1]
            type: keypair
            value: ''
          - operation: delete
            path: spec.template.spec.containers[0].command[1]
            type: string
            value: ''
          - operation: add
            path: spec.template.spec.containers[0].command[1]
            type: string
            value: '10'
          - operation: modify
            path: spec.template.spec.containers[0].command[2]
            type: string
            value: '9'
        resource: apps/v1/Deployment
        selectors: null
      status: Ready
      version: v1
  status: Ready
specs:
  transformSpecs:
    - paths:
        - operation: modify
          path: spec.replicas
          type: int
          value: '3'
        - operation: delete
          path: spec.replicas
          type: int
          value: ''
        - operation: add
          path: spec.replicas
          type: int
          value: '1'
        - operation: modify
          path: spec.template.spec.containers[0].name
          type: string
          value: web2
        - operation: add
          path: spec.template.spec.containers[0].ports[1].name
          type: string
          value: https
        - operation: add
          path: spec.template.spec.containers[0].ports[1].containerPort
          type: int
          value: '443'
        - operation: add
          path: spec.template.spec.containers[0].ports[1].protocol
          type: string
          value: TCP
        - operation: add
          path: spec.template.spec.containers[0].command
          type: slice
          value: echo,1,2,3,4
        - operation: modify
          path: spec.template.spec.containers[0].command
          type: slice
          value: '5'
        - operation: add
          path: spec.template.spec.setHostnameAsFQDN
          type: bool
          value: 'True'
        - operation: add
          path: spec.template.spec.containers[0].securityContext
          type: keypair
          value: procMount:procMount
        - operation: modify
          path: spec.template.spec.containers[0]
          type: keypair
          value: imagePullPolicy:Always
        - operation: add
          path: spec.template.spec.containers[0].ports[2]
          type: keypair
          value: name:web,protocol:TCP
        - operation: add
          path: spec.template.spec.containers[0].ports[2].containerPort
          type: int
          value: '8080'
        - operation: delete
          path: spec.template.spec.containers[0].ports[1]
          type: keypair
          value: ''
        - operation: delete
          path: spec.template.spec.containers[0].command[1]
          type: string
          value: ''
        - operation: add
          path: spec.template.spec.containers[0].command[1]
          type: string
          value: '10'
        - operation: modify
          path: spec.template.spec.containers[0].command[2]
          type: string
          value: '9'
      resource: apps/v1/Deployment
      selectors: null
```
Transformed unstructured object for reference
```
&{map[
apiVersion:apps/v1 
kind:Deployment 
metadata:map[
annotations:map[deployment.kubernetes.io/revision:1 stork.libopenstorage.org/resourcetransformation-name:true] name:demo-deployment namespace:default] 
spec:map[
progressDeadlineSeconds:600 
replicas:1 
revisionHistoryLimit:10 
selector:map[matchLabels:map[app:demo]] 
strategy:map[rollingUpdate:map[maxSurge:25% maxUnavailable:25%] type:RollingUpdate] 
template:map[
metadata:map[creationTimestamp:<nil> labels:map[app:demo]] 
spec:map[
containers:[map[
command:[echo 10 9 4 5] 
image:nginx:1.12 
imagePullPolicy:Always 
name:web2 
ports:[
map[containerPort:80 name:http protocol:TCP] 
map[containerPort:8080 name:web protocol:TCP]] 
resources:map[] 
securityContext:map[procMount:procMount] 
terminationMessagePath:/dev/termination-log terminationMessagePolicy:File]] 
dnsPolicy:ClusterFirst 
restartPolicy:Always schedulerName:default-scheduler securityContext:map[] setHostnameAsFQDN:true terminationGracePeriodSeconds:30]]] 

status:map[availableReplicas:2 conditions:[map[lastTransitionTime:2023-10-09T10:41:07Z lastUpdateTime:2023-10-09T10:41:20Z message:ReplicaSet \"demo-deployment-5f8f46f749\" has successfully progressed. reason:NewReplicaSetAvailable status:True type:Progressing] map[lastTransitionTime:2023-10-18T23:44:28Z lastUpdateTime:2023-10-18T23:44:28Z message:Deployment has minimum availability. reason:MinimumReplicasAvailable status:True type:Available]] observedGeneration:1 readyReplicas:2 replicas:2 updatedReplicas:2]]}"
```