### PR TITLE
PWX-33047: Kubevirt scheduling where host and volume ips do not match

### DIFF
--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -89,6 +89,8 @@ func (m *Driver) CreateCluster(numNodes int, nodes *v1.NodeList) error {
 			Status:      storkvolume.NodeOnline,
 		}
 		node.IPs = append(node.IPs, "192.168.0."+strconv.Itoa(i+1))
+		node.IPs = append(node.IPs, "100.155.209."+strconv.Itoa(i+1))
+
 		for _, n := range nodes.Items {
 			found := false
 			if node.StorageID == n.Name {
@@ -133,9 +135,12 @@ func (m *Driver) GetClusterID() (string, error) {
 }
 
 // NewPVC Create a new PVC reference
-func (m *Driver) NewPVC(volumeName string) *v1.PersistentVolumeClaim {
+func (m *Driver) NewPVC(volumeName, namespace string) *v1.PersistentVolumeClaim {
 	pvc := &v1.PersistentVolumeClaim{}
 	pvc.Name = volumeName
+	if namespace != "" {
+		pvc.Namespace = namespace
+	}
 	pvc.Spec.VolumeName = volumeName
 	storageClassName := m.GetStorageClassName()
 	pvc.Spec.StorageClassName = &storageClassName

--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -755,10 +755,44 @@ sendResponse:
 	}
 }
 
-// isPodRunningOnVolAttachedNode returns true if the pod is running node where volume is attached
-func (e *Extender) isPodRunningOnVolAttachedNode(pod *v1.Pod, vol *volume.Info) bool {
-	log.Debugf("Pod Name: %v, Pod Node IP: %v,  Volume Node IP: %v", pod.Name, pod.Status.HostIP, vol.AttachedOn)
-	return pod.Status.HostIP == vol.AttachedOn
+// nodeHasAttachedVolume returns true if the node has local attachement for the volume
+func (e *Extender) nodeHasAttachedVolume(dNode *volume.NodeInfo, vol *volume.Info) bool {
+	if dNode == nil || vol == nil {
+		return false
+	}
+	for _, nodeIP := range dNode.IPs {
+		if nodeIP == vol.AttachedOn {
+			// Local attachment
+			return true
+		}
+	}
+	return false
+}
+
+// isPodUsingLocallyAttachedVolume returns true if the pod is running node where volume is attached
+func (e *Extender) isPodUsingLocallyAttachedVolume(pod *v1.Pod, vol *volume.Info, driverNodes []*volume.NodeInfo) bool {
+	if pod == nil || vol == nil || driverNodes == nil {
+		return false
+	}
+	log.Infof("PodName: %v, PodNodeIP: %v,  VolumeNodeIP: %v", pod.Name, pod.Status.HostIP, vol.AttachedOn)
+	if pod.Status.HostIP == vol.AttachedOn {
+		return true
+	}
+	// If pod.Status.HostIP doesn't match vol.AttachedOn, we need to check all IPs on the driver node on which volume is attached
+	for _, dNode := range driverNodes {
+		if e.nodeHasAttachedVolume(dNode, vol) {
+			for _, nodeIP := range dNode.IPs {
+				if nodeIP == pod.Status.HostIP {
+					log.Infof("PodNodeIP: %v is in the list of IPs associated with Node %v", pod.Status.HostIP, dNode.Hostname)
+					// Local attachment
+					return true
+				}
+			}
+		} else {
+			return false
+		}
+	}
+	return false
 }
 
 // isVirtLauncherPod returns true if it is a virt launcher pod
@@ -770,8 +804,7 @@ func (e *Extender) isVirtLauncherPod(pod *v1.Pod) bool {
 func (e *Extender) getLiveMigrationInfo(refPod *v1.Pod, refVMIUID types.UID) (podBeingLiveMigrated *v1.Pod, err error) {
 	pods, err := core.Instance().GetPods(refPod.Namespace, nil)
 	if err != nil {
-		msg := "unable to get Pod list in the same namespace."
-		return nil, fmt.Errorf("err: %s", msg)
+		return nil, fmt.Errorf("unable to get pod list in the same namespace")
 	}
 	// If another virt launcher pod is Running in the same namespace and has the same VMI owner reference Then it can
 	// be concluded that this Pod is where the original VM was being hosted and is being LiveMigrated to the refPod
@@ -781,9 +814,6 @@ func (e *Extender) getLiveMigrationInfo(refPod *v1.Pod, refVMIUID types.UID) (po
 			continue
 		}
 		_, vmiUID := e.getVMIInfo(&pod)
-		if vmiUID == "" {
-			continue
-		}
 		if vmiUID == refVMIUID {
 			return &pod, nil
 		}
@@ -805,7 +835,7 @@ func (e *Extender) getVMIInfo(refPod *v1.Pod) (string, types.UID) {
 func (e *Extender) GetPVNameFromPVC(pvcName string, namespace string) (string, error) {
 	pvc, err := core.Instance().GetPersistentVolumeClaim(pvcName, namespace)
 	if err != nil || pvc == nil {
-		return "", fmt.Errorf("error getting PV name for PVC (%v/%v): %w", pvcName, namespace, err)
+		return "", fmt.Errorf("error getting PV name for PVC (%v/%v): %w", namespace, pvcName, err)
 	}
 
 	return pvc.Spec.VolumeName, err
@@ -936,7 +966,7 @@ func (e *Extender) processVirtLauncherPodPrioritizeRequest(
 
 	vmiName, vmiUID := e.getVMIInfo(pod)
 	if vmiName == "" {
-		return fmt.Errorf("unable to find vmiName for pod: %v", pod.Name)
+		return fmt.Errorf("unable to find vmiName for pod %v", pod.Name)
 	}
 	podBeingLiveMigrated, err := e.getLiveMigrationInfo(pod, vmiUID)
 	if err != nil {
@@ -953,57 +983,23 @@ func (e *Extender) processVirtLauncherPodPrioritizeRequest(
 	if err != nil {
 		return fmt.Errorf("unable to find VMI Info: %w", err)
 	}
-	storklog.PodLog(pod).Debugf("VMI is using PVC: %v", vmi.RootDiskPVC)
+	storklog.PodLog(pod).Debugf("VMI is using PVC %v", vmi.RootDiskPVC)
 
 	pvName, err := e.GetPVNameFromPVC(vmi.RootDiskPVC, pod.Namespace)
 	if err != nil {
-		return fmt.Errorf("unable to inspect PVC: %v err: %w", vmi.RootDiskPVC, err)
+		return fmt.Errorf("unable to inspect PVC %v: %w", vmi.RootDiskPVC, err)
 	}
-	storklog.PodLog(pod).Debugf("PV for scoring: %v", pvName)
+	storklog.PodLog(pod).Debugf("PV for scoring %v", pvName)
 
 	volInfo, err := e.Driver.InspectVolume(pvName)
 	if err != nil {
-		return fmt.Errorf("unable to inspect PV: %v. err: %w", pvName, err)
+		return fmt.Errorf("unable to inspect PV %v: %w", pvName, err)
 	}
 
-	if podBeingLiveMigrated != nil {
-		// We give lower score to replica nodes so that if a pod is unable to schedule on the node
-		// where the volume is attached we can run it on a non replica node, so that a subsequent
-		// LiveMigration can move the pod back to the replica node in a single hop.
-		podIsRunningOnVolAttachedNode := e.isPodRunningOnVolAttachedNode(podBeingLiveMigrated, volInfo)
-
-		if podIsRunningOnVolAttachedNode {
-			// LiveMigration in progress and existing pod is running on node with volume attached => Antihyperconvergence
-			// i.e. Give lower scores to nodes with volume replicas
-			storklog.PodLog(pod).Infof("Pod %v is running with same VMI owner reference is using localAttachment.", podBeingLiveMigrated.Name)
-			e.updateVirtLauncherPodPrioritizeScores(encoder,
-				args,
-				volInfo,
-				false, /*preferLocalAttachment*/
-				true /*antihyperconvergence*/)
-		} else {
-			// LiveMigration in progress but existing pod is using NFS.
-			// Use Antihyperconvergence to give lower score to replica nodes without volume attachment
-			// Use preferLocalAttachment to give highest score to node with volume attachment
-
-			e.updateVirtLauncherPodPrioritizeScores(encoder,
-				args,
-				volInfo,
-				true, /*preferLocalAttachment*/
-				true /*antihyperconvergence*/)
-		}
-	} else {
-		// Default behavior for LiveMigration not in progress is hyperconvergence
-		// We should still give a higher score to node with volume attachment. We might not
-		// have attachment info avilable in this scenario and the same score will be
-		// applied for all the replica nodes. However, if volume attachment info is available
-		// that node should get higher score. All non replica nodes will get lower score.
-		e.updateVirtLauncherPodPrioritizeScores(encoder,
-			args,
-			volInfo,
-			true, /*preferLocalAttachment*/
-			false /*antihyperconvergence*/)
-	}
+	e.updateVirtLauncherPodPrioritizeScores(encoder,
+		args,
+		volInfo,
+		podBeingLiveMigrated)
 	return nil
 }
 
@@ -1011,26 +1007,19 @@ func (e *Extender) updateVirtLauncherPodPrioritizeScores(
 	encoder *json.Encoder,
 	args schedulerapi.ExtenderArgs,
 	volInfo *volume.Info,
-	preferLocalAttachment bool,
-	antihyperconvergence bool) {
+	podBeingLiveMigrated *v1.Pod) {
 	pod := args.Pod
-
-	// Default behavior is no special preference to local attachment
-	localNodeScore := int64(nodePriorityScore)
 	// Default behavior is hyperconvergence
 	replicaNodeScore := int64(nodePriorityScore)
 	remoteNodeScore := int64(defaultScore)
 
-	if antihyperconvergence {
+	// If this is a pod being live migrated then we prefer antihyperconvergence
+	// We give lower score to replica nodes so that if a pod is unable to schedule on the node
+	// where the volume is attached we can run it on a non replica node, so that a subsequent
+	// LiveMigration can move the pod back to the replica node in a single hop.
+	if podBeingLiveMigrated != nil {
 		remoteNodeScore = int64(nodePriorityScore)
 		replicaNodeScore = int64(defaultScore)
-	}
-
-	// preferLocalAttachment = true but AttachedOn = "" can occur if there is just one pod
-	// getting scheduled and there is no LiveMigration ongoing
-	if preferLocalAttachment && volInfo.AttachedOn != "" {
-		storklog.PodLog(pod).Debugf("Prioritize for volume attachedOn: %v", volInfo.AttachedOn)
-		localNodeScore = int64(2 * nodePriorityScore)
 	}
 
 	respList := schedulerapi.HostPriorityList{}
@@ -1043,38 +1032,41 @@ func (e *Extender) updateVirtLauncherPodPrioritizeScores(
 		}
 	} else {
 		driverNodes = volume.RemoveDuplicateOfflineNodes(driverNodes)
+		isExistingPodUsingLocallyAttachedVolume := e.isPodUsingLocallyAttachedVolume(podBeingLiveMigrated, volInfo, driverNodes)
+		if isExistingPodUsingLocallyAttachedVolume {
+			storklog.PodLog(pod).Infof("Existing pod is using locally attached volume")
+		}
+
 		for _, dnode := range driverNodes {
 			for _, knode := range args.Nodes.Items {
-				var score int64
-				isUpdated := false
+				// Initialize with score to with score for remote node
+				// It would be updated if the node being score is a replica node
+				score := remoteNodeScore
 				if volume.IsNodeMatch(&knode, dnode) {
-					isUpdated = false
 					// Score replica nodes
-					for _, dataNodes := range volInfo.DataNodes {
-						if dataNodes == dnode.StorageID {
+					for _, dataNode := range volInfo.DataNodes {
+						if dataNode == dnode.StorageID {
+							// Current node has the volume replica
 							score = replicaNodeScore
-							isUpdated = true
-							break
-						}
-					}
+							nodeHasAttachedVolume := e.nodeHasAttachedVolume(dnode, volInfo)
 
-					if preferLocalAttachment && volInfo.AttachedOn != "" {
-						// Update score of node for volume attachment
-						for _, nodeIP := range dnode.IPs {
-							if nodeIP == volInfo.AttachedOn {
-								// Local attachment
-								storklog.PodLog(pod).Debugf("Updating score of node: %v for local attachment", dnode.StorageID)
-								score = localNodeScore
-								isUpdated = true
+							if podBeingLiveMigrated != nil {
+								// LiveMigration in progress
+								// If existing pod is not using attached volume and current node has attached volume, assign a higher score to it
+								if !isExistingPodUsingLocallyAttachedVolume && nodeHasAttachedVolume {
+									storklog.PodLog(pod).Infof("Node %v has attached volume", dataNode)
+									score = int64(2 * nodePriorityScore)
+								}
+							} else {
+								if nodeHasAttachedVolume {
+									// There is no LiveMigration in progress
+									// When a new pod gets scheduling request
+									// assign a higher score for local volume attachment
+									score = int64(2 * nodePriorityScore)
+								}
 							}
 						}
 					}
-
-					if !isUpdated {
-						// Update score of non replica nodes
-						score = remoteNodeScore
-					}
-
 					if dnode.Status == volume.NodeOffline {
 						score = 0
 					} else if dnode.Status != volume.NodeOnline {

--- a/pkg/extender/extender_test.go
+++ b/pkg/extender/extender_test.go
@@ -2449,7 +2449,7 @@ func kubevirtPodSchedulingAttachedOnMismatch(t *testing.T) {
 	pod := newKubevirtPod("KubevirtPod2", "KubevirtNS2", map[string]bool{"KubevirtVolume2": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("KubevirtVolume2", provNodes, 3, map[string]string{"kubevirtPodScheduling": "true"}, false, false, "192.168.0.1"); err != nil {
+	if err := driver.ProvisionVolume("KubevirtVolume2", provNodes, 3, map[string]string{"kubevirtPodScheduling": "true"}, false, false, "192.168.0.2"); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2496,8 +2496,8 @@ func kubevirtPodSchedulingAttachedOnMismatch(t *testing.T) {
 		t,
 		nodes,
 		[]float64{
-			2 * nodePriorityScore,
 			defaultScore,
+			2 * nodePriorityScore,
 			defaultScore,
 			nodePriorityScore,
 			nodePriorityScore,
@@ -2507,7 +2507,7 @@ func kubevirtPodSchedulingAttachedOnMismatch(t *testing.T) {
 	// Live Migration Scenario2:
 	// Existing Pod is running on a with volume attachment but pod.Status.HostIP != vol.AttachedOn
 	// Determination if this Pod is using a local volume attachment is done based on driver node IPs.
-	pod.Status.HostIP = "100.155.209.1"
+	pod.Status.HostIP = "100.155.209.2"
 	_, err = core.Instance().UpdatePod(pod)
 	if err != nil {
 		t.Fatalf("Error creating pod: %v", err)

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -250,7 +250,7 @@ func newPod(podName string, volumes []string) *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{Name: podName},
 	}
 	for _, volume := range volumes {
-		pvc := driver.NewPVC(volume)
+		pvc := driver.NewPVC(volume, "")
 		podVolume := v1.Volume{}
 		podVolume.PersistentVolumeClaim = &v1.PersistentVolumeClaimVolumeSource{
 			ClaimName: pvc.Name,


### PR DESCRIPTION
**What type of PR is this?**
Addressing the scenario where pod.Status.HostIP != vol.AttachedOn but Pod is using locally attached volume.
Also addressing some review comments from my previous PR.

In the interest of not repeating the same set of calls multiple times and making it more understandable, decision of hyperconvergence/antihyperconvergence & preferLocalAttachment have been moved inside the function but the core logic stands as is. Only major change is that the definition of **isPodUsingLocallyAttachedVolume** has changed now.

Note: 
This PR is currently to the kubevirt-test branch. Changes will be merged in Master when we decide the release version for it.


