### PR TITLE
[PWX-35357] updating retain flag description

### DIFF
--- a/pkg/storkctl/schedulepolicy.go
+++ b/pkg/storkctl/schedulepolicy.go
@@ -203,7 +203,7 @@ func newCreateSchedulePolicyCommand(cmdFactory Factory, ioStreams genericcliopti
 	// Picking up user inputs and setting the defaults for flags
 	createSchedulePolicyCommand.Flags().StringVarP(&schedulePolicyType, "policy-type", "t", "Interval", "Select Type of schedule policy to apply. Interval / Daily / Weekly / Monthly.")
 	createSchedulePolicyCommand.Flags().IntVarP(&intervalMinutes, intervalMinutesFlag, "i", 30, "Specify the interval, in minutes, after which Stork should trigger the operation.")
-	createSchedulePolicyCommand.Flags().IntVarP(&retain, "retain", "", 0, "Specify how many backups triggered as part of this schedule should be retained.")
+	createSchedulePolicyCommand.Flags().IntVarP(&retain, "retain", "", 0, "For backup operations,specify how many backups triggered as part of this schedule should be retained.")
 	createSchedulePolicyCommand.Flags().StringVarP(&time, timeFlag, "", "12:00AM", "Specify the time of the day in the 12 hour AM/PM format, when Stork should trigger the operation.")
 	createSchedulePolicyCommand.Flags().StringVarP(&dailyForceFullSnapshotDay, forceFullSnapshotDayFlag, "", "Monday", "For daily scheduled backup operations, specify on which day to trigger a full backup.")
 	createSchedulePolicyCommand.Flags().StringVarP(&dayOfWeek, dayOfWeekFlag, "", "Sunday", "Specify the day of the week when Stork should trigger the operation. You can use both the abbreviated or the full name of the day of the week.")


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Update the --retain flag description in storkctl create schedulepolicy command
from  `--retain int  Specify how many backups triggered as part of this schedule should be retained.`

to `--retain int  For backup operations, specify how many backups triggered as part of this schedule should be retained.`

**Does this PR change a user-facing CRD or CLI?**:
Yes
```
[root@ip-10-13-193-200 ~]# storkctl create schedulepolicy -h
Create schedule policy

Usage:
  storkctl create schedulepolicy [flags]

Aliases:
  schedulepolicy, sp

Flags:
      --date-of-month int                Specify the date of the month when Stork should trigger the operation. (default 1)
      --day-of-week string               Specify the day of the week when Stork should trigger the operation. You can use both the abbreviated or the full name of the day of the week. (default "Sunday")
      --force-full-snapshot-day string   For daily scheduled backup operations, specify on which day to trigger a full backup. (default "Monday")
  -h, --help                             help for schedulepolicy
  -i, --interval-minutes int             Specify the interval, in minutes, after which Stork should trigger the operation. (default 30)
  -t, --policy-type string               Select Type of schedule policy to apply. Interval / Daily / Weekly / Monthly. (default "Interval")
      --retain int                       For backup operations, specify how many backups triggered as part of this schedule should be retained.
      --time string                      Specify the time of the day in the 12 hour AM/PM format, when Stork should trigger the operation. (default "12:00AM")
```

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.11

