### PR TITLE
set default version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ifeq ($(BUILD_TYPE),debug)
 BUILDFLAGS += -gcflags "-N -l"
 endif
 
-RELEASE_VER := 2.7.0
+RELEASE_VER := 99.9.9
 BASE_DIR    := $(shell git rev-parse --show-toplevel)
 GIT_SHA     := $(shell git rev-parse --short HEAD)
 BIN         :=$(BASE_DIR)/bin


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Modify the default version of stork in Makefile so that build pipelines can pick it up easily.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
24.2.0
