### PR TITLE
[PWX-32202] storkctl perform failover CLI changes

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -140,10 +140,9 @@ func main() {
 			Value: 120,
 			Usage: "The interval in seconds to monitor the health of the storage driver (min: 30)",
 		},
-		cli.BoolFlag{
-			Name:   "action-controller",
-			Usage:  "Start the Action controller (default: false)",
-			Hidden: true,
+		cli.BoolTFlag{
+			Name:  "action-controller",
+			Usage: "Start the Action controller (default: true)",
 		},
 		cli.BoolTFlag{
 			Name:  "migration-controller",

--- a/pkg/action/failback.go
+++ b/pkg/action/failback.go
@@ -55,7 +55,7 @@ func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv
 			return
 		}
 
-		if !utils.IsSubList(namespaces, action.Spec.ActionParameter.FailbackParameter.Namespaces) {
+		if isSubList, _ := utils.IsSubList(namespaces, action.Spec.ActionParameter.FailbackParameter.Namespaces); !isSubList {
 			msg := fmt.Sprintf("Namespaces provided for failback is not a subset of namespaces from migrationschedule %s", migrationSchedule.Name)
 			log.ActionLog(action).Infof(msg)
 			ac.recorder.Event(action,

--- a/pkg/apis/stork/v1alpha1/action.go
+++ b/pkg/apis/stork/v1alpha1/action.go
@@ -34,27 +34,100 @@ type Action struct {
 
 // ActionSpec specifies the type of Action
 type ActionSpec struct {
-	ActionType ActionType `json:"actionType"`
+	ActionType      ActionType       `json:"actionType"`
+	ActionParameter *ActionParameter `json:"actionParameter"`
 }
 
 // ActionType lists the various actions that can be performed
 type ActionType string
 
 const (
-	// to start apps on destination cluster
+	// ActionTypeNearSyncFailover action type to start apps on destination cluster in nearsync DR case
+	ActionTypeNearSyncFailover ActionType = "nearsyncFailover"
+	// ActionTypeFailover action type to start apps in destination cluster for sync and async DRs
 	ActionTypeFailover ActionType = "failover"
+	// ActionTypeFailback action type to migrate back to source and start apps in source
+	ActionTypeFailback ActionType = "failback"
 )
+
+// ActionParameter lists the parameters required to perform the action
+type ActionParameter ActionParameterItem
+
+type ActionParameterItem struct {
+	FailoverParameter *FailoverParameter `json:"failoverParameter,omitempty"`
+	FailbackParameter *FailbackParameter `json:"failbackParameter,omitempty"`
+}
+
+type FailoverParameter struct {
+	FailoverNamespaces         []string `json:"failoverNamespaces"`
+	MigrationScheduleReference string   `json:"migrationScheduleReference"`
+	DeactivateSource           bool     `json:"deactivateSource"`
+}
+
+type FailbackParameter struct {
+	Namespaces                 []string `json:"namespaces"`
+	MigrationScheduleReference string   `json:"migrationScheduleReference"`
+}
 
 // ActionStatus is the current status of the Action
-type ActionStatus string
+type ActionStatusType string
 
 const (
+	// ActionStatusInitial means Action CR has been created
+	ActionStatusInitial ActionStatusType = ""
 	// ActionStatusScheduled means Action is yet to start
-	ActionStatusScheduled ActionStatus = "Scheduled"
+	ActionStatusScheduled ActionStatusType = "Scheduled"
 	// ActionStatusInProgress means Action is in progress
-	ActionStatusInProgress ActionStatus = "In-Progress"
+	ActionStatusInProgress ActionStatusType = "In-Progress"
 	// ActionStatusFailed means that Action has failed
-	ActionStatusFailed ActionStatus = "Failed"
+	ActionStatusFailed ActionStatusType = "Failed"
 	// ActionStatusSuccessful means Action has completed successfully
-	ActionStatusSuccessful ActionStatus = "Successful"
+	ActionStatusSuccessful ActionStatusType = "Successful"
 )
+
+// ActionStageType is the stage of the action
+type ActionStageType string
+
+const (
+	// ActionStageInitial for when action is created
+	ActionStageInitial ActionStageType = ""
+	// ActionStageScaleDownDestination for scaling down apps in destination
+	ActionStageScaleDownDestination ActionStageType = "ScaleDownDestination"
+	// ActionStageScaleDownSource for scaling down apps in source
+	ActionStageScaleDownSource ActionStageType = "ScaleDownSource"
+	// ActionStageScaleUpDestination for scaling apps in destination
+	ActionStageScaleUpDestination ActionStageType = "ScaleUpDestination"
+	// ActionStageScaleUpSource for scaling apps in source
+	ActionStageScaleUpSource ActionStageType = "ScaleUpSource"
+	// ActionStageFinal is the final stage for action
+	ActionStageFinal ActionStageType = "Final"
+)
+
+// ActionStatus is the status of action operation
+type ActionStatus struct {
+	Stage           ActionStageType  `json:"stage"`
+	Status          ActionStatusType `json:"status"`
+	FinishTimestamp meta.Time        `json:"finishTimestamp"`
+	Summary         *ActionSummary   `json:"summary"`
+	Reason          string           `json:"reason"`
+}
+
+// ActionSummary lists the summary of the action
+type ActionSummary ActionSummaryItem
+
+// ActionSummary has summary for each action type
+type ActionSummaryItem struct {
+	FailoverSummaryItem []*FailoverSummary `json:"failoverSummary,omitempty"`
+	FailbackSummaryItem []*FailbackSummary `json:"failbackSummary,omitempty"`
+}
+
+type FailoverSummary struct {
+	Namespace string           `json:"namespace"`
+	Status    ActionStatusType `json:"status"`
+	Reason    string           `json:"reason"`
+}
+type FailbackSummary struct {
+	Namespace string           `json:"namespace"`
+	Status    ActionStatusType `json:"status"`
+	Reason    string           `json:"reason"`
+}

--- a/pkg/storkctl/action.go
+++ b/pkg/storkctl/action.go
@@ -68,7 +68,9 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 					Spec: storkv1.ActionSpec{
 						ActionType: storkv1.ActionTypeFailover,
 					},
-					Status: storkv1.ActionStatusScheduled,
+					Status: storkv1.ActionStatus{
+						Status: storkv1.ActionStatusScheduled,
+					},
 				}
 				_, err = storkops.Instance().CreateAction(&action)
 				if err != nil {
@@ -88,7 +90,7 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 }
 
 func isActionIncomplete(action *storkv1.Action) bool {
-	return action.Status == storkv1.ActionStatusScheduled || action.Status == storkv1.ActionStatusInProgress
+	return action.Status.Status == storkv1.ActionStatusScheduled || action.Status.Status == storkv1.ActionStatusInProgress
 }
 
 // check if there is already an Action scheduled or in-progress

--- a/pkg/storkctl/action.go
+++ b/pkg/storkctl/action.go
@@ -2,7 +2,6 @@ package storkctl
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"strings"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd/util"
 )
@@ -59,14 +59,14 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 		Short: "Initiate failover of the given migration schedule",
 		Run: func(c *cobra.Command, args []string) {
 			if len(referenceMigrationSchedule) == 0 {
-				util.CheckErr(fmt.Errorf("referenceMigrationSchedule name needs to be provided for failover"))
+				util.CheckErr(fmt.Errorf("reference MigrationSchedule name needs to be provided for failover"))
 				return
 			}
 			// namespace of the migrationSchedule is provided by user using the -n / --namespace global flag
 			migrationScheduleNs := cmdFactory.GetNamespace()
 			migrSchedObj, err := storkops.Instance().GetMigrationSchedule(referenceMigrationSchedule, migrationScheduleNs)
 			if err != nil {
-				util.CheckErr(fmt.Errorf("unable to find the referenceMigrationSchedule %v in the %v namespace", referenceMigrationSchedule, migrationScheduleNs))
+				util.CheckErr(fmt.Errorf("unable to find the reference MigrationSchedule %v in the %v namespace", referenceMigrationSchedule, migrationScheduleNs))
 				return
 			}
 			if !skipDeactivateSource {
@@ -82,7 +82,7 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 			// update the migrationNamespaces list by fetching namespaces based on provided label selectors
 			migrationNamespaces, err := getMigrationNamespaces(migrationNamespaceList, migrationNamespaceSelectors)
 			if err != nil {
-				util.CheckErr(fmt.Errorf("unable to get the namespaces based on the --namespace-selectors in the provided migrationSchedule: %v", err))
+				util.CheckErr(fmt.Errorf("unable to get the namespaces based on the --namespace-selectors in the provided MigrationSchedule: %v", err))
 				return
 			}
 			// at most one of exclude-namespaces or include-namespaces can be provided
@@ -94,7 +94,7 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 					// Branch 1: Only failover some of the namespaces being migrated by the given migrationSchedule
 					namespaceList = includeNamespaceList
 				} else {
-					util.CheckErr(fmt.Errorf("provided namespaces %v are not a subset of the namespaces being migrated by the given migrationSchedule", nonSubsetStrings))
+					util.CheckErr(fmt.Errorf("provided namespaces %v are not a subset of the namespaces being migrated by the given MigrationSchedule", nonSubsetStrings))
 					return
 				}
 			} else if len(excludeNamespaceList) != 0 {
@@ -102,7 +102,7 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 					// Branch 2: Exclude some of the namespaces being migrated by the given migrationSchedule from failover
 					namespaceList = excludeListAFromListB(excludeNamespaceList, migrationNamespaces)
 				} else {
-					util.CheckErr(fmt.Errorf("provided namespaces %v are not a subset of the namespaces being migrated by the given migrationSchedule", nonSubsetStrings))
+					util.CheckErr(fmt.Errorf("provided namespaces %v are not a subset of the namespaces being migrated by the given MigrationSchedule", nonSubsetStrings))
 					return
 				}
 			} else {
@@ -121,17 +121,17 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 			action, err := createActionCR(actionName, migrationScheduleNs, actionType, actionParameters)
 			migrationScheduleName := migrationScheduleNs + "/" + referenceMigrationSchedule
 			if err != nil {
-				util.CheckErr(fmt.Errorf("failed to start failover for migrationSchedule %v : %v", migrationScheduleName, err))
+				util.CheckErr(fmt.Errorf("failed to start failover for MigrationSchedule %v : %v", migrationScheduleName, err))
 				return
 			}
-			printMsg(fmt.Sprintf("Started failover for migrationSchedule %v", migrationScheduleName), ioStreams.Out)
+			printMsg(fmt.Sprintf("Started failover for MigrationSchedule %v", migrationScheduleName), ioStreams.Out)
 			printMsg(getActionStatusMessage(action), ioStreams.Out)
 		},
 	}
 	performFailoverCommand.Flags().BoolVar(&skipDeactivateSource, "skip-deactivate-source", false, "If present, applications in the source cluster will not be scaled down as part of the failover.")
-	performFailoverCommand.Flags().StringVarP(&referenceMigrationSchedule, "migration-reference", "m", "", "Specify the migration schedule to failover. Also specify the namespace of this migrationSchedule using the -n flag")
-	performFailoverCommand.Flags().StringSliceVar(&includeNamespaceList, "include-namespaces", nil, "Specify the comma-separated list of subset namespaces to be failed over. By default, all namespaces part of the migrationSchedule are failed over")
-	performFailoverCommand.Flags().StringSliceVar(&excludeNamespaceList, "exclude-namespaces", nil, "Specify the comma-separated list of subset namespaces to be skipped during the failover. By default, all namespaces part of the migrationSchedule are failed over")
+	performFailoverCommand.Flags().StringVarP(&referenceMigrationSchedule, "migration-reference", "m", "", "Specify the MigrationSchedule to failover. Also specify the namespace of this MigrationSchedule using the -n flag")
+	performFailoverCommand.Flags().StringSliceVar(&includeNamespaceList, "include-namespaces", nil, "Specify the comma-separated list of subset namespaces to be failed over. By default, all namespaces part of the MigrationSchedule are failed over")
+	performFailoverCommand.Flags().StringSliceVar(&excludeNamespaceList, "exclude-namespaces", nil, "Specify the comma-separated list of subset namespaces to be skipped during the failover. By default, all namespaces part of the MigrationSchedule are failed over")
 	return performFailoverCommand
 }
 

--- a/pkg/storkctl/action.go
+++ b/pkg/storkctl/action.go
@@ -2,6 +2,7 @@ package storkctl
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"strings"
 	"time"
 
@@ -159,5 +160,11 @@ func getActionStatusMessage(action *storkv1.Action) string {
 }
 
 func getActionName(actionType storkv1.ActionType, referenceResourceName string) string {
-	return strings.Join([]string{string(actionType), referenceResourceName, GetCurrentTime().Format(nameTimeSuffixFormat)}, "-")
+	actionPrefix := string(actionType)
+	actionSuffix := GetCurrentTime().Format(nameTimeSuffixFormat)
+	lenAffixes := len(actionPrefix) + len(actionSuffix) + 2 // +2 for the 2 '-'s
+	if len(referenceResourceName) >= validation.DNS1123SubdomainMaxLength-lenAffixes {
+		referenceResourceName = referenceResourceName[:validation.DNS1123SubdomainMaxLength-lenAffixes]
+	}
+	return strings.Join([]string{actionPrefix, referenceResourceName, actionSuffix}, "-")
 }

--- a/pkg/storkctl/action.go
+++ b/pkg/storkctl/action.go
@@ -20,23 +20,22 @@ const (
 	actionWaitInterval   time.Duration = 10 * time.Second
 )
 
-func newTriggerCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	triggerCommands := &cobra.Command{
-		Use:    "trigger",
-		Short:  "trigger actions",
-		Hidden: true,
+func newPerformCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	performCommands := &cobra.Command{
+		Use:   "perform",
+		Short: "perform actions",
 	}
 
-	triggerCommands.AddCommand(
+	performCommands.AddCommand(
 		newFailoverCommand(cmdFactory, ioStreams),
 	)
-	return triggerCommands
+	return performCommands
 }
 
 func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	failoverCommand := &cobra.Command{
 		Use:   failoverCommand,
-		Short: "Initiate failover for the given namespaces",
+		Short: "Initiate failover of the given migration schedule",
 		Run: func(c *cobra.Command, args []string) {
 			namespaces, err := cmdFactory.GetAllNamespaces()
 			if err != nil {
@@ -86,6 +85,9 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 			}
 		},
 	}
+	failoverCommand.Flags().BoolVar(&deactivateSource, "deactivate-source", false, "If present, resources in the source cluster will be deactivated as part of the failover")
+	failoverCommand.Flags().StringVarP(&referenceMigrationSchedule, "migration-reference", "m", "", "Specify the migration schedule to be failovered")
+
 	return failoverCommand
 }
 

--- a/pkg/storkctl/action_test.go
+++ b/pkg/storkctl/action_test.go
@@ -4,62 +4,95 @@
 package storkctl
 
 import (
+	"fmt"
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestPerformFailoverNoMigrationSchedule(t *testing.T) {
 	cmdArgs := []string{"perform", "failover"}
-	expected := "error: reference MigrationSchedule name needs to be provided for failover"
+	expected := "error: referenceMigrationSchedule name needs to be provided for failover"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
 func TestPerformFailoverInvalidMigrationSchedule(t *testing.T) {
 	cmdArgs := []string{"perform", "failover", "-m", "invalid-migr-sched"}
-	expected := "error: unable to find the reference MigrationSchedule in the given namespace"
+	expected := "error: unable to find the referenceMigrationSchedule invalid-migr-sched in the default namespace"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
-func TestPerformFailoverWithInvalidNamespaceList(t *testing.T) {
+func TestPerformFailoverWithInvalidNamespaces(t *testing.T) {
 	defer resetTest()
-	createClusterPair(t, "clusterPair1", "default", "async-dr")
-	cmdArgs := []string{"create", "migrationschedule", "-i", "15", "-c", "clusterPair1",
-		"--namespaces", "default", "test-migrationschedule", "-n", "default"}
-	expected := "MigrationSchedule test-migrationschedule created successfully\n"
-	testCommon(t, cmdArgs, nil, expected, false)
+	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
+	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--include-namespaces", "ns1", "--exclude-namespaces", "ns2", "--skip-deactivate-source", "-n", "kube-system"}
+	expected := "error: can provide only one of --include-namespaces or --exclude-namespaces values at once"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
 
-	cmdArgs = []string{"perform", "failover", "-m", "test-migrationschedule", "--namespaces", "namespace1"}
-	expected = "error: provided namespaces are invalid with respect to the referenceMigrationSchedule"
+func TestPerformFailoverWithInvalidIncludeNamespaceList(t *testing.T) {
+	defer resetTest()
+	createClusterPair(t, "clusterPair1", "ns1", "async-dr")
+	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1"}, "ns1", false, t)
+	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--include-namespaces", "namespace1", "-n", "ns1"}
+	expected := "error: provided namespaces [namespace1] are not a subset of the namespaces being migrated by the given migrationSchedule"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestPerformFailoverWithInvalidExcludeNamespaceList(t *testing.T) {
+	defer resetTest()
+	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
+	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
+	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--exclude-namespaces", "ns3", "-n", "kube-system"}
+	expected := "error: provided namespaces [ns3] are not a subset of the namespaces being migrated by the given migrationSchedule"
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
 func TestPerformFailoverMissingClusterPair(t *testing.T) {
 	defer resetTest()
-	// Create migrationSchedule
-	testms := storkv1.MigrationSchedule{
-		Spec: storkv1.MigrationScheduleSpec{
-			SchedulePolicyName: "default-migration-policy",
-			Template: storkv1.MigrationTemplateSpec{
-				Spec: storkv1.MigrationSpec{
-					ClusterPair: "clusterPair1",
-					Namespaces:  []string{"default"},
-				},
-			},
-		},
-	}
-	testms.Namespace = "default"
-	testms.Name = "test-migrationschedule"
-	_, err := storkops.Instance().CreateMigrationSchedule(&testms)
-	require.NoError(t, err, "Error creating migrationSchedule")
-
-	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule"}
-	expected := "error: unable to find the cluster pair in the given namespace"
+	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
+	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "-n", "kube-system"}
+	expected := "error: unable to find the cluster pair clusterPair1 in the kube-system namespace"
 	testCommon(t, cmdArgs, nil, expected, true)
 
 	//create clusterPair and try again
-	createClusterPair(t, "clusterPair1", "default", "async-dr")
-	expected = "Use the command `storkctl get failover failover-test-migrationschedule -n default` to get the status of the failover\n"
+	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
+	failoverActionName := mockGetActionName(storkv1.ActionTypeFailover, "test-migrationschedule")
+	expected = fmt.Sprintf("Started failover for migrationSchedule kube-system/test-migrationschedule\nTo check failover status use the command : `storkctl get failover %v -n kube-system`\n", failoverActionName)
 	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestPerformFailoverWithIncludeNamespaceList(t *testing.T) {
+	defer resetTest()
+	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
+	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--include-namespaces", "ns1", "--skip-deactivate-source", "-n", "kube-system"}
+	failoverActionName := mockGetActionName(storkv1.ActionTypeFailover, "test-migrationschedule")
+	expected := fmt.Sprintf("Started failover for migrationSchedule kube-system/test-migrationschedule\nTo check failover status use the command : `storkctl get failover %v -n kube-system`\n", failoverActionName)
+	testCommon(t, cmdArgs, nil, expected, false)
+	actionObj, err := storkops.Instance().GetAction(failoverActionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.FailoverNamespaces, []string{"ns1"})
+	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.DeactivateSource, false)
+}
+
+func TestPerformFailoverWithExcludeNamespaceList(t *testing.T) {
+	defer resetTest()
+	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
+	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
+	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--exclude-namespaces", "ns1", "-n", "kube-system"}
+	failoverActionName := mockGetActionName(storkv1.ActionTypeFailover, "test-migrationschedule")
+	expected := fmt.Sprintf("Started failover for migrationSchedule kube-system/test-migrationschedule\nTo check failover status use the command : `storkctl get failover %v -n kube-system`\n", failoverActionName)
+	testCommon(t, cmdArgs, nil, expected, false)
+	actionObj, err := storkops.Instance().GetAction(failoverActionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.FailoverNamespaces, []string{"ns2"})
+}
+
+func mockGetActionName(actionType storkv1.ActionType, referenceResourceName string) string {
+	mockNow := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.Local)
+	setMockTime(&mockNow)
+	return strings.Join([]string{string(actionType), referenceResourceName, GetCurrentTime().Format(nameTimeSuffixFormat)}, "-")
 }

--- a/pkg/storkctl/action_test.go
+++ b/pkg/storkctl/action_test.go
@@ -1,0 +1,65 @@
+//go:build unittest
+// +build unittest
+
+package storkctl
+
+import (
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPerformFailoverNoMigrationSchedule(t *testing.T) {
+	cmdArgs := []string{"perform", "failover"}
+	expected := "error: reference MigrationSchedule name needs to be provided for failover"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestPerformFailoverInvalidMigrationSchedule(t *testing.T) {
+	cmdArgs := []string{"perform", "failover", "-m", "invalid-migr-sched"}
+	expected := "error: unable to find the reference MigrationSchedule in the given namespace"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestPerformFailoverWithInvalidNamespaceList(t *testing.T) {
+	defer resetTest()
+	createClusterPair(t, "clusterPair1", "default", "async-dr")
+	cmdArgs := []string{"create", "migrationschedule", "-i", "15", "-c", "clusterPair1",
+		"--namespaces", "default", "test-migrationschedule", "-n", "default"}
+	expected := "MigrationSchedule test-migrationschedule created successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	cmdArgs = []string{"perform", "failover", "-m", "test-migrationschedule", "--namespaces", "namespace1"}
+	expected = "error: provided namespaces are invalid with respect to the referenceMigrationSchedule"
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestPerformFailoverMissingClusterPair(t *testing.T) {
+	defer resetTest()
+	// Create migrationSchedule
+	testms := storkv1.MigrationSchedule{
+		Spec: storkv1.MigrationScheduleSpec{
+			SchedulePolicyName: "default-migration-policy",
+			Template: storkv1.MigrationTemplateSpec{
+				Spec: storkv1.MigrationSpec{
+					ClusterPair: "clusterPair1",
+					Namespaces:  []string{"default"},
+				},
+			},
+		},
+	}
+	testms.Namespace = "default"
+	testms.Name = "test-migrationschedule"
+	_, err := storkops.Instance().CreateMigrationSchedule(&testms)
+	require.NoError(t, err, "Error creating migrationSchedule")
+
+	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule"}
+	expected := "error: unable to find the cluster pair in the given namespace"
+	testCommon(t, cmdArgs, nil, expected, true)
+
+	//create clusterPair and try again
+	createClusterPair(t, "clusterPair1", "default", "async-dr")
+	expected = "Use the command `storkctl get failover failover-test-migrationschedule -n default` to get the status of the failover\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}

--- a/pkg/storkctl/common.go
+++ b/pkg/storkctl/common.go
@@ -2,8 +2,6 @@ package storkctl
 
 import (
 	"fmt"
-	"github.com/libopenstorage/stork/pkg/k8sutils"
-	"github.com/sirupsen/logrus"
 	"io"
 	"strings"
 	"time"
@@ -55,46 +53,4 @@ func isValidResourceType(resourceType string, apiResource metav1.APIResource) bo
 		return true
 	}
 	return false
-}
-
-// We fetch the value of adminNamespace from the stork-controller-cm created in kube-system namespace
-func getAdminNamespace() string {
-	adminNs, err := k8sutils.GetConfigValue(k8sutils.StorkControllerConfigMapName, metav1.NamespaceSystem, k8sutils.AdminNsKey)
-	if err != nil {
-		logrus.Warnf("Error in reading %v cm for the key %v, switching to default value : %v",
-			k8sutils.StorkControllerConfigMapName, k8sutils.AdminNsKey, err)
-		adminNs = k8sutils.DefaultAdminNamespace
-	}
-	return adminNs
-}
-
-// isSubset returns true if the first slice is subset of the second slice.
-// If false it also returns the list of non subset strings.
-func isSubset(listA []string, listB []string) (bool, []string) {
-	nonSubsetStrings := make([]string, 0)
-	superset := make(map[string]bool)
-	for _, str := range listB {
-		superset[str] = true
-	}
-	for _, str := range listA {
-		if !superset[str] {
-			nonSubsetStrings = append(nonSubsetStrings, str)
-		}
-	}
-	return len(nonSubsetStrings) == 0, nonSubsetStrings
-}
-
-// excludeListAFromListB takes 2 slices of strings as input and returns subset of B which is disjoint from A
-func excludeListAFromListB(listA []string, listB []string) []string {
-	nonCommonStrings := make([]string, 0)
-	setA := make(map[string]bool)
-	for _, str := range listA {
-		setA[str] = true
-	}
-	for _, str := range listB {
-		if !setA[str] {
-			nonCommonStrings = append(nonCommonStrings, str)
-		}
-	}
-	return nonCommonStrings
 }

--- a/pkg/storkctl/common.go
+++ b/pkg/storkctl/common.go
@@ -2,6 +2,8 @@ package storkctl
 
 import (
 	"fmt"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
+	"github.com/sirupsen/logrus"
 	"io"
 	"strings"
 	"time"
@@ -53,4 +55,46 @@ func isValidResourceType(resourceType string, apiResource metav1.APIResource) bo
 		return true
 	}
 	return false
+}
+
+// We fetch the value of adminNamespace from the stork-controller-cm created in kube-system namespace
+func getAdminNamespace() string {
+	adminNs, err := k8sutils.GetConfigValue(k8sutils.StorkControllerConfigMapName, metav1.NamespaceSystem, k8sutils.AdminNsKey)
+	if err != nil {
+		logrus.Warnf("Error in reading %v cm for the key %v, switching to default value : %v",
+			k8sutils.StorkControllerConfigMapName, k8sutils.AdminNsKey, err)
+		adminNs = k8sutils.DefaultAdminNamespace
+	}
+	return adminNs
+}
+
+// isSubset returns true if the first slice is subset of the second slice.
+// If false it also returns the list of non subset strings.
+func isSubset(listA []string, listB []string) (bool, []string) {
+	nonSubsetStrings := make([]string, 0)
+	superset := make(map[string]bool)
+	for _, str := range listB {
+		superset[str] = true
+	}
+	for _, str := range listA {
+		if !superset[str] {
+			nonSubsetStrings = append(nonSubsetStrings, str)
+		}
+	}
+	return len(nonSubsetStrings) == 0, nonSubsetStrings
+}
+
+// excludeListAFromListB takes 2 slices of strings as input and returns subset of B which is disjoint from A
+func excludeListAFromListB(listA []string, listB []string) []string {
+	nonCommonStrings := make([]string, 0)
+	setA := make(map[string]bool)
+	for _, str := range listA {
+		setA[str] = true
+	}
+	for _, str := range listB {
+		if !setA[str] {
+			nonCommonStrings = append(nonCommonStrings, str)
+		}
+	}
+	return nonCommonStrings
 }

--- a/pkg/storkctl/common.go
+++ b/pkg/storkctl/common.go
@@ -10,7 +10,7 @@ import (
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	discovery "k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery"
 	"k8s.io/utils/strings/slices"
 )
 

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"github.com/libopenstorage/stork/pkg/utils"
 	"io"
 	"log"
 	"os"
@@ -215,7 +216,7 @@ func newActivateMigrationsCommand(cmdFactory Factory, ioStreams genericclioption
 func doesMigrationScheduleMigrateNamespaces(migrSched storkv1.MigrationSchedule, activationNs []string) (bool, error) {
 	namespaceList := migrSched.Spec.Template.Spec.Namespaces
 	namespaceSelectors := migrSched.Spec.Template.Spec.NamespaceSelectors
-	migrationNamespaces, err := getMigrationNamespaces(namespaceList, namespaceSelectors)
+	migrationNamespaces, err := utils.GetMergedNamespacesWithLabelSelector(namespaceList, namespaceSelectors)
 	if err != nil {
 		return false, fmt.Errorf("unable to get the namespaces based on the provided --namespace-selectors : %v", err)
 	}

--- a/pkg/storkctl/migrationschedule.go
+++ b/pkg/storkctl/migrationschedule.go
@@ -7,10 +7,8 @@ import (
 	"time"
 
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
-	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
@@ -70,13 +68,7 @@ func newCreateMigrationScheduleCommand(cmdFactory Factory, ioStreams genericclio
 			var transformSpecs []string
 			var includeOptionalResourceTypes []string
 
-			// We fetch the value of adminNamespace from the stork-controller-cm created in kube-system namespace
-			adminNs, err := k8sutils.GetConfigValue(k8sutils.StorkControllerConfigMapName, meta.NamespaceSystem, k8sutils.AdminNsKey)
-			if err != nil {
-				logrus.Warnf("Error in reading %v cm for the key %v, switching to default value : %v",
-					k8sutils.StorkControllerConfigMapName, k8sutils.AdminNsKey, err)
-				adminNs = k8sutils.DefaultAdminNamespace
-			}
+			adminNs := getAdminNamespace()
 
 			if len(args) != 1 {
 				util.CheckErr(fmt.Errorf("exactly one name needs to be provided for migration schedule name"))

--- a/pkg/storkctl/storkctl.go
+++ b/pkg/storkctl/storkctl.go
@@ -37,7 +37,7 @@ func NewCommand(cmdFactory Factory, in io.Reader, out io.Writer, errOut io.Write
 		newSuspendCommand(cmdFactory, ioStreams),
 		newResumeCommand(cmdFactory, ioStreams),
 		newVersionCommand(cmdFactory, ioStreams),
-		newTriggerCommand(cmdFactory, ioStreams),
+		newPerformCommand(cmdFactory, ioStreams),
 	)
 
 	cmds.PersistentFlags().AddGoFlagSet(flag.CommandLine)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"os"
 	"strings"
 	"time"
@@ -23,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/utils/strings/slices"
 )
 
 const (
@@ -362,11 +362,44 @@ func GetMergedNamespacesWithLabelSelector(namespaceList []string, namespaceSelec
 	return migrationNamespaces, nil
 }
 
-func IsSubList(list1 []string, list2 []string) bool {
-	for _, element := range list2 {
-		if !slices.Contains(list1, element) {
-			return false
+// IsSubList returns true if the first slice is sublist of the second slice.
+// If false it also returns the list of non subset strings.
+func IsSubList(listA []string, listB []string) (bool, []string) {
+	nonSubsetStrings := make([]string, 0)
+	superset := make(map[string]bool)
+	for _, str := range listB {
+		superset[str] = true
+	}
+	for _, str := range listA {
+		if !superset[str] {
+			nonSubsetStrings = append(nonSubsetStrings, str)
 		}
 	}
-	return true
+	return len(nonSubsetStrings) == 0, nonSubsetStrings
+}
+
+// ExcludeListAFromListB takes 2 slices of strings as input and returns subset of B which is disjoint from A
+func ExcludeListAFromListB(listA []string, listB []string) []string {
+	nonCommonStrings := make([]string, 0)
+	setA := make(map[string]bool)
+	for _, str := range listA {
+		setA[str] = true
+	}
+	for _, str := range listB {
+		if !setA[str] {
+			nonCommonStrings = append(nonCommonStrings, str)
+		}
+	}
+	return nonCommonStrings
+}
+
+// GetAdminNamespace we fetch the value of adminNamespace from the stork-controller-cm created in kube-system namespace
+func GetAdminNamespace() string {
+	adminNs, err := k8sutils.GetConfigValue(k8sutils.StorkControllerConfigMapName, metav1.NamespaceSystem, k8sutils.AdminNsKey)
+	if err != nil {
+		logrus.Warnf("Error in reading %v cm for the key %v, switching to default value : %v",
+			k8sutils.StorkControllerConfigMapName, k8sutils.AdminNsKey, err)
+		adminNs = k8sutils.DefaultAdminNamespace
+	}
+	return adminNs
 }

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -1495,7 +1495,9 @@ func createActionCR(
 		Spec: storkv1.ActionSpec{
 			ActionType: storkv1.ActionTypeFailover,
 		},
-		Status: storkv1.ActionStatusScheduled,
+		Status: storkv1.ActionStatus{
+			Status: storkv1.ActionStatusScheduled,
+		},
 	}
 	return storkops.Instance().CreateAction(&actionSpec)
 }

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -158,7 +158,7 @@ var volumeDriver volume.Driver
 
 var storkVolumeDriver storkdriver.Driver
 var objectStoreDriver objectstore.Driver
-var dash *aetosutil.Dashboard
+var tpDash *aetosutil.Dashboard
 
 var snapshotScaleCount int
 var migrationScaleCount int
@@ -215,6 +215,7 @@ func doDashboardSetup() {
 	aetosLog = aetosLogger.GetLogInstance()
 	logrus.Infof("Getting dashboard utils in dosetup")
 	Dash = aetosutils.Get()
+	tpDash = aetosutil.Get()
 	Dash.TestLog = aetosLog
 	aetosLog.Out = io.MultiWriter(aetosLog.Out)
 	logLevel := os.Getenv("LOG_LEVEL")
@@ -2017,8 +2018,8 @@ func getByteDataFromFile(filePath string) ([]byte, error) {
 
 func updateDashStats(testName string, testResult *string) {
 	var err error
-	dash.IsEnabled, err = strconv.ParseBool(os.Getenv(enableDashStats))
-	if dash.IsEnabled && err == nil {
+	tpDash.IsEnabled, err = strconv.ParseBool(os.Getenv(enableDashStats))
+	if tpDash.IsEnabled && err == nil {
 		logrus.Infof("Dash is not enabled, stork integration tests will NOT push stats from this run to Aetos.")
 	}
 	dashStats := make(map[string]string)
@@ -2042,5 +2043,5 @@ func updateDashStats(testName string, testResult *string) {
 		DashStats: dashStats,
 	}
 
-	stats.PushStatsToAetos(dash, testName, dashProductName, dashStatsType, eventStat)
+	stats.PushStatsToAetos(tpDash, testName, dashProductName, dashStatsType, eventStat)
 }


### PR DESCRIPTION
**What type of PR is this?**
>feature
>unit-test

**What this PR does / why we need it**:
To add storkctl perform failover cli command. 
This command creates an action CR with actionType:failover for which we will add logic in the ActionController to perform the actual failover.

Another change is that we will create static copy of migrationSchedules in remote cluster irrespective of autoSuspend value

**Does this PR change a user-facing CRD or CLI?**:
Yes, it adds a new storkctl command `storkctl perform failover`
```
[root@olavangad-84-0 ~]# storkctl perform failover -h
Initiate failover of the given migration schedule

Usage:
  storkctl perform failover [flags]

Flags:
      --exclude-namespaces strings   Specify the comma-separated list of subset namespaces to be skipped during the failover. By default, all namespaces part of the migrationSchedule are failed over
  -h, --help                         help for failover
      --include-namespaces strings   Specify the comma-separated list of subset namespaces to be failed over. By default, all namespaces part of the migrationSchedule are failed over
  -m, --migration-reference string   Specify the migration schedule to failover. Also specify the namespace of this migrationSchedule using the -n flag
      --skip-deactivate-source       If present, applications in the source cluster will not be scaled down as part of the failover.

Global Flags:
      --alsologtostderr                   log to standard error as well as files
      --burst int                         restrict number of k8s API requests from stork (default 2000)
      --context string                    name of the kubeconfig context to use
      --kubeconfig string                 path to the kubeconfig file to use for CLI requests
      --log_backtrace_at traceLocations   when logging hits line file:N, emit a stack trace
      --log_dir string                    If non-empty, write log files in this directory
      --log_link string                   If non-empty, add symbolic links in this directory to the log files
      --logbuflevel int                   Buffer log messages logged at this level or lower (-1 means don't buffer; 0 means buffer INFO only; ...). Has limited applicability on non-prod platforms.
      --logtostderr                       log to standard error instead of files
  -n, --namespace string                  If present, the namespace scope for this CLI request (default "default")
  -o, --output string                     output format. One of: table|json|yaml (default "table")
      --qps int                           restrict number of k8s API requests from stork (default 1000)
      --stderrthreshold severityFlag      logs at or above this threshold go to stderr (default 2)
  -v, --v Level                           log level for V logs
      --vmodule vModuleFlag               comma-separated list of pattern=N settings for file-filtered logging
  -w, --watch                             watch stork resources

```

**Is a release note needed?**:
Yes, TBD

**Does this change need to be cherry-picked to a release branch?**:
Yes, 24.2.0

**Testing Details**:
1. Have tested that remote copy of migrationSchedule is created irrespective of autoSuspend value.
2. Have added comprehensive unit tests for storkctl perform failover and tested the corner cases manually as well.

