### PR TITLE
PWX-33887: storkctl to support namespacemapping during applicationrestore creation.

### DIFF
--- a/pkg/storkctl/applicationrestore.go
+++ b/pkg/storkctl/applicationrestore.go
@@ -34,6 +34,7 @@ func newCreateApplicationRestoreCommand(cmdFactory Factory, ioStreams genericcli
 	var backupName string
 	var replacePolicy string
 	var resources string
+	var nsMapping string
 
 	createApplicationRestoreCommand := &cobra.Command{
 		Use:     applicationRestoreSubcommand,
@@ -83,7 +84,7 @@ func newCreateApplicationRestoreCommand(cmdFactory Factory, ioStreams genericcli
 				applicationRestore.Spec.IncludeResources = objects
 			}
 
-			applicationRestore.Spec.NamespaceMapping = getDefaultNamespaceMapping(backup)
+			applicationRestore.Spec.NamespaceMapping = getNamespaceMapping(backup, nsMapping)
 			applicationRestore.Name = applicationRestoreName
 			applicationRestore.Namespace = cmdFactory.GetNamespace()
 			_, err = storkops.Instance().CreateApplicationRestore(applicationRestore)
@@ -109,6 +110,7 @@ func newCreateApplicationRestoreCommand(cmdFactory Factory, ioStreams genericcli
 	createApplicationRestoreCommand.Flags().StringVarP(&backupLocation, "backupLocation", "l", "", "BackupLocation to use for the restore")
 	createApplicationRestoreCommand.Flags().StringVarP(&backupName, "backupName", "b", "", "Backup to restore from")
 	createApplicationRestoreCommand.Flags().StringVarP(&replacePolicy, "replacePolicy", "r", "Retain", "Policy to use if resources being restored already exist (Retain or Delete).")
+	createApplicationRestoreCommand.Flags().StringVarP(&nsMapping, "namespaceMapping", "", "", "Namespace mapping for each of the backed up namespaces, ex: <\"srcns1:destns1,srcns2:destns2\">")
 	createApplicationRestoreCommand.Flags().StringVarP(&resources, "resources", "", "",
 		"Specific resources for restoring, should be given in format \"<kind>/<namespace>/<name>,<kind>/<namespace>/<name>,<kind>/<name>\", ex: \"<Deployment>/<ns1>/<dep1>,<PersistentVolumeClaim>/<ns1>/<pvc1>,<ClusterRole>/<clusterrole1>\"")
 
@@ -292,10 +294,22 @@ func waitForApplicationRestore(name, namespace string, ioStreams genericclioptio
 	return msg, err
 }
 
-func getDefaultNamespaceMapping(backup *storkv1.ApplicationBackup) map[string]string {
+func getNamespaceMapping(backup *storkv1.ApplicationBackup, inputMappings string) map[string]string {
+	inputMappingMap := make(map[string]string)
+	if len(inputMappings) > 0 {
+		for _, inputMapping := range strings.Split(inputMappings, ",") {
+			nsMapping := strings.Split(inputMapping, ":")
+			if len(nsMapping) == 2 {
+				inputMappingMap[nsMapping[0]] = nsMapping[1]
+			}
+		}
+	}
 	nsMapping := make(map[string]string)
 	for _, ns := range backup.Spec.Namespaces {
 		nsMapping[ns] = ns
+		if newNS, ok := inputMappingMap[ns]; ok {
+			nsMapping[ns] = newNS
+		}
 	}
 	return nsMapping
 }

--- a/pkg/storkctl/applicationrestore_test.go
+++ b/pkg/storkctl/applicationrestore_test.go
@@ -260,6 +260,24 @@ func TestResoreWithNamespaceMapping(t *testing.T) {
 	restore, err := storkops.Instance().GetApplicationRestore("restore1", "test")
 	require.NoError(t, err, "Error getting restore")
 	require.Equal(t, "namespace2", restore.Spec.NamespaceMapping["namespace1"], "ApplicationRestore namespace mapping mismatch")
+
+	createApplicationBackupAndVerify(t, "backup2", "test", []string{"namespace1", "namespace2"}, "backuplocation1", "", "", "")
+	_, err = storkops.Instance().GetApplicationBackup("backup2", "test")
+	require.NoError(t, err, "Error getting backup")
+
+	cmdArgs = []string{"create", "apprestores", "-n", "test", "restore2", "--backupLocation", "backuplocation1", "--backupName", "backup2", "--namespaceMapping", "namespace1:newnamespace1,namespace2:newnamespace2"}
+	expected = "ApplicationRestore restore2 started successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	restore, err = storkops.Instance().GetApplicationRestore("restore2", "test")
+	require.NoError(t, err, "Error getting restore")
+	require.Equal(t, 2, len(restore.Spec.NamespaceMapping), "ApplicationRestore namespaces in namespace mapping mismatch")
+	require.Equal(t, "newnamespace1", restore.Spec.NamespaceMapping["namespace1"], "ApplicationRestore namespace mapping mismatch")
+	require.Equal(t, "newnamespace2", restore.Spec.NamespaceMapping["namespace2"], "ApplicationRestore namespace mapping mismatch")
+
+	cmdArgs = []string{"create", "apprestores", "-n", "test", "restore3", "--backupLocation", "backuplocation1", "--backupName", "backup2", "--namespaceMapping", "namespace1=newnamespace1,namespace2=newnamespace2"}
+	expected = "error: invalid input namespace mapping namespace1=newnamespace1"
+	testCommon(t, cmdArgs, nil, expected, true)
 }
 
 func TestCreateApplicationRestoreNoBackuplocation(t *testing.T) {

--- a/pkg/storkctl/applicationrestore_test.go
+++ b/pkg/storkctl/applicationrestore_test.go
@@ -245,6 +245,23 @@ func TestSpecificObjectRestore(t *testing.T) {
 
 }
 
+func TestResoreWithNamespaceMapping(t *testing.T) {
+	defer resetTest()
+
+	createBackupLocationAndVerify(t, "backuplocation1", "test")
+	createApplicationBackupAndVerify(t, "backup1", "test", []string{"namespace1"}, "backuplocation1", "", "", "")
+	_, err := storkops.Instance().GetApplicationBackup("backup1", "test")
+	require.NoError(t, err, "Error getting backup")
+
+	cmdArgs := []string{"create", "apprestores", "-n", "test", "restore1", "--backupLocation", "backuplocation1", "--backupName", "backup1", "--namespaceMapping", "namespace1:namespace2"}
+	expected := "ApplicationRestore restore1 started successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	restore, err := storkops.Instance().GetApplicationRestore("restore1", "test")
+	require.NoError(t, err, "Error getting restore")
+	require.Equal(t, "namespace2", restore.Spec.NamespaceMapping["namespace1"], "ApplicationRestore namespace mapping mismatch")
+}
+
 func TestCreateApplicationRestoreNoBackuplocation(t *testing.T) {
 	cmdArgs := []string{"create", "apprestores", "-n", "test", "restoreName", "--backupLocation", "backupLocation", "--backupName", "backupName"}
 	expected := "error: backuplocation backupLocation does not exist in namespace test"


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Added the param for creating applicationrestore with namespacemapping with storkctl.

**Does this PR change a user-facing CRD or CLI?**:
<!--
yes
ex:
➜  stork git:(master) ✗  bin/linux/storkctl create  applicationrestores restore1 -b back1 -l bl1 --namespaceMapping "mysql:mysql1" -n kube-system
ApplicationRestore restore1 started successfully
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Applicationrestore created with storkctl was always restoring to namespace with same name as source.
User Impact: User could not restore to a different namespace with appliactionrestore created with storkctl.
Resolution: Storkctl now has support to accept namespace mapping as a parameter for restoring to different namespace.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.10.0
-->

**Test**
updated in ticket PWX-33887.