### PR TITLE
Add container name to vmAutoExecRules

### DIFF
--- a/pkg/resourcecollector/virtualmachine.go
+++ b/pkg/resourcecollector/virtualmachine.go
@@ -24,6 +24,8 @@ const (
 	VMFreezeCmd = "/usr/bin/virt-freezer --freeze --name %s --namespace %s"
 	//VMUnFreezeCmd is the template for VM unfreeze command
 	VMUnFreezeCmd = "/usr/bin/virt-freezer --unfreeze --name %s --namespace %s"
+	// VMContainerName is the name of the container to use for freeze/thaw
+	VMContainerName = "compute"
 )
 
 // IsVirtualMachineRunning returns true if virtualMachine is in running state
@@ -381,6 +383,7 @@ func getRuleItemWithAction(podSelector map[string]string, ruleAction string) sto
 	ruleInfoItem := storkapi.RuleItem{
 		PodSelector: podSelector,
 		Actions:     actions,
+		Container:   VMContainerName,
 	}
 	return ruleInfoItem
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
When there is more than one container for virt-launcher pod, freeze/thaw rule will fail to execute without container name.
This PR will ensure the autoExecRules are run on compute container. 

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
No
**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```
issue
**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
24.1.0
