### PR TITLE
PB-5061: Kubevirt - Phase 2 Populate Resources for VM Backup in stork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -334,7 +334,7 @@ replace (
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v0.0.0-20230511212757-41751b27d69f
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240201054218-ab9ae1d8091d
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3

--- a/go.sum
+++ b/go.sum
@@ -2945,8 +2945,8 @@ github.com/portworx/px-backup-api v1.2.2-0.20230904054048-eb1f23dd7431/go.mod h1
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987 h1:VNBTmIPjJRZ2QP64zdsrif3ELDHiMzoyNNX74VNHgZ8=
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987/go.mod h1:g3pw2lI2AjqAixUCRhaBdKTY98znsCPR7NGRrlpimVU=
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4 h1:4hTAVUup7vdmmYeAj4d0P+k5tUX69ftkttse0wOhlVU=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27 h1:1Q50KWDMei8O+ckB2UzUKC6eRT6Aiwxg6u99C9wtrK0=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0 h1:KXN6ublTdb+tSfEwmrS7rxIjC0ys3w6agfm5CnyTdb0=

--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -45,6 +45,11 @@ type ApplicationBackupSpec struct {
 	BackupType       string            `json:"backupType"`
 	// CSISnapshotClassMap is 1 to 1 Map of CSI Provisioner to its Corresponding VolumeSnapshotClass to be used for backup
 	CSISnapshotClassMap map[string]string `json:"csiSnapshotClassMap"`
+	// BackupObjectType set to All for Namespace backup, VirtualMachine for VM specific Backup
+	BackupObjectType string `json:"backupObjectType"`
+	// SkipAutoExecRules is false by default, if set true will skip auto exec rules for VM specific backup.
+	// This field is unused for non VM specific Backup.
+	SkipAutoExecRules bool `json:"skipAutoExecRules"`
 }
 
 // ApplicationBackupReclaimPolicyType is the reclaim policy for the application backup
@@ -130,6 +135,8 @@ type ApplicationBackupStageType string
 const (
 	// ApplicationBackupStageInitial for when backup is created
 	ApplicationBackupStageInitial ApplicationBackupStageType = ""
+	// ApplicationBackupStageImportResource for when vm resources are imported
+	ApplicationBackupStageImportResource ApplicationBackupStageType = "ImportResource"
 	// ApplicationBackupStagePreExecRule for when the PreExecRule is being executed
 	ApplicationBackupStagePreExecRule ApplicationBackupStageType = "PreExecRule"
 	// ApplicationBackupStagePostExecRule for when the PostExecRule is being executed

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -90,6 +90,17 @@ const (
 	backupObjectUIDKey              = kdmpAnnotationPrefix + "backupobject-uid"
 	restoreObjectUIDKey             = kdmpAnnotationPrefix + "restoreobject-uid"
 	skipResourceAnnotation          = "stork.libopenstorage.org/skip-resource"
+	//VmFreezePrefix prefix for freeze rule action
+	vmFreezePrefix = "vm-freeze-pre-rule"
+	//VmUnFreezePrefix prefix for freeze rule action
+	vmUnFreezePrefix = "vm-unfreeze-post-rule"
+	// AnnotationsKeys used in ruleCr auto created during VirtualMachine specific Backup request
+	// for vm freeze and unfreeze operation.
+	annotationKeyPrefix = "portworx.io/"
+	backupUIDKey        = annotationKeyPrefix + "backup-uid"
+	createdByKey        = annotationKeyPrefix + "created-by"
+	createdByValue      = annotationKeyPrefix + "stork"
+	lastUpdateKey       = annotationKeyPrefix + "last-update"
 )
 
 var (
@@ -116,6 +127,8 @@ type ApplicationBackupController struct {
 	terminationChannels  map[string][]chan bool
 	execRulesCompleted   map[string]bool
 	reconcileTime        time.Duration
+	vmIncludeResource    map[string][]stork_api.ObjectInfo
+	vmIncludeResourceMap map[string]map[stork_api.ObjectInfo]bool
 }
 
 // Init Initialize the application backup controller
@@ -133,6 +146,8 @@ func (a *ApplicationBackupController) Init(mgr manager.Manager, backupAdminNames
 	a.reconcileTime = time.Duration(syncTime) * time.Second
 	a.terminationChannels = make(map[string][]chan bool)
 	a.execRulesCompleted = make(map[string]bool)
+	a.vmIncludeResource = make(map[string][]stork_api.ObjectInfo)
+	a.vmIncludeResourceMap = make(map[string]map[stork_api.ObjectInfo]bool)
 	return controllers.RegisterTo(mgr, "application-backup-controller", a, &stork_api.ApplicationBackup{})
 }
 
@@ -265,6 +280,14 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 			if _, ok := a.execRulesCompleted[string(backup.UID)]; ok {
 				delete(a.execRulesCompleted, string(backup.UID))
 				log.ApplicationBackupLog(backup).Infof("deleted post exec flag entry from controller map for backup [%v/%v]", backup.Namespace, backup.Name)
+			}
+			if _, ok := a.vmIncludeResource[string(backup.UID)]; ok {
+				delete(a.vmIncludeResource, string(backup.UID))
+				log.ApplicationBackupLog(backup).Infof("cleaning up vmIncludeResources for VM backupObjectType %v", a.vmIncludeResource)
+			}
+			if _, ok := a.vmIncludeResourceMap[string(backup.UID)]; ok {
+				delete(a.vmIncludeResourceMap, string(backup.UID))
+				log.ApplicationBackupLog(backup).Infof("cleaning up vmIncludeResources for VM backupObjectType")
 			}
 			// Calling cleanupResources which will cleanup the resources created by applicationbackup controller.
 			// In the case of kdmp driver, it will cleanup the dataexport CRs.
@@ -402,6 +425,41 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 					string(stork_api.ApplicationBackupStatusFailed),
 					message)
 				return nil
+			}
+		}
+		fallthrough
+	case stork_api.ApplicationBackupStageImportResource:
+		if IsBackupObjectTypeVirtualMachine(backup) {
+			logrus.Infof("This is a VM specific backup, processing resource collection of vm resources")
+			updateCrFunction := func() error {
+				err = a.client.Update(context.TODO(), backup)
+				if err != nil {
+					log.ApplicationBackupLog(backup).Errorf("error updating Cr in VMBackupProcessingStage: %v", err)
+					return err
+				}
+				return nil
+			}
+			updateCr, err := a.createVMSpecificBackupResources(backup)
+			if err != nil {
+				backup.Status.Status = stork_api.ApplicationBackupStatusFailed
+				backup.Status.Reason = fmt.Sprintf("error Updating Backup CR for VMObject Backup : %v", err)
+				backup.Status.Stage = stork_api.ApplicationBackupStageFinal
+				backup.Status.FinishTimestamp = metav1.Now()
+				backup.Status.LastUpdateTimestamp = metav1.Now()
+				err = fmt.Errorf("error Updating Backup CR for VMObject Backup : %v", err)
+				log.ApplicationBackupLog(backup).Errorf(err.Error())
+				a.recorder.Event(backup,
+					v1.EventTypeWarning,
+					string(stork_api.ApplicationBackupStatusFailed),
+					err.Error())
+				return updateCrFunction()
+			}
+			if updateCr {
+				backup.Status.Stage = stork_api.ApplicationBackupStagePreExecRule
+				backup.Status.LastUpdateTimestamp = metav1.Now()
+				log.ApplicationBackupLog(backup).Infof("Auto exec Rules created, updating the CR")
+				//return updateCrFunction()
+
 			}
 		}
 		fallthrough
@@ -564,9 +622,14 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 
 	backup.Status.Stage = stork_api.ApplicationBackupStageVolumes
 	namespacedName := types.NamespacedName{}
-	if IsVolsToBeBackedUp(backup) {
+	if a.IsVolsToBeBackedUp(backup) {
 		isResourceTypePVC := IsResourceTypePVC(backup)
-		objectMap := stork_api.CreateObjectsMap(backup.Spec.IncludeResources)
+		var objectMap map[stork_api.ObjectInfo]bool
+		if IsBackupObjectTypeVirtualMachine(backup) {
+			objectMap = a.vmIncludeResourceMap[string(backup.UID)]
+		} else {
+			objectMap = stork_api.CreateObjectsMap(backup.Spec.IncludeResources)
+		}
 		info := stork_api.ObjectInfo{
 			GroupVersionKind: metav1.GroupVersionKind{
 				Group:   "core",
@@ -1584,7 +1647,13 @@ func (a *ApplicationBackupController) backupResources(
 
 	// Always backup optional resources. When restorting they need to be
 	// explicitly added to the spec
-	objectMap := stork_api.CreateObjectsMap(backup.Spec.IncludeResources)
+	var objectMap map[stork_api.ObjectInfo]bool
+	if IsBackupObjectTypeVirtualMachine(backup) {
+		objectMap = a.vmIncludeResourceMap[string(backup.UID)]
+	} else {
+		objectMap = stork_api.CreateObjectsMap(backup.Spec.IncludeResources)
+	}
+
 	namespacelist := backup.Spec.Namespaces
 	// GetResources takes more time, if we have more number of namespaces
 	// So, submitting it in batches and in between each batch,
@@ -2030,7 +2099,7 @@ func (a *ApplicationBackupController) createCRD() error {
 }
 
 // IsVolsToBeBackedUp for a given backupspec do we need to have volumes backed up
-func IsVolsToBeBackedUp(backup *stork_api.ApplicationBackup) bool {
+func (a *ApplicationBackupController) IsVolsToBeBackedUp(backup *stork_api.ApplicationBackup) bool {
 	// If ResourceType is mentioned and doesn't have PVC in it we would
 	// like to skip the vol backups IFF includeResources doesn't have any ref to PVC
 	if len(backup.Spec.ResourceTypes) != 0 {
@@ -2040,7 +2109,11 @@ func IsVolsToBeBackedUp(backup *stork_api.ApplicationBackup) bool {
 
 		// Now we know ResourceType doesn't have PVC, but user could have given a includeResource
 		// which could have entry to backup a PVC
+
 		objectInfo := backup.Spec.IncludeResources
+		if IsBackupObjectTypeVirtualMachine(backup) {
+			objectInfo = a.vmIncludeResource[string(backup.UID)]
+		}
 		for _, object := range objectInfo {
 			if object.Kind == "PersistentVolumeClaim" {
 				return true
@@ -2108,4 +2181,108 @@ func (a *ApplicationBackupController) checkVolumeDriverCombination(volumes []*st
 		return nonKdmpDriverOnly
 	}
 	return mixedDriver
+}
+
+// createRuleCrObject create RuleCr from RuleItems
+func createRuleCrObject(rules []stork_api.RuleItem, backup *stork_api.ApplicationBackup, name string) *stork_api.Rule {
+
+	rulesObject := &stork_api.Rule{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Rules:      rules,
+	}
+
+	rulesObject.Name = name + "-" + string(backup.GetUID())
+	rulesObject.Namespace = backup.GetNamespace()
+
+	var annotations = make(map[string]string)
+	annotations[backupUIDKey] = string(backup.GetUID())
+	annotations[createdByKey] = createdByValue
+	annotations[lastUpdateKey] = metav1.Now().String()
+
+	rulesObject.Annotations = annotations
+
+	return rulesObject
+}
+
+// createVMRuleCr calls CreateRule if rule doesn't exist.
+func createVMRuleCr(rule *stork_api.Rule) error {
+	_, err := storkops.Instance().CreateRule(rule)
+	if err != nil {
+		if k8s_errors.IsAlreadyExists(err) {
+			// rule already exists, its not error for us
+			logrus.Debugf("Rule %v in %v namespace alreay exists, skipping recreate", rule.Name, rule.Namespace)
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// createVMSpecificBackupResources creates rulesCr and populateInclude resources with resources
+// associated to each of the VM specified in backup.Spec.IncludeResources
+func (a *ApplicationBackupController) createVMSpecificBackupResources(backup *stork_api.ApplicationBackup) (bool, error) {
+
+	returnErrorm := func(message string, err error) error {
+		logrus.Errorf(message, err)
+		return err
+	}
+	preExecRule, postExecRule, err := a.createVMIncludeResources(backup)
+	if err != nil {
+		return false, err
+	}
+	if preExecRule != nil && postExecRule != nil {
+		// create preExec ruleCr with freeze actions for the VMs
+		err = createVMRuleCr(preExecRule)
+		if err != nil {
+			return false, returnErrorm("error Creating PreExec ruleCR for vm freeze: %v", err)
+		}
+		backup.Spec.PreExecRule = preExecRule.Name
+
+		// create postExec ruleCr with unfreeze actions for the VMs
+		err = createVMRuleCr(postExecRule)
+		if err != nil {
+			return false, returnErrorm("error Creating PostExec ruleCR for vm unfreeze: %v", err)
+		}
+		backup.Spec.PostExecRule = postExecRule.Name
+		return true, nil
+	}
+	return false, nil
+}
+
+// createVMIncludeResources fetches resources for VM specified in includreResources or in namespace
+// and namespace filter.
+func (a *ApplicationBackupController) createVMIncludeResources(backup *stork_api.ApplicationBackup) (
+	*stork_api.Rule,
+	*stork_api.Rule,
+	error) {
+
+	// First VMs from various filters provided.
+	vmList, objectMap, err := resourcecollector.GetVMIncludeListFromBackup(backup)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Second fetch VM resources from the list of filtered VMs and freeze/thaw rule for each of them.
+	vmIncludeResources, objectMap, preExecRule, postExecRule := resourcecollector.GetVMIncludeResourceInfoList(vmList,
+		objectMap, backup.Spec.SkipAutoExecRules)
+
+	// update in memory data structure for later use.
+	a.vmIncludeResourceMap[string(backup.UID)] = objectMap
+	a.vmIncludeResource[string(backup.UID)] = vmIncludeResources
+
+	if len(preExecRule) <= 0 || len(postExecRule) <= 0 {
+		// No VMs needed free/thaw rule, skip creating ruleCr
+		return nil, nil, nil
+	}
+	// create preExecRuleCr with freeze actions
+	freezeRulesObject := createRuleCrObject(preExecRule, backup, vmFreezePrefix)
+	// create postExecRuleCr with unfreeze actions
+	unFreezeRulesObject := createRuleCrObject(postExecRule, backup, vmUnFreezePrefix)
+
+	return freezeRulesObject, unFreezeRulesObject, nil
+}
+
+// IsBackupObjectTypeVirtualMachine returns true if backupObjectType is VirtualMachine
+func IsBackupObjectTypeVirtualMachine(backup *stork_api.ApplicationBackup) bool {
+	return backup.Spec.BackupObjectType == resourcecollector.PxBackupObjectType_virtualMachine
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/kubevirt.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/kubevirt.go
@@ -22,6 +22,9 @@ type Ops interface {
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)
+
+	// GetVersion gets the version of kubevirt control plane
+	GetVersion() (string, error)
 }
 
 // Instance returns a singleton instance of the client.
@@ -79,6 +82,19 @@ type Client struct {
 func (c *Client) SetConfig(cfg *rest.Config) {
 	c.config = cfg
 	c.kubevirt = nil
+}
+
+// GetVersion gets the version of kubevirt control plane
+func (c *Client) GetVersion() (string, error) {
+	if err := c.initClient(); err != nil {
+		return "", err
+	}
+	versionInfo, err := c.kubevirt.ServerVersion().Get()
+	if err != nil {
+		return "", err
+	}
+	version := versionInfo.String()
+	return version, nil
 }
 
 // initClient the k8s client if uninitialized

--- a/vendor/github.com/portworx/sched-ops/k8s/openshift/securitycontextconstraints.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/openshift/securitycontextconstraints.go
@@ -14,6 +14,8 @@ type SecurityContextConstraintsOps interface {
 	ListSecurityContextConstraints() (*ocpsecurityv1api.SecurityContextConstraintsList, error)
 	// GetSecurityContextConstraints takes name of the securityContextConstraints and returns the corresponding securityContextConstraints object, and an error if there is any.
 	GetSecurityContextConstraints(string) (*ocpsecurityv1api.SecurityContextConstraints, error)
+	// CreateSecurityContextConstraints creates securityContextConstraints
+	CreateSecurityContextConstraints(*ocpsecurityv1api.SecurityContextConstraints) (*ocpsecurityv1api.SecurityContextConstraints, error)
 	// UpdateSecurityContextConstraints takes the representation of a securityContextConstraints and updates it. Returns the server's representation of the securityContextConstraints, and an error, if there is any.
 	UpdateSecurityContextConstraints(*ocpsecurityv1api.SecurityContextConstraints) (*ocpsecurityv1api.SecurityContextConstraints, error)
 }
@@ -36,6 +38,14 @@ func (c *Client) GetSecurityContextConstraints(name string) (result *ocpsecurity
 		return nil, err
 	}
 	return c.getOcpSecurityClient().SecurityContextConstraints().Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// CreateSecurityContextConstraints creates securityContextConstraints
+func (c *Client) CreateSecurityContextConstraints(securityContextConstraints *ocpsecurityv1api.SecurityContextConstraints) (result *ocpsecurityv1api.SecurityContextConstraints, err error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.getOcpSecurityClient().SecurityContextConstraints().Create(context.TODO(), securityContextConstraints, metav1.CreateOptions{})
 }
 
 // UpdateSecurityContextConstraints takes the representation of a securityContextConstraints and updates it. Returns the server's representation of the securityContextConstraints, and an error, if there is any.

--- a/vendor/github.com/portworx/sched-ops/k8s/storage/storageclass.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/storage/storageclass.go
@@ -10,9 +10,12 @@ import (
 
 // ScOps is an interface to perform k8s storage class operations
 type ScOps interface {
+	// GetAllStorageClasses returns all storageClasses
+	// Added this function since GetStorageClasses method was failing to list the Storage Classes when an empty label selector is passed
+	GetAllStorageClasses() (*storagev1.StorageClassList, error)
 	// GetStorageClasses returns all storageClasses that match given optional label selector
 	GetStorageClasses(labelSelector map[string]string) (*storagev1.StorageClassList, error)
-	// GetStorageClass returns the storage class for the give namme
+	// GetStorageClass returns the storage class for the give name
 	GetStorageClass(name string) (*storagev1.StorageClass, error)
 	// GetDefaultStorageClasses returns all storageClasses that are set as default
 	GetDefaultStorageClasses() (*storagev1.StorageClassList, error)
@@ -127,4 +130,13 @@ func (c *Client) AnnotateStorageClassAsDefault(name string) error {
 		return err
 	}
 	return nil
+}
+
+// GetAllStorageClasses returns all storageClasses
+// Added this function since GetStorageClasses method was failing to list the Storage Classes when an empty label selector is passed
+func (c *Client) GetAllStorageClasses() (*storagev1.StorageClassList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.storage.StorageClasses().List(context.TODO(), metav1.ListOptions{})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1093,7 +1093,7 @@ github.com/portworx/px-object-controller/client/listers/objectservice/v1alpha1
 github.com/portworx/px-object-controller/pkg/client
 github.com/portworx/px-object-controller/pkg/controller
 github.com/portworx/px-object-controller/pkg/utils
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86 => github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86 => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -2482,7 +2482,7 @@ sigs.k8s.io/yaml
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v0.0.0-20230511212757-41751b27d69f
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 # github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240201054218-ab9ae1d8091d
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
This PR implements PB-5061 kubevirt - phase 2 populate includeResource for VM backup. 

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
yes
This introduces new filed backupObjectType: VirtualMachine 

<img width="664" alt="Screenshot 2024-01-24 at 7 19 01 AM" src="https://github.com/libopenstorage/stork/assets/134993502/007310b6-d412-4cef-89b9-1691c18def48">

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```
no
**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
no



The CR otuput which gets populated with IncludeResources with configMap and PVC
<img width="2056" alt="Screenshot 2024-01-24 at 7 19 40 AM" src="https://github.com/libopenstorage/stork/assets/134993502/cf4c8c36-c37f-45f0-9cf7-8856845e127d">

