### PR TITLE
PWX-22740: Using patch instead of update for volumesnapshotschedule update.

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,12 +3,14 @@ package utils
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/aquilax/truncate"
+	patch "github.com/evanphx/json-patch"
 	"github.com/libopenstorage/stork/drivers"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/core"
@@ -17,6 +19,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -279,4 +283,47 @@ func GetPortworxNamespace() (string, error) {
 	}
 	logrus.Warnf("unable to find [%s] service in cluster", PXServiceName)
 	return "", fmt.Errorf("can't find [%s] Portworx service from list of services", PXServiceName)
+}
+
+// CreateVolumeSnapshotSchedulePatch will return the patch between two volumesnapshot schedule objects
+func CreateVolumeSnapshotSchedulePatch(snapshot *stork_api.VolumeSnapshotSchedule, updatedSnapshot *stork_api.VolumeSnapshotSchedule) ([]byte, error) {
+	oldData, err := runtime.Encode(unstructured.UnstructuredJSONScheme, snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal old data: %v", err)
+	}
+	newData, err := runtime.Encode(unstructured.UnstructuredJSONScheme, updatedSnapshot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal new data: %v", err)
+	}
+
+	patchBytes, err := patch.CreateMergePatch(oldData, newData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create merge patch: %v", err)
+	}
+
+	patchBytes, err = addResourceVersion(patchBytes, snapshot.ResourceVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add resource version: %v", err)
+	}
+
+	return patchBytes, nil
+}
+
+func addResourceVersion(patchBytes []byte, resourceVersion string) ([]byte, error) {
+	var patchMap map[string]interface{}
+	err := json.Unmarshal(patchBytes, &patchMap)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling patch: %v", err)
+	}
+	u := unstructured.Unstructured{Object: patchMap}
+	a, err := meta.Accessor(&u)
+	if err != nil {
+		return nil, fmt.Errorf("error creating accessor: %v", err)
+	}
+	a.SetResourceVersion(resourceVersion)
+	versionBytes, err := json.Marshal(patchMap)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling json patch: %v", err)
+	}
+	return versionBytes, nil
 }


### PR DESCRIPTION
Signed-Off-By: Diptiranjan


**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Using patch instead of update to avoid update error like 
"SDK update error: the object has been modified; please apply your changes to the latest version and try again"

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->


**Does this change need to be cherry-picked to a release branch?**:
<!--
yes
-->
```
23.11.0
```

**Test**
Tested with 10 volumes with 10 volumesnapshotschedules with 2 min interval policy.
1. Case where number of snapshots <  retain value:
```
➜  mysql-1-pvc git:(PWX-22740) ✗ kp -n mysql2 get volumesnapshotschedule vsc1  -o yaml
apiVersion: stork.libopenstorage.org/v1alpha1
kind: VolumeSnapshotSchedule
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"stork.libopenstorage.org/v1alpha1","kind":"VolumeSnapshotSchedule","metadata":{"annotations":{"portworx/cloud-cred-id":"6b89b884-f2a1-43d3-b709-ee1074fccda2","portworx/snapshot-type":"cloud","stork.libopenstorage.org/snapshot-restore-namespaces":"otherNamespace"},"name":"vsc1","namespace":"mysql2"},"spec":{"reclaimPolicy":"Delete","schedulePolicyName":"every-2m","suspend":false,"template":{"spec":{"persistentVolumeClaimName":"mysql-data"}}}}
    portworx/cloud-cred-id: 6b89b884-f2a1-43d3-b709-ee1074fccda2
    portworx/snapshot-type: cloud
    stork.libopenstorage.org/snapshot-restore-namespaces: otherNamespace
  creationTimestamp: "2023-11-16T09:44:34Z"
  generation: 13
  name: vsc1
  namespace: mysql2
  resourceVersion: "20204202"
  uid: c983ce35-f3bb-4c33-8e7b-672cf9c0e21d
spec:
  postExecRule: ""
  preExecRule: ""
  reclaimPolicy: Delete
  schedulePolicyName: every-2m
  suspend: false
  template:
    spec:
      persistentVolumeClaimName: mysql-data
      snapshotDataName: ""
status:
  items:
    Interval:
    - creationTimestamp: "2023-11-16T09:44:34Z"
      finishTimestamp: "2023-11-16T09:44:54Z"
      name: vsc1-interval-2023-11-16-094434
      status: Ready
    - creationTimestamp: "2023-11-16T09:46:34Z"
      finishTimestamp: "2023-11-16T09:46:55Z"
      name: vsc1-interval-2023-11-16-094634
      status: Ready
    - creationTimestamp: "2023-11-16T09:48:35Z"
      finishTimestamp: "2023-11-16T09:48:55Z"
      name: vsc1-interval-2023-11-16-094835
      status: Ready
    - creationTimestamp: "2023-11-16T09:50:35Z"
      finishTimestamp: "2023-11-16T09:50:55Z"
      name: vsc1-interval-2023-11-16-095035
      status: Ready
    - creationTimestamp: "2023-11-16T09:52:35Z"
      finishTimestamp: "2023-11-16T09:52:55Z"
      name: vsc1-interval-2023-11-16-095235
      status: Ready
    - creationTimestamp: "2023-11-16T09:54:35Z"
      finishTimestamp: "2023-11-16T09:54:55Z"
      name: vsc1-interval-2023-11-16-095435
      status: Ready

```
2. With Pending snapshots
```
➜  mysql-1-pvc git:(PWX-22740) ✗ kp -n mysql2 get volumesnapshotschedule vsc1  -o yaml
apiVersion: stork.libopenstorage.org/v1alpha1
kind: VolumeSnapshotSchedule
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"stork.libopenstorage.org/v1alpha1","kind":"VolumeSnapshotSchedule","metadata":{"annotations":{"portworx/cloud-cred-id":"6b89b884-f2a1-43d3-b709-ee1074fccda2","portworx/snapshot-type":"cloud","stork.libopenstorage.org/snapshot-restore-namespaces":"otherNamespace"},"name":"vsc1","namespace":"mysql2"},"spec":{"reclaimPolicy":"Delete","schedulePolicyName":"every-2m","suspend":false,"template":{"spec":{"persistentVolumeClaimName":"mysql-data"}}}}
    portworx/cloud-cred-id: 6b89b884-f2a1-43d3-b709-ee1074fccda2
    portworx/snapshot-type: cloud
    stork.libopenstorage.org/post-snapshot-rule: ""
    stork.libopenstorage.org/pre-snapshot-rule: ""
    stork.libopenstorage.org/snapshot-restore-namespaces: otherNamespace
    stork.libopenstorage.org/snapshotScheduleName: vsc1
    stork.libopenstorage.org/snapshotSchedulePolicyType: Interval
  creationTimestamp: "2023-11-16T09:44:34Z"
  generation: 25
  name: vsc1
  namespace: mysql2
  resourceVersion: "20209030"
  uid: c983ce35-f3bb-4c33-8e7b-672cf9c0e21d
spec:
  postExecRule: ""
  preExecRule: ""
  reclaimPolicy: Delete
  schedulePolicyName: every-2m
  suspend: false
  template:
    spec:
      persistentVolumeClaimName: mysql-data
      snapshotDataName: ""
status:
  items:
    Interval:
    - creationTimestamp: "2023-11-16T09:46:34Z"
      finishTimestamp: "2023-11-16T09:46:55Z"
      name: vsc1-interval-2023-11-16-094634
      status: Ready
    - creationTimestamp: "2023-11-16T09:48:35Z"
      finishTimestamp: "2023-11-16T09:48:55Z"
      name: vsc1-interval-2023-11-16-094835
      status: Ready
    - creationTimestamp: "2023-11-16T09:50:35Z"
      finishTimestamp: "2023-11-16T09:50:55Z"
      name: vsc1-interval-2023-11-16-095035
      status: Ready
    - creationTimestamp: "2023-11-16T09:52:35Z"
      finishTimestamp: "2023-11-16T09:52:55Z"
      name: vsc1-interval-2023-11-16-095235
      status: Ready
    - creationTimestamp: "2023-11-16T09:54:35Z"
      finishTimestamp: "2023-11-16T09:54:55Z"
      name: vsc1-interval-2023-11-16-095435
      status: Ready
    - creationTimestamp: "2023-11-16T09:56:35Z"
      finishTimestamp: "2023-11-16T09:56:55Z"
      name: vsc1-interval-2023-11-16-095635
      status: Ready
    - creationTimestamp: "2023-11-16T09:58:35Z"
      finishTimestamp: "2023-11-16T09:58:55Z"
      name: vsc1-interval-2023-11-16-095835
      status: Ready
    - creationTimestamp: "2023-11-16T10:00:35Z"
      finishTimestamp: "2023-11-16T10:00:55Z"
      name: vsc1-interval-2023-11-16-100035
      status: Ready
    - creationTimestamp: "2023-11-16T10:02:35Z"
      finishTimestamp: "2023-11-16T10:02:55Z"
      name: vsc1-interval-2023-11-16-100235
      status: Ready
    - creationTimestamp: "2023-11-16T10:04:35Z"
      finishTimestamp: "2023-11-16T10:04:55Z"
      name: vsc1-interval-2023-11-16-100435
      status: Ready
    - creationTimestamp: "2023-11-16T10:06:35Z"
      finishTimestamp: null
      name: vsc1-interval-2023-11-16-100635
      status: Pending

```
3. With retain number of snapshots
```
➜  mysql-1-pvc git:(PWX-22740) ✗ kp -n mysql1 get volumesnapshotschedule vsc1  -o yaml
apiVersion: stork.libopenstorage.org/v1alpha1
kind: VolumeSnapshotSchedule
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"stork.libopenstorage.org/v1alpha1","kind":"VolumeSnapshotSchedule","metadata":{"annotations":{"portworx/cloud-cred-id":"6b89b884-f2a1-43d3-b709-ee1074fccda2","portworx/snapshot-type":"cloud","stork.libopenstorage.org/snapshot-restore-namespaces":"otherNamespace"},"name":"vsc1","namespace":"mysql1"},"spec":{"reclaimPolicy":"Delete","schedulePolicyName":"every-2m","suspend":false,"template":{"spec":{"persistentVolumeClaimName":"mysql-data"}}}}
    portworx/cloud-cred-id: 6b89b884-f2a1-43d3-b709-ee1074fccda2
    portworx/snapshot-type: cloud
    stork.libopenstorage.org/post-snapshot-rule: ""
    stork.libopenstorage.org/pre-snapshot-rule: ""
    stork.libopenstorage.org/snapshot-restore-namespaces: otherNamespace
    stork.libopenstorage.org/snapshotScheduleName: vsc1
    stork.libopenstorage.org/snapshotSchedulePolicyType: Interval
  creationTimestamp: "2023-11-10T09:46:14Z"
  generation: 12945
  name: vsc1
  namespace: mysql1
  resourceVersion: "20203720"
  uid: 25d5e6f6-85be-4e8c-90a5-afeb5e39bcab
spec:
  postExecRule: ""
  preExecRule: ""
  reclaimPolicy: Delete
  schedulePolicyName: every-2m
  suspend: false
  template:
    spec:
      persistentVolumeClaimName: mysql-data
      snapshotDataName: ""
status:
  items:
    Interval:
    - creationTimestamp: "2023-11-16T09:35:04Z"
      finishTimestamp: "2023-11-16T09:35:34Z"
      name: vsc1-interval-2023-11-16-093504
      status: Ready
    - creationTimestamp: "2023-11-16T09:37:04Z"
      finishTimestamp: "2023-11-16T09:37:34Z"
      name: vsc1-interval-2023-11-16-093704
      status: Ready
    - creationTimestamp: "2023-11-16T09:39:04Z"
      finishTimestamp: "2023-11-16T09:39:34Z"
      name: vsc1-interval-2023-11-16-093904
      status: Ready
    - creationTimestamp: "2023-11-16T09:41:05Z"
      finishTimestamp: "2023-11-16T09:41:35Z"
      name: vsc1-interval-2023-11-16-094105
      status: Ready
    - creationTimestamp: "2023-11-16T09:43:05Z"
      finishTimestamp: "2023-11-16T09:43:35Z"
      name: vsc1-interval-2023-11-16-094305
      status: Ready
    - creationTimestamp: "2023-11-16T09:45:05Z"
      finishTimestamp: "2023-11-16T09:45:35Z"
      name: vsc1-interval-2023-11-16-094505
      status: Ready
    - creationTimestamp: "2023-11-16T09:47:05Z"
      finishTimestamp: "2023-11-16T09:47:35Z"
      name: vsc1-interval-2023-11-16-094705
      status: Ready
    - creationTimestamp: "2023-11-16T09:49:05Z"
      finishTimestamp: "2023-11-16T09:49:45Z"
      name: vsc1-interval-2023-11-16-094905
      status: Ready
    - creationTimestamp: "2023-11-16T09:51:05Z"
      finishTimestamp: "2023-11-16T09:51:35Z"
      name: vsc1-interval-2023-11-16-095105
      status: Ready
    - creationTimestamp: "2023-11-16T09:53:05Z"
      finishTimestamp: "2023-11-16T09:53:45Z"
      name: vsc1-interval-2023-11-16-095305
      status: Ready

```

Log with the error message was not found.
```
➜  mysql-1-pvc git:(PWX-22740) ✗ kp logs -lname=stork  | grep -i "Operation cannot be fulfilled"
➜  mysql-1-pvc git:(PWX-22740) ✗
```

Without the fix, could hit the issue with stork:23.8.0
```
➜  mysql-1-pvc git:(PWX-22740) ✗ kp logs -lname=stork  | grep -i "Operation cannot be fulfilled"
time="2023-11-16T12:11:15Z" level=error msg="*controllers.SnapshotScheduleController: mysql9/vsc1: Operation cannot be fulfilled on volumesnapshotschedules.stork.libopenstorage.org \"vsc1\": the object has been modified; please apply your changes to the latest version and try again"
```