### PR TITLE
PB-5442: CRD Changes For ApplicationBackup CRD

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -43,6 +43,8 @@ type ApplicationBackupSpec struct {
 	IncludeResources []ObjectInfo      `json:"includeResources"`
 	ResourceTypes    []string          `json:"resourceTypes"`
 	BackupType       string            `json:"backupType"`
+	// CSISnapshotClassMap is 1 to 1 Map of CSI Provisioner to its Corresponding VolumeSnapshotClass to be used for backup
+	CSISnapshotClassMap map[string]string `json:"csiSnapshotClassMap"`
 }
 
 // ApplicationBackupReclaimPolicyType is the reclaim policy for the application backup

--- a/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/stork/v1alpha1/zz_generated.deepcopy.go
@@ -340,6 +340,13 @@ func (in *ApplicationBackupSpec) DeepCopyInto(out *ApplicationBackupSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.CSISnapshotClassMap != nil {
+		in, out := &in.CSISnapshotClassMap, &out.CSISnapshotClassMap
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:  We need API Changes in ApplicationBackup to add a map of CSI Drivers to their respective VolumeSnapshot that will be handy in case of csi based backup


**Does this PR change a user-facing CRD or CLI?**: CRD
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
--> We need API Changes in ApplicationBackup to add a map of CSI Drivers to their respective VolumeSnapshot that will be handy in case of csi based backup

**Is a release note needed?**: 
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact: user will now have to use **csiSnapshotClassMap** instead of **CsiSnapshotClassName** as that will deprecated to increase more flexibility in case of multiple csi provisioner
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

