### PR TITLE
PB-4848: Support kubevirt operatore restore using kubevirt ns backup

### DIFF
--- a/pkg/resourcecollector/priorityclass.go
+++ b/pkg/resourcecollector/priorityclass.go
@@ -1,0 +1,50 @@
+package resourcecollector
+
+import (
+	"fmt"
+
+	"github.com/portworx/sched-ops/k8s/apps"
+	v1 "k8s.io/api/scheduling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	ignorePCList = []string{
+		"openshift-user-critical",
+		"system-cluster-critical",
+		"system-node-critical",
+		"k8s-cluster-critical",
+	}
+)
+
+// validatePriorityClassToBeCollected checks if the PC is referred by any
+// of the deployments in the namespace that is getting backed. Ignores backup of
+// PCs that system defaults which are referred by deployments in the NS.
+func (r *ResourceCollector) validatePriorityClassToBeCollected(
+	object runtime.Unstructured,
+	namespace string,
+) (bool, error) {
+	var pc v1.PriorityClass
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &pc); err != nil {
+		return false, fmt.Errorf("error converting unstructured to priorityClass Object: %v", err)
+	}
+	dlist, err := apps.Instance().ListDeployments(namespace, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, str := range ignorePCList {
+		// Ignore system default PC
+		if str == pc.Name {
+			return false, nil
+		}
+	}
+	for _, deployment := range dlist.Items {
+
+		if deployment.Spec.Template.Spec.PriorityClassName == pc.Name {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -218,7 +218,8 @@ func GetSupportedK8SResources(kind string, optionalResourceTypes []string) bool 
 		"PodDisruptionBudget",
 		"Endpoints",
 		"ValidatingWebhookConfiguration",
-		"MutatingWebhookConfiguration":
+		"MutatingWebhookConfiguration",
+		"PriorityClass":
 		return true
 	case "Job":
 		return slice.ContainsString(optionalResourceTypes, "job", strings.ToLower) ||
@@ -651,7 +652,6 @@ func (r *ResourceCollector) getParticularResourceInNamespaces(
 			// is backed up.
 			// With this now a user can choose to backup all resources in a ns and some
 			// selected resources from different ns
-
 			collect, err = r.objectToBeCollected(objectToInclude, labelSelectors, excludeSelectors, resourceMap, runtimeObject, ns, allDrivers, opts, crbs)
 			if err != nil {
 				if apierrors.IsForbidden(err) {
@@ -830,6 +830,8 @@ func (r *ResourceCollector) objectToBeCollected(
 		return r.mutatingWebHookToBeCollected(object, namespace)
 	case "ValidatingWebhookConfiguration":
 		return r.validatingWebHookToBeCollected(object, namespace)
+	case "PriorityClass":
+		return r.validatePriorityClassToBeCollected(object, namespace)
 	}
 
 	return true, nil


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
This PR fixes bug PB-4848 for px-backup to support kubevirt operator backup/restore using kubevirt namespace based backup and restore.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
NO
**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```
No

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
24.1.0
