### PR TITLE
PB-4632: Skip Default Kubernetes Endpoint

### DIFF
--- a/pkg/resourcecollector/endpoint.go
+++ b/pkg/resourcecollector/endpoint.go
@@ -18,6 +18,10 @@ func (r *ResourceCollector) endpointsToBeCollected(
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &endpoint); err != nil {
 		return false, fmt.Errorf("error converting to endpoint: %v", err)
 	}
+	// Don't migrate the kubernetes endpoint
+	if endpoint.GetName() == "kubernetes" && endpoint.GetNamespace() == v1.NamespaceDefault {
+		return false, nil
+	}
 
 	if endpoint.Annotations != nil {
 		// collect endpoint which has include-resources annotation applied


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: We need in case of all namespace backup we backup default k8s endpoint which will be already there in any cluster so stork will skip that resource and mark it as partial restore. So to avoid partial restore we skip the default endpoint


**Does this PR change a user-facing CRD or CLI?**: no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: yes
We are excluding the default kubernetes endpoint in default namespace to be backed up because wherever we will be doing the restore the k8s endpoint will always be there and will result in partial restore as this resource will be skipped because the resource already exist. To avoid this scenario we are not backing this specific object.
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: yes. 23.9
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->


<img width="1728" alt="Screenshot 2023-11-03 at 2 40 10 PM" src="https://github.com/libopenstorage/stork/assets/125460878/4201d811-923a-443a-b685-90fe79ea3abb">



<img width="1728" alt="Screenshot 2023-11-03 at 2 39 55 PM" src="https://github.com/libopenstorage/stork/assets/125460878/7deccd90-62f9-41ec-98f4-0160032ce337">






