### PR TITLE
PWX-32199: Improvements to storkctl cli create migration schedule

### DIFF
--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -107,6 +107,8 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 					return
 				}
 			} else {
+				//we reach here if user has not set the interval flag value.
+				//So we take either the user input for schedulePolicyName or the default schedulePolicyName
 				logrus.Infof("schedulePolicy name is %s", schedulePolicyName)
 				_, err := storkops.Instance().GetSchedulePolicy(schedulePolicyName)
 				if err != nil {
@@ -152,12 +154,10 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 	createMigrationScheduleCommand.Flags().BoolVarP(&startApplications, "startApplications", "a", false, "Start applications on the destination cluster after migration")
 	createMigrationScheduleCommand.Flags().StringVarP(&preExecRule, "preExecRule", "", "", "Rule to run before executing migration")
 	createMigrationScheduleCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Rule to run after executing migration")
-	createMigrationScheduleCommand.Flags().StringVarP(&schedulePolicyName, "schedulePolicyName", "s", "default-migration-policy", "Name of the schedule policy to use. "+
-		"If you want to create a new interval policy, use interval flag instead.")
+	createMigrationScheduleCommand.Flags().StringVarP(&schedulePolicyName, "schedulePolicyName", "s", "default-migration-policy", "Name of the schedule policy to use. If you want to create a new interval policy, use the interval flag instead")
 	createMigrationScheduleCommand.Flags().BoolVar(&suspend, "suspend", false, "Flag to denote whether schedule should be suspended on creation")
-	createMigrationScheduleCommand.Flags().BoolVar(&autoSuspend, "auto-suspend", true, "If set to true, in the event of a disaster, Stork will automatically suspend the DR migration schedules on your source cluster, "+
-		"allowing you to migrate your application to an active Kubernetes cluster. ")
-	createMigrationScheduleCommand.Flags().IntVarP(&intervalMinutes, "interval", "i", 30, "Specify the periodic interval, in minutes, after which Stork should trigger the operation.")
+	createMigrationScheduleCommand.Flags().BoolVar(&autoSuspend, "auto-suspend", true, "In case of a disaster, Stork will automatically suspend DR migration schedules on your source cluster, enabling migration to an active Kubernetes cluster")
+	createMigrationScheduleCommand.Flags().IntVarP(&intervalMinutes, "interval", "i", 30, "Specify the periodic interval, in minutes, after which Stork should trigger the migration")
 	createMigrationScheduleCommand.Flags().StringToStringVar(&annotations, "annotations", map[string]string{}, "Add required annotations to the resource in the format key1=value1,key2=value2,... ")
 	return createMigrationScheduleCommand
 }

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -65,8 +65,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 			// Default value of includeVolumes for syncDr is false and for async DR is true
 			if isSyncDr {
 				if c.Flags().Changed("includeVolumes") && includeVolumes {
-					util.CheckErr(fmt.Errorf("IncludeVolumes can only be set to false because the volumes are already present " +
-						"on the destination cluster as we deal with a single Portworx cluster in sync-dr usecases"))
+					util.CheckErr(fmt.Errorf("IncludeVolumes can only be set to false in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"))
 					return
 				}
 				includeVolumes = false
@@ -77,13 +76,17 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				return
 			}
 
-			//Allow the user to only add one of the flags schedulePolicyName or interval
+			//There are 4 possible cases for schedulePolicyName and interval flags
+			//user provides both schedulePolicyName and interval value -> we throw an error saying you can only fill one of the values
+			//user provides interval value only -> we will create a new schedule policy and use that in the migrationSchedule
+			//user provides schedulePolicyName only -> we will check if such a schedule policy exists and if yes use that schedulePolicy.
+			//user doesn't provide schedulePolicyName nor interval value -> we go ahead with the "default-migration-policy"
+
 			if c.Flags().Changed("schedulePolicyName") && c.Flags().Changed("interval") {
 				util.CheckErr(fmt.Errorf("must provide only one of schedulePolicyName or interval values"))
 				return
 			}
 
-			//If value for interval is explicitly set by the user, we will ignore schedulePolicyName
 			if c.Flags().Changed("interval") {
 				var policyItem storkv1.SchedulePolicyItem
 				var intervalPolicy storkv1.IntervalPolicy
@@ -96,7 +99,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 					return
 				}
 				policyItem.Interval = &intervalPolicy
-				//name of the schedule policy created will be same as the migration schedule name provided as an input.
+				//name of the schedule policy created will be same as the migration schedule name provided in the input.
 				schedulePolicyName = migrationScheduleName
 				var schedulePolicy storkv1.SchedulePolicy
 				schedulePolicy.Name = schedulePolicyName
@@ -107,8 +110,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 					return
 				}
 			} else {
-				//we reach here if user has not set the interval flag value.
-				//So we take either the user input for schedulePolicyName or the default schedulePolicyName
+				// case 3 and 4 are covered in this branch
 				logrus.Infof("schedulePolicy name is %s", schedulePolicyName)
 				_, err := storkops.Instance().GetSchedulePolicy(schedulePolicyName)
 				if err != nil {
@@ -147,18 +149,18 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 			printMsg(msg, ioStreams.Out)
 		},
 	}
-	createMigrationScheduleCommand.Flags().StringSliceVarP(&namespaceList, "namespaces", "", nil, "Comma separated list of namespaces to migrate")
-	createMigrationScheduleCommand.Flags().StringVarP(&clusterPair, "clusterPair", "c", "", "ClusterPair name for migration")
-	createMigrationScheduleCommand.Flags().BoolVarP(&includeResources, "includeResources", "r", true, "Include resources in the migration")
-	createMigrationScheduleCommand.Flags().BoolVarP(&includeVolumes, "includeVolumes", "", true, "Include volumes in the migration")
-	createMigrationScheduleCommand.Flags().BoolVarP(&startApplications, "startApplications", "a", false, "Start applications on the destination cluster after migration")
-	createMigrationScheduleCommand.Flags().StringVarP(&preExecRule, "preExecRule", "", "", "Rule to run before executing migration")
-	createMigrationScheduleCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Rule to run after executing migration")
+	createMigrationScheduleCommand.Flags().StringSliceVarP(&namespaceList, "namespaces", "", nil, "Specify the comma-separated list of namespaces to be included in the migration")
+	createMigrationScheduleCommand.Flags().StringVarP(&clusterPair, "clusterPair", "c", "", "Specify the name of the ClusterPair in the same namespace to be used for the migration")
+	createMigrationScheduleCommand.Flags().BoolVarP(&includeResources, "includeResources", "r", true, "Specify whether Kubernetes resources should be migrated")
+	createMigrationScheduleCommand.Flags().BoolVarP(&includeVolumes, "includeVolumes", "", true, "Specify whether the underlying Portworx volumes should be migratedSpecifies whether Kubernetes resources should be migrated")
+	createMigrationScheduleCommand.Flags().BoolVarP(&startApplications, "startApplications", "a", false, "Specify whether the applications should be scaled up on the target cluster after a successful migration")
+	createMigrationScheduleCommand.Flags().StringVarP(&preExecRule, "preExecRule", "", "", "Specify the name of the rule to be executed before every migration is triggered")
+	createMigrationScheduleCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Specify the name of the rule to be executed after every migration is triggered")
 	createMigrationScheduleCommand.Flags().StringVarP(&schedulePolicyName, "schedulePolicyName", "s", "default-migration-policy", "Name of the schedule policy to use. If you want to create a new interval policy, use the interval flag instead")
 	createMigrationScheduleCommand.Flags().BoolVar(&suspend, "suspend", false, "Flag to denote whether schedule should be suspended on creation")
-	createMigrationScheduleCommand.Flags().BoolVar(&autoSuspend, "autoSuspend", true, "In case of a disaster, Stork will automatically suspend DR migration schedules on your source cluster, enabling migration to an active Kubernetes cluster")
-	createMigrationScheduleCommand.Flags().IntVarP(&intervalMinutes, "interval", "i", 30, "Specify the periodic interval, in minutes, after which Stork should trigger the migration")
-	createMigrationScheduleCommand.Flags().StringToStringVar(&annotations, "annotations", map[string]string{}, "Add required annotations to the resource in the format key1=value1,key2=value2,... ")
+	createMigrationScheduleCommand.Flags().BoolVar(&autoSuspend, "autoSuspend", true, "In case of a disaster, Stork will automatically suspend DR migration schedules on your source cluster")
+	createMigrationScheduleCommand.Flags().IntVarP(&intervalMinutes, "interval", "i", 30, "Specify the time interval, in minutes, at which Stork should trigger migrations")
+	createMigrationScheduleCommand.Flags().StringToStringVar(&annotations, "annotations", map[string]string{}, "Add required annotations to the resource in comma-separated key value pairs. key1=value1,key2=value2,... ")
 	return createMigrationScheduleCommand
 }
 

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -70,7 +70,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 			if isSyncDr {
 				//covers the unlikely scenario where user sets the --exclude-volumes=false value in the command for a sync-dr migration use case
 				if c.Flags().Changed("exclude-volumes") && includeVolumes {
-					util.CheckErr(fmt.Errorf("the --exclude-volumes flag can only be set to true in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"))
+					util.CheckErr(fmt.Errorf("--exclude-volumes can only be set to true in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"))
 					return
 				}
 				includeVolumes = false

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -156,7 +156,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 	createMigrationScheduleCommand.Flags().StringVarP(&postExecRule, "postExecRule", "", "", "Rule to run after executing migration")
 	createMigrationScheduleCommand.Flags().StringVarP(&schedulePolicyName, "schedulePolicyName", "s", "default-migration-policy", "Name of the schedule policy to use. If you want to create a new interval policy, use the interval flag instead")
 	createMigrationScheduleCommand.Flags().BoolVar(&suspend, "suspend", false, "Flag to denote whether schedule should be suspended on creation")
-	createMigrationScheduleCommand.Flags().BoolVar(&autoSuspend, "auto-suspend", true, "In case of a disaster, Stork will automatically suspend DR migration schedules on your source cluster, enabling migration to an active Kubernetes cluster")
+	createMigrationScheduleCommand.Flags().BoolVar(&autoSuspend, "autoSuspend", true, "In case of a disaster, Stork will automatically suspend DR migration schedules on your source cluster, enabling migration to an active Kubernetes cluster")
 	createMigrationScheduleCommand.Flags().IntVarP(&intervalMinutes, "interval", "i", 30, "Specify the periodic interval, in minutes, after which Stork should trigger the migration")
 	createMigrationScheduleCommand.Flags().StringToStringVar(&annotations, "annotations", map[string]string{}, "Add required annotations to the resource in the format key1=value1,key2=value2,... ")
 	return createMigrationScheduleCommand

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -66,10 +66,11 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				isSyncDr = true
 			}
 
-			// Default value of includeVolumes for syncDr is false and for async DR is true
+			// Default value of includeVolumes for asyncDr is true and for sync DR is false
 			if isSyncDr {
+				//covers the unlikely scenario where user sets the --exclude-volumes=false value in the command for a sync-dr migration use case
 				if c.Flags().Changed("exclude-volumes") && includeVolumes {
-					util.CheckErr(fmt.Errorf("the flag exclude-volumes can only be set to true in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"))
+					util.CheckErr(fmt.Errorf("the --exclude-volumes flag can only be set to true in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"))
 					return
 				}
 				includeVolumes = false
@@ -99,7 +100,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				// Validate the user input
 				err := intervalPolicy.Validate()
 				if err != nil {
-					util.CheckErr(fmt.Errorf("could not create a schedule policy with specified interval. %v", err))
+					util.CheckErr(fmt.Errorf("could not create a schedule policy with specified interval: %v", err))
 					return
 				}
 				policyItem.Interval = &intervalPolicy
@@ -110,7 +111,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				schedulePolicy.Policy = policyItem
 				_, err = storkops.Instance().CreateSchedulePolicy(&schedulePolicy)
 				if err != nil {
-					util.CheckErr(fmt.Errorf("could not create a schedule policy with specified interval. %v", err))
+					util.CheckErr(fmt.Errorf("could not create a schedule policy with specified interval: %v", err))
 					return
 				}
 			} else {
@@ -159,7 +160,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 	createMigrationScheduleCommand.Flags().BoolVarP(&startApplications, "start-applications", "a", false, "If present, the applications will be scaled up on the target cluster after a successful migration")
 	createMigrationScheduleCommand.Flags().StringVarP(&preExecRule, "pre-exec-rule", "", "", "Specify the name of the rule to be executed before every migration is triggered")
 	createMigrationScheduleCommand.Flags().StringVarP(&postExecRule, "post-exec-rule", "", "", "Specify the name of the rule to be executed after every migration is triggered")
-	createMigrationScheduleCommand.Flags().StringVarP(&schedulePolicyName, "schedule-policy-name", "s", "default-migration-policy", "Name of the schedule policy to use. If you want to create a new interval policy, use the interval flag instead")
+	createMigrationScheduleCommand.Flags().StringVarP(&schedulePolicyName, "schedule-policy-name", "s", "default-migration-policy", "Name of the schedule policy to use. If you want to create a new interval policy, use the --interval flag instead")
 	createMigrationScheduleCommand.Flags().BoolVar(&suspend, "suspend", false, "Flag to denote whether schedule should be suspended on creation")
 	createMigrationScheduleCommand.Flags().BoolVar(&disableAutoSuspend, "disable-auto-suspend", false, "Prevent automatic suspension of DR migration schedules on the source cluster in case of a disaster")
 	createMigrationScheduleCommand.Flags().IntVarP(&intervalMinutes, "interval", "i", 30, "Specify the time interval, in minutes, at which Stork should trigger migrations")

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -6,7 +6,6 @@ import (
 
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
@@ -116,7 +115,6 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				}
 			} else {
 				// case 3 and 4 are covered in this branch
-				logrus.Infof("schedulePolicy name is %s", schedulePolicyName)
 				_, err := storkops.Instance().GetSchedulePolicy(schedulePolicyName)
 				if err != nil {
 					util.CheckErr(fmt.Errorf("unable to get schedulepolicy %v: %v", schedulePolicyName, err))

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -254,7 +254,7 @@ func TestCreateMigrationScheduleSyncDrExcludeVolumesFalse(t *testing.T) {
 	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
 	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair,
 		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace, "--exclude-volumes=" + strconv.FormatBool(false)}
-	expected := "error: the --exclude-volumes flags can only be set to true in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"
+	expected := "error: --exclude-volumes can only be set to true in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -55,6 +55,8 @@ func createMigrationScheduleAndVerify(
 	})
 	require.True(t, err == nil || errors.IsAlreadyExists(err), "Error creating schedulepolicy")
 
+	createClusterPair(t, clusterpair, namespace, "async-dr")
+
 	expected := "MigrationSchedule " + name + " created successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
@@ -67,6 +69,7 @@ func createMigrationScheduleAndVerify(
 	require.Equal(t, namespaces, migration.Spec.Template.Spec.Namespaces, "MigrationSchedule namespace mismatch")
 	require.Equal(t, preExecRule, migration.Spec.Template.Spec.PreExecRule, "MigrationSchedule preExecRule mismatch")
 	require.Equal(t, postExecRule, migration.Spec.Template.Spec.PostExecRule, "MigrationSchedule postExecRule mismatch")
+	require.Equal(t, true, *migration.Spec.Template.Spec.IncludeVolumes, "MigrationSchedule includeVolumes mismatch")
 }
 
 func TestGetMigrationSchedulesOneMigrationSchedule(t *testing.T) {
@@ -204,20 +207,34 @@ func TestGetMigrationSchedulesWithStatus(t *testing.T) {
 }
 
 func TestCreateMigrationSchedulesNoNamespace(t *testing.T) {
-	cmdArgs := []string{"create", "migrationschedules", "-c", "clusterPair1", "migration1"}
+	defer resetTest()
+	clusterPairName := "clusterPair1"
+	createClusterPair(t, clusterPairName, "default", "async-dr")
+	cmdArgs := []string{"create", "migrationschedules", "-c", clusterPairName, "migration1"}
 
 	expected := "error: need to provide atleast one namespace to migrate"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
 func TestCreateMigrationSchedulesNoClusterPair(t *testing.T) {
+	defer resetTest()
 	cmdArgs := []string{"create", "migrationschedules", "migration1"}
 
 	expected := "error: ClusterPair name needs to be provided for migration schedule"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
+func TestCreateMigrationSchedulesInvalidClusterPair(t *testing.T) {
+	defer resetTest()
+	clusterPairName := "clusterPair1"
+	cmdArgs := []string{"create", "migrationschedule", "-c", clusterPairName, "migration1"}
+
+	expected := "error: unable to find the cluster pair in the given namespace"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
 func TestCreateMigrationSchedulesNoName(t *testing.T) {
+	defer resetTest()
 	cmdArgs := []string{"create", "migrationschedules"}
 
 	expected := "error: exactly one name needs to be provided for migration schedule name"
@@ -229,6 +246,62 @@ func TestCreateMigrationSchedules(t *testing.T) {
 	createMigrationScheduleAndVerify(t, "createmigration", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
 }
 
+func TestCreateMigrationScheduleSyncDrIncludeVolumesTrue(t *testing.T) {
+	defer resetTest()
+	clusterPair := "clusterpair1"
+	namespace := "namespace1"
+	name := "createmigrationschedule"
+	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
+	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair,
+		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace, "--includeVolumes=" + strconv.FormatBool(true)}
+	expected := "error: IncludeVolumes can only be set to false because the volumes are already present on the destination cluster as we deal with a single Portworx cluster in sync-dr usecases"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestCreateMigrationScheduleWithIntervalAndVerify(t *testing.T) {
+	defer resetTest()
+	clusterPair := "clusterpair1"
+	namespace := "namespace1"
+	name := "createmigrationschedule"
+	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
+	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair,
+		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace}
+	expected := "MigrationSchedule createmigrationschedule created successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// Make sure it was created correctly
+	migration, err := storkops.Instance().GetMigrationSchedule(name, namespace)
+	require.NoError(t, err, "Error getting migration schedule")
+	schedulePolicy, err := storkops.Instance().GetSchedulePolicy(name)
+	require.NoError(t, err, "Error getting schedule policy")
+	require.Equal(t, name, migration.Name, "MigrationSchedule name mismatch")
+	require.Equal(t, namespace, migration.Namespace, "MigrationSchedule namespace mismatch")
+	require.Equal(t, clusterPair, migration.Spec.Template.Spec.ClusterPair, "MigrationSchedule clusterpair mismatch")
+	require.Equal(t, []string{namespace}, migration.Spec.Template.Spec.Namespaces, "MigrationSchedule namespace mismatch")
+	//verifying includeVolumes default for syncDR usecase is false
+	require.Equal(t, false, *migration.Spec.Template.Spec.IncludeVolumes, "MigrationSchedule includeVolumes mismatch")
+	require.Equal(t, 15, schedulePolicy.Policy.Interval.IntervalMinutes, "MigrationSchedule schedulePolicy interval mismatch")
+	require.Equal(t, map[string]string{"key1": "value1"}, migration.Annotations, "MigrationSchedule annotations mismatch")
+}
+
+func TestCreateMigrationScheduleWithBothIntervalAndPolicyName(t *testing.T) {
+	defer resetTest()
+	createClusterPair(t, "clusterPair1", "namespace1", "async-dr")
+	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-s", "test-policy", "-c", "clusterPair1",
+		"--namespaces", "namespace1", "migrationschedule", "-n", "namespace1"}
+	expected := "error: must provide only one of schedulePolicyName or interval values"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestCreateMigrationScheduleWithInvalidInterval(t *testing.T) {
+	defer resetTest()
+	createClusterPair(t, "clusterPair1", "namespace1", "async-dr")
+	cmdArgs := []string{"create", "migrationschedules", "-i", "-15", "-c", "clusterPair1",
+		"--namespaces", "namespace1", "migrationschedule", "-n", "namespace1"}
+	expected := "error: could not create a schedule policy with specified interval. Invalid intervalMinutes (-15) in Interval policy"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
 func TestCreateDuplicateMigrationSchedules(t *testing.T) {
 	defer resetTest()
 	createMigrationScheduleAndVerify(t, "createmigrationschedule", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
@@ -238,6 +311,28 @@ func TestCreateDuplicateMigrationSchedules(t *testing.T) {
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
+func TestDefaultMigrationSchedulePolicy(t *testing.T) {
+	defer resetTest()
+	// Create schedule without the default policy present
+	createClusterPair(t, "clusterpair1", "default", "async-dr")
+	cmdArgs := []string{"create", "migrationschedules", "defaultpolicy", "-n", "test", "-c", "clusterpair1", "--namespaces", "test", "-n", "default"}
+	expected := "error: unable to get schedulepolicy default-migration-policy: schedulepolicies.stork.libopenstorage.org \"default-migration-policy\" not found"
+	testCommon(t, cmdArgs, nil, expected, true)
+
+	// Create again adding default policy
+	_, err := storkops.Instance().CreateSchedulePolicy(&storkv1.SchedulePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default-migration-policy",
+		},
+		Policy: storkv1.SchedulePolicyItem{
+			Interval: &storkv1.IntervalPolicy{
+				IntervalMinutes: 1,
+			}},
+	})
+	require.NoError(t, err, "Error creating schedulepolicy")
+	expected = "MigrationSchedule defaultpolicy created successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
 func TestDeleteMigrationSchedulesNoMigrationName(t *testing.T) {
 	cmdArgs := []string{"delete", "migrationschedules"}
 
@@ -279,30 +374,6 @@ func TestDeleteMigrationSchedules(t *testing.T) {
 	cmdArgs = []string{"delete", "migrationschedules", "-c", "clusterpair1"}
 	expected = "MigrationSchedule deletemigration1 deleted successfully\n"
 	expected += "MigrationSchedule deletemigration2 deleted successfully\n"
-	testCommon(t, cmdArgs, nil, expected, false)
-}
-
-func TestDefaultMigrationSchedulePolicy(t *testing.T) {
-	defer resetTest()
-	createMigrationScheduleAndVerify(t, "deletemigration", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", false)
-
-	// Create schedule without the default policy present
-	cmdArgs := []string{"create", "migrationschedules", "defaultpolicy", "-n", "test", "-c", "clusterpair", "--namespaces", "test"}
-	expected := "error: error getting schedulepolicy default-migration-policy: schedulepolicies.stork.libopenstorage.org \"default-migration-policy\" not found"
-	testCommon(t, cmdArgs, nil, expected, true)
-
-	// Create again adding default policy
-	_, err := storkops.Instance().CreateSchedulePolicy(&storkv1.SchedulePolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "default-migration-policy",
-		},
-		Policy: storkv1.SchedulePolicyItem{
-			Interval: &storkv1.IntervalPolicy{
-				IntervalMinutes: 1,
-			}},
-	})
-	require.NoError(t, err, "Error creating schedulepolicy")
-	expected = "MigrationSchedule defaultpolicy created successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 
@@ -362,4 +433,26 @@ func TestSuspendResumeMigrationSchedule(t *testing.T) {
 	expected = "MigrationSchedule " + name + " resumed successfully\nMigrationSchedule " + name1 + " resumed successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
+}
+
+func createClusterPair(t *testing.T, clusterPairName string, namespace string, mode string) {
+	options := make(map[string]string)
+	if mode == "async-dr" {
+		options["backuplocation"] = "value1"
+		options["ip"] = "value2"
+		options["port"] = "value3"
+		options["token"] = "value4"
+	}
+	clusterPair := &storkv1.ClusterPair{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterPairName,
+			Namespace: namespace,
+		},
+
+		Spec: storkv1.ClusterPairSpec{
+			Options: options,
+		},
+	}
+	_, err := storkops.Instance().CreateClusterPair(clusterPair)
+	require.True(t, err == nil || errors.IsAlreadyExists(err), "Error creating cluster pair")
 }

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -282,6 +282,7 @@ func TestCreateMigrationScheduleWithIntervalAndVerify(t *testing.T) {
 	require.Equal(t, false, *migration.Spec.Template.Spec.IncludeVolumes, "MigrationSchedule includeVolumes mismatch")
 	require.Equal(t, 15, schedulePolicy.Policy.Interval.IntervalMinutes, "MigrationSchedule schedulePolicy interval mismatch")
 	require.Equal(t, map[string]string{"key1": "value1"}, migration.Annotations, "MigrationSchedule annotations mismatch")
+	require.Equal(t, true, migration.Spec.AutoSuspend, "MigrationSchedule annotations mismatch")
 }
 
 func TestCreateMigrationScheduleWithBothIntervalAndPolicyName(t *testing.T) {

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -299,7 +299,7 @@ func TestCreateMigrationScheduleWithInvalidInterval(t *testing.T) {
 	createClusterPair(t, "clusterPair1", "namespace1", "async-dr")
 	cmdArgs := []string{"create", "migrationschedules", "-i", "-15", "-c", "clusterPair1",
 		"--namespaces", "namespace1", "migrationschedule", "-n", "namespace1"}
-	expected := "error: could not create a schedule policy with specified interval. Invalid intervalMinutes (-15) in Interval policy"
+	expected := "error: could not create a schedule policy with specified interval: Invalid intervalMinutes (-15) in Interval policy"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -254,7 +254,7 @@ func TestCreateMigrationScheduleSyncDrExcludeVolumesFalse(t *testing.T) {
 	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
 	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair,
 		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace, "--exclude-volumes=" + strconv.FormatBool(false)}
-	expected := "error: the flag exclude-volumes can only be set to true in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"
+	expected := "error: the --exclude-volumes flags can only be set to true in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -282,7 +282,7 @@ func TestCreateMigrationScheduleWithIntervalAndVerify(t *testing.T) {
 	require.Equal(t, false, *migration.Spec.Template.Spec.IncludeVolumes, "MigrationSchedule includeVolumes mismatch")
 	require.Equal(t, 15, schedulePolicy.Policy.Interval.IntervalMinutes, "MigrationSchedule schedulePolicy interval mismatch")
 	require.Equal(t, map[string]string{"key1": "value1"}, migration.Annotations, "MigrationSchedule annotations mismatch")
-	require.Equal(t, true, migration.Spec.AutoSuspend, "MigrationSchedule annotations mismatch")
+	require.Equal(t, true, migration.Spec.AutoSuspend, "MigrationSchedule autoSuspend mismatch")
 }
 
 func TestCreateMigrationScheduleWithBothIntervalAndPolicyName(t *testing.T) {

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -254,7 +254,7 @@ func TestCreateMigrationScheduleSyncDrExcludeVolumesFalse(t *testing.T) {
 	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
 	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair,
 		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace, "--exclude-volumes=" + strconv.FormatBool(false)}
-	expected := "error: --exclude-volumes can only be set to true in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"
+	expected := "error: --exclude-volumes can only be set to true if it is a sync-dr use case or storage options are not provided in the cluster pair"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -38,10 +38,10 @@ func createMigrationScheduleAndVerify(
 ) {
 	cmdArgs := []string{"create", "migrationschedules", "-s", schedulePolicyName, "-n", namespace, "-c", clusterpair, "--namespaces", strings.Join(namespaces, ","), name, "--suspend=" + strconv.FormatBool(suspend)}
 	if preExecRule != "" {
-		cmdArgs = append(cmdArgs, "--preExecRule", preExecRule)
+		cmdArgs = append(cmdArgs, "--pre-exec-rule", preExecRule)
 	}
 	if postExecRule != "" {
-		cmdArgs = append(cmdArgs, "--postExecRule", postExecRule)
+		cmdArgs = append(cmdArgs, "--post-exec-rule", postExecRule)
 	}
 
 	_, err := storkops.Instance().CreateSchedulePolicy(&storkv1.SchedulePolicy{
@@ -246,15 +246,15 @@ func TestCreateMigrationSchedules(t *testing.T) {
 	createMigrationScheduleAndVerify(t, "createmigration", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
 }
 
-func TestCreateMigrationScheduleSyncDrIncludeVolumesTrue(t *testing.T) {
+func TestCreateMigrationScheduleSyncDrExcludeVolumesFalse(t *testing.T) {
 	defer resetTest()
 	clusterPair := "clusterpair1"
 	namespace := "namespace1"
 	name := "createmigrationschedule"
 	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
 	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair,
-		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace, "--includeVolumes=" + strconv.FormatBool(true)}
-	expected := "error: IncludeVolumes can only be set to false in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"
+		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace, "--exclude-volumes=" + strconv.FormatBool(false)}
+	expected := "error: the flag exclude-volumes can only be set to true in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
@@ -290,7 +290,7 @@ func TestCreateMigrationScheduleWithBothIntervalAndPolicyName(t *testing.T) {
 	createClusterPair(t, "clusterPair1", "namespace1", "async-dr")
 	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-s", "test-policy", "-c", "clusterPair1",
 		"--namespaces", "namespace1", "migrationschedule", "-n", "namespace1"}
-	expected := "error: must provide only one of schedulePolicyName or interval values"
+	expected := "error: must provide only one of schedule-policy-name or interval values"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -254,7 +254,7 @@ func TestCreateMigrationScheduleSyncDrIncludeVolumesTrue(t *testing.T) {
 	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
 	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair,
 		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace, "--includeVolumes=" + strconv.FormatBool(true)}
-	expected := "error: IncludeVolumes can only be set to false because the volumes are already present on the destination cluster as we deal with a single Portworx cluster in sync-dr usecases"
+	expected := "error: IncludeVolumes can only be set to false in case of a sync-dr usecase as there is a single stretched cluster from storage perspective"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
>improvement
>unit-test

**What this PR does / why we need it**:
[PWX-32199](https://portworx.atlassian.net/browse/PWX-32199)
We are updating the storkctl create migrationschedule to add support for --interval , --auto-suspend and --annotations flags.

**Does this PR change a user-facing CRD or CLI?**:
Yes, storkctl create migrationschedules cli command is updated with new flags

```[root@ip-10-13-195-219 ~]# storkctl create migrationschedules -h
Create a migration schedule

Usage:
  storkctl create migrationschedules [flags]

Aliases:
  migrationschedules, migrationschedule

Flags:
      --annotations stringToString    Add required annotations to the resource in comma-separated key value pairs. key1=value1,key2=value2,...  (default [])
  -c, --cluster-pair string           Specify the name of the ClusterPair in the same namespace to be used for the migration
      --disable-auto-suspend          Prevent automatic suspension of DR migration schedules on the source cluster in case of a disaster
      --exclude-resources             If present, Kubernetes resources will not be migrated
      --exclude-volumes               If present, the underlying Portworx volumes will not be migrated. This is the only allowed and default behaviour in sync-dr use cases.
  -h, --help                          help for migrationschedules
  -i, --interval int                  Specify the time interval, in minutes, at which Stork should trigger migrations (default 30)
      --namespaces strings            Specify the comma-separated list of namespaces to be included in the migration
      --post-exec-rule string         Specify the name of the rule to be executed after every migration is triggered
      --pre-exec-rule string          Specify the name of the rule to be executed before every migration is triggered
  -s, --schedule-policy-name string   Name of the schedule policy to use. If you want to create a new interval policy, use the --interval flag instead (default "default-migration-policy")
  -a, --start-applications            If present, the applications will be scaled up on the target cluster after a successful migration
      --suspend                       Flag to denote whether schedule should be suspended on creation
```

**Is a release note needed?**:
Not sure, will update

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.10.0

Testing details:
Have added unit tests covering all the branches.
Have manually created migration schedules using the command and verified migrations are scheduled as expected in my local cluster.
Will be taking up integration tests for these changes as the next task.


[PWX-32199]: https://portworx.atlassian.net/browse/PWX-32199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ