### PR TITLE
[PWX-35512] Preventing pods from being assigned on nodes not available to Volume Driver

### DIFF
--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -39,6 +39,8 @@ const (
 	regionPriorityScore float64 = 10
 	// defaultScore Score assigned to a node which doesn't have data for any volume
 	defaultScore float64 = 5
+	// invalidNodeScore Score assigned to a node which is not available to the volume driver
+	invalidNodeScore float64 = 0
 	// storageDownNodeScorePenaltyPercentage is the percentage by which a node's score
 	// will take a hit if the node's status is StorageDown
 	storageDownNodeScorePenaltyPercentage float64 = 50
@@ -560,7 +562,7 @@ func (e *Extender) processPrioritizeRequest(w http.ResponseWriter, req *http.Req
 		storklog.PodLog(pod).Debugf("%+v", node.Status.Addresses)
 	}
 
-	// Intialize scores to 0
+	// Initialize scores to 0
 	priorityMap := make(map[string]int)
 	for _, node := range args.Nodes.Items {
 		for _, address := range node.Status.Addresses {
@@ -696,8 +698,14 @@ func (e *Extender) processPrioritizeRequest(w http.ResponseWriter, req *http.Req
 				storklog.PodLog(pod).Debugf("Volume %v allocated in regions: %v", volume.VolumeName, regionInfo.PreferredLocality)
 
 				for k8sNodeIndex, node := range args.Nodes.Items {
-					storageNode := k8sNodeIndexStorageNodeMap[k8sNodeIndex]
-					priorityMap[node.Name] += int(e.getNodeScore(node, volume, &rackInfo, &zoneInfo, &regionInfo, storageNode))
+					if storageNode, keyExists := k8sNodeIndexStorageNodeMap[k8sNodeIndex]; !keyExists {
+						// the k8sNodeIndex's corresponding node isn't available to the driver,
+						// so we shouldn't schedule pods on this node
+						// we will assign a negative score here and set it to 0 when encoding the response
+						priorityMap[node.Name] = -1
+					} else {
+						priorityMap[node.Name] += int(e.getNodeScore(node, volume, &rackInfo, &zoneInfo, &regionInfo, storageNode))
+					}
 				}
 			}
 
@@ -715,6 +723,8 @@ sendResponse:
 		score, ok := priorityMap[node.Name]
 		if !ok || score == 0 {
 			score = int(defaultScore)
+		} else if score == -1 {
+			score = int(invalidNodeScore)
 		}
 		hostPriority := schedulerapi.HostPriority{Host: node.Name, Score: int64(score)}
 		respList = append(respList, hostPriority)
@@ -759,17 +769,23 @@ func (e *Extender) updateForAntiHyperconvergence(
 		}
 	}
 	for k8sNodeIndex, node := range args.Nodes.Items {
-		storageNode := k8sNodeIndexStorageNodeMap[k8sNodeIndex]
-		// storageNode.StorageID = datanodeID
-		// Give defaultScore to the nodes where NeedsAntiHyperconvergence volume exist
-		// to give them a lower score
-		if val, ok := needsAntiHyperconvergenceReplicaNodes[storageNode.StorageID]; ok && val {
-			priorityMap[node.Name] = int(defaultScore)
-		} else if storageNode.Status == volume.NodeOnline {
-			// In a scenario where regular volumes do not exist
-			// Raise the score of non replica nodes to give them
-			// a score higher than the default score
-			priorityMap[node.Name] += int(nodePriorityScore)
+		if storageNode, keyExists := k8sNodeIndexStorageNodeMap[k8sNodeIndex]; !keyExists {
+			// the k8sNodeIndex's corresponding node isn't available to the driver,
+			// so we shouldn't schedule pods on this node
+			// we will assign a negative score here and set it to 0 when encoding the response
+			priorityMap[node.Name] = -1
+		} else {
+			// storageNode.StorageID = datanodeID
+			// Give defaultScore to the nodes where NeedsAntiHyperconvergence volume exist
+			// to give them a lower score
+			if val, ok := needsAntiHyperconvergenceReplicaNodes[storageNode.StorageID]; ok && val {
+				priorityMap[node.Name] = int(defaultScore)
+			} else if storageNode.Status == volume.NodeOnline {
+				// In a scenario where regular volumes do not exist
+				// Raise the score of non replica nodes to give them
+				// a score higher than the default score
+				priorityMap[node.Name] += int(nodePriorityScore)
+			}
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
>bug
>unit-test

**What this PR does / why we need it**:
As discussed in [PWX-35512](https://portworx.atlassian.net/browse/PWX-35512), if for some reason a node received as part of the Prioritize request is not available to the driver, we should avoid scheduling pods on that node. This is achieved by assigning the node a 0 score so that this node is ignored by the k8s scheduler during scheduling.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Maybe

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.11

**Testing Details**
I have added unit tests for both hyperconverged and anti-hyperconverged cases.
The QA can replicate the original issue to ensure that the proposed fix is working as expected.


[PWX-35512]: https://portworx.atlassian.net/browse/PWX-35512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ