### PR TITLE
pb-4887: Added fix in handling the already exists error while creating

### DIFF
--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -1201,22 +1201,36 @@ func (c *csiDriver) restoreVolumeSnapshotClass(vsClass interface{}) (interface{}
 	if c.v1SnapshotRequired {
 		vsClass.(*kSnapshotv1.VolumeSnapshotClass).ResourceVersion = ""
 		vsClass.(*kSnapshotv1.VolumeSnapshotClass).UID = ""
-		newVSClass, err = c.snapshotClient.SnapshotV1().VolumeSnapshotClasses().Create(context.TODO(), vsClass.(*kSnapshotv1.VolumeSnapshotClass), metav1.CreateOptions{})
+		_, err = c.snapshotClient.SnapshotV1().VolumeSnapshotClasses().Get(context.TODO(), vsClass.(*kSnapshotv1.VolumeSnapshotClass).Name, metav1.GetOptions{})
 		if err != nil {
-			if k8s_errors.IsAlreadyExists(err) {
-				return vsClass, nil
+			// did not find vs class, create one
+			if k8s_errors.IsNotFound(err) {
+				newVSClass, err = c.snapshotClient.SnapshotV1().VolumeSnapshotClasses().Create(context.TODO(), vsClass.(*kSnapshotv1.VolumeSnapshotClass), metav1.CreateOptions{})
+				if err != nil {
+					if !k8s_errors.IsAlreadyExists(err) {
+						return nil, err
+					}
+				}
 			}
-			return nil, err
+		} else {
+			return vsClass, nil
 		}
 	} else {
 		vsClass.(*kSnapshotv1beta1.VolumeSnapshotClass).ResourceVersion = ""
 		vsClass.(*kSnapshotv1beta1.VolumeSnapshotClass).UID = ""
-		newVSClass, err = c.snapshotClient.SnapshotV1beta1().VolumeSnapshotClasses().Create(context.TODO(), vsClass.(*kSnapshotv1beta1.VolumeSnapshotClass), metav1.CreateOptions{})
+		_, err = c.snapshotClient.SnapshotV1beta1().VolumeSnapshotClasses().Get(context.TODO(), vsClass.(*kSnapshotv1beta1.VolumeSnapshotClass).Name, metav1.GetOptions{})
 		if err != nil {
-			if k8s_errors.IsAlreadyExists(err) {
-				return vsClass, nil
+			// did not find vs class, create one
+			if k8s_errors.IsNotFound(err) {
+				newVSClass, err = c.snapshotClient.SnapshotV1beta1().VolumeSnapshotClasses().Create(context.TODO(), vsClass.(*kSnapshotv1beta1.VolumeSnapshotClass), metav1.CreateOptions{})
+				if err != nil {
+					if !k8s_errors.IsAlreadyExists(err) {
+						return nil, err
+					}
+				}
 			}
-			return nil, err
+		} else {
+			return vsClass, nil
 		}
 	}
 	return newVSClass, nil


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
    pb-4887: Added fix in handling the already exists error while creating
    volumesnapshotclass during restore.

            - If we have csi-snapshot-webhook webhook, the creation of
              volumesnapshotclass fails with different eror message for already exists error.
            - So add a get call and then calling create volumesnapshot call,
              if Get failed with NotFound error.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: csi based restore fails on some of the setup that had csi-snapshot-webhook admin webhook as we get different error for alreadyexist error, while creating the volumesnapshotclass resource.
User Impact: CSI based restore was failing on the setup that has csi-snapshot-webhook admin webhook
Resolution: Added a get call before create call, such that create call will happen only the get failed with "NotFound" error.

```

**Does this change need to be cherry-picked to a release branch?**:
23.9

**Testing:**
1) Validated the Native CSI restore and kdmp localsnapshot restore, which was failing with out fix.