### PR TITLE
pb-5019: upgrade the golang version to 1.21.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: go
 go:
-  - 1.21.2
+  - 1.21.4
 before_install:
   - sudo apt-get update -yq || true
   - sudo apt-get install go-md2man -y

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ STORK_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_IMAGE):$(DOCKER_HUB_STORK_TAG)
 CMD_EXECUTOR_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_CMD_EXECUTOR_IMAGE):$(DOCKER_HUB_CMD_EXECUTOR_TAG)
 STORK_TEST_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_TEST_IMAGE):$(DOCKER_HUB_STORK_TEST_TAG)
 
-DOCK_BUILD_CNT := golang:1.21.2
+DOCK_BUILD_CNT := golang:1.21.4
 
 # DO NOT update this to the latest version. We need to keep this old enough so that
 # px_statfs.so can be loaded on OCP 4.12 which uses RHEL8. Use "ldd -r -v ./bin/px_statfs.so" to


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>improvement


**What this PR does / why we need it**:
```
pb-5019: upgrade the golang version to 1.21.4 to fix CVE.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
Issue: Security CVE 2023-45283 with commandexecutor.
Resolution: Upgrading golang version to 1.21.4

**Does this change need to be cherry-picked to a release branch?**:
23.9.1 and 23.11 branches
