### PR TITLE
PWX-31058: Supporting exclude resource types in migration.

### DIFF
--- a/pkg/apis/stork/v1alpha1/migration.go
+++ b/pkg/apis/stork/v1alpha1/migration.go
@@ -31,6 +31,7 @@ type MigrationSpec struct {
 	SkipDeletedNamespaces        *bool             `json:"skipDeletedNamespaces"`
 	TransformSpecs               []string          `json:"transformSpecs"`
 	IgnoreOwnerReferencesCheck   *bool             `json:"ignoreOwnerReferencesCheck"`
+	ExcludeResourceTypes         []string          `json:"excludeResourceTypes"`
 }
 
 // MigrationStatus is the status of a migration operation

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -2826,7 +2826,14 @@ func getRelatedCRDListWRTGroupAndCategories(client *apiextensionsclient.Clientse
 	return filteredCRDList
 }
 
-func (m *MigrationController) getResources(namespaces []string, migration *stork_api.Migration, labelSelectors map[string]string, excludeSelectors map[string]string, resourceCollectorOpts resourcecollector.Options, remote bool) ([]runtime.Unstructured, []v1.PersistentVolumeClaim, error) {
+func (m *MigrationController) getResources(
+	namespaces []string,
+	migration *stork_api.Migration,
+	labelSelectors map[string]string,
+	excludeSelectors map[string]string,
+	resourceCollectorOpts resourcecollector.Options,
+	remote bool,
+) ([]runtime.Unstructured, []v1.PersistentVolumeClaim, error) {
 
 	var objects []runtime.Unstructured
 	var pvcs []v1.PersistentVolumeClaim

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -625,15 +625,16 @@ func (m *MigrationController) purgeMigratedResources(
 		excludeSelectors = migration.Spec.ExcludeSelectors
 	}
 	excludeSelectors[StashCRLabel] = "true"
-	destObjects, _, err := rc.GetResources(
+
+	destObjects, _, err := m.getResources(
 		migrationNamespaces,
+		migration,
 		migration.Spec.Selectors,
 		excludeSelectors,
-		nil,
-		migration.Spec.IncludeOptionalResourceTypes,
-		false,
 		resourceCollectorOpts,
+		true,
 	)
+
 	if err != nil {
 		m.recorder.Event(migration,
 			v1.EventTypeWarning,
@@ -642,14 +643,13 @@ func (m *MigrationController) purgeMigratedResources(
 		log.MigrationLog(migration).Errorf("Error getting resources: %v", err)
 		return err
 	}
-	srcObjects, _, err := m.resourceCollector.GetResources(
+	srcObjects, _, err := m.getResources(
 		migrationNamespaces,
+		migration,
 		migration.Spec.Selectors,
 		migration.Spec.ExcludeSelectors,
-		nil,
-		migration.Spec.IncludeOptionalResourceTypes,
-		false,
 		resourceCollectorOpts,
+		false,
 	)
 	if err != nil {
 		m.recorder.Event(migration,
@@ -994,15 +994,15 @@ func (m *MigrationController) migrateResources(migration *stork_api.Migration, m
 			return err
 		}
 	} else {
-		allObjects, pvcsWithOwnerRef, err = m.resourceCollector.GetResources(
+		allObjects, pvcsWithOwnerRef, err = m.getResources(
 			migrationNamespaces,
+			migration,
 			migration.Spec.Selectors,
 			migration.Spec.ExcludeSelectors,
-			nil,
-			migration.Spec.IncludeOptionalResourceTypes,
-			false,
 			resourceCollectorOpts,
+			false,
 		)
+
 		if err != nil {
 			m.recorder.Event(migration,
 				v1.EventTypeWarning,
@@ -2824,4 +2824,56 @@ func getRelatedCRDListWRTGroupAndCategories(client *apiextensionsclient.Clientse
 	}
 
 	return filteredCRDList
+}
+
+func (m *MigrationController) getResources(namespaces []string, migration *stork_api.Migration, labelSelectors map[string]string, excludeSelectors map[string]string, resourceCollectorOpts resourcecollector.Options, remote bool) ([]runtime.Unstructured, []v1.PersistentVolumeClaim, error) {
+
+	var objects []runtime.Unstructured
+	var pvcs []v1.PersistentVolumeClaim
+	var err error
+
+	rc := m.resourceCollector
+	if remote {
+		rc = resourcecollector.ResourceCollector{
+			Driver: m.volDriver,
+		}
+		remoteConfig, err := getClusterPairSchedulerConfig(migration.Spec.ClusterPair, migration.Namespace)
+		if err != nil {
+			return objects, pvcs, err
+		}
+
+		log.MigrationLog(migration).Infof("Setting context for getting resources in remote cluster")
+		// use seperate resource collector for collecting resources
+		// from destination cluster
+		err = rc.Init(remoteConfig)
+		if err != nil {
+			log.MigrationLog(migration).Errorf("Error initializing resource collector: %v", err)
+			return objects, pvcs, err
+		}
+	}
+
+	if len(migration.Spec.ExcludeResourceTypes) > 0 {
+		objects, pvcs, err = rc.GetResourcesExcludingTypes(
+			namespaces,
+			migration.Spec.ExcludeResourceTypes,
+			labelSelectors,
+			excludeSelectors,
+			nil,
+			migration.Spec.IncludeOptionalResourceTypes,
+			false,
+			resourceCollectorOpts,
+		)
+	} else {
+		objects, pvcs, err = rc.GetResources(
+			namespaces,
+			labelSelectors,
+			excludeSelectors,
+			nil,
+			migration.Spec.IncludeOptionalResourceTypes,
+			false,
+			resourceCollectorOpts,
+		)
+	}
+
+	return objects, pvcs, err
 }

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -179,6 +179,29 @@ func resourceToBeCollected(resource metav1.APIResource, grp schema.GroupVersion,
 	return GetSupportedK8SResources(resource.Kind, optionalResourceTypes)
 }
 
+func resourceToBeCollectedWithExcludeTypes(resource metav1.APIResource, grp schema.GroupVersion, crdKinds []metav1.GroupVersionKind, optionalResourceTypes []string, exlcudeTypes []string) bool {
+	// Ignore CSI Snapshot object
+	if resource.Kind == "VolumeSnapshot" {
+		return false
+	}
+
+	for _, excludeType := range exlcudeTypes {
+		if strings.EqualFold(resource.Kind, excludeType) {
+			return false
+		}
+	}
+
+	// Include all namespaced CRDs
+	for _, res := range crdKinds {
+		if res.Kind == resource.Kind &&
+			res.Group == grp.Group && res.Version == grp.Version && resource.Namespaced {
+			return true
+		}
+	}
+
+	return GetSupportedK8SResources(resource.Kind, optionalResourceTypes)
+}
+
 // GetSupportedK8SResources returns supported k8s resources by resource collector
 // pkgs, this can be used to validate list of resources supported by different stork
 // controller like migration, backup, clone etc
@@ -379,6 +402,106 @@ func (r *ResourceCollector) GetResourcesForType(
 	return objects, pvcsWithOwnerReference, nil
 }
 
+func (r *ResourceCollector) GetResourcesExcludingTypes(
+	namespaces []string,
+	excludeResourceTypes []string,
+	labelSelectors map[string]string,
+	excludeSelectors map[string]string,
+	includeObjects map[stork_api.ObjectInfo]bool,
+	optionalResourceTypes []string,
+	allDrivers bool,
+	opts Options,
+) ([]runtime.Unstructured, []v1.PersistentVolumeClaim, error) {
+	err := r.discoveryHelper.Refresh()
+	if err != nil {
+		return nil, nil, err
+	}
+	allObjects := make([]runtime.Unstructured, 0)
+	// Map to prevent collection of duplicate objects
+	resourceMap := make(map[types.UID]bool)
+	var crdResources []metav1.GroupVersionKind
+	var crdList *stork_api.ApplicationRegistrationList
+	if !reflect.ValueOf(storkcache.Instance()).IsNil() {
+		crdList, err = storkcache.Instance().ListApplicationRegistrations()
+	} else {
+		crdList, err = r.storkOps.ListApplicationRegistrations()
+	}
+	if err != nil {
+		logrus.Warnf("Unable to get registered crds, err %v", err)
+	} else {
+		if crdList != nil {
+			for _, crd := range crdList.Items {
+				for _, kind := range crd.Resources {
+					crdResources = append(crdResources, kind.GroupVersionKind)
+				}
+			}
+		}
+	}
+
+	crbs, err := r.rbacOps.ListClusterRoleBindings()
+	if err != nil {
+		if !apierrors.IsForbidden(err) {
+			return nil, nil, err
+		}
+	}
+
+	for _, group := range r.discoveryHelper.Resources() {
+		groupVersion, err := schema.ParseGroupVersion(group.GroupVersion)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, resource := range group.APIResources {
+			if !resourceToBeCollectedWithExcludeTypes(resource, groupVersion, crdResources, optionalResourceTypes, excludeResourceTypes) {
+				continue
+			}
+			objectsCollected, err := r.getParticularResourceInNamespaces(
+				resource,
+				crdResources,
+				groupVersion,
+				crbs,
+				namespaces,
+				labelSelectors,
+				excludeSelectors,
+				includeObjects,
+				optionalResourceTypes,
+				allDrivers,
+				opts,
+				resourceMap,
+			)
+
+			if err != nil {
+				return nil, nil, err
+			}
+			allObjects = append(allObjects, objectsCollected...)
+		}
+	}
+
+	allObjects, pvcObjectsWithOwnerRef, err := r.pruneOwnedResources(allObjects, resourceMap, opts.IgnoreOwnerReferencesCheck)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Creating a list of PVCs with owner reference before calling prepareResourcesForCollection
+	// prepareResourcesForCollection can update the PVC metadata which is required when updating
+	// owner references on the destination PVC objects
+	var pvcsWithOwnerReference []v1.PersistentVolumeClaim
+	var pvc v1.PersistentVolumeClaim
+	for _, o := range pvcObjectsWithOwnerRef {
+		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(o.UnstructuredContent(), &pvc); err != nil {
+			logrus.Warnf("unable to cast pvcs with owner reference: %v", err)
+		}
+		pvcsWithOwnerReference = append(pvcsWithOwnerReference, pvc)
+	}
+
+	err = r.prepareResourcesForCollection(allObjects, namespaces, opts, crdList)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return allObjects, pvcsWithOwnerReference, nil
+}
+
 // GetResources gets all the resources in the given list of namespaces which match the labelSelectors
 // and all PVCs which have an owner reference set
 func (r *ResourceCollector) GetResources(
@@ -433,72 +556,25 @@ func (r *ResourceCollector) GetResources(
 			if !resourceToBeCollected(resource, groupVersion, crdResources, optionalResourceTypes) {
 				continue
 			}
-			for _, ns := range namespaces {
-				var dynamicClient dynamic.ResourceInterface
-				if !resource.Namespaced {
-					dynamicClient = r.dynamicInterface.Resource(groupVersion.WithResource(resource.Name))
-				} else {
-					dynamicClient = r.dynamicInterface.Resource(groupVersion.WithResource(resource.Name)).Namespace(ns)
-				}
+			objectsCollected, err := r.getParticularResourceInNamespaces(
+				resource,
+				crdResources,
+				groupVersion,
+				crbs,
+				namespaces,
+				labelSelectors,
+				excludeSelectors,
+				includeObjects,
+				optionalResourceTypes,
+				allDrivers,
+				opts,
+				resourceMap,
+			)
 
-				var objectToInclude map[stork_api.ObjectInfo]bool
-				if !IsNsPresentInIncludeResource(includeObjects, ns) {
-					objectToInclude = make(map[stork_api.ObjectInfo]bool)
-				} else {
-					objectToInclude = includeObjects
-				}
-
-				var selectors string
-				// PVs don't get the labels from their PVCs, so don't use the label selector
-				switch resource.Kind {
-				case "PersistentVolume":
-				default:
-					selectors = labels.Set(labelSelectors).String()
-				}
-				objectsList, err := gatherResourceInChunks(dynamicClient, opts, selectors)
-				if err != nil {
-					if apierrors.IsForbidden(err) {
-						continue
-					}
-					return nil, nil, err
-				}
-				objects, err := meta.ExtractList(objectsList)
-				if err != nil {
-					return nil, nil, err
-				}
-				for _, o := range objects {
-					runtimeObject, ok := o.(runtime.Unstructured)
-					if !ok {
-						return nil, nil, fmt.Errorf("error casting object: %v", o)
-					}
-
-					var err error
-					var collect bool
-					// If a namespace is present in both namespace list and IncludeResource Object,
-					// IncludeResource takes priority and only those resources are backed up.
-					// If a ns is only present in namespace list, all resources in that ns
-					// is backed up.
-					// With this now a user can choose to backup all resources in a ns and some
-					// selected resources from different ns
-
-					collect, err = r.objectToBeCollected(objectToInclude, labelSelectors, excludeSelectors, resourceMap, runtimeObject, ns, allDrivers, opts, crbs)
-					if err != nil {
-						if apierrors.IsForbidden(err) {
-							continue
-						}
-						return nil, nil, fmt.Errorf("error processing object %v: %v", runtimeObject, err)
-					}
-					if !collect {
-						continue
-					}
-					metadata, err := meta.Accessor(runtimeObject)
-					if err != nil {
-						return nil, nil, err
-					}
-					allObjects = append(allObjects, runtimeObject)
-					resourceMap[metadata.GetUID()] = true
-				}
+			if err != nil {
+				return nil, nil, err
 			}
+			allObjects = append(allObjects, objectsCollected...)
 		}
 	}
 
@@ -525,6 +601,91 @@ func (r *ResourceCollector) GetResources(
 	}
 
 	return allObjects, pvcsWithOwnerReference, nil
+}
+
+func (r *ResourceCollector) getParticularResourceInNamespaces(
+	resource metav1.APIResource,
+	crdResources []metav1.GroupVersionKind,
+	groupVersion schema.GroupVersion,
+	crbs *rbacv1.ClusterRoleBindingList,
+	namespaces []string,
+	labelSelectors map[string]string,
+	excludeSelectors map[string]string,
+	includeObjects map[stork_api.ObjectInfo]bool,
+	optionalResourceTypes []string,
+	allDrivers bool,
+	opts Options,
+	resourceMap map[types.UID]bool,
+) ([]runtime.Unstructured, error) {
+	allObjects := make([]runtime.Unstructured, 0)
+
+	for _, ns := range namespaces {
+		var dynamicClient dynamic.ResourceInterface
+		if !resource.Namespaced {
+			dynamicClient = r.dynamicInterface.Resource(groupVersion.WithResource(resource.Name))
+		} else {
+			dynamicClient = r.dynamicInterface.Resource(groupVersion.WithResource(resource.Name)).Namespace(ns)
+		}
+
+		var objectToInclude map[stork_api.ObjectInfo]bool
+		if !IsNsPresentInIncludeResource(includeObjects, ns) {
+			objectToInclude = make(map[stork_api.ObjectInfo]bool)
+		} else {
+			objectToInclude = includeObjects
+		}
+
+		var selectors string
+		// PVs don't get the labels from their PVCs, so don't use the label selector
+		switch resource.Kind {
+		case "PersistentVolume":
+		default:
+			selectors = labels.Set(labelSelectors).String()
+		}
+		objectsList, err := gatherResourceInChunks(dynamicClient, opts, selectors)
+		if err != nil {
+			if apierrors.IsForbidden(err) {
+				continue
+			}
+			return nil, err
+		}
+		objects, err := meta.ExtractList(objectsList)
+		if err != nil {
+			return nil, err
+		}
+		for _, o := range objects {
+			runtimeObject, ok := o.(runtime.Unstructured)
+			if !ok {
+				return nil, fmt.Errorf("error casting object: %v", o)
+			}
+
+			var err error
+			var collect bool
+			// If a namespace is present in both namespace list and IncludeResource Object,
+			// IncludeResource takes priority and only those resources are backed up.
+			// If a ns is only present in namespace list, all resources in that ns
+			// is backed up.
+			// With this now a user can choose to backup all resources in a ns and some
+			// selected resources from different ns
+
+			collect, err = r.objectToBeCollected(objectToInclude, labelSelectors, excludeSelectors, resourceMap, runtimeObject, ns, allDrivers, opts, crbs)
+			if err != nil {
+				if apierrors.IsForbidden(err) {
+					continue
+				}
+				return nil, fmt.Errorf("error processing object %v: %v", runtimeObject, err)
+			}
+			if !collect {
+				continue
+			}
+			metadata, err := meta.Accessor(runtimeObject)
+			if err != nil {
+				return nil, err
+			}
+			allObjects = append(allObjects, runtimeObject)
+			resourceMap[metadata.GetUID()] = true
+		}
+	}
+	return allObjects, nil
 }
 
 // gatherResourceInChunks() collects all the resources present per ns or resource types.


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Supporting `excludeResourceTypes` with migration to exclude a particular kind of resources

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: A particular kind of k8s resource could not be excluded with migration.
User Impact: Using labels for excluding selectors does not work in certain cases where the resource is controlled by some operator which resets the user set labels.
Resolution: With the supported excludeResourceTypes, now a certain kind of resources can be excluded from migration.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes
-->
```
23.11.0
```

**Test**
Tests with following has been done and have been updated in the ticket.
1. Excluding only a particular resource kind like Deployment or PersistentVolumeClaim.
2. Excluding multiple resource kinds 

Existing Integration test with the fix will be updated later.