### PR TITLE
update google cloud sdk to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN asdf install kubelogin latest
 RUN asdf global kubelogin latest
 
 #Install Google Cloud SDK
-ARG GCLOUD_SDK=google-cloud-cli-444.0.0-linux-x86_64.tar.gz
+ARG GCLOUD_SDK=google-cloud-cli-455.0.0-linux-x86_64.tar.gz
 ARG GCLOUD_INSTALL_DIR="/usr/lib"
 RUN curl -q -o $GCLOUD_SDK https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
     tar xf $GCLOUD_SDK -C $GCLOUD_INSTALL_DIR && rm -rf $GCLOUD_SDK && \


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Update GCloud SDK to the latest available version.
They have updated golang version to 1.21.3 and other dependencies which will help address multiple vulnerabilities observed in https://aetos.pwx.purestorage.com/security/Stork/23-11/2023-11-28-10-57-26-333496

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
```
Update google cloud sdk to to v455.0.0 to fix vulnerabilities.
```

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.11
