### PR TITLE
PWX-34866: Fix error message when namespaces and namespaceSelectors a…

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -334,6 +334,15 @@ func (m *MigrationController) handle(ctx context.Context, migration *stork_api.M
 			err.Error())
 		return nil
 	}
+	if len(migrationNamespaces) == 0 {
+		err := fmt.Errorf("no valid namespace found based on the provided 'Namespaces' and 'NamespaceSelectors'")
+		log.MigrationLog(migration).Errorf(err.Error())
+		m.recorder.Event(migration,
+			v1.EventTypeWarning,
+			string(stork_api.MigrationStatusFailed),
+			err.Error())
+		return nil
+	}
 	// Check whether namespace is allowed to be migrated before each stage
 	// Restrict migration to only the namespace that the object belongs
 	// except for the namespace designated by the admin


### PR DESCRIPTION
…re invalid.


**What type of PR is this?**
When invalid namespaces and namespaceSelectors are specified by mistake, the error during migration is following  "namespaces for migration cannot be empty". This is sreturned from following https://github.com/libopenstorage/stork/blob/df7b1d2405dd816f71491f7fc92d85bbc7d11a95/drivers/volume/portworx/portworx.go#L2591
This code is triggered from MigrationStageVolumes. If extracted migrationNamespaces are emptry we should fail early. Also this message should be more descriptive. Existing error message gives an impression that we need "namespaces" to be non empty which isn't true as one can specify namespaceSelectors too.

**Testing notes**:
* Didn't do any testing yet. Creating clusters to verify the error message. Will post here once done.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, 23.10.0
