### PR TITLE
Pb-4844: Changes in stork for it to enable debug level log messages for kopia operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -333,7 +333,7 @@ replace (
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v0.0.0-20230511212757-41751b27d69f
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
-	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20231130175942-e8a1e0c64972
+	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20231218141125-9b389a7c1a98
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -2894,8 +2894,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v1.0.5/go.mod h1:APVvOesVSAnne5SClsPxPdfvZTVDojXh1/G3qb5wjGI=
 github.com/portworx/dcos-secrets v0.0.0-20180616013705-8e8ec3f66611/go.mod h1:4hklRW/4DQpLqkcXcjtNprbH2tz/sJaNtqinfPWl/LA=
-github.com/portworx/kdmp v0.4.1-0.20231130175942-e8a1e0c64972 h1:9UBxkJyCz+UzsUMa+dAYhThmQ0T9nShQJePVQrDEKpk=
-github.com/portworx/kdmp v0.4.1-0.20231130175942-e8a1e0c64972/go.mod h1:mMZUDNoAfslBw6DxEXKN2KSEt14l/HIGtt1CzgOghp0=
+github.com/portworx/kdmp v0.4.1-0.20231218141125-9b389a7c1a98 h1:gdCYAMznWjlQF0eepXtRakdOYI98STjeX41BcF8z1sI=
+github.com/portworx/kdmp v0.4.1-0.20231218141125-9b389a7c1a98/go.mod h1:mMZUDNoAfslBw6DxEXKN2KSEt14l/HIGtt1CzgOghp0=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200929023115-b312c7519467/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
@@ -376,13 +376,19 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 		}
 		return true, c.updateStatus(dataExport, data)
 	case kdmpapi.DataExportStageTransferInProgress:
+		var reason string
+		if dataExport.Status.Status == kdmpapi.DataExportStatusSuccessful {
+			reason = ""
+		} else {
+			reason = dataExport.Status.Reason
+		}
 		if dataExport.Status.Status == kdmpapi.DataExportStatusSuccessful ||
 			dataExport.Status.Status == kdmpapi.DataExportStatusFailed {
 			// set to the next stage
 			data := updateDataExportDetail{
 				stage:  kdmpapi.DataExportStageCleanup,
 				status: dataExport.Status.Status,
-				reason: "",
+				reason: reason,
 			}
 			return false, c.updateStatus(dataExport, data)
 		}

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackup.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiabackup/kopiabackup.go
@@ -287,6 +287,9 @@ func jobFor(
 		"/data",
 	}, " ")
 
+	// Read the config map from the job option and then add the debug level log if required
+	cmd = utils.CheckAndAddKopiaDebugModeEnabled(cmd, jobOption)
+
 	if jobOption.Compression != "" {
 		splitCmd := strings.Split(cmd, " ")
 		splitCmd = append(splitCmd, "--compression", jobOption.Compression)

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiadelete/kopiadelete.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiadelete/kopiadelete.go
@@ -201,6 +201,8 @@ func jobFor(
 		jobOption.VolumeBackupDeleteNamespace,
 	}, " ")
 
+	cmd = utils.CheckAndAddKopiaDebugModeEnabled(cmd, jobOption)
+
 	kopiaExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.KopiaExecutorImage,
 		jobOption.KopiaImageExecutorSource,
 		jobOption.KopiaImageExecutorSourceNs,

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -204,6 +204,8 @@ func jobFor(
 		jobOption.MaintenanceType,
 	}, " ")
 
+	cmd = utils.CheckAndAddKopiaDebugModeEnabled(cmd, jobOption)
+
 	kopiaExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.KopiaExecutorImage,
 		jobOption.KopiaImageExecutorSource,
 		jobOption.KopiaImageExecutorSourceNs,

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiarestore/kopiarestore.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiarestore/kopiarestore.go
@@ -206,6 +206,8 @@ func jobFor(
 		vb.Status.SnapshotID,
 	}, " ")
 
+	cmd = utils.CheckAndAddKopiaDebugModeEnabled(cmd, jobOption)
+
 	kopiaExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.KopiaExecutorImage,
 		jobOption.KopiaImageExecutorSource,
 		jobOption.KopiaImageExecutorSourceNs,
@@ -369,7 +371,7 @@ func roleFor() *rbacv1.Role {
 			},
 			{
 				APIGroups: []string{"kdmp.portworx.com"},
-				Resources: []string{"volumebackups"},
+				Resources: []string{"volumebackups", "dataexports"},
 				Verbs:     []string{rbacv1.VerbAll},
 			},
 		},

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
@@ -19,6 +19,7 @@ type JobOpts struct {
 	VolumeBackupName            string
 	VolumeBackupNamespace       string
 	VolumeBackupDeleteName      string
+	KopiaDebugMode              bool
 	VolumeBackupDeleteNamespace string
 	DataExportName              string
 	SnapshotID                  string

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/utils/utils.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/utils/utils.go
@@ -63,6 +63,10 @@ const (
 	PvcBoundSuccessMsg = "pvc bounded successfully"
 	// PvcBoundFailedMsg pvc not bounded msg
 	PvcBoundFailedMsg = "pvc not bounded"
+	// KopiaDebugModeEnabled - debug level log messages are enabled for kopia
+	KopiaDebugModeEnabled = "kopia-debug-mode"
+	// KopiaExecutorDebugModeCMKey - key present in the config maps, which enables debug log level in kopia
+	KopiaExecutorDebugModeCMKey = "KDMP_KOPIAEXECUTOR_ENABLE_DEBUG_MODE"
 )
 
 var (
@@ -875,4 +879,15 @@ func IsJobPodMountFailed(job *batchv1.Job, namespace string) bool {
 		}
 	}
 	return false
+}
+
+func CheckAndAddKopiaDebugModeEnabled(cmd string, jobOption drivers.JobOpts) string {
+	// check for the particular key-value pair
+	isKeyPresent := GetConfigValue(jobOption.JobConfigMap, jobOption.JobConfigMapNs, KopiaExecutorDebugModeCMKey)
+	if isKeyPresent == "true" {
+		splitCmd := strings.Split(cmd, " ")
+		splitCmd = append(splitCmd, "--log-level", "debug")
+		cmd = strings.Join(splitCmd, " ")
+	}
+	return cmd
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1041,7 +1041,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20231130175942-e8a1e0c64972 => github.com/portworx/kdmp v0.4.1-0.20231130175942-e8a1e0c64972
+# github.com/portworx/kdmp v0.4.1-0.20231130175942-e8a1e0c64972 => github.com/portworx/kdmp v0.4.1-0.20231218141125-9b389a7c1a98
 ## explicit; go 1.21
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1
@@ -2479,7 +2479,7 @@ sigs.k8s.io/yaml
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v0.0.0-20230511212757-41751b27d69f
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
-# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20231130175942-e8a1e0c64972
+# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20231218141125-9b389a7c1a98
 # github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7


### PR DESCRIPTION
**What type of PR is this?**

>improvement


**What this PR does / why we need it**:
This PR introduces a change where we can access debug level logs for kopia operations. We need the this, so that in future whenever required, we could use it to view logs in debug level.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

Link to PX-Backup PR related to this particular PR is: https://github.com/portworx/px-backup/pull/1407
Link to KDMP PR related to this particular PR is: https://github.com/portworx/kdmp/pull/324

Attaching some screenshots for the reference:
![Screenshot 2023-11-27 at 4 05 47 PM](https://github.com/libopenstorage/stork/assets/148333439/815b1d25-e2f5-4b5b-af59-ed18cbffacd9)
![Screenshot 2023-11-27 at 4 12 44 PM](https://github.com/libopenstorage/stork/assets/148333439/d03f5a76-f9b3-40eb-84e8-f17e99686d19)
![Screenshot 2023-11-27 at 4 15 43 PM](https://github.com/libopenstorage/stork/assets/148333439/7951c351-53ba-4d15-bab1-81970b18b711)
![Screenshot 2023-11-27 at 10 50 26 AM](https://github.com/libopenstorage/stork/assets/148333439/cd3559d1-b80e-4f71-b3fa-b2df2a44b60b)
