### PR TITLE
[PWX-35181] Changing the kubeconfig used by discoveryClient

### DIFF
--- a/pkg/storkctl/applicationbackup.go
+++ b/pkg/storkctl/applicationbackup.go
@@ -65,7 +65,7 @@ func newCreateApplicationBackupCommand(cmdFactory Factory, ioStreams genericclio
 			}
 
 			if len(resourceTypes) > 0 {
-				resourceList, err := getResourceTypes(resourceTypes, ioStreams)
+				resourceList, err := getResourceTypes(resourceTypes, ioStreams, cmdFactory)
 				if err != nil {
 					util.CheckErr(err)
 					return
@@ -287,11 +287,11 @@ func waitForApplicationBackup(name, namespace string, ioStreams genericclioption
 	return msg, err
 }
 
-func getResourceTypes(resourceType string, ioStreams genericclioptions.IOStreams) ([]string, error) {
+func getResourceTypes(resourceType string, ioStreams genericclioptions.IOStreams, cmdFactory Factory) ([]string, error) {
 	resourceList := make([]string, 0)
 	resourceTypes := strings.Split(resourceType, ",")
 
-	discoveryClient, err := getDiscoveryClientForApiResources()
+	discoveryClient, err := getDiscoveryClientForApiResources(cmdFactory)
 	if err != nil {
 		return resourceList, fmt.Errorf("error getting discoveryclient: %v", err)
 	}

--- a/pkg/storkctl/applicationbackup.go
+++ b/pkg/storkctl/applicationbackup.go
@@ -65,7 +65,7 @@ func newCreateApplicationBackupCommand(cmdFactory Factory, ioStreams genericclio
 			}
 
 			if len(resourceTypes) > 0 {
-				resourceList, err := getResourceTypes(resourceTypes, ioStreams, cmdFactory)
+				resourceList, err := getResourceTypes(resourceTypes, cmdFactory, ioStreams)
 				if err != nil {
 					util.CheckErr(err)
 					return
@@ -287,7 +287,7 @@ func waitForApplicationBackup(name, namespace string, ioStreams genericclioption
 	return msg, err
 }
 
-func getResourceTypes(resourceType string, ioStreams genericclioptions.IOStreams, cmdFactory Factory) ([]string, error) {
+func getResourceTypes(resourceType string, cmdFactory Factory, ioStreams genericclioptions.IOStreams) ([]string, error) {
 	resourceList := make([]string, 0)
 	resourceTypes := strings.Split(resourceType, ",")
 

--- a/pkg/storkctl/common.go
+++ b/pkg/storkctl/common.go
@@ -30,9 +30,8 @@ func printMsg(msg string, out io.Writer) {
 	}
 }
 
-func getDiscoveryClientForApiResources() (discovery.DiscoveryInterface, error) {
-	tempFactory := NewFactory()
-	config, err := tempFactory.GetConfig()
+func getDiscoveryClientForApiResources(cmdFactory Factory) (discovery.DiscoveryInterface, error) {
+	config, err := cmdFactory.GetConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -161,7 +161,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 			//validate excludeResourceTypes
 			if len(excludeResourceTypes) != 0 {
 				resourceTypes := strings.Join(excludeResourceTypes, ",")
-				excludeResourceTypes, err = getResourceTypes(resourceTypes, ioStreams)
+				excludeResourceTypes, err = getResourceTypes(resourceTypes, ioStreams, cmdFactory)
 				if err != nil {
 					util.CheckErr(err)
 					return

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -161,7 +161,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 			//validate excludeResourceTypes
 			if len(excludeResourceTypes) != 0 {
 				resourceTypes := strings.Join(excludeResourceTypes, ",")
-				excludeResourceTypes, err = getResourceTypes(resourceTypes, ioStreams, cmdFactory)
+				excludeResourceTypes, err = getResourceTypes(resourceTypes, cmdFactory, ioStreams)
 				if err != nil {
 					util.CheckErr(err)
 					return


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Fix for Bug identified by QA during testing

**Does this PR change a user-facing CRD or CLI?**:
Yes, fixes the resource Type validation in exclude-resource-types flag in storkctl create migrationschedule and storkctl create applicationbackup

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.11

**Testing Details**
When trying to run the command from a devVM we were observing the below error :
```
storkctl create migrationschedule ms-ex2 -c cp --namespaces default --exclude-resource-types deployment --kubeconfig=/root/go/src/github.com/libopenstorage/stork/configs/src_53.yaml
error: error getting discoveryclient: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```

Now after these changes, the above command passed successfully
```
storkctl create migrationschedule ms-ex3 -c cp --namespaces default --exclude-resource-types deployment --kubeconfig=/root/go/src/github.com/libopenstorage/stork/configs/src_53.yaml

MigrationSchedule ms-ex3 created successfully
```
