### PR TITLE
[PWX:35392] fixing the mistake made in namespace validation

### DIFF
--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -578,13 +578,17 @@ func getMigrationNamespaces(namespaceList []string, namespaceSelectors map[strin
 	for _, ns := range namespaceList {
 		uniqueNamespaces[ns] = true
 	}
-	labelSelectorNamespaces, err := core.Instance().ListNamespaces(namespaceSelectors)
-	if err != nil {
-		return nil, err
+
+	for key, val := range namespaceSelectors {
+		namespaces, err := core.Instance().ListNamespaces(map[string]string{key: val})
+		if err != nil {
+			return nil, err
+		}
+		for _, namespace := range namespaces.Items {
+			uniqueNamespaces[namespace.GetName()] = true
+		}
 	}
-	for _, ns := range labelSelectorNamespaces.Items {
-		uniqueNamespaces[ns.GetName()] = true
-	}
+
 	migrationNamespaces := make([]string, 0, len(uniqueNamespaces))
 	for namespace := range uniqueNamespaces {
 		migrationNamespaces = append(migrationNamespaces, namespace)


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
The validation added for namespace validation in storkctl create migrationschedule has a bug.
The selectors were being AND'ed instead of OR'ed

**Does this PR change a user-facing CRD or CLI?**:
Yes updates a validation for storkctl create migrationschedule

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.11

