### PR TITLE
upgrade aws-iam-authenticator version to latest 0.6.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN microdnf clean all && microdnf install -y python3.9 ca-certificates tar gzip
 RUN python3 -m pip install awscli && python3 -m pip install oci-cli && python3 -m pip install rsa --upgrade
 
 
-RUN curl -Lo /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.11/aws-iam-authenticator_0.6.11_linux_amd64 && \
+RUN curl -Lo /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.14/aws-iam-authenticator_0.6.14_linux_amd64 && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
 #Install asdf


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade aws-iam-authenticator to latest version to address Critical CVEs

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Update existing CVE release note

**Does this change need to be cherry-picked to a release branch?**:
Yes, 23.11

**Testing Details**
QA team will be responsible to test migration and backup flows for any regressions.