### PR TITLE
PB-5689: Default Creation of VolumeSnapshotClass should be optional

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -38,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -61,6 +63,9 @@ const (
 	annPVBindCompleted     = "pv.kubernetes.io/bind-completed"
 	annPVBoundByController = "pv.kubernetes.io/bound-by-controller"
 	restoreUIDLabel        = "restoreUID"
+	createDefaultVSEnv     = "CREATE_DEFAULT_VOLUMESNAPSHOTCLASS"
+	// snapshotClassNamePrefix is the prefix for snapshot classes per CSI driver
+	snapshotClassNamePrefix = "stork-csi-snapshot-class-"
 )
 
 // CsiBackupObject represents a backup of a series of CSI objects
@@ -186,6 +191,15 @@ func (c *csi) Init(_ interface{}) error {
 	c.v1SnapshotRequired, err = version.RequiresV1VolumeSnapshot()
 	if err != nil {
 		return err
+	}
+
+	// If this env var exist then only create volumeSnapshotClass for all csi drivers present in cluster, if not.
+	isCreationNeeded := os.Getenv(createDefaultVSEnv)
+	if isCreationNeeded == "true" || isCreationNeeded == "True" {
+		err = c.createDefaultSnapshotClasses()
+		if err != nil {
+			return err
+		}
 	}
 
 	c.snapshotter, err = snapshotter.NewCSIDriver()
@@ -1863,6 +1877,93 @@ func (c *csi) GetCSIPodPrefix() (string, error) {
 // IsVirtualMachineSupported returns true if the driver supports VM scheduling
 func (c *csi) IsVirtualMachineSupported() bool {
 	return false
+}
+func (c *csi) createDefaultSnapshotClasses() error {
+	var existingSnapshotClassesDriverList []string
+	if c.v1SnapshotRequired {
+		existingSnapshotClasses, err := c.snapshotClient.SnapshotV1().VolumeSnapshotClasses().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			logrus.Infof("CSI v1 VolumeSnapshotClass CRD does not exist, skipping default SnapshotClass creation - error:  %v", err)
+			return nil
+		}
+		for _, existingSnapClass := range existingSnapshotClasses.Items {
+			logrus.Infof("Driver name %s", existingSnapClass.Driver)
+			existingSnapshotClassesDriverList = append(existingSnapshotClassesDriverList, existingSnapClass.Driver)
+		}
+	} else {
+		existingSnapshotClasses, err := c.snapshotClient.SnapshotV1beta1().VolumeSnapshotClasses().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			logrus.Infof("CSI v1beta1 VolumeSnapshotClass CRD does not exist, skipping default SnapshotClass creation - error: %v", err)
+			return nil
+		}
+		for _, existingSnapClass := range existingSnapshotClasses.Items {
+			logrus.Infof("Driver name %s", existingSnapClass.Driver)
+			existingSnapshotClassesDriverList = append(existingSnapshotClassesDriverList, existingSnapClass.Driver)
+		}
+	}
+
+	logrus.Infof("Creating default CSI SnapshotClasses")
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get config for creating default CSI snapshot classes: %v", err)
+	}
+
+	k8sClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to get client for creating default CSI snapshot classes: %v", err)
+	}
+
+	ok, err := version.RequiresV1CSIdriver()
+	if err != nil {
+		return err
+	}
+	var csiDriverNameList []string
+	if ok {
+		// Get all drivers
+		driverList, err := k8sClient.StorageV1().CSIDrivers().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to list all CSI drivers(V1): %v", err)
+		}
+		// Fill the driver names from CSIDrivers to list
+		for _, driver := range driverList.Items {
+			csiDriverNameList = append(csiDriverNameList, driver.Name)
+		}
+	} else {
+
+		// Get all drivers
+		driverList, err := k8sClient.StorageV1beta1().CSIDrivers().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to list all CSI drivers(V1beta1): %v", err)
+		}
+		// Fill the driver names from CSIDrivers to list
+		for _, driver := range driverList.Items {
+			csiDriverNameList = append(csiDriverNameList, driver.Name)
+		}
+	}
+
+	// Create VolumeSnapshotClass for each driver
+	for _, driverName := range csiDriverNameList {
+		foundSnapClass := false
+		for _, existingSnapClassDriverName := range existingSnapshotClassesDriverList {
+			if driverName == existingSnapClassDriverName {
+				logrus.Infof("CSI VolumeSnapshotClass exists for driver %v. Skipping creation of snapshotclass", driverName)
+				foundSnapClass = true
+				break
+			}
+		}
+		if foundSnapClass {
+			continue
+		}
+		snapshotClassName := snapshotClassNamePrefix + driverName
+		_, err := c.createVolumeSnapshotClass(snapshotClassName, driverName)
+		if err != nil && !k8s_errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create default snapshotclass %s: %v", snapshotClassName, err)
+		} else if k8s_errors.IsAlreadyExists(err) {
+			logrus.Infof("VolumeSnapshotClass %s already exists, skipping default snapshotclass creation", snapshotClassName)
+		}
+	}
+
+	return nil
 }
 
 func init() {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
We need this PR to make creation of CSI SnapshotClasses as optional, now user will have to pass the env variable `CREATE_DEFAULT_VOLUMESNAPSHOTCLASS` to create those. Default behaviour will be not to create any.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
--> no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
--> yes

```release-note
Issue: VolumeSnapshotClass was getting created for those CSI Drivers who doesn't support snapshot. Later creates issue when creating backup.
User Impact: Need to add env var to stork deployment if they want to create by default by stork
Resolution: Added a new env variable to in stork deployment to take user option to create volumesnapshotclass

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
--> yes 24.3.0-px-backup-2.7.0

CSI Driver:
```
❯ kc get csidriver         
NAME                 ATTACHREQUIRED   PODINFOONMOUNT   STORAGECAPACITY   TOKENREQUESTS   REQUIRESREPUBLISH   MODES        AGE
driver.longhorn.io   true             true             false             <unset>         false               Persistent   61m
```

```
❯ kc get volumesnapshotclass 
No resources found
```

Deploy Edited 
```
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "3"
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"scheduler.alpha.kubernetes.io/critical-pod":""},"labels":{"tier":"control-plane"},"name":"stork","namespace":"kube-system"},"spec":{"replicas":3,"selector":{"matchLabels":{"name":"stork"}},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"},"template":{"metadata":{"annotations":{"scheduler.alpha.kubernetes.io/critical-pod":""},"labels":{"name":"stork","tier":"control-plane"}},"spec":{"affinity":{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"name","operator":"In","values":["stork"]}]},"topologyKey":"kubernetes.io/hostname"}]}},"containers":[{"command":["/stork","--verbose","--leader-elect=true","--health-monitor-interval=120","--webhook-controller=true"],"image":"openstorage/stork:23.11.0","imagePullPolicy":"Always","name":"stork","resources":{"requests":{"cpu":"0.1"}}}],"hostPID":false,"serviceAccountName":"stork-account"}}}}
    scheduler.alpha.kubernetes.io/critical-pod: ""
  creationTimestamp: "2024-02-19T09:39:55Z"
  generation: 9
  labels:
    tier: control-plane
  name: stork
  namespace: kube-system
  resourceVersion: "23899"
  uid: ff41a2a6-e059-4722-bc23-d70f35fb240e
spec:
  progressDeadlineSeconds: 600
  replicas: 3
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      name: stork
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      annotations:
        scheduler.alpha.kubernetes.io/critical-pod: ""
      creationTimestamp: null
      labels:
        name: stork
        tier: control-plane
    spec:
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: name
                operator: In
                values:
                - stork
            topologyKey: kubernetes.io/hostname
      containers:
      - command:
        - /stork
        - --verbose
        - --leader-elect=true
        - --health-monitor-interval=120
        - --webhook-controller=true
        env:
        - name: CREATE_DEFAULT_VOLUMESNAPSHOTCLASS
          value: "true"
        image: pure-artifactory.dev.purestorage.com/px-docker-dev-virtual/pamathur/stork:pb5689
        imagePullPolicy: Always
        name: stork
        resources:
          requests:
            cpu: 100m
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      serviceAccount: stork-account
      serviceAccountName: stork-account
      terminationGracePeriodSeconds: 30
status:
  availableReplicas: 3
  conditions:
  - lastTransitionTime: "2024-02-19T09:39:55Z"
    lastUpdateTime: "2024-02-19T09:55:34Z"
    message: ReplicaSet "stork-5579b58d5b" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  - lastTransitionTime: "2024-02-19T10:03:07Z"
    lastUpdateTime: "2024-02-19T10:03:07Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  observedGeneration: 9
  readyReplicas: 3
  replicas: 3
  updatedReplicas: 3
```

Now check for VSC

```
❯ kc get volumesnapshotclass -w
NAME                                          DRIVER               DELETIONPOLICY   AGE
stork-csi-snapshot-class-driver.longhorn.io   driver.longhorn.io   Retain           0s
```