### PR TITLE
PWX-34294: storkctl need to parse https px endpoints properly, also need to assign default ports for http and https endpoints.

### DIFF
--- a/pkg/storkctl/clusterpair_test.go
+++ b/pkg/storkctl/clusterpair_test.go
@@ -4,6 +4,7 @@
 package storkctl
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -153,6 +154,62 @@ func TestCreateUniDirectionalClusterPairMissingParameters(t *testing.T) {
 	expected = "error: source kubeconfig and destination kubeconfig file should be different"
 	testCommon(t, cmdArgs, nil, expected, true)
 
+}
+
+func TestGetHostPortFromEndPoint(t *testing.T) {
+	ep := "http://px-ep1.com"
+	host, port, err := getHostPortFromEndPoint(ep)
+	require.NoError(t, err, fmt.Sprintf("hitting error while getting host and port for endpoint %s", ep))
+	require.Equal(t, "http://px-ep1.com", host)
+	require.Equal(t, "80", port)
+
+	ep = "https://px-ep1.com"
+	host, port, err = getHostPortFromEndPoint(ep)
+	require.NoError(t, err, fmt.Sprintf("hitting error while getting host and port for endpoint %s", ep))
+	require.Equal(t, "https://px-ep1.com", host)
+	require.Equal(t, "443", port)
+
+	ep = "http://px-ep1.com:10000"
+	host, port, err = getHostPortFromEndPoint(ep)
+	require.NoError(t, err, fmt.Sprintf("hitting error while getting host and port for endpoint %s", ep))
+	require.Equal(t, "http://px-ep1.com", host)
+	require.Equal(t, "10000", port)
+
+	ep = "https://px-ep1.com:10001"
+	host, port, err = getHostPortFromEndPoint(ep)
+	require.NoError(t, err, fmt.Sprintf("hitting error while getting host and port for endpoint %s", ep))
+	require.Equal(t, "https://px-ep1.com", host)
+	require.Equal(t, "10001", port)
+
+	ep = "px-ep1.com"
+	host, port, err = getHostPortFromEndPoint(ep)
+	require.NoError(t, err, fmt.Sprintf("hitting error while getting host and port for endpoint %s", ep))
+	require.Equal(t, "px-ep1.com", host)
+	require.Equal(t, "80", port)
+
+	ep = "px-ep1.com:500"
+	host, port, err = getHostPortFromEndPoint(ep)
+	require.NoError(t, err, fmt.Sprintf("hitting error while getting host and port for endpoint %s", ep))
+	require.Equal(t, "px-ep1.com", host)
+	require.Equal(t, "500", port)
+
+	ep = "10.123.146.176"
+	_, _, err = getHostPortFromEndPoint(ep)
+	require.Error(t, err, fmt.Sprintf("Received unexpected error:\nport is needed along with ip address %s", ep))
+
+	ep = "10.123.146.176:9001"
+	host, port, err = getHostPortFromEndPoint(ep)
+	require.NoError(t, err, fmt.Sprintf("hitting error while getting host and port for endpoint %s", ep))
+	require.Equal(t, "10.123.146.176", host)
+	require.Equal(t, "9001", port)
+
+	ep = "htt://px-ep1.com"
+	_, _, err = getHostPortFromEndPoint(ep)
+	require.Error(t, err, "Received unexpected error:\ninvalid url scheme px-ep1.com, expected http or https only")
+
+	ep = "htt://px-ep1.com:80"
+	_, _, err = getHostPortFromEndPoint(ep)
+	require.Error(t, err, "Received unexpected error:\ninvalid url scheme px-ep1.com, expected http or https only")
 }
 
 func createTempFile(t *testing.T, fileName string, fileContent string) *os.File {


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
bug

**What this PR does / why we need it**:
1. Need to accept both https/http px endpoints.
2. Need to provide default port as 80 or 443 with host names if not provided.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: https px endpoints were not working with storkctl create clusterpair.
User Impact: Migrations between clusters with ssl enabled px endpoints were not working.
Resolution: Both https and http endpoints with the scheme is now accepted as src-ep and dest-ep with storkctl create clusterpair.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.10.0
-->

**Test**
Tested with
1. https endpoints 
2. http endpoints
3. Endpoints without port
4. Endpoints without scheme
5. Auto fetching endpoints
Details have been added in PWX-34294