### PR TITLE
fix url to download fedora qcow image from

### DIFF
--- a/test/integration_test/specs/kubevirt-templates/fedora/fedora-template-pvc-rootdisk.yaml
+++ b/test/integration_test/specs/kubevirt-templates/fedora/fedora-template-pvc-rootdisk.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: containerized-data-importer
   annotations:
-    cdi.kubevirt.io/storage.import.endpoint: https://ftp-nyc.osuosl.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-37-1.7.x86_64.qcow2
+    cdi.kubevirt.io/storage.import.endpoint:  https://ftp-nyc.osuosl.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2
 spec:
   storageClassName: sc-sharedv4svc-nolock
   accessModes:


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
* The old url being used to download the template for fedora has been changed so replacing it with the new url that works

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
