### PR TITLE
PWX-35276: Fixing the stork crash for csi volume cloning.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -2773,7 +2773,7 @@ func (p *portworx) UpdateMigratedPersistentVolumeSpec(
 		if err != nil {
 			logrus.Warnf("failed in getting the storage class [%v]: %v", pv.Spec.StorageClassName, err)
 		}
-		if sc != nil {
+		if sc != nil && vInfo != nil {
 			if isCsiProvisioner(sc.Provisioner) {
 				// add csi section in the pv spec
 				if pv.Spec.CSI == nil {


### PR DESCRIPTION
Signed-Off-By:  Diptiranjan

**What type of PR is this?**
bug


**What this PR does / why we need it**:
Fixing the crash in UpdateMigratedPersistentVolumeSpec when vInfo gets passed as nil.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Cloning app with csi volumes hit stork crash.
User Impact: Users could not do app cloning if PVCs in the namespaces use portworx csi volumes
Resolution: Fixed the stork crash for app cloning with csi portworx volumes.

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 23.11

**Test**:
```
➜  stork git:(23.11) ✗ storkctl get applicationclone -n kube-system
NAME       SOURCE    DESTINATION     STAGE   STATUS       VOLUMES   RESOURCES   CREATED               ELAPSED
clone-es   es-thi2   es-thi2-clone   Final   Successful   3/3       8           07 Dec 23 12:45 UTC   4s
➜  stork git:(23.11) ✗ ks describe applicationclone clone-es
Name:         clone-es
Namespace:    kube-system
Labels:       <none>
Annotations:  openstorage.io/auth-secret-name: px-user-token
              openstorage.io/auth-secret-namespace: portworx
API Version:  stork.libopenstorage.org/v1alpha1
Kind:         ApplicationClone
Metadata:
  Creation Timestamp:  2023-12-07T12:45:51Z
  Finalizers:
    stork.libopenstorage.org/finalizer-cleanup
  Generation:  7
  Managed Fields:
    API Version:  stork.libopenstorage.org/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:kubectl.kubernetes.io/last-applied-configuration:
          f:openstorage.io/auth-secret-name:
          f:openstorage.io/auth-secret-namespace:
      f:spec:
        .:
        f:destinationNamespace:
        f:sourceNamespace:
    Manager:      kubectl-client-side-apply
    Operation:    Update
    Time:         2023-12-07T12:45:51Z
    API Version:  stork.libopenstorage.org/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"stork.libopenstorage.org/finalizer-cleanup":
      f:spec:
        f:includeOptionalResourceTypes:
        f:postExecRule:
        f:preExecRule:
        f:replacePolicy:
        f:selectors:
      f:status:
        .:
        f:finishTimestamp:
        f:resources:
        f:stage:
        f:status:
        f:volumes:
    Manager:         stork
    Operation:       Update
    Time:            2023-12-07T12:45:51Z
  Resource Version:  32844973
  UID:               93cc437b-a1e6-4659-a169-df1be88d390f
Spec:
  Destination Namespace:            es-thi2-clone
  Include Optional Resource Types:  <nil>
  Post Exec Rule:
  Pre Exec Rule:
  Replace Policy:                   Retain
  Selectors:                        <nil>
  Source Namespace:                 es-thi2
Status:
  Finish Timestamp:  2023-12-07T12:45:55Z
  Resources:
    Group:    core
    Kind:     PersistentVolumeClaim
    Name:     elasticdata-vol-elasticsearch-data-0
    Reason:   Resource cloned successfully for namespace es-thi2-clone
    Status:   Successful
    Version:  v1
    Group:    core
    Kind:     PersistentVolumeClaim
    Name:     elasticdata-vol-elasticsearch-data-1
    Reason:   Resource cloned successfully for namespace es-thi2-clone
    Status:   Successful
    Version:  v1
    Group:    core
    Kind:     PersistentVolumeClaim
    Name:     elasticdata-vol-elasticsearch-data-2
    Reason:   Resource cloned successfully for namespace es-thi2-clone
    Status:   Successful
    Version:  v1
    Group:    core
    Kind:     PersistentVolume
    Name:     pvc-c484f84b-6850-4603-a26b-4bb558925e40
    Reason:   Resource cloned successfully for namespace es-thi2-clone
    Status:   Successful
    Version:  v1
    Group:    core
    Kind:     PersistentVolume
    Name:     pvc-b69e663a-40cb-4021-81d8-fb6c97da4197
    Reason:   Resource cloned successfully for namespace es-thi2-clone
    Status:   Successful
    Version:  v1
    Group:    core
    Kind:     PersistentVolume
    Name:     pvc-c7348aec-0366-4429-bfd2-eafa67cf289b
    Reason:   Resource cloned successfully for namespace es-thi2-clone
    Status:   Successful
    Version:  v1
    Group:    core
    Kind:     Service
    Name:     elasticsearch-data
    Reason:   Resource cloned successfully for namespace es-thi2-clone
    Status:   Successful
    Version:  v1
    Group:    apps
    Kind:     StatefulSet
    Name:     elasticsearch-data
    Reason:   Resource cloned successfully for namespace es-thi2-clone
    Status:   Successful
    Version:  v1
  Stage:      Final
  Status:     Successful
  Volumes:
    Clone Volume:             pvc-b69e663a-40cb-4021-81d8-fb6c97da4197
    Persistent Volume Claim:  elasticdata-vol-elasticsearch-data-0
    Reason:                   Volume cloned succesfully
    Status:                   Successful
    Volume:                   pvc-b4ae22ff-d35b-4dfb-8b4e-6d9676fc0baa
    Clone Volume:             pvc-c7348aec-0366-4429-bfd2-eafa67cf289b
    Persistent Volume Claim:  elasticdata-vol-elasticsearch-data-1
    Reason:                   Volume cloned succesfully
    Status:                   Successful
    Volume:                   pvc-c706aa00-c0de-4160-8278-47a53129d71a
    Clone Volume:             pvc-c484f84b-6850-4603-a26b-4bb558925e40
    Persistent Volume Claim:  elasticdata-vol-elasticsearch-data-2
    Reason:                   Volume cloned succesfully
    Status:                   Successful
    Volume:                   pvc-5c7a0f99-9fd6-40cb-82b6-3964d221d6a7
Events:
  Type    Reason      Age                  From   Message
  ----    ------      ----                 ----   -------
  Normal  Successful  9m10s                stork  Volume pvc-b4ae22ff-d35b-4dfb-8b4e-6d9676fc0baa cloned successfully
  Normal  Successful  9m10s                stork  Volume pvc-c706aa00-c0de-4160-8278-47a53129d71a cloned successfully
  Normal  Successful  9m10s                stork  Volume pvc-5c7a0f99-9fd6-40cb-82b6-3964d221d6a7 cloned successfully
  Normal  Successful  9m9s                 stork  /v1, Kind=PersistentVolumeClaim elasticdata-vol-elasticsearch-data-0: Resource cloned successfully for namespace es-thi2-clone
  Normal  Successful  9m9s                 stork  /v1, Kind=PersistentVolumeClaim elasticdata-vol-elasticsearch-data-1: Resource cloned successfully for namespace es-thi2-clone
  Normal  Successful  9m9s                 stork  /v1, Kind=PersistentVolumeClaim elasticdata-vol-elasticsearch-data-2: Resource cloned successfully for namespace es-thi2-clone
  Normal  Successful  9m9s                 stork  /v1, Kind=PersistentVolume pvc-c484f84b-6850-4603-a26b-4bb558925e40: Resource cloned successfully for namespace es-thi2-clone
  Normal  Successful  9m9s                 stork  /v1, Kind=PersistentVolume pvc-b69e663a-40cb-4021-81d8-fb6c97da4197: Resource cloned successfully for namespace es-thi2-clone
  Normal  Successful  9m9s                 stork  /v1, Kind=PersistentVolume pvc-c7348aec-0366-4429-bfd2-eafa67cf289b: Resource cloned successfully for namespace es-thi2-clone
  Normal  Successful  9m9s (x2 over 9m9s)  stork  (combined from similar events): apps/v1, Kind=StatefulSet elasticsearch-data: Resource cloned successfully for namespace es-thi2-clone
➜  stork git:(23.11) ✗ kubectl get po -n es-thi2-clone
NAME                   READY   STATUS    RESTARTS   AGE
elasticsearch-data-0   1/1     Running   0          9m44s
elasticsearch-data-1   1/1     Running   0          9m24s
elasticsearch-data-2   1/1     Running   0          9m18s

➜  stork git:(23.11) ✗ ks get pvc -n es-thi2-clone
NAME                                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
elasticdata-vol-elasticsearch-data-0   Bound    pvc-b69e663a-40cb-4021-81d8-fb6c97da4197   2Gi        RWO            px-csi-auth    11m
elasticdata-vol-elasticsearch-data-1   Bound    pvc-c7348aec-0366-4429-bfd2-eafa67cf289b   2Gi        RWO            px-csi-auth    11m
elasticdata-vol-elasticsearch-data-2   Bound    pvc-c484f84b-6850-4603-a26b-4bb558925e40   2Gi        RWO            px-csi-auth    11m

➜  stork git:(23.11) ✗ ks get sc px-csi-auth -o yaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"allowVolumeExpansion":true,"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{},"name":"px-csi-auth"},"parameters":{"csi.storage.k8s.io/controller-expand-secret-name":"px-user-token","csi.storage.k8s.io/controller-expand-secret-namespace":"portworx","csi.storage.k8s.io/node-publish-secret-name":"px-user-token","csi.storage.k8s.io/node-publish-secret-namespace":"portworx","csi.storage.k8s.io/provisioner-secret-name":"px-user-token","csi.storage.k8s.io/provisioner-secret-namespace":"portworx","repl":"2"},"provisioner":"pxd.portworx.com","reclaimPolicy":"Delete","volumeBindingMode":"Immediate"}
  creationTimestamp: "2023-12-02T11:15:42Z"
  name: px-csi-auth
  resourceVersion: "29932264"
  uid: 0f3fce13-530d-4560-9548-0c2c05dd66b6
parameters:
  csi.storage.k8s.io/controller-expand-secret-name: px-user-token
  csi.storage.k8s.io/controller-expand-secret-namespace: portworx
  csi.storage.k8s.io/node-publish-secret-name: px-user-token
  csi.storage.k8s.io/node-publish-secret-namespace: portworx
  csi.storage.k8s.io/provisioner-secret-name: px-user-token
  csi.storage.k8s.io/provisioner-secret-namespace: portworx
  repl: "2"
provisioner: pxd.portworx.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
```
