### PR TITLE
PB-4201 :: OCP snapshot routed back to ceph/rbd from kdmp

### DIFF
--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -778,10 +778,6 @@ func IsCSIDriverWithoutSnapshotSupport(pv *v1.PersistentVolume) bool {
 				return true
 			}
 		}
-		// For now, it is decided to take generic backup for OCP provisoiners.
-		if driverName == ocpCephfsProvisioner || driverName == ocpRbdProvisioner {
-			return true
-		}
 		// vsphere, efs, azure file and google file does not support snapshot.
 		// So defaulting to kdmp by not setting volumesnapshot class.
 		for _, name := range csiDriverWithoutSnapshotSupport {

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -213,16 +213,11 @@ func (a *ApplicationBackupController) updateWithAllNamespaces(backup *stork_api.
 		return fmt.Errorf("error updating with all namespaces for wildcard: %v", err)
 	}
 	pxNs, _ := utils.GetPortworxNamespace()
-	// Create a map to store the namespaces to be ignored for fast lookup
-	ignoreNamespaces := map[string]bool{
-		pxNs:              true,
-		"kube-system":     true,
-		"kube-public":     true,
-		"kube-node-lease": true,
-	}
+	// add portworx ns to Ignored NS map
+	utils.IgnoreNamespaces[pxNs] = true
 	namespacesToBackup := make([]string, 0)
 	for _, ns := range namespaces.Items {
-		if _, found := ignoreNamespaces[ns.Name]; !found {
+		if _, found := utils.IgnoreNamespaces[ns.Name]; !found {
 			namespacesToBackup = append(namespacesToBackup, ns.Name)
 		}
 	}
@@ -307,15 +302,10 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		if len(backup.Spec.Namespaces) == 0 {
 			pxNs, _ = utils.GetPortworxNamespace()
 		}
-		// Create a map to store the namespaces to be ignored for fast lookup
-		ignoreNamespaces := map[string]bool{
-			pxNs:              true,
-			"kube-system":     true,
-			"kube-public":     true,
-			"kube-node-lease": true,
-		}
+		// add portworx ns to Ignored NS map
+		utils.IgnoreNamespaces[pxNs] = true
 		for _, namespace := range namespaces.Items {
-			if _, found := ignoreNamespaces[namespace.Name]; !found {
+			if _, found := utils.IgnoreNamespaces[namespace.Name]; !found {
 				selectedNamespaces = append(selectedNamespaces, namespace.Name)
 			}
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -102,6 +102,13 @@ const (
 	PXServiceName = "portworx-service"
 )
 
+// Map of ignored namespace to be backed up for faster lookout
+var IgnoreNamespaces = map[string]bool{
+	"kube-system":     true,
+	"kube-public":     true,
+	"kube-node-lease": true,
+}
+
 // ParseKeyValueList parses a list of key=values string into a map
 func ParseKeyValueList(expressions []string) (map[string]string, error) {
 	matchLabels := make(map[string]string)


### PR DESCRIPTION
- check for driver ocpRbdProvisioner and ocpCephfsProvisioner removed
- IgnoreNamespaces map moved to utils


**What type of PR is this?**

improvement


**What this PR does / why we need it**:

This PR ensures the volume snapshots in case of ceph/rbd provisioner is taken by csi itself rather than KDMP as overflowing of data over PVD size is fixed. It also includes enhancement of ignore namespaces for future utility.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no.
-->

**Is a release note needed?**:
<!--
no.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
Branch corresponding to px-backup 2.7.0 release
-->

