### PR TITLE
PWX-35513: Fix for correctly updating the volume labels from the locator.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -518,12 +518,7 @@ func (p *portworx) inspectVolume(volDriver volume.VolumeDriver, volumeID string)
 		info.ParentID = vols[0].Source.Parent
 	}
 
-	if len(vols[0].Locator.GetVolumeLabels()) > 0 {
-		info.Labels = vols[0].Locator.GetVolumeLabels()
-	} else {
-		info.Labels = make(map[string]string)
-	}
-
+	info.Labels = make(map[string]string)
 	for k, v := range vols[0].Spec.GetVolumeLabels() {
 		info.Labels[k] = v
 	}

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -1868,6 +1868,19 @@ func updateClusterDomain(t *testing.T, clusterDomains *storkv1.ClusterDomains, a
 	}
 }
 
+func updatePXVolumeLabel(t *testing.T, volume string, labelsMap map[string]string) {
+	labels := make([]string, 0)
+	for k, v := range labelsMap {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+	labelString := strings.Join(labels, ",")
+	pxNode := node.GetStorageDriverNodes()[0]
+	out, err := volumeDriver.GetPxctlCmdOutput(
+		pxNode, fmt.Sprintf("volume update %s --label %s", volume, labelString))
+	require.NoError(t, err)
+	logrus.Infof(out)
+}
+
 func getSupportedOperatorCRMapping() map[string][]meta_v1.APIResource {
 	operatorAppToCRMap := make(map[string][]meta_v1.APIResource)
 	// mongodbcommunity CR

--- a/test/integration_test/specs/test-sv4-replica1-prefer-remote-only/portworx/px-sc.yaml
+++ b/test/integration_test/specs/test-sv4-replica1-prefer-remote-only/portworx/px-sc.yaml
@@ -1,0 +1,13 @@
+##### Portworx storage class
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: test-sv4-replica1-prefer-remote-only
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "1"
+  sharedv4: "true"
+  sharedv4_svc_type: "ClusterIP"
+  "stork.libopenstorage.org/preferRemoteNodeOnly": "true"
+allowVolumeExpansion: true
+

--- a/test/integration_test/specs/test-sv4-replica1-prefer-remote-only/test-sv4-svc-repl1-prefer-remote-only.yaml
+++ b/test/integration_test/specs/test-sv4-replica1-prefer-remote-only/test-sv4-svc-repl1-prefer-remote-only.yaml
@@ -1,0 +1,81 @@
+##### Portworx persistent volume claim
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-sv4-replica1-prefer-remote-only
+spec:
+  storageClassName: test-sv4-replica1-prefer-remote-only
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-sv4-replica1-prefer-remote-only
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-sv4-replica1-prefer-remote-only
+  template:
+    metadata:
+      labels:
+        app: test-sv4-replica1-prefer-remote-only
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - test-sv4-replica1-prefer-remote-only
+            topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: sv4test
+        image: portworx/sharedv4-test:torpedo
+        imagePullPolicy: Always
+        command: ["python", "/app/fileio.py"]
+        args: ["--lock", "--interval=0.25", "$(SHARED_FILE)", "$(LOCAL_FILE)"]
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: SHARED_FILE
+            value: "/shared-vol/$(MY_POD_NAME)"
+          - name: LOCAL_FILE
+            value: "/local-vol/$(MY_POD_NAME)"
+        volumeMounts:
+        - name: test-sv4-replica1-prefer-remote-only
+          mountPath: /shared-vol
+        - name: local-vol
+          mountPath: /local-vol
+      - name: sv4test-reader
+        image: portworx/sharedv4-test:torpedo
+        imagePullPolicy: Always
+        command: ["python", "/app/reader.py"]
+        # sleeping for 9 seconds from 3 * number of pods * seconds
+        args: ["--interval=9", "$(LOCAL_FILE)"]
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: LOCAL_FILE
+            value: "/local-vol/$(MY_POD_NAME)"
+        volumeMounts:
+        - name: local-vol
+          mountPath: /local-vol
+      volumes:
+      - name: test-sv4-replica1-prefer-remote-only
+        persistentVolumeClaim:
+          claimName: test-sv4-replica1-prefer-remote-only
+      - name: local-vol
+        emptyDir: {}
+
+


### PR DESCRIPTION
Signed-Off-By:  Diptiranjan

-    Fix for correctly updating the volume labels from the locator.
-    Integration test for the above fix.

**What type of PR is this?**
>bug

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Stork was not honoring locator volume labels correctly while scheduling pods.
User Impact: Occasionally, pod can not get scheduled if preferRemoteNodeOnly=true but later px volume gets updated with preferRemoteNodeOnly=false and no remote nodes are available for scheduling.
Resolution: With the fix, pod can still get scheduled on the node where the volume replica exists.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 23.11
-->

**Test**
1. Ran test manually.
2. Integration test output 
```
=== RUN   TestExtender
time="2024-01-09 16:21:39" level=info msg="Set kubeConfig to Source"
2024-01-09 16:21:39 +0000:[INFO] [k8s.(*K8s).parseK8SNode:#866] - Parsed node [ip-10-13-192-160.pwx.purestorage.com] as Type: Worker, Zone: , Region
2024-01-09 16:21:39 +0000:[INFO] [k8s.(*K8s).parseK8SNode:#866] - Parsed node [ip-10-13-196-194.pwx.purestorage.com] as Type: Master, Zone: , Region
2024-01-09 16:21:39 +0000:[INFO] [k8s.(*K8s).parseK8SNode:#866] - Parsed node [ip-10-13-198-107.pwx.purestorage.com] as Type: Worker, Zone: , Region
2024-01-09 16:21:39 +0000:[INFO] [k8s.(*K8s).parseK8SNode:#866] - Parsed node [ip-10-13-199-55.pwx.purestorage.com] as Type: Worker, Zone: , Region
2024-01-09 16:21:39 +0000:[INFO] RefreshDriverEndpoints: volume driver's namespace (portworx namespace) is updated to [kube-system]
2024-01-09 16:21:40 +0000:[INFO] [portworx.(*portworx).testAndSetEndpoint:#2877] - Using 10.233.45.53:9020 as endpoint for portworx volume driver
2024-01-09 16:21:40 +0000:[INFO] [portworx.(*portworx).testAndSetEndpoint:#2877] - Using 10.233.45.53:9020 as endpoint for portworx volume driver
2024-01-09 16:21:40 +0000:[INFO] [portworx.(*portworx).updateNode:#693] - Updating node [ip-10-13-192-160.pwx.purestorage.com]
2024-01-09 16:21:41 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#828] - PX is enabled on node ip-10-13-192-160.pwx.purestorage.com.
2024-01-09 16:21:41 +0000:[INFO] [portworx.(*portworx).updateNode:#693] - Updating node [ip-10-13-196-194.pwx.purestorage.com]
2024-01-09 16:21:41 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#812] - PX is not enabled on node ip-10-13-196-194.pwx.purestorage.com. Will be skipped for tests.
2024-01-09 16:21:41 +0000:[INFO] [portworx.(*portworx).updateNode:#693] - Updating node [ip-10-13-198-107.pwx.purestorage.com]
2024-01-09 16:21:42 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#828] - PX is enabled on node ip-10-13-198-107.pwx.purestorage.com.
2024-01-09 16:21:42 +0000:[INFO] [portworx.(*portworx).updateNode:#693] - Updating node [ip-10-13-199-55.pwx.purestorage.com]
2024-01-09 16:21:42 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#828] - PX is enabled on node ip-10-13-199-55.pwx.purestorage.com.
=== RUN   TestExtender/antihyperconvergenceAfterVolumeLabelUpdate
2024-01-09 16:21:43 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1855] - Setting provisioner of test-sv4-replica1-prefer-remote-only to kubernetes.io/portworx-volume
2024-01-09 16:21:43 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1900] - [test-sv4-replica1-prefer-remote-only] Created storage class: test-sv4-replica1-prefer-remote-only
2024-01-09 16:21:43 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1975] - [test-sv4-replica1-prefer-remote-only] Created PVC: test-sv4-replica1-prefer-remote-only
{Volumes:[{Name:test-sv4-replica1-prefer-remote-only VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:&PersistentVolumeClaimVolumeSource{ClaimName:test-sv4-replica1-prefer-remote-only,ReadOnly:false,} RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}} {Name:local-vol VolumeSource:{HostPath:nil EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,} GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}}] InitContainers:[] Containers:[{Name:sv4test Image:portworx/sharedv4-test:torpedo Command:[python /app/fileio.py] Args:[--lock --interval=0.25 $(SHARED_FILE) $(LOCAL_FILE)] WorkingDir: Ports:[] EnvFrom:[] Env:[{Name:MY_POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:SHARED_FILE Value:/shared-vol/$(MY_POD_NAME) ValueFrom:nil} {Name:LOCAL_FILE Value:/local-vol/$(MY_POD_NAME) ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:test-sv4-replica1-prefer-remote-only ReadOnly:false MountPath:/shared-vol SubPath: MountPropagation:<nil> SubPathExpr:} {Name:local-vol ReadOnly:false MountPath:/local-vol SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:Always SecurityContext:nil Stdin:false StdinOnce:false TTY:false} {Name:sv4test-reader Image:portworx/sharedv4-test:torpedo Command:[python /app/reader.py] Args:[--interval=9 $(LOCAL_FILE)] WorkingDir: Ports:[] EnvFrom:[] Env:[{Name:MY_POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:LOCAL_FILE Value:/local-vol/$(MY_POD_NAME) ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:local-vol ReadOnly:false MountPath:/local-vol SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:Always SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] EphemeralContainers:[] RestartPolicy: TerminationGracePeriodSeconds:<nil> ActiveDeadlineSeconds:<nil> DNSPolicy: NodeSelector:map[] ServiceAccountName: DeprecatedServiceAccount: AutomountServiceAccountToken:<nil> NodeName: HostNetwork:false HostPID:false HostIPC:false ShareProcessNamespace:<nil> SecurityContext:nil ImagePullSecrets:[] Hostname: Subdomain: Affinity:&Affinity{NodeAffinity:nil,PodAffinity:nil,PodAntiAffinity:&PodAntiAffinity{RequiredDuringSchedulingIgnoredDuringExecution:[]PodAffinityTerm{PodAffinityTerm{LabelSelector:&v1.LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:app,Operator:In,Values:[test-sv4-replica1-prefer-remote-only],},},},Namespaces:[],TopologyKey:kubernetes.io/hostname,NamespaceSelector:nil,},},PreferredDuringSchedulingIgnoredDuringExecution:[]WeightedPodAffinityTerm{},},} SchedulerName: Tolerations:[] HostAliases:[] PriorityClassName: Priority:<nil> DNSConfig:nil ReadinessGates:[] RuntimeClassName:<nil> EnableServiceLinks:<nil> PreemptionPolicy:<nil> Overhead:map[] TopologySpreadConstraints:[] SetHostnameAsFQDN:<nil> OS:nil HostUsers:<nil>}
2024-01-09 16:21:43 +0000:[INFO] [k8s.(*K8s).createCoreObject:#2344] - [test-sv4-replica1-prefer-remote-only] Created deployment: test-sv4-replica1-prefer-remote-only
time="2024-01-09 16:21:43" level=info msg="Waiting for all Pods to come online"
2024/01/09 16:21:43 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Failed to get pods for deployment. Err: replicasets.apps "test-sv4-replica1-prefer-remote-only" not found}, Next try in [10s], timeout [10m0s]
2024-01-09 16:21:53 +0000:[INFO] [k8s.(*K8s).WaitForRunning:#2905] - [test-sv4-replica1-prefer-remote-only] Validated deployment: test-sv4-replica1-prefer-remote-only
time="2024-01-09 16:21:54" level=info msg="Using http://portworx-service.kube-system.svc.cluster.local:9001 as endpoint for portworx REST API"
time="2024-01-09 16:21:54" level=info msg="Using portworx-service.kube-system.svc.cluster.local:9020 as endpoint for portworx gRPC API"
time="2024-01-09 16:21:54" level=info msg="Update Volume: Volume update successful for volume pvc-667b5643-1c1b-48a4-8b24-42cab0927e33\n"
time="2024-01-09 16:21:54" level=info msg="Delete application pods"
time="2024-01-09 16:21:54" level=info msg="Waiting for all Pods to come online"
2024/01/09 16:21:54 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Pod(s): []string{"test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr"} not yet ready}, Next try in [10s], timeout [2m0s]
2024/01/09 16:22:04 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:22:14 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:22:25 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:22:35 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:22:45 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:22:55 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:23:05 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:23:15 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:23:25 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:23:35 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:23:45 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not ready yet. Cause: Expected replicas: 1 Available replicas: 0 Current pods overview:
  pod name:test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr namespace:test-sv4-replica1-prefer-remote-only-volumelabelupdate running:true ready:false node:
}, Next try in [10s], timeout [2m0s]
2024/01/09 16:23:55 DoRetryWithTimeout - Error: {app test-sv4-replica1-prefer-remote-only is not terminated yet. Cause: pods: [test-sv4-replica1-prefer-remote-only-5896bb8b54-r7thr] are still present}, Next try in [10s], timeout [10m0s]
2024-01-09 16:24:05 +0000:[INFO] [k8s.(*K8s).WaitForDestroy:#3397] - [test-sv4-replica1-prefer-remote-only] Validated destroy of Deployment: test-sv4-replica1-prefer-remote-only
2024-01-09 16:24:05 +0000:[INFO] [k8s.(*K8s).DeleteVolumes:#4017] - [test-sv4-replica1-prefer-remote-only] Destroyed PVC: test-sv4-replica1-prefer-remote-only
time="2024-01-09 16:24:05" level=info msg="Test status at end of TestExtender/antihyperconvergenceAfterVolumeLabelUpdate test: Pass"
time="2024-01-09 16:24:05" level=warning msg="Skipping testrail update for this case, testID: 94378, testrun: 0"
--- PASS: TestExtender (145.89s)
    --- PASS: TestExtender/antihyperconvergenceAfterVolumeLabelUpdate (141.67s)
=== RUN   TestExtenderWebhookStatfs
time="2024-01-09 16:24:08" level=info msg="Using stork volume driver: pxd"
time="2024-01-09 16:24:08" level=info msg="Set kubeConfig to Source"
2024-01-09 16:24:08 +0000:[INFO] [k8s.(*K8s).parseK8SNode:#866] - Parsed node [ip-10-13-192-160.pwx.purestorage.com] as Type: Worker, Zone: , Region
2024-01-09 16:24:08 +0000:[INFO] [k8s.(*K8s).parseK8SNode:#866] - Parsed node [ip-10-13-196-194.pwx.purestorage.com] as Type: Master, Zone: , Region
2024-01-09 16:24:08 +0000:[INFO] [k8s.(*K8s).parseK8SNode:#866] - Parsed node [ip-10-13-198-107.pwx.purestorage.com] as Type: Worker, Zone: , Region
2024-01-09 16:24:08 +0000:[INFO] [k8s.(*K8s).parseK8SNode:#866] - Parsed node [ip-10-13-199-55.pwx.purestorage.com] as Type: Worker, Zone: , Region
2024-01-09 16:24:08 +0000:[INFO] RefreshDriverEndpoints: volume driver's namespace (portworx namespace) is updated to [kube-system]
2024-01-09 16:24:09 +0000:[INFO] [portworx.(*portworx).testAndSetEndpoint:#2877] - Using 10.233.45.53:9020 as endpoint for portworx volume driver
2024-01-09 16:24:09 +0000:[INFO] [portworx.(*portworx).testAndSetEndpoint:#2877] - Using 10.233.45.53:9020 as endpoint for portworx volume driver
2024-01-09 16:24:09 +0000:[INFO] [portworx.(*portworx).updateNode:#693] - Updating node [ip-10-13-192-160.pwx.purestorage.com]
2024-01-09 16:24:10 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#828] - PX is enabled on node ip-10-13-192-160.pwx.purestorage.com.
2024-01-09 16:24:10 +0000:[INFO] [portworx.(*portworx).updateNode:#693] - Updating node [ip-10-13-196-194.pwx.purestorage.com]
2024-01-09 16:24:10 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#812] - PX is not enabled on node ip-10-13-196-194.pwx.purestorage.com. Will be skipped for tests.
2024-01-09 16:24:10 +0000:[INFO] [portworx.(*portworx).updateNode:#693] - Updating node [ip-10-13-198-107.pwx.purestorage.com]
2024-01-09 16:24:11 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#828] - PX is enabled on node ip-10-13-198-107.pwx.purestorage.com.
2024-01-09 16:24:11 +0000:[INFO] [portworx.(*portworx).updateNode:#693] - Updating node [ip-10-13-199-55.pwx.purestorage.com]
2024-01-09 16:24:11 +0000:[INFO] [schedops.(*k8sSchedOps).IsPXEnabled:#828] - PX is enabled on node ip-10-13-199-55.pwx.purestorage.com.
2024-01-09 16:24:12 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1855] - Setting provisioner of virt-launcher-sim-sc to kubernetes.io/portworx-volume
2024-01-09 16:24:12 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1880] - [virt-launcher-sim] Found existing storage class: virt-launcher-sim-sc
2024-01-09 16:24:12 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1975] - [virt-launcher-sim] Created PVC: virt-launcher-sim-pvc
{Volumes:[{Name:virt-launcher-sim-vol VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:&PersistentVolumeClaimVolumeSource{ClaimName:virt-launcher-sim-pvc,ReadOnly:false,} RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}} {Name:local-vol VolumeSource:{HostPath:nil EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,} GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}}] InitContainers:[] Containers:[{Name:sv4test Image:portworx/sharedv4-test:torpedo Command:[python /app/fileio.py] Args:[--lock --interval=0.25 $(SHARED_FILE) $(LOCAL_FILE)] WorkingDir: Ports:[] EnvFrom:[] Env:[{Name:MY_POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:SHARED_FILE Value:/shared-vol/$(MY_POD_NAME) ValueFrom:nil} {Name:LOCAL_FILE Value:/local-vol/$(MY_POD_NAME) ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:virt-launcher-sim-vol ReadOnly:false MountPath:/shared-vol SubPath: MountPropagation:<nil> SubPathExpr:} {Name:local-vol ReadOnly:false MountPath:/local-vol SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:Always SecurityContext:nil Stdin:false StdinOnce:false TTY:false} {Name:sv4test-reader Image:portworx/sharedv4-test:torpedo Command:[python /app/reader.py] Args:[--interval=9 $(LOCAL_FILE)] WorkingDir: Ports:[] EnvFrom:[] Env:[{Name:MY_POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:LOCAL_FILE Value:/local-vol/$(MY_POD_NAME) ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:local-vol ReadOnly:false MountPath:/local-vol SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:Always SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] EphemeralContainers:[] RestartPolicy: TerminationGracePeriodSeconds:<nil> ActiveDeadlineSeconds:<nil> DNSPolicy: NodeSelector:map[] ServiceAccountName: DeprecatedServiceAccount: AutomountServiceAccountToken:<nil> NodeName: HostNetwork:false HostPID:false HostIPC:false ShareProcessNamespace:<nil> SecurityContext:nil ImagePullSecrets:[] Hostname: Subdomain: Affinity:&Affinity{NodeAffinity:nil,PodAffinity:nil,PodAntiAffinity:&PodAntiAffinity{RequiredDuringSchedulingIgnoredDuringExecution:[]PodAffinityTerm{PodAffinityTerm{LabelSelector:&v1.LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:app,Operator:In,Values:[virt-launcher-sim-app],},},},Namespaces:[],TopologyKey:kubernetes.io/hostname,NamespaceSelector:nil,},},PreferredDuringSchedulingIgnoredDuringExecution:[]WeightedPodAffinityTerm{},},} SchedulerName: Tolerations:[] HostAliases:[] PriorityClassName: Priority:<nil> DNSConfig:nil ReadinessGates:[] RuntimeClassName:<nil> EnableServiceLinks:<nil> PreemptionPolicy:<nil> Overhead:map[] TopologySpreadConstraints:[] SetHostnameAsFQDN:<nil> OS:nil HostUsers:<nil>}
2024-01-09 16:24:12 +0000:[INFO] [k8s.(*K8s).createCoreObject:#2344] - [virt-launcher-sim] Created deployment: virt-launcher-sim-dep
2024-01-09 16:24:13 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1855] - Setting provisioner of virt-launcher-sim-sc-enc to kubernetes.io/portworx-volume
2024-01-09 16:24:13 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1880] - [virt-launcher-sim-enc] Found existing storage class: virt-launcher-sim-sc-enc
2024-01-09 16:24:13 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1975] - [virt-launcher-sim-enc] Created PVC: virt-launcher-sim-pvc-enc
2024-01-09 16:24:13 +0000:[INFO] [k8s.(*K8s).createCoreObject:#2486] - [virt-launcher-sim-enc] Created Secret: volume-secrets
{Volumes:[{Name:virt-launcher-sim-vol-enc VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:&PersistentVolumeClaimVolumeSource{ClaimName:virt-launcher-sim-pvc-enc,ReadOnly:false,} RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}} {Name:local-vol VolumeSource:{HostPath:nil EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,} GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}}] InitContainers:[] Containers:[{Name:sv4test Image:portworx/sharedv4-test:torpedo Command:[python /app/fileio.py] Args:[--lock --interval=0.25 $(SHARED_FILE) $(LOCAL_FILE)] WorkingDir: Ports:[] EnvFrom:[] Env:[{Name:MY_POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:SHARED_FILE Value:/shared-vol/$(MY_POD_NAME) ValueFrom:nil} {Name:LOCAL_FILE Value:/local-vol/$(MY_POD_NAME) ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:virt-launcher-sim-vol-enc ReadOnly:false MountPath:/shared-vol SubPath: MountPropagation:<nil> SubPathExpr:} {Name:local-vol ReadOnly:false MountPath:/local-vol SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:Always SecurityContext:nil Stdin:false StdinOnce:false TTY:false} {Name:sv4test-reader Image:portworx/sharedv4-test:torpedo Command:[python /app/reader.py] Args:[--interval=9 $(LOCAL_FILE)] WorkingDir: Ports:[] EnvFrom:[] Env:[{Name:MY_POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:LOCAL_FILE Value:/local-vol/$(MY_POD_NAME) ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:local-vol ReadOnly:false MountPath:/local-vol SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:Always SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] EphemeralContainers:[] RestartPolicy: TerminationGracePeriodSeconds:<nil> ActiveDeadlineSeconds:<nil> DNSPolicy: NodeSelector:map[] ServiceAccountName: DeprecatedServiceAccount: AutomountServiceAccountToken:<nil> NodeName: HostNetwork:false HostPID:false HostIPC:false ShareProcessNamespace:<nil> SecurityContext:nil ImagePullSecrets:[] Hostname: Subdomain: Affinity:&Affinity{NodeAffinity:nil,PodAffinity:nil,PodAntiAffinity:&PodAntiAffinity{RequiredDuringSchedulingIgnoredDuringExecution:[]PodAffinityTerm{PodAffinityTerm{LabelSelector:&v1.LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:app,Operator:In,Values:[virt-launcher-sim-app-enc],},},},Namespaces:[],TopologyKey:kubernetes.io/hostname,NamespaceSelector:nil,},},PreferredDuringSchedulingIgnoredDuringExecution:[]WeightedPodAffinityTerm{},},} SchedulerName: Tolerations:[] HostAliases:[] PriorityClassName: Priority:<nil> DNSConfig:nil ReadinessGates:[] RuntimeClassName:<nil> EnableServiceLinks:<nil> PreemptionPolicy:<nil> Overhead:map[] TopologySpreadConstraints:[] SetHostnameAsFQDN:<nil> OS:nil HostUsers:<nil>}
2024-01-09 16:24:13 +0000:[INFO] [k8s.(*K8s).createCoreObject:#2344] - [virt-launcher-sim-enc] Created deployment: virt-launcher-sim-dep-enc
2024-01-09 16:24:13 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1855] - Setting provisioner of test-sv4-sc-svc to kubernetes.io/portworx-volume
2024-01-09 16:24:13 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1880] - [test-sv4-svc] Found existing storage class: test-sv4-sc-svc
2024-01-09 16:24:13 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1975] - [test-sv4-svc] Created PVC: test-sv4-pvc-svc
{Volumes:[{Name:test-sv4-vol-svc VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:&PersistentVolumeClaimVolumeSource{ClaimName:test-sv4-pvc-svc,ReadOnly:false,} RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}} {Name:local-vol VolumeSource:{HostPath:nil EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,} GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}}] InitContainers:[] Containers:[{Name:sv4test Image:portworx/sharedv4-test:torpedo Command:[python /app/fileio.py] Args:[--lock --interval=0.25 $(SHARED_FILE) $(LOCAL_FILE)] WorkingDir: Ports:[] EnvFrom:[] Env:[{Name:MY_POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:SHARED_FILE Value:/shared-vol/$(MY_POD_NAME) ValueFrom:nil} {Name:LOCAL_FILE Value:/local-vol/$(MY_POD_NAME) ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:test-sv4-vol-svc ReadOnly:false MountPath:/shared-vol SubPath: MountPropagation:<nil> SubPathExpr:} {Name:local-vol ReadOnly:false MountPath:/local-vol SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:Always SecurityContext:nil Stdin:false StdinOnce:false TTY:false} {Name:sv4test-reader Image:portworx/sharedv4-test:torpedo Command:[python /app/reader.py] Args:[--interval=9 $(LOCAL_FILE)] WorkingDir: Ports:[] EnvFrom:[] Env:[{Name:MY_POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:LOCAL_FILE Value:/local-vol/$(MY_POD_NAME) ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:local-vol ReadOnly:false MountPath:/local-vol SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:Always SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] EphemeralContainers:[] RestartPolicy: TerminationGracePeriodSeconds:<nil> ActiveDeadlineSeconds:<nil> DNSPolicy: NodeSelector:map[] ServiceAccountName: DeprecatedServiceAccount: AutomountServiceAccountToken:<nil> NodeName: HostNetwork:false HostPID:false HostIPC:false ShareProcessNamespace:<nil> SecurityContext:nil ImagePullSecrets:[] Hostname: Subdomain: Affinity:&Affinity{NodeAffinity:nil,PodAffinity:nil,PodAntiAffinity:&PodAntiAffinity{RequiredDuringSchedulingIgnoredDuringExecution:[]PodAffinityTerm{PodAffinityTerm{LabelSelector:&v1.LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:app,Operator:In,Values:[test-sv4-app-svc],},},},Namespaces:[],TopologyKey:kubernetes.io/hostname,NamespaceSelector:nil,},},PreferredDuringSchedulingIgnoredDuringExecution:[]WeightedPodAffinityTerm{},},} SchedulerName: Tolerations:[] HostAliases:[] PriorityClassName: Priority:<nil> DNSConfig:nil ReadinessGates:[] RuntimeClassName:<nil> EnableServiceLinks:<nil> PreemptionPolicy:<nil> Overhead:map[] TopologySpreadConstraints:[] SetHostnameAsFQDN:<nil> OS:nil HostUsers:<nil>}
2024-01-09 16:24:13 +0000:[INFO] [k8s.(*K8s).createCoreObject:#2344] - [test-sv4-svc] Created deployment: test-sv4-dep-svc
2024-01-09 16:24:14 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1855] - Setting provisioner of test-sv4-sc-svc-enc to kubernetes.io/portworx-volume
2024-01-09 16:24:14 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1880] - [test-sv4-svc-enc] Found existing storage class: test-sv4-sc-svc-enc
2024-01-09 16:24:14 +0000:[INFO] [k8s.(*K8s).createStorageObject:#1975] - [test-sv4-svc-enc] Created PVC: test-sv4-pvc-svc-enc
2024-01-09 16:24:14 +0000:[INFO] [k8s.(*K8s).createCoreObject:#2486] - [test-sv4-svc-enc] Created Secret: volume-secrets
{Volumes:[{Name:test-sv4-vol-svc-enc VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:&PersistentVolumeClaimVolumeSource{ClaimName:test-sv4-pvc-svc-enc,ReadOnly:false,} RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}} {Name:local-vol VolumeSource:{HostPath:nil EmptyDir:&EmptyDirVolumeSource{Medium:,SizeLimit:<nil>,} GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:nil NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil PortworxVolume:nil ScaleIO:nil StorageOS:nil CSI:nil Ephemeral:nil}}] InitContainers:[] Containers:[{Name:sv4test Image:portworx/sharedv4-test:torpedo Command:[python /app/fileio.py] Args:[--lock --interval=0.25 $(SHARED_FILE) $(LOCAL_FILE)] WorkingDir: Ports:[] EnvFrom:[] Env:[{Name:MY_POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:SHARED_FILE Value:/shared-vol/$(MY_POD_NAME) ValueFrom:nil} {Name:LOCAL_FILE Value:/local-vol/$(MY_POD_NAME) ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:test-sv4-vol-svc-enc ReadOnly:false MountPath:/shared-vol SubPath: MountPropagation:<nil> SubPathExpr:} {Name:local-vol ReadOnly:false MountPath:/local-vol SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:Always SecurityContext:nil Stdin:false StdinOnce:false TTY:false} {Name:sv4test-reader Image:portworx/sharedv4-test:torpedo Command:[python /app/reader.py] Args:[--interval=9 $(LOCAL_FILE)] WorkingDir: Ports:[] EnvFrom:[] Env:[{Name:MY_POD_NAME Value: ValueFrom:&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {Name:LOCAL_FILE Value:/local-vol/$(MY_POD_NAME) ValueFrom:nil}] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:local-vol ReadOnly:false MountPath:/local-vol SubPath: MountPropagation:<nil> SubPathExpr:}] VolumeDevices:[] LivenessProbe:nil ReadinessProbe:nil StartupProbe:nil Lifecycle:nil TerminationMessagePath: TerminationMessagePolicy: ImagePullPolicy:Always SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] EphemeralContainers:[] RestartPolicy: TerminationGracePeriodSeconds:<nil> ActiveDeadlineSeconds:<nil> DNSPolicy: NodeSelector:map[] ServiceAccountName: DeprecatedServiceAccount: AutomountServiceAccountToken:<nil> NodeName: HostNetwork:false HostPID:false HostIPC:false ShareProcessNamespace:<nil> SecurityContext:nil ImagePullSecrets:[] Hostname: Subdomain: Affinity:&Affinity{NodeAffinity:nil,PodAffinity:nil,PodAntiAffinity:&PodAntiAffinity{RequiredDuringSchedulingIgnoredDuringExecution:[]PodAffinityTerm{PodAffinityTerm{LabelSelector:&v1.LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:app,Operator:In,Values:[test-sv4-app-svc-enc],},},},Namespaces:[],TopologyKey:kubernetes.io/hostname,NamespaceSelector:nil,},},PreferredDuringSchedulingIgnoredDuringExecution:[]WeightedPodAffinityTerm{},},} SchedulerName: Tolerations:[] HostAliases:[] PriorityClassName: Priority:<nil> DNSConfig:nil ReadinessGates:[] RuntimeClassName:<nil> EnableServiceLinks:<nil> PreemptionPolicy:<nil> Overhead:map[] TopologySpreadConstraints:[] SetHostnameAsFQDN:<nil> OS:nil HostUsers:<nil>}
2024-01-09 16:24:14 +0000:[INFO] [k8s.(*K8s).createCoreObject:#2344] - [test-sv4-svc-enc] Created deployment: test-sv4-dep-svc-enc
2024-01-09 16:24:14 +0000:[INFO] [k8s.(*K8s).ScaleApplication:#4913] - Scale all Deployments
2024-01-09 16:24:14 +0000:[INFO] [k8s.(*K8s).ScaleApplication:#4935] - Deployment virt-launcher-sim-dep scaled to 3 successfully.
2024-01-09 16:24:14 +0000:[INFO] [k8s.(*K8s).ScaleApplication:#4913] - Scale all Deployments
2024-01-09 16:24:14 +0000:[INFO] [k8s.(*K8s).ScaleApplication:#4935] - Deployment virt-launcher-sim-dep-enc scaled to 3 successfully.
2024-01-09 16:24:15 +0000:[INFO] [k8s.(*K8s).ScaleApplication:#4913] - Scale all Deployments
2024-01-09 16:24:15 +0000:[INFO] [k8s.(*K8s).ScaleApplication:#4935] - Deployment test-sv4-dep-svc scaled to 3 successfully.
2024-01-09 16:24:15 +0000:[INFO] [k8s.(*K8s).ScaleApplication:#4913] - Scale all Deployments
2024-01-09 16:24:15 +0000:[INFO] [k8s.(*K8s).ScaleApplication:#4935] - Deployment test-sv4-dep-svc-enc scaled to 3 successfully.
2024/01/09 16:24:16 DoRetryWithTimeout - Error: {app virt-launcher-sim-dep is not ready yet. Cause: Expected replicas: 3 Available replicas: 0 Current pods overview:
  pod name:virt-launcher-sim-dep-5c466fd7dc-cs57v namespace:virt-launcher-sim-webhook-statfs-test running:true ready:false node:
  pod name:virt-launcher-sim-dep-5c466fd7dc-mmzvj namespace:virt-launcher-sim-webhook-statfs-test running:true ready:false node:
  pod name:virt-launcher-sim-dep-5c466fd7dc-x92gt namespace:virt-launcher-sim-webhook-statfs-test running:true ready:false node:
}, Next try in [10s], timeout [10m0s]
2024/01/09 16:24:26 DoRetryWithTimeout - Error: {app virt-launcher-sim-dep is not ready yet. Cause: Expected replicas: 3 Available replicas: 1 Current pods overview:
  pod name:virt-launcher-sim-dep-5c466fd7dc-cs57v namespace:virt-launcher-sim-webhook-statfs-test running:false ready:false node:10.13.192.160
  pod name:virt-launcher-sim-dep-5c466fd7dc-mmzvj namespace:virt-launcher-sim-webhook-statfs-test running:true ready:true node:10.13.198.107
  pod name:virt-launcher-sim-dep-5c466fd7dc-x92gt namespace:virt-launcher-sim-webhook-statfs-test running:false ready:false node:10.13.199.55
}, Next try in [10s], timeout [10m0s]
2024-01-09 16:24:36 +0000:[INFO] [k8s.(*K8s).WaitForRunning:#2905] - [virt-launcher-sim] Validated deployment: virt-launcher-sim-dep
2024/01/09 16:24:36 DoRetryWithTimeout - Error: {app virt-launcher-sim-dep-enc is not ready yet. Cause: Expected replicas: 3 Available replicas: 0 Current pods overview:
  pod name:virt-launcher-sim-dep-enc-7f664b6f9d-k7lxc namespace:virt-launcher-sim-enc-webhook-statfs-test running:false ready:false node:10.13.198.107
  pod name:virt-launcher-sim-dep-enc-7f664b6f9d-r6psb namespace:virt-launcher-sim-enc-webhook-statfs-test running:false ready:false node:10.13.199.55
  pod name:virt-launcher-sim-dep-enc-7f664b6f9d-rdvxx namespace:virt-launcher-sim-enc-webhook-statfs-test running:false ready:false node:10.13.192.160
}, Next try in [10s], timeout [10m0s]
2024/01/09 16:24:46 DoRetryWithTimeout - Error: {app virt-launcher-sim-dep-enc is not ready yet. Cause: Expected replicas: 3 Available replicas: 2 Current pods overview:
  pod name:virt-launcher-sim-dep-enc-7f664b6f9d-k7lxc namespace:virt-launcher-sim-enc-webhook-statfs-test running:true ready:true node:10.13.198.107
  pod name:virt-launcher-sim-dep-enc-7f664b6f9d-r6psb namespace:virt-launcher-sim-enc-webhook-statfs-test running:false ready:false node:10.13.199.55
  pod name:virt-launcher-sim-dep-enc-7f664b6f9d-rdvxx namespace:virt-launcher-sim-enc-webhook-statfs-test running:true ready:true node:10.13.192.160
}, Next try in [10s], timeout [10m0s]
2024-01-09 16:24:56 +0000:[INFO] [k8s.(*K8s).WaitForRunning:#2905] - [virt-launcher-sim-enc] Validated deployment: virt-launcher-sim-dep-enc
2024-01-09 16:24:56 +0000:[INFO] [k8s.(*K8s).WaitForRunning:#2905] - [test-sv4-svc] Validated deployment: test-sv4-dep-svc
2024-01-09 16:24:57 +0000:[INFO] [k8s.(*K8s).WaitForRunning:#2905] - [test-sv4-svc-enc] Validated deployment: test-sv4-dep-svc-enc
time="2024-01-09 16:24:57" level=info msg="validating statfs in pod virt-launcher-sim-dep-5c466fd7dc-cs57v in namespace virt-launcher-sim-webhook-statfs-test"
time="2024-01-09 16:24:57" level=info msg="isBindMount=true"
time="2024-01-09 16:24:57" level=info msg="statfs(/shared-vol)=nfs"
time="2024-01-09 16:24:57" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:24:57" level=info msg="validating statfs in pod virt-launcher-sim-dep-5c466fd7dc-mmzvj in namespace virt-launcher-sim-webhook-statfs-test"
time="2024-01-09 16:24:58" level=info msg="isBindMount=false"
time="2024-01-09 16:24:58" level=info msg="statfs(/shared-vol)=nfs"
time="2024-01-09 16:24:58" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:24:58" level=info msg="validating statfs in pod virt-launcher-sim-dep-5c466fd7dc-x92gt in namespace virt-launcher-sim-webhook-statfs-test"
time="2024-01-09 16:24:58" level=info msg="isBindMount=false"
time="2024-01-09 16:24:58" level=info msg="statfs(/shared-vol)=nfs"
time="2024-01-09 16:24:58" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:24:58" level=info msg="validated statfs for context virt-launcher-sim"
time="2024-01-09 16:24:58" level=info msg="Testing configmap update function 0"
time="2024-01-09 16:24:58" level=info msg="Using pod virt-launcher-sim-webhook-statfs-test/virt-launcher-sim-dep-5c466fd7dc-cs57v for the configMap update test"
time="2024-01-09 16:24:58" level=info msg="Changing configMap in namespace virt-launcher-sim-webhook-statfs-test"
time="2024-01-09 16:24:58" level=info msg="ConfigMap.Data[ld.so.preload] does not match: expected /etc/px_statfs.so, actual dummy-value"
time="2024-01-09 16:25:01" level=info msg="checking if the ConfigMap matches"
time="2024-01-09 16:25:01" level=info msg="Testing configmap update function 1"
time="2024-01-09 16:25:01" level=info msg="Using pod virt-launcher-sim-webhook-statfs-test/virt-launcher-sim-dep-5c466fd7dc-llm8k for the configMap update test"
time="2024-01-09 16:25:01" level=info msg="Changing configMap in namespace virt-launcher-sim-webhook-statfs-test"
time="2024-01-09 16:25:01" level=info msg="Updating byte at index 10680 from 0 to 1"
time="2024-01-09 16:25:01" level=info msg="ConfigMap.Data[px_statfs.so.sha256] does not match: expected d5162d0e2f204346bef6660541929af5fd40eb0b2bb0e1a34bdba81b626930d6\n, actual dummy-value"
time="2024-01-09 16:25:04" level=info msg="checking if the ConfigMap matches"
time="2024-01-09 16:25:04" level=info msg="Testing configmap update function 2"
time="2024-01-09 16:25:04" level=info msg="Using pod virt-launcher-sim-webhook-statfs-test/virt-launcher-sim-dep-5c466fd7dc-ch7wb for the configMap update test"
time="2024-01-09 16:25:04" level=info msg="Changing configMap in namespace virt-launcher-sim-webhook-statfs-test"
time="2024-01-09 16:25:04" level=info msg="Updating byte at index 10680 from 0 to 1"
time="2024-01-09 16:25:04" level=info msg="ConfigMap.Data[px_statfs.so.sha256] does not match: expected d5162d0e2f204346bef6660541929af5fd40eb0b2bb0e1a34bdba81b626930d6\n, actual "
time="2024-01-09 16:25:07" level=info msg="checking if the ConfigMap matches"
time="2024-01-09 16:25:07" level=info msg="Validated configMap update in context virt-launcher-sim"
time="2024-01-09 16:25:07" level=info msg="validating statfs in pod virt-launcher-sim-dep-enc-7f664b6f9d-k7lxc in namespace virt-launcher-sim-enc-webhook-statfs-test"
time="2024-01-09 16:25:07" level=info msg="isBindMount=false"
time="2024-01-09 16:25:08" level=info msg="statfs(/shared-vol)=nfs"
time="2024-01-09 16:25:08" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:25:08" level=info msg="validating statfs in pod virt-launcher-sim-dep-enc-7f664b6f9d-r6psb in namespace virt-launcher-sim-enc-webhook-statfs-test"
time="2024-01-09 16:25:08" level=info msg="isBindMount=false"
time="2024-01-09 16:25:08" level=info msg="statfs(/shared-vol)=nfs"
time="2024-01-09 16:25:08" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:25:08" level=info msg="validating statfs in pod virt-launcher-sim-dep-enc-7f664b6f9d-rdvxx in namespace virt-launcher-sim-enc-webhook-statfs-test"
time="2024-01-09 16:25:08" level=info msg="isBindMount=true"
time="2024-01-09 16:25:08" level=info msg="statfs(/shared-vol)=nfs"
time="2024-01-09 16:25:08" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:25:08" level=info msg="validated statfs for context virt-launcher-sim-enc"
time="2024-01-09 16:25:08" level=info msg="validating statfs in pod test-sv4-dep-svc-5776d4686d-7qdkk in namespace test-sv4-svc-webhook-statfs-test"
time="2024-01-09 16:25:08" level=info msg="isBindMount=true"
time="2024-01-09 16:25:09" level=info msg="statfs(/shared-vol)=ext2/ext3"
time="2024-01-09 16:25:09" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:25:09" level=info msg="validating statfs in pod test-sv4-dep-svc-5776d4686d-829rt in namespace test-sv4-svc-webhook-statfs-test"
time="2024-01-09 16:25:09" level=info msg="isBindMount=false"
time="2024-01-09 16:25:09" level=info msg="statfs(/shared-vol)=nfs"
time="2024-01-09 16:25:09" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:25:09" level=info msg="validating statfs in pod test-sv4-dep-svc-5776d4686d-97zv5 in namespace test-sv4-svc-webhook-statfs-test"
time="2024-01-09 16:25:09" level=info msg="isBindMount=false"
time="2024-01-09 16:25:09" level=info msg="statfs(/shared-vol)=nfs"
time="2024-01-09 16:25:09" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:25:09" level=info msg="validated statfs for context test-sv4-svc"
time="2024-01-09 16:25:09" level=info msg="validating statfs in pod test-sv4-dep-svc-enc-7b947c78fc-fmtl7 in namespace test-sv4-svc-enc-webhook-statfs-test"
time="2024-01-09 16:25:09" level=info msg="isBindMount=false"
time="2024-01-09 16:25:10" level=info msg="statfs(/shared-vol)=nfs"
time="2024-01-09 16:25:10" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:25:10" level=info msg="validating statfs in pod test-sv4-dep-svc-enc-7b947c78fc-hkj5w in namespace test-sv4-svc-enc-webhook-statfs-test"
time="2024-01-09 16:25:10" level=info msg="isBindMount=false"
time="2024-01-09 16:25:10" level=info msg="statfs(/shared-vol)=nfs"
time="2024-01-09 16:25:10" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:25:10" level=info msg="validating statfs in pod test-sv4-dep-svc-enc-7b947c78fc-pswbn in namespace test-sv4-svc-enc-webhook-statfs-test"
time="2024-01-09 16:25:10" level=info msg="isBindMount=true"
time="2024-01-09 16:25:10" level=info msg="statfs(/shared-vol)=ext2/ext3"
time="2024-01-09 16:25:10" level=info msg="statfs(/local-vol)=ext2/ext3"
time="2024-01-09 16:25:10" level=info msg="validated statfs for context test-sv4-svc-enc"
time="2024-01-09 16:25:10" level=info msg="Destroying apps"
2024/01/09 16:25:10 DoRetryWithTimeout - Error: {app virt-launcher-sim-dep is not terminated yet. Cause: pods: [virt-launcher-sim-dep-5c466fd7dc-cs57v (node=ip-10-13-192-160.pwx.purestorage.com) virt-launcher-sim-dep-5c466fd7dc-mmzvj (node=ip-10-13-198-107.pwx.purestorage.com) virt-launcher-sim-dep-5c466fd7dc-x298q virt-launcher-sim-dep-5c466fd7dc-x92gt (node=ip-10-13-199-55.pwx.purestorage.com)] are still present}, Next try in [10s], timeout [10m0s]
2024/01/09 16:25:20 DoRetryWithTimeout - Error: {app virt-launcher-sim-dep is not terminated yet. Cause: pods: [virt-launcher-sim-dep-5c466fd7dc-cs57v (node=ip-10-13-192-160.pwx.purestorage.com) virt-launcher-sim-dep-5c466fd7dc-mmzvj (node=ip-10-13-198-107.pwx.purestorage.com) virt-launcher-sim-dep-5c466fd7dc-x92gt (node=ip-10-13-199-55.pwx.purestorage.com)] are still present}, Next try in [10s], timeout [10m0s]
2024/01/09 16:25:30 DoRetryWithTimeout - Error: {app virt-launcher-sim-dep is not terminated yet. Cause: pods: [virt-launcher-sim-dep-5c466fd7dc-mmzvj (node=ip-10-13-198-107.pwx.purestorage.com) virt-launcher-sim-dep-5c466fd7dc-x92gt (node=ip-10-13-199-55.pwx.purestorage.com)] are still present}, Next try in [10s], timeout [10m0s]
2024/01/09 16:25:40 DoRetryWithTimeout - Error: {app virt-launcher-sim-dep is not terminated yet. Cause: pods: [virt-launcher-sim-dep-5c466fd7dc-mmzvj (node=ip-10-13-198-107.pwx.purestorage.com) virt-launcher-sim-dep-5c466fd7dc-x92gt (node=ip-10-13-199-55.pwx.purestorage.com)] are still present}, Next try in [10s], timeout [10m0s]
2024/01/09 16:25:51 DoRetryWithTimeout - Error: {app virt-launcher-sim-dep is not terminated yet. Cause: pods: [virt-launcher-sim-dep-5c466fd7dc-mmzvj (node=ip-10-13-198-107.pwx.purestorage.com)] are still present}, Next try in [10s], timeout [10m0s]
2024-01-09 16:26:01 +0000:[INFO] [k8s.(*K8s).WaitForDestroy:#3397] - [virt-launcher-sim] Validated destroy of Deployment: virt-launcher-sim-dep
2024-01-09 16:26:01 +0000:[INFO] [k8s.(*K8s).DeleteVolumes:#4017] - [virt-launcher-sim] Destroyed PVC: virt-launcher-sim-pvc
2024-01-09 16:26:01 +0000:[INFO] [k8s.(*K8s).WaitForDestroy:#3397] - [virt-launcher-sim-enc] Validated destroy of Deployment: virt-launcher-sim-dep-enc
2024-01-09 16:26:01 +0000:[INFO] [k8s.(*K8s).DeleteVolumes:#4017] - [virt-launcher-sim-enc] Destroyed PVC: virt-launcher-sim-pvc-enc
2024-01-09 16:26:01 +0000:[INFO] [k8s.(*K8s).WaitForDestroy:#3397] - [test-sv4-svc] Validated destroy of Deployment: test-sv4-dep-svc
2024-01-09 16:26:01 +0000:[INFO] [k8s.(*K8s).DeleteVolumes:#4017] - [test-sv4-svc] Destroyed PVC: test-sv4-pvc-svc
2024-01-09 16:26:01 +0000:[INFO] [k8s.(*K8s).WaitForDestroy:#3397] - [test-sv4-svc-enc] Validated destroy of Deployment: test-sv4-dep-svc-enc
2024-01-09 16:26:01 +0000:[INFO] [k8s.(*K8s).DeleteVolumes:#4017] - [test-sv4-svc-enc] Destroyed PVC: test-sv4-pvc-svc-enc
--- PASS: TestExtenderWebhookStatfs (115.82s)
PASS

DONE 3 tests in 287.311s
Tests passed
```