### PR TITLE
feat: removed creation of default vsc from stork

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -194,108 +193,9 @@ func (c *csi) Init(_ interface{}) error {
 		return err
 	}
 
-	err = c.createDefaultSnapshotClasses()
-	if err != nil {
-		return err
-	}
-
 	c.snapshotter, err = snapshotter.NewCSIDriver()
 	if err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func (c *csi) createDefaultSnapshotClasses() error {
-	var existingSnapshotClassesDriverList []string
-	if c.v1SnapshotRequired {
-		existingSnapshotClasses, err := c.snapshotClient.SnapshotV1().VolumeSnapshotClasses().List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			logrus.Infof("CSI v1 VolumeSnapshotClass CRD does not exist, skipping default SnapshotClass creation - error:  %v", err)
-			return nil
-		}
-		for _, existingSnapClass := range existingSnapshotClasses.Items {
-			logrus.Infof("Driver name %s", existingSnapClass.Driver)
-			existingSnapshotClassesDriverList = append(existingSnapshotClassesDriverList, existingSnapClass.Driver)
-		}
-	} else {
-		existingSnapshotClasses, err := c.snapshotClient.SnapshotV1beta1().VolumeSnapshotClasses().List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			logrus.Infof("CSI v1beta1 VolumeSnapshotClass CRD does not exist, skipping default SnapshotClass creation - error: %v", err)
-			return nil
-		}
-		for _, existingSnapClass := range existingSnapshotClasses.Items {
-			logrus.Infof("Driver name %s", existingSnapClass.Driver)
-			existingSnapshotClassesDriverList = append(existingSnapshotClassesDriverList, existingSnapClass.Driver)
-		}
-	}
-
-	logrus.Infof("Creating default CSI SnapshotClasses")
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get config for creating default CSI snapshot classes: %v", err)
-	}
-
-	k8sClient, err := clientset.NewForConfig(config)
-	if err != nil {
-		return fmt.Errorf("failed to get client for creating default CSI snapshot classes: %v", err)
-	}
-
-	ok, err := version.RequiresV1CSIdriver()
-	if err != nil {
-		return err
-	}
-	var csiDriverNameList []string
-	if ok {
-		// Get all drivers
-		driverList, err := k8sClient.StorageV1().CSIDrivers().List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to list all CSI drivers(V1): %v", err)
-		}
-		// Fill the driver names from CSIDrivers to list
-		for _, driver := range driverList.Items {
-			csiDriverNameList = append(csiDriverNameList, driver.Name)
-		}
-	} else {
-
-		// Get all drivers
-		driverList, err := k8sClient.StorageV1beta1().CSIDrivers().List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to list all CSI drivers(V1beta1): %v", err)
-		}
-		// Fill the driver names from CSIDrivers to list
-		for _, driver := range driverList.Items {
-			csiDriverNameList = append(csiDriverNameList, driver.Name)
-		}
-	}
-
-	// Create VolumeSnapshotClass for each driver
-	for _, driverName := range csiDriverNameList {
-		// skip drivers with native supports
-		if c.HasNativeVolumeDriverSupport(driverName) {
-			logrus.Infof("CSI driver %s has native support, skipping default snapshotclass creation", driverName)
-			continue
-		}
-
-		foundSnapClass := false
-		for _, existingSnapClassDriverName := range existingSnapshotClassesDriverList {
-			if driverName == existingSnapClassDriverName {
-				logrus.Infof("CSI VolumeSnapshotClass exists for driver %v. Skipping creation of snapshotclass", driverName)
-				foundSnapClass = true
-				break
-			}
-		}
-		if foundSnapClass {
-			continue
-		}
-		snapshotClassName := c.getDefaultSnapshotClassName(driverName)
-		_, err := c.createVolumeSnapshotClass(snapshotClassName, driverName)
-		if err != nil && !k8s_errors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create default snapshotclass %s: %v", snapshotClassName, err)
-		} else if k8s_errors.IsAlreadyExists(err) {
-			logrus.Infof("VolumeSnapshotClass %s already exists, skipping default snapshotclass creation", snapshotClassName)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
For KDMP clean up we are removing creation of default VolumeSnapshotClass from stork. As we don’t know whether that particular csi driver has a capability of volumeSnapshot or not
User has to create a VolumeSnapshotClass if required by them.

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
- Removes creation of default VolumeSnapshotClass from stork

- Before updating the stork with latest changes, stork creating default VSC
<img width="1152" alt="Screenshot 2024-01-30 at 4 18 24 PM" src="https://github.com/libopenstorage/stork/assets/146064543/70e49a05-65d8-4958-926e-c7dc6d73a619">

- Deleted stork created VSC class, and restarted the stork with latest changes, stork did not create VSC by default.
<img width="1152" alt="Screenshot 2024-01-30 at 4 16 54 PM" src="https://github.com/libopenstorage/stork/assets/146064543/69f04855-988f-4607-a505-84e65758d3a2">


