### PR TITLE
PB-5430 :: Remove check for drivers without snapshot support

### DIFF
--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -54,16 +54,7 @@ const (
 	// provisioner name
 	PvProvisionedByAnnotation = "pv.kubernetes.io/provisioned-by"
 	pureCSIProvisioner        = "pure-csi"
-	ocpCephfsProvisioner      = "openshift-storage.cephfs.csi.ceph.com"
-	ocpRbdProvisioner         = "openshift-storage.rbd.csi.ceph.com"
-	vSphereCSIProvisioner     = "csi.vsphere.vmware.com"
-	efsCSIProvisioner         = "efs.csi.aws.com"
-	azureFileCSIProvisioner   = "file.csi.azure.com"
 
-	azureFileIntreeProvisioner = "kubernetes.io/azure-file"
-	googleFileCSIProvisioner   = "com.google.csi.filestore"
-	// Note: filestore.csi.storage.gke.io this provisoner supports snapshot. So not adding in csiDriverWithoutSnapshotSupport list
-	gkeFileCSIProvisioner       = "filestore.csi.storage.gke.io"
 	pureBackendParam            = "backend"
 	pureFileParam               = "file"
 	csiDriverWithOutSnapshotKey = "CSI_DRIVER_WITHOUT_SNAPSHOT"
@@ -82,13 +73,6 @@ var (
 		LinstorDriverName,
 		CSIDriverName,
 		KDMPDriverName,
-	}
-	csiDriverWithoutSnapshotSupport = []string{
-		vSphereCSIProvisioner,
-		efsCSIProvisioner,
-		azureFileCSIProvisioner,
-		azureFileIntreeProvisioner,
-		googleFileCSIProvisioner,
 	}
 )
 
@@ -775,13 +759,6 @@ func IsCSIDriverWithoutSnapshotSupport(pv *v1.PersistentVolume) bool {
 		// pure FB csi driver does not support snapshot
 		if driverName == pureCSIProvisioner {
 			if pv.Spec.CSI.VolumeAttributes[pureBackendParam] == pureFileParam {
-				return true
-			}
-		}
-		// vsphere, efs, azure file and google file does not support snapshot.
-		// So defaulting to kdmp by not setting volumesnapshot class.
-		for _, name := range csiDriverWithoutSnapshotSupport {
-			if name == driverName {
 				return true
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Removes hard coded CSI driver in which case kdmp was selected. This is a part of series of changes for KDMP localsnapshot cleanup

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
