### PR TITLE
change stash strategy test name to not include it in migration suite

### DIFF
--- a/test/integration_test/migration_features_test.go
+++ b/test/integration_test/migration_features_test.go
@@ -24,7 +24,7 @@ var (
 	StashCRLabel = "stash-cr"
 )
 
-func TestMigrationStashStrategy(t *testing.T) {
+func TestStashStrategyMigration(t *testing.T) {
 	// reset mock time before running any tests
 	err := setMockTime(nil)
 	require.NoError(t, err, "Error resetting mock time")


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
* Stash strategy migration test keep failing, until we debug this, renaming it so it does not get run as part of the migration suite
* We will still be running it in a separate job, that way it will be easier to debug.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
