### PR TITLE
pb-5027: post-exec failure scenario should fail the backup

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -781,7 +781,6 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 				if backup.Spec.PostExecRule != "" {
 					log.ApplicationBackupLog(backup).Infof("Starting post-exec rule for non-kdmp driver path")
 					err = a.runPostExecRule(backup)
-					a.execRulesCompleted[string(backup.UID)] = true
 					if err != nil {
 						message := fmt.Sprintf("Error running PostExecRule: %v", err)
 						log.ApplicationBackupLog(backup).Errorf(message)
@@ -796,10 +795,12 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 						backup.Status.Reason = message
 						err = a.client.Update(context.TODO(), backup)
 						if err != nil {
+							log.ApplicationBackupLog(backup).Errorf("failed to update post exec rule failure status in cr %v", err)
 							return err
 						}
 						return fmt.Errorf("%v", message)
 					}
+					a.execRulesCompleted[string(backup.UID)] = true
 				}
 			}
 		}
@@ -1059,7 +1060,7 @@ func (a *ApplicationBackupController) runPostExecRule(backup *stork_api.Applicat
 	for _, ns := range backup.Spec.Namespaces {
 		_, err = rule.ExecuteRule(r, rule.PostExecRule, backup, ns)
 		if err != nil {
-			return fmt.Errorf("error executing PreExecRule for namespace %v: %v", ns, err)
+			return fmt.Errorf("error executing PostExecRule for namespace %v: %v", ns, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
- When user gives wrong command for post-exec rule then backup doesn't fail in eks setup because of cr update fails.
- via reconciler when the cr update should be attempted repeatedly.


**What type of PR is this?**Bug
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: If a wrong command given in post-exec rule we need to fail the backup even if the update to the application backup CR fails.


**Does this PR change a user-facing CRD or CLI?**: No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: No  , this is failure scenario
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: 23.9.1 
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

