### PR TITLE
pb-4669: Adding support for partial success backups

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -71,6 +71,7 @@ type ApplicationBackupStatus struct {
 	TotalSize            uint64                           `json:"totalSize"`
 	ResourceCount        int                              `json:"resourceCount"`
 	LargeResourceEnabled bool                             `json:"largeResourceEnabled"`
+	FailedVolCount       int                              `json:"failedVolCount"`
 }
 
 // ObjectInfo contains info about an object being backed up or restored
@@ -83,6 +84,8 @@ type ObjectInfo struct {
 // ApplicationBackupResourceInfo is the info for the backup of a resource
 type ApplicationBackupResourceInfo struct {
 	ObjectInfo `json:",inline"`
+	Status     ApplicationBackupStatusType `json:"status"`
+	Reason     string                      `json:"reason"`
 }
 
 // ApplicationBackupVolumeInfo is the info for the backup of a volume
@@ -120,6 +123,8 @@ const (
 	ApplicationBackupStatusPartialSuccess ApplicationBackupStatusType = "PartialSuccess"
 	// ApplicationBackupStatusSuccessful for when backup has completed successfully
 	ApplicationBackupStatusSuccessful ApplicationBackupStatusType = "Successful"
+	// ApplicationBackupStatusSkip for when backup has been skipped
+	ApplicationBackupStatusSkip ApplicationBackupStatusType = "Skipped"
 )
 
 // ApplicationBackupStageType is the stage of the backup

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -577,7 +577,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 			continue
 		}
 		for _, volumeBackup := range backup.Status.Volumes {
-			if volumeBackup.Namespace != namespace {
+			if volumeBackup.Namespace != namespace || volumeBackup.Status == storkapi.ApplicationBackupStatusFailed || volumeBackup.Status == storkapi.ApplicationBackupStatusSkip {
 				continue
 			}
 			// If a list of resources was specified during restore check if


### PR DESCRIPTION
**What type of PR is this?**
Improvement

**What this PR does / why we need it**:
```
 pb-4669: Adding support for partial success backups
    - A backup involving multiple PVC, if one of the PVC backup
      fails, backup will mark that PVC as Failed and proceed to
      next PVCs rather than failing the entire backup
    - For the failed PVC, corresponding resources are not backed up.
    - New status called PartialSuccess is introduced to signify the
      same
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Yes

**Does this change need to be cherry-picked to a release branch?**:
Yes

**Note**
All test notes are captured in ticket PB-4669 