### PR TITLE
PB-5270 PB-5271 : fail backup and restore if admin namespace is not present

### DIFF
--- a/pkg/applicationmanager/applicationmanager.go
+++ b/pkg/applicationmanager/applicationmanager.go
@@ -50,7 +50,7 @@ func (a *ApplicationManager) Init(mgr manager.Manager, adminNamespace string, st
 	}
 
 	scheduleController := controllers.NewApplicationBackupSchedule(mgr, a.Recorder)
-	if err := scheduleController.Init(mgr); err != nil {
+	if err := scheduleController.Init(mgr, adminNamespace); err != nil {
 		return err
 	}
 	syncController := &controllers.BackupSyncController{

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -118,7 +118,7 @@ type ApplicationBackupController struct {
 	reconcileTime        time.Duration
 }
 
-// Init Initialize the application backup controller
+// Init initialize Namespacesthe application backup controller.
 func (a *ApplicationBackupController) Init(mgr manager.Manager, backupAdminNamespace string, syncTime int64) error {
 	err := a.createCRD()
 	if err != nil {

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -118,7 +118,7 @@ type ApplicationBackupController struct {
 	reconcileTime        time.Duration
 }
 
-// Init initialize Namespacesthe application backup controller.
+// Init initialize the application backup controller.
 func (a *ApplicationBackupController) Init(mgr manager.Manager, backupAdminNamespace string, syncTime int64) error {
 	err := a.createCRD()
 	if err != nil {

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -24,7 +24,7 @@ const (
 
 // RegisterTo creates a new controller for a provided config and registers it to the controller manager.
 func RegisterTo(mgr manager.Manager, name string, r reconcile.Reconciler, watchedObjects ...client.Object) error {
-	// Create a new controller
+	// Create a new controller.
 	c, err := controller.New(name, mgr, controller.Options{
 		Reconciler:              r,
 		MaxConcurrentReconciles: 10,
@@ -33,7 +33,7 @@ func RegisterTo(mgr manager.Manager, name string, r reconcile.Reconciler, watche
 		return err
 	}
 
-	// Watch for changes to primary resource
+	// Watch for changes to primary resource.
 	for _, obj := range watchedObjects {
 		if err = c.Watch(&source.Kind{Type: obj}, &handler.EnqueueRequestForObject{}); err != nil {
 			return err

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -24,7 +24,7 @@ const (
 
 // RegisterTo creates a new controller for a provided config and registers it to the controller manager.
 func RegisterTo(mgr manager.Manager, name string, r reconcile.Reconciler, watchedObjects ...client.Object) error {
-	// Create a new controller.
+	// Create a new controller
 	c, err := controller.New(name, mgr, controller.Options{
 		Reconciler:              r,
 		MaxConcurrentReconciles: 10,
@@ -33,7 +33,7 @@ func RegisterTo(mgr manager.Manager, name string, r reconcile.Reconciler, watche
 		return err
 	}
 
-	// Watch for changes to primary resource.
+	// Watch for changes to primary resource
 	for _, obj := range watchedObjects {
 		if err = c.Watch(&source.Kind{Type: obj}, &handler.EnqueueRequestForObject{}); err != nil {
 			return err

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -389,3 +389,18 @@ func GetPxNamespaceFromStorkDeploy(storkDeployName, storkDeployNamespace string)
 	}
 	return namespace, service, nil
 }
+
+// CheckNamespaceExists checks if the specified namespace exists in a Kubernetes cluster.
+func CheckNamespaceExists(ns string) (bool, error) {
+	namespaces, err := core.Instance().ListNamespaces(nil)
+	if err != nil {
+		return false, err
+	}
+
+	for _, namespace := range namespaces.Items {
+		if ns == namespace.Name {
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("namespace %s does not exist", ns)
+}


### PR DESCRIPTION
**What type of PR is this?**
bug-fix

**What this PR does / why we need it**:
If the custom admin namespace is set and not present, backup as well as restore should fail. However, currently they work by creating the set admin namespace themselves and proceeding ahead. However, the admin namespace related operations should ideally be handled by the user and not through automation. This pull-request errors out the backup and restore operations if the set admin namespace is not found. Once the user creates the admin namespace manually again, the backup and restore should work as expected.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

