### PR TITLE
[PWX-34809] Adding the remaining params to storkctl create migrationschedule

### DIFF
--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -5,7 +5,10 @@ import (
 	"time"
 
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
+	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
@@ -39,6 +42,17 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 	var disableAutoSuspend bool
 	var intervalMinutes int
 	var annotations map[string]string
+	var namespaceSelectors map[string]string
+	var adminClusterPair string
+	var ignoreOwnerReferencesCheck bool
+	var purgeDeletedResources bool
+	var skipServiceUpdate bool
+	var includeNetworkPolicyWithCIDR bool
+	var disableSkipDeletedNamespaces bool
+	var transformSpec string
+	var includeOptionalResourceTypes []string
+	var selectors map[string]string
+	var excludeSelectors map[string]string
 
 	createMigrationScheduleCommand := &cobra.Command{
 		Use:     migrationScheduleSubcommand,
@@ -49,6 +63,16 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 			var autoSuspend = !disableAutoSuspend
 			var includeResources = !excludeResources
 			var includeVolumes = !excludeVolumes
+			var skipDeletedNamespaces = !disableSkipDeletedNamespaces
+			var transformSpecs []string
+
+			//we fetch the value of adminNamespace from the stork-controller-cm created in kube-system namespace
+			adminNs, err := k8sutils.GetConfigValue(k8sutils.StorkControllerConfigMapName, meta.NamespaceSystem, k8sutils.AdminNsKey)
+			if err != nil {
+				logrus.Warnf("error in reading %v cm for the key %v, switching to default value : %v",
+					k8sutils.StorkControllerConfigMapName, k8sutils.ResourceCountLimitKeyName, err)
+				adminNs = k8sutils.DefaultAdminNamespace
+			}
 
 			if len(args) != 1 {
 				util.CheckErr(fmt.Errorf("exactly one name needs to be provided for migration schedule name"))
@@ -60,7 +84,15 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				return
 			}
 
-			//Identify whether it is a Sync-Dr or Async-Dr use-case from the ClusterPair spec
+			//verify the admin cluster pair exists in the admin namespace
+			if c.Flags().Changed("admin-cluster-pair") {
+				_, err := storkops.Instance().GetClusterPair(adminClusterPair, adminNs)
+				if err != nil {
+					util.CheckErr(fmt.Errorf("unable to find the admin cluster pair in the admin namespace"))
+					return
+				}
+			}
+
 			migrationScheduleNs := cmdFactory.GetNamespace()
 			clusterPairObj, err := storkops.Instance().GetClusterPair(clusterPair, migrationScheduleNs)
 			if err != nil {
@@ -68,15 +100,15 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				return
 			}
 			isStorageOptionsProvided := true
-			//clusterPairObj.Spec.Options map is empty for syncDr and should be non-empty for volume migration in asyncDR
+			//clusterPairObj.Spec.Options map is empty for syncDr and ideally should be non-empty for volume migration in asyncDR
 			if len(clusterPairObj.Spec.Options) == 0 {
 				isStorageOptionsProvided = false
 			}
 
-			// Default value of includeVolumes for asyncDr with StorageOptions provided is true and for sync DR is false
+			// Default value of includeVolumes when StorageOptions are provided is true and else is false
 			if !isStorageOptionsProvided {
-				//covers the scenario where user sets the --exclude-volumes=false value in the command for a use case where clusterPair's storage-status is Not Provided
-				//this is true if the cluster pair is created for a sync-dr use-case or if clusterPair was created without specifying storage options
+				//covers the scenario where user sets the --exclude-volumes=false value in the command for a use-case where clusterPair's storage-status is Not Provided
+				//which is true if the cluster pair is created for a sync-dr use-case or if clusterPair was created without specifying storage options
 				if c.Flags().Changed(excludeVolumesFlag) && includeVolumes {
 					util.CheckErr(fmt.Errorf("--exclude-volumes can only be set to true if it is a sync-dr use case or storage options are not provided in the cluster pair"))
 					return
@@ -84,8 +116,24 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				includeVolumes = false
 			}
 
-			if len(namespaceList) == 0 {
-				util.CheckErr(fmt.Errorf("need to provide atleast one namespace to migrate"))
+			migrationNamespaces := namespaceList
+			if len(namespaceSelectors) != 0 {
+				//update the migrationNamespaces list by fetching namespaces based on provided label selectors
+				migrationNamespaces, err = getMigrationNamespaces(namespaceList, namespaceSelectors)
+				if err != nil {
+					util.CheckErr(fmt.Errorf("unable to get the namespaces based on the provided --namespace-selectors : %v", err))
+					return
+				}
+			}
+
+			//user has to provide at-least one namespace to migrate
+			if len(migrationNamespaces) == 0 {
+				util.CheckErr(fmt.Errorf("no valid namespace found based on the provided --namespaces and --namespace-selectors"))
+				return
+			}
+
+			if err := validateNamespaceList(migrationScheduleNs, migrationNamespaces, adminNs); err != nil {
+				util.CheckErr(err)
 				return
 			}
 
@@ -131,18 +179,41 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				}
 			}
 
+			if transformSpec != "" {
+				//Validate the transformSpec
+				if err := validateTransformSpec(migrationNamespaces, transformSpec); err != nil {
+					util.CheckErr(err)
+					return
+				}
+				//Create transformSpecs []string
+				//This is done because Migration.TransformSpecs is a []string and
+				//since current allowed maximum length of the array is 1 we only took a string as user input
+				transformSpecs = append(transformSpecs, transformSpec)
+			}
+
 			migrationSchedule := &storkv1.MigrationSchedule{
 				ObjectMeta: meta.ObjectMeta{Annotations: annotations},
 				Spec: storkv1.MigrationScheduleSpec{
 					Template: storkv1.MigrationTemplateSpec{
 						Spec: storkv1.MigrationSpec{
-							ClusterPair:       clusterPair,
-							Namespaces:        namespaceList,
-							IncludeResources:  &includeResources,
-							IncludeVolumes:    &includeVolumes,
-							StartApplications: &startApplications,
-							PreExecRule:       preExecRule,
-							PostExecRule:      postExecRule,
+							ClusterPair:                  clusterPair,
+							AdminClusterPair:             adminClusterPair,
+							Namespaces:                   namespaceList,
+							NamespaceSelectors:           namespaceSelectors,
+							IncludeResources:             &includeResources,
+							IncludeVolumes:               &includeVolumes,
+							StartApplications:            &startApplications,
+							PreExecRule:                  preExecRule,
+							PostExecRule:                 postExecRule,
+							Selectors:                    selectors,
+							ExcludeSelectors:             excludeSelectors,
+							IgnoreOwnerReferencesCheck:   &ignoreOwnerReferencesCheck,
+							PurgeDeletedResources:        &purgeDeletedResources,
+							SkipServiceUpdate:            &skipServiceUpdate,
+							IncludeNetworkPolicyWithCIDR: &includeNetworkPolicyWithCIDR,
+							SkipDeletedNamespaces:        &skipDeletedNamespaces,
+							TransformSpecs:               transformSpecs,
+							IncludeOptionalResourceTypes: includeOptionalResourceTypes,
 						},
 					},
 					SchedulePolicyName: schedulePolicyName,
@@ -162,10 +233,17 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 		},
 	}
 	createMigrationScheduleCommand.Flags().StringSliceVarP(&namespaceList, "namespaces", "", nil, "Specify the comma-separated list of namespaces to be included in the migration")
+	createMigrationScheduleCommand.Flags().StringToStringVar(&namespaceSelectors, "namespace-selectors", nil, "Resources in the namespaces with the specified namespace labels will be migrated. All the labels provided in this option will be OR'ed")
 	createMigrationScheduleCommand.Flags().StringVarP(&clusterPair, "cluster-pair", "c", "", "Specify the name of the ClusterPair in the same namespace to be used for the migration")
+	createMigrationScheduleCommand.Flags().StringVar(&adminClusterPair, "admin-cluster-pair", "", "Specify the name of the admin ClusterPair used to migrate cluster-scoped resources, if the ClusterPair is present in a non-admin namespace")
 	createMigrationScheduleCommand.Flags().BoolVarP(&excludeResources, "exclude-resources", "", false, "If present, Kubernetes resources will not be migrated")
-	createMigrationScheduleCommand.Flags().BoolVarP(&excludeVolumes, excludeVolumesFlag, "", false, "If present, the underlying Portworx volumes will not be migrated. This is the only allowed and default behaviour in sync-dr use cases or if storage options are not provided in the cluster pair.")
+	createMigrationScheduleCommand.Flags().BoolVarP(&excludeVolumes, excludeVolumesFlag, "", false, "If present, the underlying Portworx volumes will not be migrated. This is the only allowed and default behaviour in sync-dr use-cases or if storage options are not provided in the cluster pair")
 	createMigrationScheduleCommand.Flags().BoolVarP(&startApplications, "start-applications", "a", false, "If present, the applications will be scaled up on the target cluster after a successful migration")
+	createMigrationScheduleCommand.Flags().BoolVar(&ignoreOwnerReferencesCheck, "ignore-owner-references-check", false, "If set, resources with ownerReferences will also be migrated, even if the corresponding owners are getting migrated")
+	createMigrationScheduleCommand.Flags().BoolVar(&purgeDeletedResources, "purge-deleted-resources", false, "Set this flag to automatically delete Kubernetes resources in the target cluster when they are removed from the source cluster")
+	createMigrationScheduleCommand.Flags().BoolVar(&skipServiceUpdate, "skip-service-update", false, "If set, service objects will be skipped during migration")
+	createMigrationScheduleCommand.Flags().BoolVar(&includeNetworkPolicyWithCIDR, "include-network-policy-with-cidr", false, "If set, the underlying network policies will be migrated even if a fixed CIDR is present on them")
+	createMigrationScheduleCommand.Flags().BoolVar(&disableSkipDeletedNamespaces, "disable-skip-deleted-namespaces", false, "If present, Stork will fail the migration when it encounters a namespace that is deleted but specified in the namespaces field. By default, Stork ignores deleted namespaces during migration")
 	createMigrationScheduleCommand.Flags().StringVarP(&preExecRule, "pre-exec-rule", "", "", "Specify the name of the rule to be executed before every migration is triggered")
 	createMigrationScheduleCommand.Flags().StringVarP(&postExecRule, "post-exec-rule", "", "", "Specify the name of the rule to be executed after every migration is triggered")
 	createMigrationScheduleCommand.Flags().StringVarP(&schedulePolicyName, schedulePolicyNameFlag, "s", "default-migration-policy", "Name of the schedule policy to use. If you want to create a new interval policy, use the --interval flag instead")
@@ -173,6 +251,10 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 	createMigrationScheduleCommand.Flags().BoolVar(&disableAutoSuspend, "disable-auto-suspend", false, "Prevent automatic suspension of DR migration schedules on the source cluster in case of a disaster")
 	createMigrationScheduleCommand.Flags().IntVarP(&intervalMinutes, intervalFlag, "i", 30, "Specify the time interval, in minutes, at which Stork should trigger migrations")
 	createMigrationScheduleCommand.Flags().StringToStringVar(&annotations, "annotations", map[string]string{}, "Add required annotations to the resource in comma-separated key value pairs. key1=value1,key2=value2,... ")
+	createMigrationScheduleCommand.Flags().StringVar(&transformSpec, "transform-spec", "", "Specify the ResourceTransformation spec to be applied during migration")
+	createMigrationScheduleCommand.Flags().StringSliceVar(&includeOptionalResourceTypes, "include-optional-resource-types", nil, "Set this flag to ensure that the Kubernetes resources associated with k8s Jobs are migrated. By default, the Job resources are not migrated")
+	createMigrationScheduleCommand.Flags().StringToStringVar(&selectors, "selectors", nil, "Only resources with the provided labels will be migrated. All the labels provided in this option will be OR'ed")
+	createMigrationScheduleCommand.Flags().StringToStringVar(&excludeSelectors, "exclude-selectors", nil, "Resources with the provided labels will be excluded from the migration. All the labels provided in this option will be OR'ed")
 	return createMigrationScheduleCommand
 }
 
@@ -441,4 +523,48 @@ func migrationSchedulePrinter(
 		rows = append(rows, row)
 	}
 	return rows, nil
+}
+
+func validateNamespaceList(migrationScheduleNs string, migrationNamespaces []string, adminNs string) error {
+	if migrationScheduleNs != adminNs {
+		for _, ns := range migrationNamespaces {
+			if ns != migrationScheduleNs {
+				err := fmt.Errorf("migration namespaces should only contain the current namespace")
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func getMigrationNamespaces(namespaceList []string, namespaceSelectors map[string]string) ([]string, error) {
+	uniqueNamespaces := make(map[string]bool)
+	for _, ns := range namespaceList {
+		uniqueNamespaces[ns] = true
+	}
+	labelSelectorNamespaces, err := core.Instance().ListNamespaces(namespaceSelectors)
+	if err != nil {
+		return nil, err
+	}
+	for _, ns := range labelSelectorNamespaces.Items {
+		uniqueNamespaces[ns.GetName()] = true
+	}
+	migrationNamespaces := make([]string, 0, len(uniqueNamespaces))
+	for namespace := range uniqueNamespaces {
+		migrationNamespaces = append(migrationNamespaces, namespace)
+	}
+	return migrationNamespaces, nil
+}
+
+func validateTransformSpec(migrationNamespaces []string, transformSpec string) error {
+	for _, ns := range migrationNamespaces {
+		resTransform, err := storkops.Instance().GetResourceTransformation(transformSpec, ns)
+		if err != nil {
+			return fmt.Errorf("unable to retrieve transformation %s/%s, err: %v", ns, transformSpec, err)
+		}
+		if err = storkops.Instance().ValidateResourceTransformation(resTransform.Name, ns, 1*time.Minute, 5*time.Second); err != nil {
+			return fmt.Errorf("transformation %s/%s is not in ready state, state: %s", ns, transformSpec, resTransform.Status.Status)
+		}
+	}
+	return nil
 }

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -74,7 +74,7 @@ func createMigrationScheduleAndVerify(
 
 func TestGetMigrationSchedulesOneMigrationSchedule(t *testing.T) {
 	defer resetTest()
-	createMigrationScheduleAndVerify(t, "getmigrationscheduletest", "testpolicy", "test", "clusterpair1", []string{"namespace1"}, "preExec", "postExec", true)
+	createMigrationScheduleAndVerify(t, "getmigrationscheduletest", "testpolicy", "test", "clusterpair1", []string{"test"}, "preExec", "postExec", true)
 
 	expected := "NAME                       POLICYNAME   CLUSTERPAIR    SUSPEND   LAST-SUCCESS-TIME   LAST-SUCCESS-DURATION\n" +
 		"getmigrationscheduletest   testpolicy   clusterpair1   true                          \n"
@@ -85,8 +85,8 @@ func TestGetMigrationSchedulesOneMigrationSchedule(t *testing.T) {
 
 func TestGetMigrationSchedulesMultiple(t *testing.T) {
 	defer resetTest()
-	createMigrationScheduleAndVerify(t, "getmigrationscheduletest1", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
-	createMigrationScheduleAndVerify(t, "getmigrationscheduletest2", "testpolicy", "default", "clusterpair2", []string{"namespace1"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "getmigrationscheduletest1", "testpolicy", "default", "clusterpair1", []string{"default"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "getmigrationscheduletest2", "testpolicy", "default", "clusterpair2", []string{"default"}, "", "", true)
 
 	expected := "NAME                        POLICYNAME   CLUSTERPAIR    SUSPEND   LAST-SUCCESS-TIME   LAST-SUCCESS-DURATION\n" +
 		"getmigrationscheduletest1   testpolicy   clusterpair1   true                          \n" +
@@ -113,8 +113,8 @@ func TestGetMigrationSchedulesMultipleNamespaces(t *testing.T) {
 	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test2"}})
 	require.NoError(t, err, "Error creating test2 namespace")
 
-	createMigrationScheduleAndVerify(t, "getmigrationscheduletest1", "testpolicy", "test1", "clusterpair1", []string{"namespace1"}, "", "", true)
-	createMigrationScheduleAndVerify(t, "getmigrationscheduletest2", "testpolicy", "test2", "clusterpair2", []string{"namespace1"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "getmigrationscheduletest1", "testpolicy", "test1", "clusterpair1", []string{"test1"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "getmigrationscheduletest2", "testpolicy", "test2", "clusterpair2", []string{"test2"}, "", "", true)
 
 	expected := "NAME                        POLICYNAME   CLUSTERPAIR    SUSPEND   LAST-SUCCESS-TIME   LAST-SUCCESS-DURATION\n" +
 		"getmigrationscheduletest1   testpolicy   clusterpair1   true                          \n"
@@ -132,8 +132,8 @@ func TestGetMigrationSchedulesMultipleNamespaces(t *testing.T) {
 
 func TestGetMigrationSchedulesWithClusterPair(t *testing.T) {
 	defer resetTest()
-	createMigrationScheduleAndVerify(t, "getmigrationscheduletest1", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
-	createMigrationScheduleAndVerify(t, "getmigrationscheduletest2", "testpolicy", "default", "clusterpair2", []string{"namespace1"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "getmigrationscheduletest1", "testpolicy", "default", "clusterpair1", []string{"default"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "getmigrationscheduletest2", "testpolicy", "default", "clusterpair2", []string{"default"}, "", "", true)
 
 	expected := "NAME                        POLICYNAME   CLUSTERPAIR    SUSPEND   LAST-SUCCESS-TIME   LAST-SUCCESS-DURATION\n" +
 		"getmigrationscheduletest1   testpolicy   clusterpair1   true                          \n"
@@ -144,7 +144,7 @@ func TestGetMigrationSchedulesWithClusterPair(t *testing.T) {
 
 func TestGetMigrationSchedulesWithStatus(t *testing.T) {
 	defer resetTest()
-	createMigrationScheduleAndVerify(t, "getmigrationschedulestatustest", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "getmigrationschedulestatustest", "testpolicy", "default", "clusterpair1", []string{"default"}, "", "", true)
 	migrationSchedule, err := storkops.Instance().GetMigrationSchedule("getmigrationschedulestatustest", "default")
 	require.NoError(t, err, "Error getting migration schedule")
 
@@ -212,7 +212,7 @@ func TestCreateMigrationSchedulesNoNamespace(t *testing.T) {
 	createClusterPair(t, clusterPairName, "default", "async-dr")
 	cmdArgs := []string{"create", "migrationschedules", "-c", clusterPairName, "migration1"}
 
-	expected := "error: need to provide atleast one namespace to migrate"
+	expected := "error: no valid namespace found based on the provided --namespaces and --namespace-selectors"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
@@ -233,6 +233,18 @@ func TestCreateMigrationSchedulesInvalidClusterPair(t *testing.T) {
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
+func TestCreateMigrationSchedulesInvalidAdminClusterPair(t *testing.T) {
+	defer resetTest()
+	clusterPair := "clusterpair1"
+	namespace := "namespace1"
+	name := "createmigrationschedule"
+	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
+	cmdArgs := []string{"create", "migrationschedules", "-c", clusterPair, "--admin-cluster-pair", "adminclusterpair",
+		"--namespaces", namespace, name}
+	expected := "error: unable to find the admin cluster pair in the admin namespace"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
 func TestCreateMigrationSchedulesNoName(t *testing.T) {
 	defer resetTest()
 	cmdArgs := []string{"create", "migrationschedules"}
@@ -243,7 +255,24 @@ func TestCreateMigrationSchedulesNoName(t *testing.T) {
 
 func TestCreateMigrationSchedules(t *testing.T) {
 	defer resetTest()
-	createMigrationScheduleAndVerify(t, "createmigration", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "createmigration", "testpolicy", "default", "clusterpair1", []string{"default"}, "", "", true)
+}
+
+func TestCreateMigrationScheduleWithNamespaceSelector(t *testing.T) {
+	defer resetTest()
+	clusterPair := "clusterpair1"
+	namespace := "test-ns"
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespace,
+			Labels: map[string]string{"key": "value"},
+		}})
+	require.NoError(t, err, "Error creating test-ns namespace")
+	createClusterPair(t, clusterPair, "test-ns", "async-dr")
+	cmdArgs := []string{"create", "migrationschedules", "-c", clusterPair, "-i", "15",
+		"--namespace-selectors", "key=value", "-n", namespace, "ms"}
+	expected := "MigrationSchedule ms created successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
 }
 
 func TestCreateMigrationScheduleSyncDrExcludeVolumesFalse(t *testing.T) {
@@ -261,10 +290,13 @@ func TestCreateMigrationScheduleSyncDrExcludeVolumesFalse(t *testing.T) {
 func TestCreateMigrationScheduleWithIntervalAndVerify(t *testing.T) {
 	defer resetTest()
 	clusterPair := "clusterpair1"
+	adminClusterPair := "adminClusterPair"
 	namespace := "namespace1"
 	name := "createmigrationschedule"
 	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
-	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair,
+	//create admin cluster pair in default admin namespace
+	createClusterPair(t, adminClusterPair, "kube-system", "async-dr")
+	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair, "admin-cluster-pair", adminClusterPair,
 		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace}
 	expected := "MigrationSchedule createmigrationschedule created successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
@@ -294,6 +326,68 @@ func TestCreateMigrationScheduleWithBothIntervalAndPolicyName(t *testing.T) {
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
+func TestCreateMigrationScheduleWithInvalidNamespaces(t *testing.T) {
+	defer resetTest()
+	namespace := "test-ns"
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespace,
+			Labels: map[string]string{"key": "value"},
+		}})
+	require.NoError(t, err, "Error creating test-ns namespace")
+	createClusterPair(t, "clusterPair1", "namespace1", "async-dr")
+	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", "clusterPair1",
+		"--namespaces", "namespace1", "--namespace-selectors", "key=value", "migrationschedule", "-n", "namespace1"}
+	expected := "error: migration namespaces should only contain the current namespace"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestCreateMigrationScheduleInAdminNamespace(t *testing.T) {
+	defer resetTest()
+	namespace := "test-ns"
+	adminNamespace := "kube-system"
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespace,
+			Labels: map[string]string{"key": "value"},
+		}})
+	require.NoError(t, err, "Error creating test-ns namespace")
+	createClusterPair(t, "clusterPair1", adminNamespace, "async-dr")
+	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", "clusterPair1",
+		"--namespaces", "namespace1", "--namespace-selectors", "key=value", "migrationschedule", "-n", adminNamespace}
+	expected := "MigrationSchedule migrationschedule created successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestCreateMigrationScheduleWithMissingTransformSpec(t *testing.T) {
+	defer resetTest()
+	createClusterPair(t, "clusterPair1", "namespace1", "async-dr")
+	cmdArgs := []string{"create", "migrationschedule", "-i", "15", "-c", "clusterPair1",
+		"--namespaces", "namespace1", "migrationschedule", "-n", "namespace1", "--transform-spec", "test-rt"}
+	expected := "error: unable to retrieve transformation namespace1/test-rt, err: resourcetransformations.stork.libopenstorage.org \"test-rt\" not found"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestCreateMigrationScheduleWithInvalidTransformSpec(t *testing.T) {
+	defer resetTest()
+	createClusterPair(t, "clusterPair1", "default", "async-dr")
+	cmdArgs := []string{"create", "migrationschedule", "-i", "15", "-c", "clusterPair1",
+		"--namespaces", "default", "migrationschedule", "--transform-spec", "test-rt", "-n", "default"}
+	createResourceTransformation(t, "test-rt", "default", storkv1.ResourceTransformationStatusFailed)
+	expected := "error: transformation default/test-rt is not in ready state, state: Failed"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestCreateMigrationScheduleWithValidTransformSpec(t *testing.T) {
+	defer resetTest()
+	createClusterPair(t, "clusterPair1", "default", "async-dr")
+	cmdArgs := []string{"create", "migrationschedule", "-i", "15", "-c", "clusterPair1",
+		"--namespaces", "default", "migrationschedule", "--transform-spec", "test-rt", "-n", "default"}
+	createResourceTransformation(t, "test-rt", "default", storkv1.ResourceTransformationStatusReady)
+	expected := "MigrationSchedule migrationschedule created successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
 func TestCreateMigrationScheduleWithInvalidInterval(t *testing.T) {
 	defer resetTest()
 	createClusterPair(t, "clusterPair1", "namespace1", "async-dr")
@@ -305,8 +399,8 @@ func TestCreateMigrationScheduleWithInvalidInterval(t *testing.T) {
 
 func TestCreateDuplicateMigrationSchedules(t *testing.T) {
 	defer resetTest()
-	createMigrationScheduleAndVerify(t, "createmigrationschedule", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
-	cmdArgs := []string{"create", "migrationschedules", "-s", "testpolicy", "-c", "clusterpair1", "--namespaces", "namespace1", "createmigrationschedule"}
+	createMigrationScheduleAndVerify(t, "createmigrationschedule", "testpolicy", "default", "clusterpair1", []string{"default"}, "", "", true)
+	cmdArgs := []string{"create", "migrationschedules", "-s", "testpolicy", "-c", "clusterpair1", "--namespaces", "default", "createmigrationschedule"}
 
 	expected := "Error from server (AlreadyExists): migrationschedules.stork.libopenstorage.org \"createmigrationschedule\" already exists"
 	testCommon(t, cmdArgs, nil, expected, true)
@@ -315,8 +409,8 @@ func TestCreateDuplicateMigrationSchedules(t *testing.T) {
 func TestDefaultMigrationSchedulePolicy(t *testing.T) {
 	defer resetTest()
 	// Create schedule without the default policy present
-	createClusterPair(t, "clusterpair1", "default", "async-dr")
-	cmdArgs := []string{"create", "migrationschedules", "defaultpolicy", "-n", "test", "-c", "clusterpair1", "--namespaces", "test", "-n", "default"}
+	createClusterPair(t, "clusterpair1", "test", "async-dr")
+	cmdArgs := []string{"create", "migrationschedules", "defaultmigrationschedule", "-c", "clusterpair1", "--namespaces", "test", "-n", "test"}
 	expected := "error: unable to get schedulepolicy default-migration-policy: schedulepolicies.stork.libopenstorage.org \"default-migration-policy\" not found"
 	testCommon(t, cmdArgs, nil, expected, true)
 
@@ -331,7 +425,7 @@ func TestDefaultMigrationSchedulePolicy(t *testing.T) {
 			}},
 	})
 	require.NoError(t, err, "Error creating schedulepolicy")
-	expected = "MigrationSchedule defaultpolicy created successfully\n"
+	expected = "MigrationSchedule defaultmigrationschedule created successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 func TestDeleteMigrationSchedulesNoMigrationName(t *testing.T) {
@@ -351,7 +445,7 @@ func TestDeleteMigrationSchedulesNoMigration(t *testing.T) {
 
 func TestDeleteMigrationSchedules(t *testing.T) {
 	defer resetTest()
-	createMigrationScheduleAndVerify(t, "deletemigration", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", false)
+	createMigrationScheduleAndVerify(t, "deletemigration", "testpolicy", "default", "clusterpair1", []string{"default"}, "", "", false)
 
 	cmdArgs := []string{"delete", "migrationschedules", "deletemigration"}
 	expected := "MigrationSchedule deletemigration deleted successfully\n"
@@ -361,16 +455,16 @@ func TestDeleteMigrationSchedules(t *testing.T) {
 	expected = "Error from server (NotFound): migrationschedules.stork.libopenstorage.org \"deletemigration\" not found"
 	testCommon(t, cmdArgs, nil, expected, true)
 
-	createMigrationScheduleAndVerify(t, "deletemigration1", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
-	createMigrationScheduleAndVerify(t, "deletemigration2", "testpolicy", "default", "clusterpair2", []string{"namespace1"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "deletemigration1", "testpolicy", "default", "clusterpair1", []string{"default"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "deletemigration2", "testpolicy", "default", "clusterpair2", []string{"default"}, "", "", true)
 
 	cmdArgs = []string{"delete", "migrationschedules", "deletemigration1", "deletemigration2"}
 	expected = "MigrationSchedule deletemigration1 deleted successfully\n"
 	expected += "MigrationSchedule deletemigration2 deleted successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
-	createMigrationScheduleAndVerify(t, "deletemigration1", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
-	createMigrationScheduleAndVerify(t, "deletemigration2", "testpolicy", "default", "clusterpair1", []string{"namespace1"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "deletemigration1", "testpolicy", "default", "clusterpair1", []string{"default"}, "", "", true)
+	createMigrationScheduleAndVerify(t, "deletemigration2", "testpolicy", "default", "clusterpair1", []string{"default"}, "", "", true)
 
 	cmdArgs = []string{"delete", "migrationschedules", "-c", "clusterpair1"}
 	expected = "MigrationSchedule deletemigration1 deleted successfully\n"
@@ -383,7 +477,7 @@ func TestSuspendResumeMigrationSchedule(t *testing.T) {
 	name1 := "testmigrationschedule-2"
 	namespace := "default"
 	defer resetTest()
-	createMigrationScheduleAndVerify(t, name, "testpolicy", namespace, "clusterpair1", []string{"namespace1"}, "", "", false)
+	createMigrationScheduleAndVerify(t, name, "testpolicy", namespace, "clusterpair1", []string{namespace}, "", "", false)
 
 	cmdArgs := []string{"suspend", "migrationschedules", name}
 	expected := "MigrationSchedule " + name + " suspended successfully\n"
@@ -425,7 +519,7 @@ func TestSuspendResumeMigrationSchedule(t *testing.T) {
 	testCommon(t, cmdArgs, nil, expected, true)
 
 	// test multiple suspend/resume using same clusterpair
-	createMigrationScheduleAndVerify(t, name1, "testpolicy", namespace, "clusterpair1", []string{"namespace1"}, "", "", false)
+	createMigrationScheduleAndVerify(t, name1, "testpolicy", namespace, "clusterpair1", []string{namespace}, "", "", false)
 	cmdArgs = []string{"suspend", "migrationschedules", "-c", "clusterpair1"}
 	expected = "MigrationSchedule " + name + " suspended successfully\nMigrationSchedule " + name1 + " suspended successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
@@ -438,11 +532,13 @@ func TestSuspendResumeMigrationSchedule(t *testing.T) {
 
 func createClusterPair(t *testing.T, clusterPairName string, namespace string, mode string) {
 	options := make(map[string]string)
+	storageStatus := storkv1.ClusterPairStatusNotProvided
 	if mode == "async-dr" {
 		options["backuplocation"] = "value1"
 		options["ip"] = "value2"
 		options["port"] = "value3"
 		options["token"] = "value4"
+		storageStatus = storkv1.ClusterPairStatusReady
 	}
 	clusterPair := &storkv1.ClusterPair{
 		ObjectMeta: metav1.ObjectMeta{
@@ -453,7 +549,38 @@ func createClusterPair(t *testing.T, clusterPairName string, namespace string, m
 		Spec: storkv1.ClusterPairSpec{
 			Options: options,
 		},
+
+		Status: storkv1.ClusterPairStatus{
+			SchedulerStatus: storkv1.ClusterPairStatusReady,
+			StorageStatus:   storageStatus,
+		},
 	}
 	_, err := storkops.Instance().CreateClusterPair(clusterPair)
 	require.True(t, err == nil || errors.IsAlreadyExists(err), "Error creating cluster pair")
+}
+
+func createResourceTransformation(t *testing.T, resourceTransformName string, namespace string, status storkv1.ResourceTransformationStatusType) {
+	_, err := storkops.Instance().CreateResourceTransformation(&storkv1.ResourceTransformation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourceTransformName,
+			Namespace: namespace,
+		},
+		Spec: storkv1.ResourceTransformationSpec{
+			Objects: []storkv1.TransformSpecs{
+				{
+					Resource: "/v1/Service",
+					Paths: []storkv1.ResourcePaths{
+						{
+							Path:  "spec.type",
+							Value: "LoadBalancer",
+							Type:  "string",
+						},
+					},
+				}},
+		},
+		Status: storkv1.ResourceTransformationStatus{
+			Status: status,
+		},
+	})
+	require.NoError(t, err, "Error creating Resource Transformation")
 }

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -296,7 +296,7 @@ func TestCreateMigrationScheduleWithIntervalAndVerify(t *testing.T) {
 	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
 	//create admin cluster pair in default admin namespace
 	createClusterPair(t, adminClusterPair, "kube-system", "async-dr")
-	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair, "admin-cluster-pair", adminClusterPair,
+	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair, "--admin-cluster-pair", adminClusterPair,
 		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace}
 	expected := "MigrationSchedule createmigrationschedule created successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -283,7 +283,7 @@ func TestCreateMigrationScheduleSyncDrExcludeVolumesFalse(t *testing.T) {
 	createClusterPair(t, clusterPair, "namespace1", "sync-dr")
 	cmdArgs := []string{"create", "migrationschedules", "-i", "15", "-c", clusterPair,
 		"--namespaces", namespace, "--annotations", "key1=value1", name, "-n", namespace, "--exclude-volumes=" + strconv.FormatBool(false)}
-	expected := "error: --exclude-volumes can only be set to true if it is a sync-dr use case or storage options are not provided in the cluster pair"
+	expected := "error: --exclude-volumes can only be set to true if it is a sync-dr use case or when storage options are not provided in the cluster pair"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
>improvement
>unit-test

**What this PR does / why we need it**:
Adding the remaining params which are a part of MigrationSchedule CR to storkctl create migrationschedule with validations as well.

**Does this PR change a user-facing CRD or CLI?**:
Yes, makes the storkctl create migrationschedule command comprehensive.

```
[root@ip-10-13-197-201 ~]# storkctl create migrationschedule -h
Create a migration schedule

Usage:
  storkctl create migrationschedules [flags]

Aliases:
  migrationschedules, migrationschedule

Flags:
      --admin-cluster-pair string            Specify the name of the admin ClusterPair used to migrate cluster-scoped resources, if the ClusterPair is present in a non-admin namespace
      --annotations stringToString           Add required annotations to the resource in comma-separated key value pairs. key1=value1,key2=value2,...  (default [])
  -c, --cluster-pair string                  Specify the name of the ClusterPair in the same namespace to be used for the migration
      --disable-auto-suspend                 Prevent automatic suspension of DR migration schedules on the source cluster in case of a disaster
      --disable-skip-deleted-namespaces      If present, Stork will fail the migration when it encounters a namespace that is deleted but specified in the namespaces field. By default, Stork ignores deleted namespaces during migration
      --exclude-resources                    If present, Kubernetes resources will not be migrated
      --exclude-selectors stringToString     Resources with the provided labels will be excluded from the migration. All the labels provided in this option will be OR'ed (default [])
      --exclude-volumes                      If present, the underlying Portworx volumes will not be migrated. This is the only allowed and default behaviour in sync-dr use-cases or when storage options are not provided in the cluster pair
  -h, --help                                 help for migrationschedules
      --ignore-owner-references-check        If set, resources with ownerReferences will also be migrated, even if the corresponding owners are getting migrated
      --include-jobs                         Set this flag to ensure that K8s Job resources are migrated. By default, the Job resources are not migrated
      --include-network-policy-with-cidr     If set, the underlying network policies will be migrated even if a fixed CIDR is present on them
  -i, --interval int                         Specify the time interval, in minutes, at which Stork should trigger migrations (default 30)
      --namespace-selectors stringToString   Resources in the namespaces with the specified namespace labels will be migrated. All the labels provided in this option will be OR'ed (default [])
      --namespaces strings                   Specify the comma-separated list of namespaces to be included in the migration
      --post-exec-rule string                Specify the name of the rule to be executed after every migration is triggered
      --pre-exec-rule string                 Specify the name of the rule to be executed before every migration is triggered
      --purge-deleted-resources              Set this flag to automatically delete Kubernetes resources in the target cluster when they are removed from the source cluster
  -s, --schedule-policy-name string          Name of the schedule policy to use. If you want to create a new interval policy, use the --interval flag instead (default "default-migration-policy")
      --selectors stringToString             Only resources with the provided labels will be migrated. All the labels provided in this option will be OR'ed (default [])
      --skip-service-update                  If set, service objects will be skipped during migration
  -a, --start-applications                   If present, the applications will be scaled up on the target cluster after a successful migration
      --suspend                              Flag to denote whether schedule should be suspended on creation
      --transform-spec string                Specify the ResourceTransformation spec to be applied during migration
```

**Is a release note needed?**:
Yes, TBD

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.11.0

**Testing Details**

- Have added unit tests for all the validations being done.
- Integration tests for successful creation of migrationschedules are a work in progress and will be added soon after this.

