### PR TITLE
chore: log namespace with the resource that causes backup to fail

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -147,7 +147,7 @@ func (a *aws) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 		// Try to get info from the PV since storage class could be deleted
 		pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)
 		if err != nil {
-			logrus.Warnf("Error getting pv %v for pvc %v: %v", pvc.Spec.VolumeName, pvc.Name, err)
+			logrus.Errorf("Error getting pv %v for pvc %v in namespace %s: %v", pvc.Spec.VolumeName, pvc.Name, pvc.Namespace, err)
 			return false
 		}
 		return a.OwnsPV(pv)

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -188,7 +188,7 @@ func (a *azure) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 		// Try to get info from the PV since storage class could be deleted
 		pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)
 		if err != nil {
-			logrus.Warnf("Error getting pv %v for pvc %v: %v", pvc.Spec.VolumeName, pvc.Name, err)
+			logrus.Errorf("Error getting pv %v for pvc %v in namespace %s: %v", pvc.Spec.VolumeName, pvc.Name, pvc.Namespace, err)
 			return false
 		}
 		return a.OwnsPV(pv)

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -129,7 +129,7 @@ func (g *gcp) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool {
 		// Try to get info from the PV since storage class could be deleted
 		pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)
 		if err != nil {
-			logrus.Warnf("Error getting pv %v for pvc %v: %v", pvc.Spec.VolumeName, pvc.Name, err)
+			logrus.Errorf("Error getting pv %v for pvc %v in namespace %s: %v", pvc.Spec.VolumeName, pvc.Name, pvc.Namespace, err)
 			return false
 		}
 		return g.OwnsPV(pv)

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -364,7 +364,7 @@ func (l *linstor) OwnsPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClaim) bool 
 		// Try to get info from the PV since storage class could be deleted
 		pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)
 		if err != nil {
-			logrus.Warnf("Error getting pv %v for pvc %v: %v", pvc.Spec.VolumeName, pvc.Name, err)
+			logrus.Errorf("Error getting pv %v for pvc %v in namespace %s: %v", pvc.Spec.VolumeName, pvc.Name, pvc.Namespace, err)
 			return false
 		}
 		return l.OwnsPV(pv)

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -773,7 +773,7 @@ func (p *portworx) IsSupportedPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClai
 		// Try to get info from the PV since storage class could be deleted
 		pv, err := coreOps.GetPersistentVolume(pvc.Spec.VolumeName)
 		if err != nil {
-			logrus.Warnf("Error getting pv %v for pvc %v: %v", pvc.Spec.VolumeName, pvc.Name, err)
+			logrus.Errorf("Error getting pv %v for pvc %v in namespace %s: %v", pvc.Spec.VolumeName, pvc.Name, pvc.Namespace, err)
 			return false
 		}
 		return p.OwnsPV(pv)

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -222,6 +222,8 @@ func (a *ApplicationBackupController) setDefaults(backup *stork_api.ApplicationB
 	return updated
 }
 
+// updateWithAllNamespaces checks all the namespaces in the cluster, selects the ones to be backed up
+// and writes them in the backup object.
 func (a *ApplicationBackupController) updateWithAllNamespaces(backup *stork_api.ApplicationBackup) error {
 	namespaces, err := core.Instance().ListNamespaces(nil)
 	if err != nil {
@@ -784,8 +786,8 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 						// as Cancelling, cancel any other started backups and then mark
 						// it as failed
 						if _, ok := err.(*volume.ErrStorageProviderBusy); ok {
-							inProgressMsg := fmt.Sprintf("Volume backups are in progress. Backups are failing for some volumes"+
-								" since the storage provider is busy: %v. Backup will be retried", err)
+							inProgressMsg := fmt.Sprintf("error: %v. Volume backups are in progress. Backups are failing for some volumes"+
+								" since the storage provider is busy. Backup will be retried", err)
 							log.ApplicationBackupLog(backup).Errorf(inProgressMsg)
 							a.recorder.Event(backup,
 								v1.EventTypeWarning,
@@ -847,7 +849,7 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 				}
 				for _, volInfo := range volumeInfos {
 					if volInfo.BackupID == "" {
-						log.ApplicationBackupLog(backup).Infof("Snapshot of volume [%v] hasn't completed yet, retry checking status", volInfo.PersistentVolumeClaim)
+						log.ApplicationBackupLog(backup).Infof("Snapshot of volume [%v] from namespace [%v] hasn't completed yet, retry checking status", volInfo.PersistentVolumeClaim, volInfo.Namespace)
 						// Some portworx volume snapshot is not completed yet
 						// hence we will retry checking the status in the next reconciler iteration
 						// *stork_api.ApplicationBackupVolumeInfo.Status is not being checked here
@@ -926,25 +928,28 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 			// Now check if there is any failure or success
 			// TODO: On failure of one volume cancel other backups?
 			for _, vInfo := range volumeInfos {
-				if vInfo.Status == stork_api.ApplicationBackupStatusInProgress || vInfo.Status == stork_api.ApplicationBackupStatusInitial ||
-					vInfo.Status == stork_api.ApplicationBackupStatusPending {
-					log.ApplicationBackupLog(backup).Infof("Volume backup still in progress: %v", vInfo.Volume)
+				switch vInfo.Status {
+				case stork_api.ApplicationBackupStatusInitial, stork_api.ApplicationBackupStatusPending, stork_api.ApplicationBackupStatusInProgress:
+					log.ApplicationBackupLog(backup).Infof("Volume backup still in progress: %v, namespace: %v ", vInfo.Volume, vInfo.Namespace)
 					inProgress = true
-				} else if vInfo.Status == stork_api.ApplicationBackupStatusFailed {
+
+				case stork_api.ApplicationBackupStatusFailed:
+					errorMsg := fmt.Sprintf("Error backing up volume %v from namespace: %v : %v", vInfo.Volume, vInfo.Namespace, vInfo.Reason)
 					a.recorder.Event(backup,
 						v1.EventTypeWarning,
 						string(vInfo.Status),
-						fmt.Sprintf("Error backing up volume %v: %v", vInfo.Volume, vInfo.Reason))
+						errorMsg)
+
 					backup.Status.Stage = stork_api.ApplicationBackupStageFinal
 					backup.Status.FinishTimestamp = metav1.Now()
 					backup.Status.Status = stork_api.ApplicationBackupStatusFailed
-					backup.Status.Reason = vInfo.Reason
-					break
-				} else if vInfo.Status == stork_api.ApplicationBackupStatusSuccessful {
+					backup.Status.Reason = errorMsg
+
+				case stork_api.ApplicationBackupStatusSuccessful:
 					a.recorder.Event(backup,
 						v1.EventTypeNormal,
 						string(vInfo.Status),
-						fmt.Sprintf("Volume %v backed up successfully", vInfo.Volume))
+						fmt.Sprintf("Volume %v from %v namespace backed up successfully", vInfo.Volume, vInfo.Namespace))
 				}
 			}
 		}
@@ -1960,7 +1965,7 @@ func (a *ApplicationBackupController) backupResources(
 			// Check the status of the resourceExport CR and update it to the applicationBackup CR
 			switch resourceExport.Status.Status {
 			case kdmpapi.ResourceExportStatusFailed:
-				message = fmt.Sprintf("Error uploading resources: %v", resourceExport.Status.Reason)
+				message = fmt.Sprintf("Error uploading resources: %v, namespace: %s", resourceExport.Status.Reason, resourceExport.Namespace)
 				backup.Status.Status = stork_api.ApplicationBackupStatusFailed
 				backup.Status.Stage = stork_api.ApplicationBackupStageFinal
 				backup.Status.Reason = message
@@ -2000,7 +2005,7 @@ func (a *ApplicationBackupController) backupResources(
 	}
 	// Upload the resources to the backup location
 	if err = a.uploadResources(backup, allObjects); err != nil {
-		message := fmt.Sprintf("Error uploading resources: %v", err)
+		message := fmt.Sprintf("Error uploading resources: %v, namespace: %s", err, backup.Namespace)
 		backup.Status.Status = stork_api.ApplicationBackupStatusFailed
 		backup.Status.Stage = stork_api.ApplicationBackupStageFinal
 		backup.Status.Reason = message
@@ -2021,7 +2026,7 @@ func (a *ApplicationBackupController) backupResources(
 	backup.Status.FinishTimestamp = metav1.Now()
 	backup.Status.Status = stork_api.ApplicationBackupStatusSuccessful
 	if len(backup.Spec.NamespaceSelector) != 0 && len(backup.Spec.Namespaces) == 0 {
-		backup.Status.Reason = "Namespace label selector did not find any namespaces with selected labels for backup"
+		backup.Status.Reason = fmt.Sprintf("Namespace label selector [%s] did not find any namespaces with selected labels for backup", backup.Spec.NamespaceSelector)
 	} else {
 		backup.Status.Reason = "Volumes and resources were backed up successfully"
 	}

--- a/pkg/applicationmanager/controllers/applicationbackupschedule.go
+++ b/pkg/applicationmanager/controllers/applicationbackupschedule.go
@@ -188,7 +188,7 @@ func (s *ApplicationBackupScheduleController) updateApplicationBackupStatus(back
 					s.recorder.Event(backupSchedule,
 						v1.EventTypeWarning,
 						string(stork_api.ApplicationBackupStatusFailed),
-						fmt.Sprintf("Error getting status of backup %v: %v", backup.Name, err))
+						fmt.Sprintf("Error getting status of backup %v from namespace %s: %v", backup.Name, backupSchedule.Namespace, err))
 					// If there was an error other than not found move to
 					// the next one. Otherwise we want to mark it as failed
 					// since the applicationbackup object is no longer
@@ -206,12 +206,12 @@ func (s *ApplicationBackupScheduleController) updateApplicationBackupStatus(back
 						s.recorder.Event(backupSchedule,
 							v1.EventTypeNormal,
 							string(stork_api.ApplicationBackupStatusSuccessful),
-							fmt.Sprintf("Scheduled backup (%v) completed successfully", backup.Name))
+							fmt.Sprintf("Scheduled backup (%v) completed successfully for namespace %s", backup.Name, backupSchedule.Namespace))
 					} else {
 						s.recorder.Event(backupSchedule,
 							v1.EventTypeWarning,
 							string(stork_api.ApplicationBackupStatusFailed),
-							fmt.Sprintf("Scheduled backup (%v) failed", backup.Name))
+							fmt.Sprintf("Scheduled backup (%v) failed for namespace %s", backup.Name, backupSchedule.Namespace))
 					}
 				}
 				updated = true

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -901,7 +901,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 				return nil
 			} else {
 				var message string
-				logrus.Infof("%s re cr %v status %v", funct, crName, resourceExport.Status.Status)
+				logrus.Infof("%s: resource-export cr [%v] status: %v", funct, crName, resourceExport.Status.Status)
 				switch resourceExport.Status.Status {
 				case kdmpapi.ResourceExportStatusFailed:
 					message = fmt.Sprintf("%s Error creating CR %v for pvc creation: %v", funct, crName, resourceExport.Status.Reason)
@@ -979,13 +979,13 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 		for _, vInfo := range volumeInfos {
 			if vInfo.Status == storkapi.ApplicationRestoreStatusInProgress || vInfo.Status == storkapi.ApplicationRestoreStatusInitial ||
 				vInfo.Status == storkapi.ApplicationRestoreStatusPending {
-				log.ApplicationRestoreLog(restore).Infof("Volume restore still in progress: %v->%v", vInfo.SourceVolume, vInfo.RestoreVolume)
+				log.ApplicationRestoreLog(restore).Infof("Volume restore still in progress: %v->%v for namespace %s", vInfo.SourceVolume, vInfo.RestoreVolume, vInfo.SourceNamespace)
 				inProgress = true
 			} else if vInfo.Status == storkapi.ApplicationRestoreStatusFailed {
 				a.recorder.Event(restore,
 					v1.EventTypeWarning,
 					string(vInfo.Status),
-					fmt.Sprintf("Error restoring volume %v->%v: %v", vInfo.SourceVolume, vInfo.RestoreVolume, vInfo.Reason))
+					fmt.Sprintf("Error restoring volume %v->%v for namespace %s: %v", vInfo.SourceVolume, vInfo.RestoreVolume, vInfo.SourceNamespace, vInfo.Reason))
 				restore.Status.Stage = storkapi.ApplicationRestoreStageFinal
 				restore.Status.FinishTimestamp = metav1.Now()
 				restore.Status.Status = storkapi.ApplicationRestoreStatusFailed
@@ -995,7 +995,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 				a.recorder.Event(restore,
 					v1.EventTypeNormal,
 					string(vInfo.Status),
-					fmt.Sprintf("Volume %v->%v restored successfully", vInfo.SourceVolume, vInfo.RestoreVolume))
+					fmt.Sprintf("Volume %v->%v restored successfully for namespace %s", vInfo.SourceVolume, vInfo.RestoreVolume, vInfo.SourceNamespace))
 			}
 		}
 	}
@@ -1021,7 +1021,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 		}
 		err = a.restoreResources(restore, updateCr)
 		if err != nil {
-			log.ApplicationRestoreLog(restore).Errorf("Error restoring resources: %v", err)
+			log.ApplicationRestoreLog(restore).Errorf("Error restoring resources from namespace %s: %v", restore.Namespace, err)
 			return err
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
This PR adds the namespace info in the logs for the cases when a backup/restore operation fails due to a certain volume/resource. Ref: [PB-5280](https://portworx.atlassian.net/browse/PB-5280)

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
Yes

**Screenshorts**
Logs with `namespace` info alongwith the PVC details.
![Screenshot from 2024-02-05 15-50-18](https://github.com/libopenstorage/stork/assets/156179360/cd617a18-c7bf-4ae8-8c50-18c90bf4a3d1)
![Screenshot from 2024-02-06 15-40-02](https://github.com/libopenstorage/stork/assets/156179360/c68b619d-ad29-449b-8958-9a3ac2e2dab9)


[PB-5280]: https://portworx.atlassian.net/browse/PB-5280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ