### PR TITLE
PB-5381: Cleanup of rule resources upon completion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -334,7 +334,7 @@ replace (
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v0.0.0-20230511212757-41751b27d69f
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240124052301-0face6685a64
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3

--- a/go.sum
+++ b/go.sum
@@ -2945,8 +2945,8 @@ github.com/portworx/px-backup-api v1.2.2-0.20230904054048-eb1f23dd7431/go.mod h1
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987 h1:VNBTmIPjJRZ2QP64zdsrif3ELDHiMzoyNNX74VNHgZ8=
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987/go.mod h1:g3pw2lI2AjqAixUCRhaBdKTY98znsCPR7NGRrlpimVU=
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4 h1:4hTAVUup7vdmmYeAj4d0P+k5tUX69ftkttse0wOhlVU=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27 h1:1Q50KWDMei8O+ckB2UzUKC6eRT6Aiwxg6u99C9wtrK0=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0 h1:KXN6ublTdb+tSfEwmrS7rxIjC0ys3w6agfm5CnyTdb0=

--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -45,6 +45,8 @@ type ApplicationBackupSpec struct {
 	BackupType       string            `json:"backupType"`
 	// CSISnapshotClassMap is 1 to 1 Map of CSI Provisioner to its Corresponding VolumeSnapshotClass to be used for backup
 	CSISnapshotClassMap map[string]string `json:"csiSnapshotClassMap"`
+	BackupObjectType    string            `json:"backupObjectType"`
+	SkipAutoExecRules   bool              `json:"skipAutoExecRules"`
 }
 
 // ApplicationBackupReclaimPolicyType is the reclaim policy for the application backup
@@ -130,6 +132,8 @@ type ApplicationBackupStageType string
 const (
 	// ApplicationBackupStageInitial for when backup is created
 	ApplicationBackupStageInitial ApplicationBackupStageType = ""
+	// ApplicationBackupStageImportResource for when vm resources are imported
+	ApplicationBackupStageImportResource ApplicationBackupStageType = "ImportResource"
 	// ApplicationBackupStagePreExecRule for when the PreExecRule is being executed
 	ApplicationBackupStagePreExecRule ApplicationBackupStageType = "PreExecRule"
 	// ApplicationBackupStagePostExecRule for when the PostExecRule is being executed

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -90,6 +90,20 @@ const (
 	backupObjectUIDKey              = kdmpAnnotationPrefix + "backupobject-uid"
 	restoreObjectUIDKey             = kdmpAnnotationPrefix + "restoreobject-uid"
 	skipResourceAnnotation          = "stork.libopenstorage.org/skip-resource"
+	//VmFreezePrefix prefix for freeze rule action
+	vmFreezePrefix = "vm-freeze-pre-rule"
+	//VmUnFreezePrefix prefix for freeze rule action
+	vmUnFreezePrefix = "vm-unfreeze-post-rule"
+	// annotationsKeys to identify these are in corrolation with px-backup request.
+	annotationKeyPrefix = "portworx.io/"
+	backupUIDKey        = annotationKeyPrefix + "backup-uid"
+	backupNameKey       = annotationKeyPrefix + "backup-name"
+	clusterNameKey      = annotationKeyPrefix + "cluster-name"
+	clusterUIDKey       = annotationKeyPrefix + "cluster-uid"
+	createdByKey        = annotationKeyPrefix + "created-by"
+	createdByValue      = annotationKeyPrefix + "stork"
+	lastUpdateKey       = annotationKeyPrefix + "last-update"
+	VmResourcePopulated = annotationKeyPrefix + "vm-resources-populated"
 )
 
 var (
@@ -116,6 +130,8 @@ type ApplicationBackupController struct {
 	terminationChannels  map[string][]chan bool
 	execRulesCompleted   map[string]bool
 	reconcileTime        time.Duration
+	vmIncludeResource    map[string][]stork_api.ObjectInfo
+	vmIncludeResourceMap map[string]map[stork_api.ObjectInfo]bool
 }
 
 // Init Initialize the application backup controller
@@ -133,6 +149,8 @@ func (a *ApplicationBackupController) Init(mgr manager.Manager, backupAdminNames
 	a.reconcileTime = time.Duration(syncTime) * time.Second
 	a.terminationChannels = make(map[string][]chan bool)
 	a.execRulesCompleted = make(map[string]bool)
+	a.vmIncludeResource = make(map[string][]stork_api.ObjectInfo)
+	a.vmIncludeResourceMap = make(map[string]map[stork_api.ObjectInfo]bool)
 	return controllers.RegisterTo(mgr, "application-backup-controller", a, &stork_api.ApplicationBackup{})
 }
 
@@ -265,6 +283,14 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 			if _, ok := a.execRulesCompleted[string(backup.UID)]; ok {
 				delete(a.execRulesCompleted, string(backup.UID))
 				log.ApplicationBackupLog(backup).Infof("deleted post exec flag entry from controller map for backup [%v/%v]", backup.Namespace, backup.Name)
+			}
+			if _, ok := a.vmIncludeResource[string(backup.UID)]; ok {
+				delete(a.vmIncludeResource, string(backup.UID))
+				log.ApplicationBackupLog(backup).Infof("cleaning up vmIncludeResources for VM backupObjectType %v", a.vmIncludeResource)
+			}
+			if _, ok := a.vmIncludeResourceMap[string(backup.UID)]; ok {
+				delete(a.vmIncludeResourceMap, string(backup.UID))
+				log.ApplicationBackupLog(backup).Infof("cleaning up vmIncludeResources for VM backupObjectType")
 			}
 			// Calling cleanupResources which will cleanup the resources created by applicationbackup controller.
 			// In the case of kdmp driver, it will cleanup the dataexport CRs.
@@ -405,6 +431,40 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 			}
 		}
 		fallthrough
+	case stork_api.ApplicationBackupStageImportResource:
+		if IsBackupObjecyTypeVirtualMachine(backup) {
+			logrus.Infof("This is a VM specific backup, processing resource collection of vm resources")
+			updateCr, err := a.createVMSpecificBackupResources(backup)
+			if err != nil {
+				backup.Status.Status = stork_api.ApplicationBackupStatusFailed
+				backup.Status.Reason = fmt.Sprintf("error Updating Backup CR for VMObject Backup : %v", err)
+				backup.Status.Stage = stork_api.ApplicationBackupStageFinal
+				backup.Status.FinishTimestamp = metav1.Now()
+				backup.Status.LastUpdateTimestamp = metav1.Now()
+				err = fmt.Errorf("error Updating Backup CR for VMObject Backup : %v", err)
+				log.ApplicationBackupLog(backup).Errorf(err.Error())
+				a.recorder.Event(backup,
+					v1.EventTypeWarning,
+					string(stork_api.ApplicationBackupStatusFailed),
+					err.Error())
+				updateCr = true
+			}
+			//updateCr = true
+			if updateCr {
+				//backup.Spec.IncludeResources = a.vmIncludeResource
+				backup.Status.Stage = stork_api.ApplicationBackupStagePreExecRule
+				backup.Status.LastUpdateTimestamp = metav1.Now()
+
+				err = a.client.Update(context.TODO(), backup)
+				if err != nil {
+					log.ApplicationBackupLog(backup).Errorf("error updating Cr in VMBackupProcessingStage: %v", err)
+					return err
+				}
+				return nil
+			}
+		}
+		//logrus.Infof("Non VM backup, moving on.")
+		fallthrough
 	case stork_api.ApplicationBackupStagePreExecRule:
 		var inProgress bool
 		a.terminationChannels[string(backup.UID)], inProgress, err = a.runPreExecRule(backup)
@@ -461,6 +521,7 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		}
 
 	case stork_api.ApplicationBackupStageFinal:
+		logrus.Errorf("########## Reached final stage return safely ############")
 		// Do Nothing
 		return nil
 	default:
@@ -564,9 +625,14 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 
 	backup.Status.Stage = stork_api.ApplicationBackupStageVolumes
 	namespacedName := types.NamespacedName{}
-	if IsVolsToBeBackedUp(backup) {
+	if a.IsVolsToBeBackedUp(backup) {
 		isResourceTypePVC := IsResourceTypePVC(backup)
-		objectMap := stork_api.CreateObjectsMap(backup.Spec.IncludeResources)
+		objectMap := map[stork_api.ObjectInfo]bool{}
+		if IsBackupObjecyTypeVirtualMachine(backup) {
+			objectMap = a.vmIncludeResourceMap[string(backup.UID)]
+		} else {
+			objectMap = stork_api.CreateObjectsMap(backup.Spec.IncludeResources)
+		}
 		info := stork_api.ObjectInfo{
 			GroupVersionKind: metav1.GroupVersionKind{
 				Group:   "core",
@@ -1584,7 +1650,13 @@ func (a *ApplicationBackupController) backupResources(
 
 	// Always backup optional resources. When restorting they need to be
 	// explicitly added to the spec
-	objectMap := stork_api.CreateObjectsMap(backup.Spec.IncludeResources)
+	objectMap := map[stork_api.ObjectInfo]bool{}
+	if IsBackupObjecyTypeVirtualMachine(backup) {
+		objectMap = a.vmIncludeResourceMap[string(backup.UID)]
+	} else {
+		objectMap = stork_api.CreateObjectsMap(backup.Spec.IncludeResources)
+	}
+
 	namespacelist := backup.Spec.Namespaces
 	// GetResources takes more time, if we have more number of namespaces
 	// So, submitting it in batches and in between each batch,
@@ -2030,7 +2102,7 @@ func (a *ApplicationBackupController) createCRD() error {
 }
 
 // IsVolsToBeBackedUp for a given backupspec do we need to have volumes backed up
-func IsVolsToBeBackedUp(backup *stork_api.ApplicationBackup) bool {
+func (a *ApplicationBackupController) IsVolsToBeBackedUp(backup *stork_api.ApplicationBackup) bool {
 	// If ResourceType is mentioned and doesn't have PVC in it we would
 	// like to skip the vol backups IFF includeResources doesn't have any ref to PVC
 	if len(backup.Spec.ResourceTypes) != 0 {
@@ -2040,7 +2112,11 @@ func IsVolsToBeBackedUp(backup *stork_api.ApplicationBackup) bool {
 
 		// Now we know ResourceType doesn't have PVC, but user could have given a includeResource
 		// which could have entry to backup a PVC
+
 		objectInfo := backup.Spec.IncludeResources
+		if IsBackupObjecyTypeVirtualMachine(backup) {
+			objectInfo = a.vmIncludeResource[string(backup.UID)]
+		}
 		for _, object := range objectInfo {
 			if object.Kind == "PersistentVolumeClaim" {
 				return true
@@ -2108,4 +2184,111 @@ func (a *ApplicationBackupController) checkVolumeDriverCombination(volumes []*st
 		return nonKdmpDriverOnly
 	}
 	return mixedDriver
+}
+
+// createRuleCrObject create RuleCr from RuleItems
+func createRuleCrObject(rules []stork_api.RuleItem, backup *stork_api.ApplicationBackup, name string) *stork_api.Rule {
+
+	rulesObject := &stork_api.Rule{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{},
+		Rules:      rules,
+	}
+
+	rulesObject.Name = name + "-" + backup.Annotations[backupUIDKey]
+	rulesObject.Namespace = backup.GetNamespace()
+
+	var annotations = make(map[string]string)
+	annotations[backupUIDKey] = backup.Annotations[backupUIDKey]
+	annotations[createdByKey] = createdByValue
+	annotations[lastUpdateKey] = metav1.Now().String()
+	annotations[clusterNameKey] = backup.Annotations[clusterNameKey]
+	annotations[clusterUIDKey] = backup.Annotations[clusterUIDKey]
+
+	rulesObject.Annotations = annotations
+
+	return rulesObject
+}
+
+// createVMRuleCr calls CreateRule if rule doesn't exist.
+func createVMRuleCr(rule *stork_api.Rule) error {
+	_, err := storkops.Instance().CreateRule(rule)
+	if err != nil {
+		if k8s_errors.IsAlreadyExists(err) {
+			// rule already exists, its not error for us
+			logrus.Debugf("Rule %v in %v namespace alreay exists, skipping recreate", rule.Name, rule.Namespace)
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// createVMSpecificBackupResources creates rulesCr and populateInclude resources with resources
+// associated to each of the VM specified in backup.Spec.IncludeResources
+func (a *ApplicationBackupController) createVMSpecificBackupResources(backup *stork_api.ApplicationBackup) (bool, error) {
+
+	returnErrorm := func(message string, err error) error {
+		logrus.Errorf(message, err)
+		return err
+	}
+	preExecRule, postExecRule, err := a.createVMIncludeResources(backup)
+	if err != nil {
+		return false, err
+	}
+	if preExecRule != nil && postExecRule != nil {
+		// create preExec ruleCr with freeze actions for the VMs
+		err = createVMRuleCr(preExecRule)
+		if err != nil {
+			return false, returnErrorm("error Creating PreExec ruleCR for vm freeze: %v", err)
+		}
+		backup.Spec.PreExecRule = preExecRule.Name
+
+		// create postExec ruleCr with unfreeze actions for the VMs
+		err = createVMRuleCr(postExecRule)
+		if err != nil {
+			return false, returnErrorm("error Creating PostExec ruleCR for vm unfreeze: %v", err)
+		}
+		backup.Spec.PostExecRule = postExecRule.Name
+		return true, nil
+	}
+	return false, nil
+}
+
+// createVMIncludeResources fetches resources for VM specified in includreResources or in namespace
+// and namespace filter.
+func (a *ApplicationBackupController) createVMIncludeResources(backup *stork_api.ApplicationBackup) (
+	*stork_api.Rule,
+	*stork_api.Rule,
+	error) {
+
+	objectMap := map[stork_api.ObjectInfo]bool{}
+	// First VMs from various filters provided.
+	vmList, objectMap, err := resourcecollector.GetVMIncludeListFromBackup(backup, objectMap)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Second fetch VM resources from the list of filtered VMs and freeze/thaw rule for each of them.
+	vmIncludeResources, objectMap, preExecRule, postExecRule := resourcecollector.GetVMIncludeResourceInfoList(vmList,
+		objectMap, backup.Spec.SkipAutoExecRules)
+
+	// update in memory data structure for later use.
+	a.vmIncludeResourceMap[string(backup.UID)] = objectMap
+	a.vmIncludeResource[string(backup.UID)] = vmIncludeResources
+
+	if len(preExecRule) <= 0 || len(postExecRule) <= 0 {
+		// No VMs needed free/thaw rule, skip creating ruleCr
+		return nil, nil, nil
+	}
+	// create preExecRuleCr with freeze actions
+	freezeRulesObject := createRuleCrObject(preExecRule, backup, vmFreezePrefix)
+	// create postExecRuleCr with unfreeze actions
+	unFreezeRulesObject := createRuleCrObject(postExecRule, backup, vmUnFreezePrefix)
+
+	return freezeRulesObject, unFreezeRulesObject, nil
+}
+
+// IsBackupObjecyTypeVirtualMachine returns true if backupObjectType is VirtualMachine
+func IsBackupObjecyTypeVirtualMachine(backup *stork_api.ApplicationBackup) bool {
+	return backup.Spec.BackupObjectType == resourcecollector.PxBackupObjectType_virtualMachine
 }

--- a/pkg/resourcecollector/virtualmachine.go
+++ b/pkg/resourcecollector/virtualmachine.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 
 	storkapi "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	kubevirtops "github.com/portworx/sched-ops/k8s/kubevirt"
+	"github.com/sirupsen/logrus"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -348,5 +351,196 @@ func getObjectInfo(resourceNames []string, namespace string, objectKind string) 
 		objectInfoList = append(objectInfoList, info)
 	}
 	return objectInfoList
+
+}
+
+// GetRuleItemWithVMAction return PreRuleItem and PostRuleItem with freeze/thaw rule for the given VM
+// This function is also used by torpedo for testing.
+func GetRuleItemWithVMAction(vm kubevirtv1.VirtualMachine) (storkapi.RuleItem, storkapi.RuleItem) {
+
+	vmPodSelector := GetVMPodLabel(vm)
+	vmfreezeAction := GetVMFreezeRule(vm)
+	vmUnFreezeAction := GetVMUnFreezeRule(vm)
+
+	//create RuleItem from podselector and freeze/unfreeze actions
+	preRuleItem := getRuleItemWithAction(vmPodSelector, vmfreezeAction)
+	postRuleItem := getRuleItemWithAction(vmPodSelector, vmUnFreezeAction)
+
+	return preRuleItem, postRuleItem
+}
+
+// getRuleItemWithAction helper function that returns RuleItem from podSelector and action string
+func getRuleItemWithAction(podSelector map[string]string, ruleAction string) storkapi.RuleItem {
+	var actions []storkapi.RuleAction
+
+	action := storkapi.RuleAction{
+		Type:  storkapi.RuleActionCommand,
+		Value: ruleAction,
+	}
+	actions = append(actions, action)
+	ruleInfoItem := storkapi.RuleItem{
+		PodSelector: podSelector,
+		Actions:     actions,
+	}
+	return ruleInfoItem
+}
+func getVmsFromNamespaceList(namespaces []string, objectMap map[storkapi.ObjectInfo]bool) (
+	[]kubevirtv1.VirtualMachine,
+	error) {
+
+	if len(namespaces) <= 0 {
+		return nil, nil
+	}
+	kv := kubevirtops.Instance()
+
+	listOptions := &metav1.ListOptions{
+		Limit: 500,
+	}
+	VmList := make([]kubevirtv1.VirtualMachine, 0)
+	for _, ns := range namespaces {
+		if IsNsPresentInIncludeResource(objectMap, ns) {
+			//We don't need to fetch resources from this ns
+			// priority is for includeResource. We already
+			// added those list to includeResources
+			continue
+		}
+		for {
+			blist, err := kv.BatchListVirtualMachines(ns, listOptions)
+			if err != nil {
+				return nil, fmt.Errorf("error fetching list VM for ns %v: %v", ns, err)
+			}
+			VmList = append(VmList, blist.Items...)
+			if blist.Continue == "" {
+				break
+			} else {
+				listOptions.Continue = blist.Continue
+			}
+		}
+	}
+	return VmList, nil
+}
+
+func getVmsFromIncludeResourceList(
+	includeResources []storkapi.ObjectInfo,
+	objectMap map[storkapi.ObjectInfo]bool) (
+	[]kubevirtv1.VirtualMachine,
+	map[storkapi.ObjectInfo]bool,
+	error) {
+
+	if len(includeResources) == 0 {
+		return nil, objectMap, nil
+	}
+
+	vmList := make([]kubevirtv1.VirtualMachine, 0)
+	kv := kubevirtops.Instance()
+	for _, resourceInfo := range includeResources {
+		if resourceInfo.Kind != "VirtualMachine" {
+			logrus.Debugf("found nonVM entry for VM BackupObject type in includeResources name:%v, kind:%v, ignoring..", resourceInfo.Name, resourceInfo.Kind)
+			continue
+		}
+		vm, err := kv.GetVirtualMachine(resourceInfo.Name, resourceInfo.Namespace)
+		if err != nil {
+			// if we could not fetch the VM specified, we error out.
+			// we continue with rest of the list if the VM is not found.
+			// If none of the VMs in the includeResource is found,
+			// we will still proceed. This will cause empty resource backup.
+			if k8s_errors.IsNotFound(err) {
+				objectMap[resourceInfo] = true
+				continue
+			}
+			logrus.Errorf("error fetching VM from includeResource list %v(%v)", resourceInfo.Name, resourceInfo.Namespace)
+			return nil, objectMap, err
+		}
+		objectMap[resourceInfo] = true
+		vmList = append(vmList, *vm)
+	}
+	return vmList, objectMap, nil
+}
+
+// GetVMIncludeListFromBackup returns all the VMs from various filters,
+func GetVMIncludeListFromBackup(backup *storkapi.ApplicationBackup, objectMap map[storkapi.ObjectInfo]bool) (
+	[]kubevirtv1.VirtualMachine,
+	map[storkapi.ObjectInfo]bool,
+	error) {
+
+	// First Fetch VM List from backup.Spec.IncludeResources
+	vmIncList, objectMap, err := getVmsFromIncludeResourceList(backup.Spec.IncludeResources, objectMap)
+	if err != nil {
+		return nil, objectMap, err
+	}
+	// Second fetch VM List from Namespace and Namespace label list
+	vmNsList, err := getVmsFromNamespaceList(backup.Spec.Namespaces, objectMap)
+	if err != nil {
+		return nil, objectMap, err
+	}
+	vmIncList = append(vmIncList, vmNsList...)
+	return vmIncList, objectMap, nil
+}
+
+// GetVMIncludeResourceInfoList returns VMs and VM resources in IncludeResource format.
+// Also returns preExec and postExec rule Item with freeze/thaw rule for each of the filter VMs
+func GetVMIncludeResourceInfoList(vmList []kubevirtv1.VirtualMachine, objectMap map[storkapi.ObjectInfo]bool, skipAutoVMRule bool) (
+	[]storkapi.ObjectInfo,
+	map[storkapi.ObjectInfo]bool,
+	[]storkapi.RuleItem,
+	[]storkapi.RuleItem,
+
+) {
+
+	freezeRulesItems := make([]storkapi.RuleItem, 0)
+	unFreezeRulesItems := make([]storkapi.RuleItem, 0)
+	vmResourceInfoList := make([]storkapi.ObjectInfo, 0)
+	for _, vm := range vmList {
+		addRule := false
+		resourceInfoList := GetObjectInfoFromVMResources(vm)
+		vmInfo := storkapi.ObjectInfo{
+			GroupVersionKind: metav1.GroupVersionKind{
+				Group:   "kubevirt.io",
+				Version: "v1",
+				Kind:    "VirtualMachine",
+			},
+			Name:      vm.Name,
+			Namespace: vm.Namespace,
+		}
+		if !objectMap[vmInfo] {
+			objectMap[vmInfo] = true
+			vmResourceInfoList = append(vmResourceInfoList, vmInfo)
+		}
+
+		for _, info := range resourceInfoList {
+			if !objectMap[info] {
+				objectMap[info] = true
+				vmResourceInfoList = append(vmResourceInfoList, info)
+			}
+			if info.Kind == "PersistentVolumeClaim" {
+				addRule = true
+			}
+		}
+
+		if skipAutoVMRule {
+			// Auto Rules are disabled hence skip it.
+			continue
+		}
+		if !IsVirtualMachineRunning(vm) {
+			// Skip auto rules for non running VMs.
+			continue
+		}
+		if !IsVMAgentConnected(vm) {
+			// qemu-guest-agent is not running, skip autoRules for this VM
+			logrus.Warnf("skipping freeze/thaw rules for VirtualMachine %v(%v) reason : Agent Not Connected",
+				vm.Name, vm.Namespace)
+			continue
+		}
+		// Only add rule if there are PVCs associated to the VM.
+		if addRule {
+			preRuleItem, postRuleItem := GetRuleItemWithVMAction(vm)
+			freezeRulesItems = append(freezeRulesItems, preRuleItem)
+			unFreezeRulesItems = append(unFreezeRulesItems, postRuleItem)
+		} else {
+			logrus.Debugf("skipping freeze/thaw rules for VirtualMachine %v(%v) reason: No PVCs attached to the VM",
+				vm.Name, vm.Namespace)
+		}
+	}
+	return vmResourceInfoList, objectMap, freezeRulesItems, unFreezeRulesItems
 
 }

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/kubevirt.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/kubevirt.go
@@ -22,6 +22,9 @@ type Ops interface {
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)
+
+	// GetVersion gets the version of kubevirt control plane
+	GetVersion() (string, error)
 }
 
 // Instance returns a singleton instance of the client.
@@ -79,6 +82,19 @@ type Client struct {
 func (c *Client) SetConfig(cfg *rest.Config) {
 	c.config = cfg
 	c.kubevirt = nil
+}
+
+// GetVersion gets the version of kubevirt control plane
+func (c *Client) GetVersion() (string, error) {
+	if err := c.initClient(); err != nil {
+		return "", err
+	}
+	versionInfo, err := c.kubevirt.ServerVersion().Get()
+	if err != nil {
+		return "", err
+	}
+	version := versionInfo.String()
+	return version, nil
 }
 
 // initClient the k8s client if uninitialized

--- a/vendor/github.com/portworx/sched-ops/k8s/openshift/securitycontextconstraints.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/openshift/securitycontextconstraints.go
@@ -14,6 +14,8 @@ type SecurityContextConstraintsOps interface {
 	ListSecurityContextConstraints() (*ocpsecurityv1api.SecurityContextConstraintsList, error)
 	// GetSecurityContextConstraints takes name of the securityContextConstraints and returns the corresponding securityContextConstraints object, and an error if there is any.
 	GetSecurityContextConstraints(string) (*ocpsecurityv1api.SecurityContextConstraints, error)
+	// CreateSecurityContextConstraints creates securityContextConstraints
+	CreateSecurityContextConstraints(*ocpsecurityv1api.SecurityContextConstraints) (*ocpsecurityv1api.SecurityContextConstraints, error)
 	// UpdateSecurityContextConstraints takes the representation of a securityContextConstraints and updates it. Returns the server's representation of the securityContextConstraints, and an error, if there is any.
 	UpdateSecurityContextConstraints(*ocpsecurityv1api.SecurityContextConstraints) (*ocpsecurityv1api.SecurityContextConstraints, error)
 }
@@ -36,6 +38,14 @@ func (c *Client) GetSecurityContextConstraints(name string) (result *ocpsecurity
 		return nil, err
 	}
 	return c.getOcpSecurityClient().SecurityContextConstraints().Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// CreateSecurityContextConstraints creates securityContextConstraints
+func (c *Client) CreateSecurityContextConstraints(securityContextConstraints *ocpsecurityv1api.SecurityContextConstraints) (result *ocpsecurityv1api.SecurityContextConstraints, err error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.getOcpSecurityClient().SecurityContextConstraints().Create(context.TODO(), securityContextConstraints, metav1.CreateOptions{})
 }
 
 // UpdateSecurityContextConstraints takes the representation of a securityContextConstraints and updates it. Returns the server's representation of the securityContextConstraints, and an error, if there is any.

--- a/vendor/github.com/portworx/sched-ops/k8s/storage/storageclass.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/storage/storageclass.go
@@ -10,9 +10,12 @@ import (
 
 // ScOps is an interface to perform k8s storage class operations
 type ScOps interface {
+	// GetAllStorageClasses returns all storageClasses
+	// Added this function since GetStorageClasses method was failing to list the Storage Classes when an empty label selector is passed
+	GetAllStorageClasses() (*storagev1.StorageClassList, error)
 	// GetStorageClasses returns all storageClasses that match given optional label selector
 	GetStorageClasses(labelSelector map[string]string) (*storagev1.StorageClassList, error)
-	// GetStorageClass returns the storage class for the give namme
+	// GetStorageClass returns the storage class for the give name
 	GetStorageClass(name string) (*storagev1.StorageClass, error)
 	// GetDefaultStorageClasses returns all storageClasses that are set as default
 	GetDefaultStorageClasses() (*storagev1.StorageClassList, error)
@@ -127,4 +130,13 @@ func (c *Client) AnnotateStorageClassAsDefault(name string) error {
 		return err
 	}
 	return nil
+}
+
+// GetAllStorageClasses returns all storageClasses
+// Added this function since GetStorageClasses method was failing to list the Storage Classes when an empty label selector is passed
+func (c *Client) GetAllStorageClasses() (*storagev1.StorageClassList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.storage.StorageClasses().List(context.TODO(), metav1.ListOptions{})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1093,7 +1093,7 @@ github.com/portworx/px-object-controller/client/listers/objectservice/v1alpha1
 github.com/portworx/px-object-controller/pkg/client
 github.com/portworx/px-object-controller/pkg/controller
 github.com/portworx/px-object-controller/pkg/utils
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86 => github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20231013094113-8ca7856dbe86 => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -2482,7 +2482,7 @@ sigs.k8s.io/yaml
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v0.0.0-20230511212757-41751b27d69f
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 # github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240124052301-0face6685a64
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20230930052008-186afa1e82c4
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3


### PR DESCRIPTION
**What type of PR is this?**
>improvement


**What this PR does / why we need it**:
When the VM backup is taken, stork creates Rule CRs which are not automatically deleted, now changes are added in the `cleanupResources` function, which detects the rules created by stork and then deletes them.
**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Attaching screenshots below for reference
<img width="1722" alt="Screenshot 2024-01-29 at 11 41 46 PM" src="https://github.com/libopenstorage/stork/assets/148333439/d3faf370-ec44-4d0e-9d9e-ff4ec3d1be72">
<img width="656" alt="Screenshot 2024-01-29 at 11 42 17 PM" src="https://github.com/libopenstorage/stork/assets/148333439/b00dc437-c440-4734-bf6e-68b104f12654">
<img width="899" alt="Screenshot 2024-01-29 at 11 43 36 PM" src="https://github.com/libopenstorage/stork/assets/148333439/d963f7fc-081f-4e9e-b7fd-0d392fadec42">
<img width="981" alt="Screenshot 2024-01-29 at 11 43 48 PM" src="https://github.com/libopenstorage/stork/assets/148333439/a7b0d694-3f5b-4d08-beba-d3f5f8fa6cbd">
<img width="732" alt="Screenshot 2024-01-29 at 11 44 23 PM" src="https://github.com/libopenstorage/stork/assets/148333439/ab0df18d-14b6-425b-bf17-e24d5591828e">

