### PR TITLE
PB-5434, PB-5559 : Refining Backup Variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bin/
 help-cmdexecutor.1
 help.1
 coverage.txt
+.vscode/
+.idea/

--- a/pkg/snapshotter/options.go
+++ b/pkg/snapshotter/options.go
@@ -32,6 +32,8 @@ type Options struct {
 	Annotations map[string]string
 	// Labels are the labels that can be applied on the snapshot related objects
 	Labels map[string]string
+	// CSISnapshotMapping is the map of all csi drivers to their respective volumeSnapshotClass to be used
+	CSISnapshotMapping map[string]string
 }
 
 // Name is used to set a snapshot name.
@@ -130,6 +132,16 @@ func Labels(labels map[string]string) Option {
 		opts.Labels = make(map[string]string)
 		for k, v := range labels {
 			opts.Labels[k] = v
+		}
+		return nil
+	}
+}
+
+func CSISnapshotMapping(snapshotMap map[string]string) Option {
+	return func(opts *Options) error {
+		opts.CSISnapshotMapping = make(map[string]string)
+		for k, v := range snapshotMap {
+			opts.CSISnapshotMapping[k] = v
 		}
 		return nil
 	}

--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -131,16 +131,27 @@ func (c *csiDriver) CreateSnapshot(opts ...Option) (string, string, string, erro
 		return "", "", "", fmt.Errorf("error getting pv %v: %v", pvName, err)
 	}
 
-	// In case the PV does not contain CSI secion itself, we will error out.
+	fmt.Printf("PV SPEC : %+v", pv.Spec)
+	// In case the PV does not contain CSI section itself, we will error out.
 	if pv.Spec.CSI == nil {
 		return "", "", "", fmt.Errorf("pv [%v] does not contain CSI section", pv.Name)
+	} else {
+		// If CSI Section Exist assign respective volumeSnapshotClass of its provisioner
+		if snapshotClass, ok := o.CSISnapshotMapping[pv.Spec.CSI.Driver]; ok {
+			o.SnapshotClassName = snapshotClass
+		}
 	}
 
 	if o.SnapshotClassName == "" {
-		return "", "", "", fmt.Errorf("snapshot class cannot be empty, use 'default' to choose the default snapshot class")
+		return "", "", "", fmt.Errorf("snapshot class cannot be empty for pvc [%s] having driver [%s] in case of "+
+			"CSI based backup or use 'default' to choose the default snapshot class, use csiSnapshotMapping in case of "+
+			"multiple provisioner", pvc.GetName(), pv.Spec.CSI.Driver)
 	}
 
-	if o.SnapshotClassName == "default" || o.SnapshotClassName == "Default" {
+	// Retaining "default" and "Default" because previous users who are using api based or CRD method to create Backup
+	// might be using those string, from newer version we will be using "Use-default-volumesnapshotclass" as identifier for using
+	// default volumesnapshotclass for creating volumeSnapshot
+	if o.SnapshotClassName == "default" || o.SnapshotClassName == "Default" || o.SnapshotClassName == "Use-default-volumesnapshotclass" {
 		// Let kubernetes choose the default snapshot class to use
 		// for this snapshot. If none is set then the volume snapshot will fail
 		o.SnapshotClassName = ""


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
This PR implements the changes we required for feature Refining Backup Variants in which we are now going to support only 3 drivers namely KDMP, CSI Native and Portworx. We have removed the support for cloud native drivers as most of the csi are matured enough to take volumeSnapshot that can be used for backup and those who doesn't will go into KDMP.


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
--> No

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
--> Yes

```release-note
Issue: Backup Confusion while taking backup 
User Impact: User will have CSI or KDMP backup in Case of Cloud Native Driver depends on type of Volume
Resolution: Removing the Complexity / Variants of Backup that might confuse user while taking backup

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
--> Yes.   
**24.3.0-px-backup-2.7.0**


CSI Drivers used for testing.
```                              
NAME                                    ATTACHREQUIRED   PODINFOONMOUNT   STORAGECAPACITY   TOKENREQUESTS   REQUIRESREPUBLISH   MODES        AGE
csi.vsphere.vmware.com                  true             false            false             <unset>         false               Persistent   6d2h
openshift-storage.cephfs.csi.ceph.com   true             false            false             <unset>         false               Persistent   5d21h
openshift-storage.rbd.csi.ceph.com      true             false            false             <unset>         false               Persistent   5d21h

```

VolumeSnapshotClass Used
```
NAME                                        DRIVER                                  DELETIONPOLICY   AGE
csi-vsphere-vsc                             csi.vsphere.vmware.com                  Delete           6d2h
ocs-storagecluster-cephfsplugin-snapclass   openshift-storage.cephfs.csi.ceph.com   Retain           5d21h
ocs-storagecluster-rbdplugin-snapclass      openshift-storage.rbd.csi.ceph.com      Retain           5d21h
```

StorageClasses
```
NAME                          PROVISIONER                             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
local-vs                      kubernetes.io/no-provisioner            Delete          WaitForFirstConsumer   false                  5d22h
ocs-storagecluster-ceph-rbd   openshift-storage.rbd.csi.ceph.com      Delete          Immediate              true                   3h36m
ocs-storagecluster-ceph-rgw   openshift-storage.ceph.rook.io/bucket   Delete          Immediate              false                  5d22h
ocs-storagecluster-cephfs     openshift-storage.cephfs.csi.ceph.com   Delete          Immediate              true                   3h36m
openshift-storage.noobaa.io   openshift-storage.noobaa.io/obc         Delete          Immediate              false                  5d22h
stork-snapshot-sc             stork-snapshot                          Delete          Immediate              false                  5d21h
thin (default)                kubernetes.io/vsphere-volume            Delete          Immediate              false                  6d3h
thin-csi                      csi.vsphere.vmware.com                  Delete          WaitForFirstConsumer   true                   6d3h
```

**Scenarios Covered**

```
1. Offload & Multiprovisioner
    -> KDMP + LocalSnapshot =  3 Provisioner ( CephFS, CephRBD & vSphere )
        3 CSI Based PVC 
        and 1 does not support snapshot ( vSphere ) ( Non CSI ) Legacy Driver - vsphere-volume

       Result - Should Pass the Backup
```

PVC's
```
NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                  AGE
mysql-data       Bound    pvc-ce5c2f84-5f5c-477f-9a24-659c5a00e982   2Gi        RWO            ocs-storagecluster-ceph-rbd   5d21h
mysql-datafs     Bound    pvc-e7d8ed98-3a3d-46f7-90a2-b44632fc70aa   2Gi        RWO            ocs-storagecluster-cephfs     12m
mysql-datath     Bound    pvc-9372548c-4679-4dec-9c92-b8547f0951dc   2Gi        RWO            thin                          5m8s
mysql-datathin   Bound    pvc-1de30817-8a8b-4d31-95d5-207cbc8962ca   2Gi        RWO            thin-csi                      9m37s
```

Command 

```
./pxbackupctl create backup --namespaces mysql --authtoken=$authtoken --endpoint localhost:10002 --name kdmp-localsnasphot --backup-location-name  kdmp-admin --backup-location-uid db72cb7f-5c67-4e86-a822-c8aded2c779c --cluster 10.13.219.232  --cluster-uid d91f895a-51a3-4196-9384-2bd8c9b95b6c --csisnapshot-map csi.vsphere.vmware.com=csi-vsphere-vsc,openshift-storage.cephfs.csi.ceph.com=ocs-storagecluster-cephfsplugin-snapclass,openshift-storage.rbd.csi.ceph.com=ocs-storagecluster-rbdplugin-snapclass --backup-type Generic
```

Application Backup CR

```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationBackup
metadata:
  annotations:
    portworx.io/backup-name: kdmp-localsnasphot
    portworx.io/backup-uid: 076ade9b-3beb-49dc-a333-e883fef41b43
    portworx.io/backuplocation-name: kdmp-admin
    portworx.io/cluster-name: 10.13.219.232
    portworx.io/cluster-uid: d91f895a-51a3-4196-9384-2bd8c9b95b6c
    portworx.io/created-by: px-backup
    portworx.io/last-update: "2024-02-12T11:21:19.595239988Z"
    portworx.io/object-lock-retention-period: "0"
    portworx.io/org-id: default
    portworx.io/skip-backup-location-name-check: "true"
  creationTimestamp: "2024-02-12T11:21:19Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2024-02-12T11:24:40Z"
  finalizers:
  - stork.libopenstorage.org/finalizer-cleanup
  generation: 46
  name: kdmp-localsnasphot-076ade9
  namespace: mysql
  resourceVersion: "5602513"
  uid: 56096ba2-f3f7-40e1-9559-999357d3a184
spec:
  backupLocation: kdmp-admin-076ade9
  backupObjectType: All
  backupType: Generic
  csiSnapshotClassMap:
    csi.vsphere.vmware.com: csi-vsphere-vsc
    openshift-storage.cephfs.csi.ceph.com: ocs-storagecluster-cephfsplugin-snapclass
    openshift-storage.rbd.csi.ceph.com: ocs-storagecluster-rbdplugin-snapclass
  includeResources: null
  namespaceSelector: ""
  namespaces:
  - mysql
  options: {}
  platformCredential: ""
  postExecRule: ""
  preExecRule: ""
  rancherProjects: null
  reclaimPolicy: Retain
  resourceTypes: null
  selectors: null
  skipAutoExecRules: false
  skipServiceUpdate: false
status:
  backupPath: mysql/kdmp-localsnasphot-076ade9/56096ba2-f3f7-40e1-9559-999357d3a184
  finishTimestamp: "2024-02-12T11:24:40Z"
  largeResourceEnabled: false
  lastUpdateTimestamp: "2024-02-12T11:24:40Z"
  reason: Volumes and resources were backed up successfully
  resourceCount: 12
  resources:
  - group: core
    kind: PersistentVolumeClaim
    name: mysql-data
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: mysql-datafs
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: mysql-datath
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: mysql-datathin
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-1de30817-8a8b-4d31-95d5-207cbc8962ca
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-9372548c-4679-4dec-9c92-b8547f0951dc
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-ce5c2f84-5f5c-477f-9a24-659c5a00e982
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-e7d8ed98-3a3d-46f7-90a2-b44632fc70aa
    namespace: ""
    version: v1
  - group: apps
    kind: Deployment
    name: mysql
    namespace: mysql
    version: v1
  - group: apps
    kind: Deployment
    name: mysqlfs
    namespace: mysql
    version: v1
  - group: apps
    kind: Deployment
    name: mysqlth
    namespace: mysql
    version: v1
  - group: apps
    kind: Deployment
    name: mysqlthin
    namespace: mysql
    version: v1
  stage: Final
  status: Successful
  totalSize: 878016992
  triggerTimestamp: "2024-02-12T11:21:19Z"
  volumes:
  - Options: null
    actualSize: 219504249
    backupID: b3aa85eeea5605dad0d0c31150daa125
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: mysql-data
    persistentVolumeClaimUID: ce5c2f84-5f5c-477f-9a24-659c5a00e982
    provisioner: openshift-storage.rbd.csi.ceph.com
    reason: Backup successful for volume
    status: Successful
    storageClass: ocs-storagecluster-ceph-rbd
    totalSize: 219504249
    volume: pvc-ce5c2f84-5f5c-477f-9a24-659c5a00e982
    volumeSnapshot: ""
    zones: null
  - Options: null
    actualSize: 219504249
    backupID: b9fe228b70840dabd82917a3db645bfb
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: mysql-datafs
    persistentVolumeClaimUID: e7d8ed98-3a3d-46f7-90a2-b44632fc70aa
    provisioner: openshift-storage.cephfs.csi.ceph.com
    reason: Backup successful for volume
    status: Successful
    storageClass: ocs-storagecluster-cephfs
    totalSize: 219504249
    volume: pvc-e7d8ed98-3a3d-46f7-90a2-b44632fc70aa
    volumeSnapshot: ""
    zones: null
  - Options: null
    actualSize: 219504249
    backupID: 7c0b0301adf8742929e9ba8a27fddf25
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: mysql-datath
    persistentVolumeClaimUID: 9372548c-4679-4dec-9c92-b8547f0951dc
    provisioner: kubernetes.io/vsphere-volume
    reason: Backup successful for volume
    status: Successful
    storageClass: thin
    totalSize: 219504249
    volume: pvc-9372548c-4679-4dec-9c92-b8547f0951dc
    volumeSnapshot: ""
    zones: null
  - Options: null
    actualSize: 219504245
    backupID: 97a9b4b76116972fbfe45327e72f9526
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: mysql-datathin
    persistentVolumeClaimUID: 1de30817-8a8b-4d31-95d5-207cbc8962ca
    provisioner: csi.vsphere.vmware.com
    reason: Backup successful for volume
    status: Successful
    storageClass: thin-csi
    totalSize: 219504245
    volume: pvc-1de30817-8a8b-4d31-95d5-207cbc8962ca
    volumeSnapshot: ""
    zones: null
```

```
2. Without Offload
 
 a. Native CSI
     
     3 CSI Based PVC 
     2 with VSC 
     1 without VSC Mapping Given

     Result - Should Fail the Backup - VSC needed for CSI Based Backup

```
Command

```
./pxbackupctl create backup --namespaces mysql --authtoken=$authtoken --endpoint localhost:10002 --name native-csi-fail --backup-location-name  kdmp-admin --backup-location-uid db72cb7f-5c67-4e86-a822-c8aded2c779c --cluster 10.13.219.232  --cluster-uid d91f895a-51a3-4196-9384-2bd8c9b95b6c --csisnapshot-map openshift-storage.cephfs.csi.ceph.com=ocs-storagecluster-cephfsplugin-snapclass,openshift-storage.rbd.csi.ceph.com=ocs-storagecluster-rbdplugin-snapclass 

```


Application Backup CR

```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationBackup
metadata:
  annotations:
    portworx.io/backup-name: native-csi-fail
    portworx.io/backup-uid: 7e9bfabf-7438-4d9d-a03e-98c75f63d9a1
    portworx.io/backuplocation-name: kdmp-admin
    portworx.io/cluster-name: 10.13.219.232
    portworx.io/cluster-uid: d91f895a-51a3-4196-9384-2bd8c9b95b6c
    portworx.io/created-by: px-backup
    portworx.io/last-update: "2024-02-12T11:50:21.841467065Z"
    portworx.io/object-lock-retention-period: "0"
    portworx.io/org-id: default
    portworx.io/skip-backup-location-name-check: "true"
  creationTimestamp: "2024-02-12T11:50:21Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2024-02-12T11:50:24Z"
  finalizers:
  - stork.libopenstorage.org/finalizer-cleanup
  generation: 6
  name: native-csi-fail-7e9bfab
  namespace: mysql
  resourceVersion: "5618489"
  uid: 4e3b8911-0a83-481d-9089-2798e2986e29
spec:
  backupLocation: kdmp-admin-7e9bfab
  backupObjectType: All
  backupType: Normal
  csiSnapshotClassMap:
    openshift-storage.cephfs.csi.ceph.com: ocs-storagecluster-cephfsplugin-snapclass
    openshift-storage.rbd.csi.ceph.com: ocs-storagecluster-rbdplugin-snapclass
  includeResources: null
  namespaceSelector: ""
  namespaces:
  - mysql
  options: {}
  platformCredential: ""
  postExecRule: ""
  preExecRule: ""
  rancherProjects: null
  reclaimPolicy: Retain
  resourceTypes: null
  selectors: null
  skipAutoExecRules: false
  skipServiceUpdate: false
status:
  backupPath: ""
  finishTimestamp: null
  largeResourceEnabled: false
  lastUpdateTimestamp: "2024-02-12T11:50:24Z"
  reason: 'Error starting ApplicationBackup for volumes: failed to ensure volumesnapshotclass
    was created: snapshot class cannot be empty for pvc [mysql-datathin] having driver
    [csi.vsphere.vmware.com] in case of CSI based backup or use ''default'' to choose
    the default snapshot class, use csiSnapshotMapping in case of multiple provisioner'
  resourceCount: 0
  resources: null
  stage: Final
  status: Failed
  totalSize: 0
  triggerTimestamp: "2024-02-12T11:50:21Z"
  volumes: null
```

```
 b. Native CSI + KDMP
 
      4 PVC 
      3 CSI Based PVC with VSC 
      and 1 does not support snapshot ( vSphere ) 

   Result - Should Pass.
```

Command 
```
./pxbackupctl create backup --namespaces mysql --authtoken=$authtoken --endpoint localhost:10002 --name native-csi --backup-location-name  kdmp-admin --backup-location-uid db72cb7f-5c67-4e86-a822-c8aded2c779c --cluster 10.13.219.232  --cluster-uid d91f895a-51a3-4196-9384-2bd8c9b95b6c --csisnapshot-map csi.vsphere.vmware.com=csi-vsphere-vsc,openshift-storage.cephfs.csi.ceph.com=ocs-storagecluster-cephfsplugin-snapclass,openshift-storage.rbd.csi.ceph.com=ocs-storagecluster-rbdplugin-snapclass
```
Application Backup CR

```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationBackup
metadata:
  annotations:
    portworx.io/backup-name: native-csi
    portworx.io/backup-uid: a300f474-3343-4d5f-82ca-1f25158169eb
    portworx.io/backuplocation-name: kdmp-admin
    portworx.io/cluster-name: 10.13.219.232
    portworx.io/cluster-uid: d91f895a-51a3-4196-9384-2bd8c9b95b6c
    portworx.io/created-by: px-backup
    portworx.io/last-update: "2024-02-12T11:31:40.38909784Z"
    portworx.io/object-lock-retention-period: "0"
    portworx.io/org-id: default
    portworx.io/skip-backup-location-name-check: "true"
  creationTimestamp: "2024-02-12T11:31:40Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2024-02-12T11:33:40Z"
  finalizers:
  - stork.libopenstorage.org/finalizer-cleanup
  generation: 20
  name: native-csi-a300f47
  namespace: mysql
  resourceVersion: "5608272"
  uid: c4bed04e-4538-4aeb-90f8-59efe28bcedc
spec:
  backupLocation: kdmp-admin-a300f47
  backupObjectType: All
  backupType: Normal
  csiSnapshotClassMap:
    csi.vsphere.vmware.com: csi-vsphere-vsc
    openshift-storage.cephfs.csi.ceph.com: ocs-storagecluster-cephfsplugin-snapclass
    openshift-storage.rbd.csi.ceph.com: ocs-storagecluster-rbdplugin-snapclass
  includeResources: null
  namespaceSelector: ""
  namespaces:
  - mysql
  options: {}
  platformCredential: ""
  postExecRule: ""
  preExecRule: ""
  rancherProjects: null
  reclaimPolicy: Retain
  resourceTypes: null
  selectors: null
  skipAutoExecRules: false
  skipServiceUpdate: false
status:
  backupPath: mysql/native-csi-a300f47/c4bed04e-4538-4aeb-90f8-59efe28bcedc
  finishTimestamp: "2024-02-12T11:33:40Z"
  largeResourceEnabled: false
  lastUpdateTimestamp: "2024-02-12T11:33:40Z"
  reason: Volumes and resources were backed up successfully
  resourceCount: 12
  resources:
  - group: core
    kind: PersistentVolume
    name: pvc-1de30817-8a8b-4d31-95d5-207cbc8962ca
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-9372548c-4679-4dec-9c92-b8547f0951dc
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-ce5c2f84-5f5c-477f-9a24-659c5a00e982
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-e7d8ed98-3a3d-46f7-90a2-b44632fc70aa
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: mysql-data
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: mysql-datafs
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: mysql-datath
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: mysql-datathin
    namespace: mysql
    version: v1
  - group: apps
    kind: Deployment
    name: mysql
    namespace: mysql
    version: v1
  - group: apps
    kind: Deployment
    name: mysqlfs
    namespace: mysql
    version: v1
  - group: apps
    kind: Deployment
    name: mysqlth
    namespace: mysql
    version: v1
  - group: apps
    kind: Deployment
    name: mysqlthin
    namespace: mysql
    version: v1
  stage: Final
  status: Successful
  totalSize: 6661955193
  triggerTimestamp: "2024-02-12T11:31:40Z"
  volumes:
  - Options:
      csi-driver-name: openshift-storage.rbd.csi.ceph.com
      volumesnapshotcontent-name: snapcontent-51be2722-f368-4925-a620-3cf87fac32a2
    actualSize: 2147483648
    backupID: backup-59efe28bcedc-659c5a00e982
    driverName: csi
    namespace: mysql
    persistentVolumeClaim: mysql-data
    persistentVolumeClaimUID: ce5c2f84-5f5c-477f-9a24-659c5a00e982
    provisioner: ""
    reason: Snapshot successful for volume
    status: Successful
    storageClass: ""
    totalSize: 2147483648
    volume: pvc-ce5c2f84-5f5c-477f-9a24-659c5a00e982
    volumeSnapshot: ""
    zones: null
  - Options:
      csi-driver-name: openshift-storage.cephfs.csi.ceph.com
      volumesnapshotcontent-name: snapcontent-8d7da59c-978d-4320-b906-acb1d6641f0e
    actualSize: 2147483648
    backupID: backup-59efe28bcedc-b44632fc70aa
    driverName: csi
    namespace: mysql
    persistentVolumeClaim: mysql-datafs
    persistentVolumeClaimUID: e7d8ed98-3a3d-46f7-90a2-b44632fc70aa
    provisioner: ""
    reason: Snapshot successful for volume
    status: Successful
    storageClass: ""
    totalSize: 2147483648
    volume: pvc-e7d8ed98-3a3d-46f7-90a2-b44632fc70aa
    volumeSnapshot: ""
    zones: null
  - Options:
      csi-driver-name: csi.vsphere.vmware.com
      volumesnapshotcontent-name: snapcontent-f598ba3d-c466-4271-8cf0-b1b6e6d0d9ad
    actualSize: 2147483648
    backupID: backup-59efe28bcedc-207cbc8962ca
    driverName: csi
    namespace: mysql
    persistentVolumeClaim: mysql-datathin
    persistentVolumeClaimUID: 1de30817-8a8b-4d31-95d5-207cbc8962ca
    provisioner: ""
    reason: Snapshot successful for volume
    status: Successful
    storageClass: ""
    totalSize: 2147483648
    volume: pvc-1de30817-8a8b-4d31-95d5-207cbc8962ca
    volumeSnapshot: ""
    zones: null
  - Options: null
    actualSize: 219504249
    backupID: 5f1556e4dc2b8e0d8af07ce5c54ea290
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: mysql-datath
    persistentVolumeClaimUID: 9372548c-4679-4dec-9c92-b8547f0951dc
    provisioner: kubernetes.io/vsphere-volume
    reason: Backup successful for volume
    status: Successful
    storageClass: thin
    totalSize: 219504249
    volume: pvc-9372548c-4679-4dec-9c92-b8547f0951dc
    volumeSnapshot: ""
    zones: null
```

When VSC is selected as Default ( +ve Scnerio )

```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationBackup
metadata:
  annotations:
    portworx.io/backup-name: kdmp-localsnasphot44
    portworx.io/backup-uid: 47e9850c-b536-4a5b-9a32-909ed24f3914
    portworx.io/backuplocation-name: kdmp-admin
    portworx.io/cluster-name: 10.13.219.232
    portworx.io/cluster-uid: d91f895a-51a3-4196-9384-2bd8c9b95b6c
    portworx.io/created-by: px-backup
    portworx.io/last-update: "2024-02-14T05:50:54.195581366Z"
    portworx.io/object-lock-retention-period: "0"
    portworx.io/org-id: default
    portworx.io/skip-backup-location-name-check: "true"
  creationTimestamp: "2024-02-14T05:50:54Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2024-02-14T05:53:47Z"
  finalizers:
  - stork.libopenstorage.org/finalizer-cleanup
  generation: 27
  name: kdmp-localsnasphot44-47e9850
  namespace: mysql
  resourceVersion: "7188221"
  uid: 5684f374-6fdb-42cd-acd1-e791afe5f827
spec:
  backupLocation: kdmp-admin-47e9850
  backupObjectType: All
  backupType: Generic
  csiSnapshotClassMap:
    csi.vsphere.vmware.com: csi-vsphere-vsc
    openshift-storage.cephfs.csi.ceph.com: default
    openshift-storage.rbd.csi.ceph.com: ocs-storagecluster-rbdplugin-snapclass
  includeResources: null
  namespaceSelector: ""
  namespaces:
  - mysql
  options: {}
  platformCredential: ""
  postExecRule: ""
  preExecRule: ""
  rancherProjects: null
  reclaimPolicy: Retain
  resourceTypes: null
  selectors: null
  skipAutoExecRules: false
  skipServiceUpdate: false
status:
  backupPath: mysql/kdmp-localsnasphot44-47e9850/5684f374-6fdb-42cd-acd1-e791afe5f827
  finishTimestamp: "2024-02-14T05:53:47Z"
  largeResourceEnabled: false
  lastUpdateTimestamp: "2024-02-14T05:53:47Z"
  reason: Volumes and resources were backed up successfully
  resourceCount: 6
  resources:
  - group: core
    kind: PersistentVolume
    name: pvc-ce5c2f84-5f5c-477f-9a24-659c5a00e982
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-e7d8ed98-3a3d-46f7-90a2-b44632fc70aa
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: mysql-data
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: mysql-datafs
    namespace: mysql
    version: v1
  - group: apps
    kind: Deployment
    name: mysql
    namespace: mysql
    version: v1
  - group: apps
    kind: Deployment
    name: mysqlfs
    namespace: mysql
    version: v1
  stage: Final
  status: Successful
  totalSize: 439008498
  triggerTimestamp: "2024-02-14T05:50:54Z"
  volumes:
  - Options: null
    actualSize: 219504249
    backupID: 03c29192b5fde988b29188053b2f83c6
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: mysql-data
    persistentVolumeClaimUID: ce5c2f84-5f5c-477f-9a24-659c5a00e982
    provisioner: openshift-storage.rbd.csi.ceph.com
    reason: Backup successful for volume
    status: Successful
    storageClass: ocs-storagecluster-ceph-rbd
    totalSize: 219504249
    volume: pvc-ce5c2f84-5f5c-477f-9a24-659c5a00e982
    volumeSnapshot: ocs-storagecluster-rbdplugin-snapclass,mysql-data-7bb74d43
    zones: null
  - Options: null
    actualSize: 219504249
    backupID: f53da08d7dea6b79c5dcc03b08380b69
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: mysql-datafs
    persistentVolumeClaimUID: e7d8ed98-3a3d-46f7-90a2-b44632fc70aa
    provisioner: openshift-storage.cephfs.csi.ceph.com
    reason: Backup successful for volume
    status: Successful
    storageClass: ocs-storagecluster-cephfs
    totalSize: 219504249
    volume: pvc-e7d8ed98-3a3d-46f7-90a2-b44632fc70aa
    volumeSnapshot: ocs-storagecluster-cephfsplugin-snapclass,mysql-datafs-fd314732
    zones: null
```


```
 c. Direct KDMP ( BACKUP_TYPE=Generic )

2 PVC 
irrespective of Snapshot Support or not

Result - Should Pass

```

