### PR TITLE
pb-5175: Upgraded the base image of cmd executor from ubi8 to ubi9

### DIFF
--- a/Dockerfile.cmdexecutor
+++ b/Dockerfile.cmdexecutor
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 MAINTAINER Portworx Inc. <support@portworx.com>
 
 ARG VERSION=master


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>improvement
**What this PR does / why we need it**:
```
    pb-5175: Upgraded the base image of cmd executor from ubi8 to ubi9

            - Upgraded the base image of cmd executor from ubi8 to ubi9 as
              we are hitting lib version mismatch error.
```

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:
```release-note
Issue: Fixed CVE 2023-45283 because of old goland 1.19.10
User Impact: cmd executor image will have CVE  2023-45283  reported
Resolution: Upgraded the golang version to 1.21.4 and base image of cmd executor from ubi8 to ubi9

```

**Does this change need to be cherry-picked to a release branch?**:
23.9.1 and 23.11

**Testing:**

Validated the cmd executor pod completed successfully.
```
[root@ip-10-13-10-160 ~]# kubectl logs -f -n portworx pod-cmd-executor-a81e752a-e18e-4319-9c72-9d12ba44d1e5
time="2023-12-11T04:32:54Z" level=info msg="Running pod command executor: 2.7.0-b4fe7b0a3"
time="2023-12-11T04:32:54Z" level=info msg="Using timeout: 900 seconds"
time="2023-12-11T04:32:54Z" level=info msg="Checking status on command: mysql --user=root --password=$MYSQL_ROOT_PASSWORD -Bse 'FLUSH TABLES WITH READ LOCK;system ${WAIT_CMD};'"
time="2023-12-11T04:32:54Z" level=info msg="check status on pod: [mysql0] mysql-77ccff5f9c-b9wrn with backoff: {2s 1 0.1 450 0s} and status file: /tmp/stork-cmd-done-a81e752a-e18e-4319-9c72-9d12ba44d1e5"
time="2023-12-11T04:32:54Z" level=info msg="Running command: mysql --user=root --password=$MYSQL_ROOT_PASSWORD -Bse 'FLUSH TABLES WITH READ LOCK;system /tmp/wait-a81e752a-e18e-4319-9c72-9d12ba44d1e5.sh;' on pod: [mysql0] mysql-77ccff5f9c-b9wrn"
time="2023-12-11T04:32:54Z" level=info msg="checked status on pod: [mysql0] mysql-77ccff5f9c-b9wrn with result: job not finished yet, will retry later"
time="2023-12-11T04:32:57Z" level=info msg="checked status on pod: [mysql0] mysql-77ccff5f9c-b9wrn with result: job finished"
time="2023-12-11T04:32:57Z" level=info msg="finished waiting for pod, 0 pods left to finish"
time="2023-12-11T04:32:57Z" level=info msg="successfully executed command: mysql --user=root --password=$MYSQL_ROOT_PASSWORD -Bse 'FLUSH TABLES WITH READ LOCK;system ${WAIT_CMD};' on all pods: [mysql0/mysql-77ccff5f9c-b9wrn]"
[root@ip-10-13-10-160 ~]#
```