### PR TITLE
storkctl create migrationschedule minor improvements

### DIFF
--- a/pkg/storkctl/schedulepolicy.go
+++ b/pkg/storkctl/schedulepolicy.go
@@ -207,7 +207,7 @@ func newCreateSchedulePolicyCommand(cmdFactory Factory, ioStreams genericcliopti
 	createSchedulePolicyCommand.Flags().StringVarP(&time, timeFlag, "", "12:00AM", "Specify the time of the day in the 12 hour AM/PM format, when Stork should trigger the operation.")
 	createSchedulePolicyCommand.Flags().StringVarP(&dailyForceFullSnapshotDay, forceFullSnapshotDayFlag, "", "Monday", "For daily scheduled backup operations, specify on which day to trigger a full backup.")
 	createSchedulePolicyCommand.Flags().StringVarP(&dayOfWeek, dayOfWeekFlag, "", "Sunday", "Specify the day of the week when Stork should trigger the operation. You can use both the abbreviated or the full name of the day of the week.")
-	createSchedulePolicyCommand.Flags().IntVarP(&dateOfMonth, dateOfMonthFlag, "", 1, "Specify the day of the month when Stork should trigger the operation.")
+	createSchedulePolicyCommand.Flags().IntVarP(&dateOfMonth, dateOfMonthFlag, "", 1, "Specify the date of the month when Stork should trigger the operation.")
 	return createSchedulePolicyCommand
 }
 


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
This PR addresses improvements requested by QA in PWX-35180, PWX-35149 and PWX-35183
1. schedule policy may get created even if migrationschedule is not created due to a failing validation. This could impact the user experience.
2. changing date-of-month flag's description in storkctl create schedulepolicy
3. creating default-migration-schedule (30 min interval) schedulepolicy incase it doesn't exist

**Does this PR change a user-facing CRD or CLI?**:
Yes
Slightly changed the description of --date-of-month flag in storkctl create schedulepolicy

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.11.0

