### PR TITLE
PWX-34118: Skip service accounts, roles and rolebindings as part of pruning of resources with ownerreferences.

### DIFF
--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -755,6 +755,9 @@ func (r *ResourceCollector) pruneOwnedResources(
 							objectType.GetKind() != "StatefulSet" &&
 							objectType.GetKind() != "ReplicaSet" &&
 							objectType.GetKind() != "DeploymentConfig" &&
+							objectType.GetKind() != "ServiceAccount" &&
+							objectType.GetKind() != "Role" &&
+							objectType.GetKind() != "RoleBinding" &&
 							objectType.GetKind() != "Service" {
 							continue
 						}


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Some of the operators like postgres were not able to reconcile on the CR and create the pods if service account, roles and rolebindings were already created.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Postgres operator throws error of serviceaccount, role and rolebindings already exist after migration.
User Impact: Unable to scale up postgres app installed via openshift operator hub after migration.
Resolution: Postgres pods came up fine after skipping the resources serviceaccount, role and rolebindings as part of resource migration if they have ownerreference set.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
Yes
-->
```
23.11.0
```

**Test**
Tested with crunchydata postgres operator 5.4.3 and details have been updated in the ticket.
