### PR TITLE
pb-5438: Resetting the pvc.Spec.Selector in the csi snapshotter  as it is dynamic provisioning.

### DIFF
--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -1553,6 +1553,11 @@ func (c *csiDriver) RestoreFromLocalSnapshot(backupLocation *storkapi.BackupLoca
 	}
 
 	// create a new pvc for restore from the snapshot
+	if pvc.Spec.Selector != nil {
+		// Remove the labelselector, as it is a dynamic provisioning.
+		logrus.Debugf("RestoreFromLocalSnapshot: pvc:%v/%v - pvc.Spec.Selector: %v", pvc.Namespace, pvc.Name, pvc.Spec.Selector)
+		pvc.Spec.Selector = nil
+	}
 	pvcName := pvc.Name
 	pvc, err = c.RestoreVolumeClaim(
 		RestoreSnapshotName(vsName),


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
pb-5438: Resetting the pvc.Spec.Selector in the csi snapshotter  as it is dynamic provisioning.
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Yes
```release-note
Issue: Restoring a PVC with label selector with CSI and KDMP backup variant will fail.
User Impact: User will not able to restore the backup taken from a static PVC with label selector for PV selection.
Resolution: Fixed the issue by removing the label selector from the restore PVC.

```

**Does this change need to be cherry-picked to a release branch?**:
2.7.0

