### PR TITLE
PWX-33934: remove tight loop around volumeBackup status check

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -660,7 +660,6 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 		namespacedName.Namespace = backup.Namespace
 		namespacedName.Name = backup.Name
 		if len(backup.Status.Volumes) != pvcCount {
-
 			for driverName, pvcs := range pvcMappings {
 				var driver volume.Driver
 				driver, err = volume.Get(driverName)
@@ -726,44 +725,31 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 					if err != nil {
 						return err
 					}
-					// In case Portworx if the snapshot ID is populated for every volume then the snapshot
-					// process is considered to be completed successfully.
-					// This ensures we don't execute the post-exec before all volume's snapshot is completed
-					if driverName == volume.PortworxDriverName {
-						startTime := time.Now()
-						for {
-							// In case below logic genuinely takes long time for many volumes
-							// the CR timestamp need to be updated. This prevents backup timeout error.
-							elapsedTime := time.Since(startTime)
-							if elapsedTime > utils.TimeoutUpdateBackupCrTimestamp {
-								backup, err = a.updateBackupCRInVolumeStage(
-									namespacedName,
-									stork_api.ApplicationBackupStatusInProgress,
-									backup.Status.Stage,
-									"Volume backups are in progress",
-									volumeInfos,
-								)
-								if err != nil {
-									return err
-								}
-								startTime = time.Now()
-							}
-							// Get fresh stock of the status for all volumes.
-							snapshotNotCompleted := false
-							volumeInfos, err = driver.GetBackupStatus(backup)
-							if err != nil {
-								log.ApplicationBackupLog(backup).Errorf("error getting backup status for driver %v: %v", driverName, err)
-								return fmt.Errorf("error getting backup status for driver %v: %v", driverName, err)
-							}
-							for _, volInfo := range volumeInfos {
-								if volInfo.BackupID == "" {
-									log.ApplicationBackupLog(backup).Tracef("Snapshot of volume %v is not done yet, need to loop till snapshot is done...", volInfo.PersistentVolumeClaim)
-									snapshotNotCompleted = true
-								}
-							}
-							if !snapshotNotCompleted {
-								break
-							}
+				}
+			}
+
+			// In case Portworx if the snapshot ID is populated for every volume then the snapshot
+			// process is considered to be completed successfully.
+			// This ensures we don't execute the post-exec before all volume's snapshot is completed
+			for driverName := range pvcMappings {
+				var driver volume.Driver
+				driver, err = volume.Get(driverName)
+				if err != nil {
+					return err
+				}
+				if driverName == volume.PortworxDriverName {
+					volumeInfos, err := driver.GetBackupStatus(backup)
+					if err != nil {
+						return fmt.Errorf("error getting backup status: %v", err)
+					}
+					for _, volInfo := range volumeInfos {
+						if volInfo.BackupID == "" {
+							log.ApplicationBackupLog(backup).Infof("Snapshot of volume [%v] hasn't completed yet, retry checking status", volInfo.PersistentVolumeClaim)
+							// Some portworx volume snapshot is not completed yet
+							// hence we will retry checking the status in the next reconciler iteration
+							// *stork_api.ApplicationBackupVolumeInfo.Status is not being checked here
+							// since backpID confirms if the snapshot is done or not already
+							return nil
 						}
 					}
 				}


### PR DESCRIPTION
- Removed the frequent BackupId check while a volume backup is in progress It was in ang called in a tight for loop, hence made it every reconciler call interval based.


**What type of PR is this?** Bug
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: When  portworx status check doesn't retiurn any error yet the backupId for a volume Info is nil then the backup logic will attempt to query the status frequently assuming that the volume  snapshot is still in progress. This status check was happening in a tight for loop, which was making portworx overwhelm with requests. Hence rate limited it by calling it every reconciler interval in such scenario. 


**Does this PR change a user-facing CRD or CLI?**: No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: No , since the actual root cause of Key not found need to be the actual release notable item.
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: 23.9 
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Unit Test :
Tried a multi volume backup and restore as below 
![Pasted Graphic 1](https://github.com/libopenstorage/stork/assets/15273500/cf1331b8-f23d-4162-9918-da45f09c41d1)

![Pasted Graphic 2](https://github.com/libopenstorage/stork/assets/15273500/32cf9a58-38ab-479f-95e9-e77f5b2a131d)

![Pasted Graphic](https://github.com/libopenstorage/stork/assets/15273500/a2527d65-8231-46db-afc0-9e5f4dc68a77)

Simulated the error scenario by stubbing in the code and observed the status is being querried every 5 second which is the reconciler's  sync timer value. The log's timing can be visualized as below

![Pasted Graphic 3](https://github.com/libopenstorage/stork/assets/15273500/c2fac283-24ab-460a-980c-bf8436e692aa)

![Pasted Graphic 4](https://github.com/libopenstorage/stork/assets/15273500/eb45663c-7fbe-45cb-9270-7e67e7db181b)
