### PR TITLE
PTX-21639: Namespace delete error should not error out if namespace does not exists in migration tests cleanup.

### DIFF
--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -2533,7 +2533,9 @@ func blowNamespacesForTest(t *testing.T, instanceID, appKey string, skipDestDele
 
 	namespace := fmt.Sprintf("%s-%s", appKey, instanceID)
 	err = core.Instance().DeleteNamespace(namespace)
-	require.NoError(t, err, "failed to delete namespace %s on destination cluster", namespace)
+	if !errors.IsNotFound(err) {
+		require.NoError(t, err, "failed to delete namespace %s on destination cluster", namespace)
+	}
 
 	// for negative cases the namespace is not even created on destination, so skip deleting it
 	if skipDestDeletion {
@@ -2543,7 +2545,9 @@ func blowNamespacesForTest(t *testing.T, instanceID, appKey string, skipDestDele
 	require.NoError(t, err, "failed to set kubeconfig to destination cluster: %v", err)
 
 	err = core.Instance().DeleteNamespace(namespace)
-	require.NoError(t, err, "failed to delete namespace %s on destination cluster", namespace)
+	if !errors.IsNotFound(err) {
+		require.NoError(t, err, "failed to delete namespace %s on destination cluster", namespace)
+	}
 
 	err = setSourceKubeConfig()
 	require.NoError(t, err, "failed to set kubeconfig to destination cluster: %v", err)


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
Namespace delete error should not error out if namespace does not exists in migration tests cleanup.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->


**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.11
-->

**Test**
https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2023.11-dev/job/migration-op-k8s-1-25-0/54/