### PR TITLE
[PWX-35476] Skip custom schedule policy creation in case migrationschedule creation will fail

### DIFF
--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -196,10 +196,9 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				var schedulePolicy storkv1.SchedulePolicy
 				schedulePolicy.Name = schedulePolicyName
 				schedulePolicy.Policy = policyItem
-				ms, err := storkops.Instance().GetMigrationSchedule(migrationScheduleName, cmdFactory.GetNamespace())
-				if ms != nil {
-					logrus.Infof("MigrationSchedule %s already exists, skipping schedulePolicy creation", migrationScheduleName)
-				} else {
+				ms, _ := storkops.Instance().GetMigrationSchedule(migrationScheduleName, cmdFactory.GetNamespace())
+				// Create custom schedulePolicy only if migrationSchedule doesn't already exist
+				if ms == nil {
 					_, err = storkops.Instance().CreateSchedulePolicy(&schedulePolicy)
 					if err != nil {
 						util.CheckErr(fmt.Errorf("could not create a schedule policy with specified interval: %v", err))

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -196,10 +196,15 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				var schedulePolicy storkv1.SchedulePolicy
 				schedulePolicy.Name = schedulePolicyName
 				schedulePolicy.Policy = policyItem
-				_, err = storkops.Instance().CreateSchedulePolicy(&schedulePolicy)
-				if err != nil {
-					util.CheckErr(fmt.Errorf("could not create a schedule policy with specified interval: %v", err))
-					return
+				ms, err := storkops.Instance().GetMigrationSchedule(migrationScheduleName, cmdFactory.GetNamespace())
+				if ms != nil {
+					logrus.Infof("MigrationSchedule %s already exists, skipping schedulePolicy creation", migrationScheduleName)
+				} else {
+					_, err = storkops.Instance().CreateSchedulePolicy(&schedulePolicy)
+					if err != nil {
+						util.CheckErr(fmt.Errorf("could not create a schedule policy with specified interval: %v", err))
+						return
+					}
 				}
 			} else if c.Flags().Changed(schedulePolicyNameFlag) {
 				_, err := storkops.Instance().GetSchedulePolicy(schedulePolicyName)

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -196,9 +196,9 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 				var schedulePolicy storkv1.SchedulePolicy
 				schedulePolicy.Name = schedulePolicyName
 				schedulePolicy.Policy = policyItem
-				ms, _ := storkops.Instance().GetMigrationSchedule(migrationScheduleName, cmdFactory.GetNamespace())
+				_, err = storkops.Instance().GetMigrationSchedule(migrationScheduleName, cmdFactory.GetNamespace())
 				// Create custom schedulePolicy only if migrationSchedule doesn't already exist
-				if ms == nil {
+				if err != nil {
 					_, err = storkops.Instance().CreateSchedulePolicy(&schedulePolicy)
 					if err != nil {
 						util.CheckErr(fmt.Errorf("could not create a schedule policy with specified interval: %v", err))

--- a/pkg/storkctl/migrationschedule_test.go
+++ b/pkg/storkctl/migrationschedule_test.go
@@ -404,10 +404,15 @@ func TestCreateMigrationScheduleWithInvalidInterval(t *testing.T) {
 func TestCreateDuplicateMigrationSchedules(t *testing.T) {
 	defer resetTest()
 	createMigrationScheduleAndVerify(t, "createmigrationschedule", "testpolicy", "default", "clusterpair1", []string{"default"}, "", "", true)
-	cmdArgs := []string{"create", "migrationschedules", "-s", "testpolicy", "-c", "clusterpair1", "--namespaces", "default", "createmigrationschedule"}
+	cmdArgs := []string{"create", "migrationschedules", "-c", "clusterpair1", "--namespaces", "default", "-i", "5", "createmigrationschedule"}
 
 	expected := "Error from server (AlreadyExists): migrationschedules.stork.libopenstorage.org \"createmigrationschedule\" already exists"
 	testCommon(t, cmdArgs, nil, expected, true)
+
+	//Also verify that the custom schedule policy was not created during the second try
+	_, err := storkops.Instance().GetSchedulePolicy("createmigrationschedule")
+	require.EqualErrorf(t, err, "schedulepolicies.stork.libopenstorage.org \"createmigrationschedule\" not found", "Schedule Policy expected not found error did not occur")
+
 }
 
 func TestMigrationScheduleWithInvalidSchedulePolicy(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
In case migration schedule creation is going to fail, we should skip creating custom schedulepolicy (if any) since it will be an orphan resource which will not be used.
[PWX-35476](https://portworx.atlassian.net/browse/PWX-35476)

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.11



[PWX-35476]: https://portworx.atlassian.net/browse/PWX-35476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ