### PR TITLE
[PWX-34991] Fetching rules from migration namespace instead of namespace to migrate

### DIFF
--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -907,11 +907,11 @@ func (m *MigrationController) runPreExecRule(migration *stork_api.Migration, mig
 			return nil, nil
 		}
 	}
-	terminationChannels := make([]chan bool, 0)
 	r, err := storkops.Instance().GetRule(migration.Spec.PreExecRule, migration.Namespace)
 	if err != nil {
 		return nil, err
 	}
+	terminationChannels := make([]chan bool, 0)
 	for _, ns := range migrationNamespaces {
 		ch, err := rule.ExecuteRule(r, rule.PreExecRule, migration, ns)
 		if err != nil {

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -909,7 +909,7 @@ func (m *MigrationController) runPreExecRule(migration *stork_api.Migration, mig
 	}
 	terminationChannels := make([]chan bool, 0)
 	for _, ns := range migrationNamespaces {
-		r, err := storkops.Instance().GetRule(migration.Spec.PreExecRule, ns)
+		r, err := storkops.Instance().GetRule(migration.Spec.PreExecRule, migration.Namespace)
 		if err != nil {
 			for _, channel := range terminationChannels {
 				channel <- true
@@ -933,7 +933,7 @@ func (m *MigrationController) runPreExecRule(migration *stork_api.Migration, mig
 
 func (m *MigrationController) runPostExecRule(migration *stork_api.Migration, migrationNamespaces []string) error {
 	for _, ns := range migrationNamespaces {
-		r, err := storkops.Instance().GetRule(migration.Spec.PostExecRule, ns)
+		r, err := storkops.Instance().GetRule(migration.Spec.PostExecRule, migration.Namespace)
 		if err != nil {
 			return err
 		}

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -910,9 +910,6 @@ func (m *MigrationController) runPreExecRule(migration *stork_api.Migration, mig
 	terminationChannels := make([]chan bool, 0)
 	r, err := storkops.Instance().GetRule(migration.Spec.PreExecRule, migration.Namespace)
 	if err != nil {
-		for _, channel := range terminationChannels {
-			channel <- true
-		}
 		return nil, err
 	}
 	for _, ns := range migrationNamespaces {

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -907,11 +907,11 @@ func (m *MigrationController) runPreExecRule(migration *stork_api.Migration, mig
 			return nil, nil
 		}
 	}
+	terminationChannels := make([]chan bool, 0)
 	r, err := storkops.Instance().GetRule(migration.Spec.PreExecRule, migration.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	terminationChannels := make([]chan bool, 0)
 	for _, ns := range migrationNamespaces {
 		ch, err := rule.ExecuteRule(r, rule.PreExecRule, migration, ns)
 		if err != nil {

--- a/pkg/migration/controllers/migration.go
+++ b/pkg/migration/controllers/migration.go
@@ -908,15 +908,14 @@ func (m *MigrationController) runPreExecRule(migration *stork_api.Migration, mig
 		}
 	}
 	terminationChannels := make([]chan bool, 0)
-	for _, ns := range migrationNamespaces {
-		r, err := storkops.Instance().GetRule(migration.Spec.PreExecRule, migration.Namespace)
-		if err != nil {
-			for _, channel := range terminationChannels {
-				channel <- true
-			}
-			return nil, err
+	r, err := storkops.Instance().GetRule(migration.Spec.PreExecRule, migration.Namespace)
+	if err != nil {
+		for _, channel := range terminationChannels {
+			channel <- true
 		}
-
+		return nil, err
+	}
+	for _, ns := range migrationNamespaces {
 		ch, err := rule.ExecuteRule(r, rule.PreExecRule, migration, ns)
 		if err != nil {
 			for _, channel := range terminationChannels {
@@ -932,15 +931,14 @@ func (m *MigrationController) runPreExecRule(migration *stork_api.Migration, mig
 }
 
 func (m *MigrationController) runPostExecRule(migration *stork_api.Migration, migrationNamespaces []string) error {
+	r, err := storkops.Instance().GetRule(migration.Spec.PostExecRule, migration.Namespace)
+	if err != nil {
+		return err
+	}
 	for _, ns := range migrationNamespaces {
-		r, err := storkops.Instance().GetRule(migration.Spec.PostExecRule, migration.Namespace)
-		if err != nil {
-			return err
-		}
-
 		_, err = rule.ExecuteRule(r, rule.PostExecRule, migration, ns)
 		if err != nil {
-			return fmt.Errorf("error executing PreExecRule for namespace %v: %v", ns, err)
+			return fmt.Errorf("error executing PostExecRule for namespace %v: %v", ns, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
As part of existing code, when users create migrationschedule and clusterpair in the admin namespace, they have to create preExec and postExec rules in both the admin Namespace as well as the namespaces to be migrated.
We fix this inconvenience by fetching the rules from adminNamespace only. 

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Yes, TBD

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.11.0

**Testing Details**
Have tested the changes in a local cluster and verified the bug as well as the fix.
Validated the fix by creating the migrationSchedule in the admin namespace and migrating default namespace. For this case the rules had to be created in the admin namespace.
