### PR TITLE
PWX-33044: add kubevirt label to the PVCs added directly to the VMs

### DIFF
--- a/test/integration_test/specs/kubevirt-fedora-multi-disks-wffc/fedora-multi-disks-wffc.yaml
+++ b/test/integration_test/specs/kubevirt-fedora-multi-disks-wffc/fedora-multi-disks-wffc.yaml
@@ -89,6 +89,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: fedora-data-disk-1
+  labels:
+    portworx.io/kubevirt: "true"
 spec:
   storageClassName: sc-sharedv4svc-nolock-wait-first-consumer
   accessModes:
@@ -101,6 +103,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: fedora-data-disk-2
+  labels:
+    portworx.io/kubevirt: "true"
 spec:
   storageClassName: sc-sharedv4svc-nolock-wait-first-consumer
   accessModes:
@@ -113,6 +117,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: fedora-data-disk-3
+  labels:
+    portworx.io/kubevirt: "true"
 spec:
   storageClassName: sc-sharedv4svc-nolock-wait-first-consumer
   accessModes:

--- a/test/integration_test/specs/kubevirt-fedora-multiple-disks/fedora-vm-multidisk.yaml
+++ b/test/integration_test/specs/kubevirt-fedora-multiple-disks/fedora-vm-multidisk.yaml
@@ -65,7 +65,7 @@ spec:
             password: password1
             chpasswd: { expire: False }
         name: cloudinitdisk
-  dataVolumeTemplates:      
+  dataVolumeTemplates:
   - metadata:
       name: fedora-root-disk
     spec:
@@ -96,11 +96,13 @@ spec:
             storage: 25Gi
         storageClassName: sc-sharedv4svc-nolock
         volumeMode: Filesystem
----        
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: fedora-data-disk-2
+  labels:
+    portworx.io/kubevirt: "true"
 spec:
   storageClassName: sc-sharedv4svc-nolock
   accessModes:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
integration-test

**What this PR does / why we need it**:
PX performs its KubeVirt-specific logic only if the volume is a KubeVirt volume based on the volume labels. When the volume is created via a dataVolume template such labels are automatically added to the PVC. However, if a PVC is added directly to the VM spec, no such labels are present and therefore no VPS is added to the PX volume.

This patch adds a label with "kubevirt" in key to the PVCs specified directly in the VM spec.

Note that the test is currently passing even without this label. That is because the namespace just happens to have "kubevirt" in the name and the namespace appears as one of the label values. If the same VM spec is used from a different namespace without "kubevirt" in the name, the VPS detection logic is skipped and replica collaction does not work.


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
no


**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
no
