### PR TITLE
PB-4069 :: Restrict initial-namespaces backup

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -222,9 +222,16 @@ func (a *ApplicationBackupController) updateWithAllNamespaces(backup *stork_api.
 		return fmt.Errorf("error updating with all namespaces for wildcard: %v", err)
 	}
 	pxNs, _ := utils.GetPortworxNamespace()
+	// Create a map to store the namespaces to be ignored for fast lookup
+	ignoreNamespaces := map[string]bool{
+		pxNs:              true,
+		"kube-system":     true,
+		"kube-public":     true,
+		"kube-node-lease": true,
+	}
 	namespacesToBackup := make([]string, 0)
 	for _, ns := range namespaces.Items {
-		if ns.Name != "kube-system" && ns.Name != pxNs {
+		if _, found := ignoreNamespaces[ns.Name]; !found {
 			namespacesToBackup = append(namespacesToBackup, ns.Name)
 		}
 	}
@@ -300,8 +307,15 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		if len(backup.Spec.Namespaces) == 0 {
 			pxNs, _ = utils.GetPortworxNamespace()
 		}
+		// Create a map to store the namespaces to be ignored for fast lookup
+		ignoreNamespaces := map[string]bool{
+			pxNs:              true,
+			"kube-system":     true,
+			"kube-public":     true,
+			"kube-node-lease": true,
+		}
 		for _, namespace := range namespaces.Items {
-			if namespace.Name != "kube-system" && namespace.Name != pxNs {
+			if _, found := ignoreNamespaces[namespace.Name]; !found {
 				selectedNamespaces = append(selectedNamespaces, namespace.Name)
 			}
 		}


### PR DESCRIPTION
- Restrict backup of initial-namespaces in case of all namespaces i.e. *
- Restrict backup of initial-namespaces in case of label-selector
- Allow backup of initial-namespaces in case API is specifically passing it i.e. namsespace=kube-public in API call initial-namespaces are https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#initial-namespaces


**What type of PR is this?**
>improvement


**What this PR does / why we need it**:
```
- Restrict backup of initial-namespaces in case of all namespaces i.e. *
- Restrict backup of initial-namespaces in case of label-selector
- Allow backup of initial-namespaces in case API is specifically passing it i.e. namsespace=kube-public in API call 

initial-namespaces are https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#initial-namespaces
```

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: #PB-4609
User Impact: User will not be able to backup initial namespaces if tried with label-selector or all namespace
Resolution: If user wants to backup initial namespace then one needs to pass it specifically as namsespace=kube-public in API calls

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->23.9

**Testing Screenshot ::**
<img width="1559" alt="image" src="https://github.com/libopenstorage/stork/assets/54888022/36772081-eea7-4be7-a32e-74e5f65c5417">
<img width="1724" alt="image" src="https://github.com/libopenstorage/stork/assets/54888022/b39adcf7-47ed-4682-b3c3-61e8f13aeaaf">
