### PR TITLE
PWX-34395: Existing pod attachment info not required for scheduling d…

### DIFF
--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -1006,7 +1006,6 @@ func (e *Extender) updateVirtLauncherPodPrioritizeScores(
 		}
 	} else {
 		driverNodes = volume.RemoveDuplicateOfflineNodes(driverNodes)
-
 		for _, dnode := range driverNodes {
 			for _, knode := range args.Nodes.Items {
 				// Initialize with score to with score for remote node
@@ -1018,11 +1017,7 @@ func (e *Extender) updateVirtLauncherPodPrioritizeScores(
 						if dataNode == dnode.StorageID {
 							// Current node has the volume replica
 							score = replicaNodeScore
-							nodeHasAttachedVolume := e.nodeHasAttachedVolume(dnode, volInfo)
-							if nodeHasAttachedVolume {
-								// There is no LiveMigration in progress
-								// When a new pod gets scheduling request
-								// assign a higher score for local volume attachment
+							if e.nodeHasAttachedVolume(dnode, volInfo) {
 								score = int64(2 * nodePriorityScore)
 							}
 						}

--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -769,36 +769,6 @@ func (e *Extender) nodeHasAttachedVolume(dNode *volume.NodeInfo, vol *volume.Inf
 	return false
 }
 
-// isPodUsingLocallyAttachedVolume returns true if the pod is running node where volume is attached
-func (e *Extender) isPodUsingLocallyAttachedVolume(pod *v1.Pod, vol *volume.Info, driverNodes []*volume.NodeInfo) bool {
-	if pod == nil || vol == nil || driverNodes == nil {
-		return false
-	}
-	if pod.Status.HostIP == vol.AttachedOn {
-		log.Debugf("Pod %v/%v is using locally attached volume on node %v", pod.Namespace, pod.Name, pod.Status.HostIP)
-		return true
-	}
-	var volAttachedNode *volume.NodeInfo
-	for _, dNode := range driverNodes {
-		if e.nodeHasAttachedVolume(dNode, vol) {
-			volAttachedNode = dNode
-			break
-		}
-	}
-	// If pod.Status.HostIP doesn't match vol.AttachedOn, we need to check all IPs on the driver node on which volume is attached
-	if volAttachedNode != nil {
-		for _, nodeIP := range volAttachedNode.IPs {
-			if nodeIP == pod.Status.HostIP {
-				log.Debugf("Pod %v/%v is using locally attached volume on node %v", pod.Namespace, pod.Name, volAttachedNode.Hostname)
-				// Local attachment
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 // isVirtLauncherPod returns true if it is a virt launcher pod
 func (e *Extender) isVirtLauncherPod(pod *v1.Pod) bool {
 	return pod.Labels["kubevirt.io"] == "virt-launcher"
@@ -1036,10 +1006,6 @@ func (e *Extender) updateVirtLauncherPodPrioritizeScores(
 		}
 	} else {
 		driverNodes = volume.RemoveDuplicateOfflineNodes(driverNodes)
-		isExistingPodUsingLocallyAttachedVolume := e.isPodUsingLocallyAttachedVolume(podBeingLiveMigrated, volInfo, driverNodes)
-		if isExistingPodUsingLocallyAttachedVolume {
-			storklog.PodLog(pod).Infof("Existing pod is using locally attached volume")
-		}
 
 		for _, dnode := range driverNodes {
 			for _, knode := range args.Nodes.Items {
@@ -1053,21 +1019,11 @@ func (e *Extender) updateVirtLauncherPodPrioritizeScores(
 							// Current node has the volume replica
 							score = replicaNodeScore
 							nodeHasAttachedVolume := e.nodeHasAttachedVolume(dnode, volInfo)
-
-							if podBeingLiveMigrated != nil {
-								// LiveMigration in progress
-								// If existing pod is not using attached volume and current node has attached volume, assign a higher score to it
-								if !isExistingPodUsingLocallyAttachedVolume && nodeHasAttachedVolume {
-									storklog.PodLog(pod).Infof("Node %v has attached volume", dataNode)
-									score = int64(2 * nodePriorityScore)
-								}
-							} else {
-								if nodeHasAttachedVolume {
-									// There is no LiveMigration in progress
-									// When a new pod gets scheduling request
-									// assign a higher score for local volume attachment
-									score = int64(2 * nodePriorityScore)
-								}
+							if nodeHasAttachedVolume {
+								// There is no LiveMigration in progress
+								// When a new pod gets scheduling request
+								// assign a higher score for local volume attachment
+								score = int64(2 * nodePriorityScore)
 							}
 						}
 					}

--- a/pkg/extender/extender_test.go
+++ b/pkg/extender/extender_test.go
@@ -2371,7 +2371,7 @@ func kubevirtPodScheduling(t *testing.T) {
 		t,
 		nodes,
 		[]float64{
-			defaultScore,
+			2 * nodePriorityScore,
 			defaultScore,
 			defaultScore,
 			nodePriorityScore,
@@ -2528,7 +2528,7 @@ func kubevirtPodSchedulingAttachedOnMismatch(t *testing.T) {
 		nodes,
 		[]float64{
 			defaultScore,
-			defaultScore,
+			2 * nodePriorityScore,
 			defaultScore,
 			nodePriorityScore,
 			nodePriorityScore,


### PR DESCRIPTION
…uring live migration

**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
* Existing Pod node will never be a part of input set of nodes due to Pod anti affinities set by kubevirt. In such a case isPodUsingLocallyAttachedVolume is not necessarily required. It does simplify the scheduling logic. 
```
kind: Pod
...
  labels:
    kubevirt.io/created-by: 30716366-8726-4024-9d8d-5500ba8ceb87
...
spec:
  affinity:
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            kubevirt.io/created-by: 30716366-8726-4024-9d8d-5500ba8ceb87
        topologyKey: kubernetes.io/hostname

```
* UTs are updated to give higher score to the nodes which have volume attached irrespective of the pod placement on them. In an actual scenario, these nodes will not be a part of the scheduling node request input.

**Does this change need to be cherry-picked to a release branch?**:
yes
