### PR TITLE
PB-5381: Cleanup of rule resources upon completion

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -2163,6 +2163,46 @@ func (a *ApplicationBackupController) cleanupResources(
 		log.ApplicationBackupLog(backup).Errorf("%v", errMsg)
 		return err
 	}
+	// Check if the backup is of the type virtual machine.
+	if IsBackupObjecyTypeVirtualMachine(backup) {
+		deleteRuleIfExists := func(ruleName string) error {
+			// Fetch the rule first
+			rule, err := storkops.Instance().GetRule(backup.Namespace, ruleName)
+			if err != nil {
+				if k8s_errors.IsNotFound(err) {
+					logrus.Infof("rule CR [%v] not found, skipping deletion", ruleName)
+					return nil
+				}
+				errMsg := fmt.Sprintf("failed to retrieve the rule CR [%v]: %v", ruleName, err)
+				log.ApplicationBackupLog(backup).Errorf("%v", errMsg)
+				return err
+			}
+
+			// Check if annotations match
+			if rule != nil &&
+				rule.Annotations[backupUIDKey] == backup.Annotations[backupUIDKey] &&
+				rule.Annotations[createdByKey] == createdByValue {
+				logrus.Infof("deleting rule CR: %v", rule.Name)
+				err := storkops.Instance().DeleteRule(rule.Name, backup.Namespace)
+				if err != nil && !k8s_errors.IsNotFound(err) {
+					errMsg := fmt.Sprintf("failed to delete the rule CR [%v]: %v", rule.Name, err)
+					log.ApplicationBackupLog(backup).Errorf("%v", errMsg)
+					return err
+				}
+			}
+			return nil
+		}
+
+		// Delete the pre-exec rule
+		if err := deleteRuleIfExists(backup.Spec.PreExecRule); err != nil {
+			return err
+		}
+
+		// Delete the post-exec rule
+		if err := deleteRuleIfExists(backup.Spec.PostExecRule); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION

**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
When the VM backup is taken, stork creates Rule CRs which are not automatically deleted, now changes are added in the `cleanupResources` function, which detects the rules created by stork and then deletes them.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Attaching screenshots below for reference
<img width="1722" alt="Screenshot 2024-01-29 at 11 41 46 PM" src="https://github.com/libopenstorage/stork/assets/148333439/d3faf370-ec44-4d0e-9d9e-ff4ec3d1be72">
<img width="656" alt="Screenshot 2024-01-29 at 11 42 17 PM" src="https://github.com/libopenstorage/stork/assets/148333439/b00dc437-c440-4734-bf6e-68b104f12654">
<img width="899" alt="Screenshot 2024-01-29 at 11 43 36 PM" src="https://github.com/libopenstorage/stork/assets/148333439/d963f7fc-081f-4e9e-b7fd-0d392fadec42">
<img width="981" alt="Screenshot 2024-01-29 at 11 43 48 PM" src="https://github.com/libopenstorage/stork/assets/148333439/a7b0d694-3f5b-4d08-beba-d3f5f8fa6cbd">
<img width="732" alt="Screenshot 2024-01-29 at 11 44 23 PM" src="https://github.com/libopenstorage/stork/assets/148333439/ab0df18d-14b6-425b-bf17-e24d5591828e">

