### PR TITLE
PB-5779: Fix no VMs in namespace issue for vm Backup in stork

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -132,6 +132,7 @@ type ApplicationBackupController struct {
 	reconcileTime        time.Duration
 	vmIncludeResource    map[string][]stork_api.ObjectInfo
 	vmIncludeResourceMap map[string]map[stork_api.ObjectInfo]bool
+	vmNsListMap          map[string]map[string]bool
 }
 
 // Init Initialize the application backup controller
@@ -151,6 +152,7 @@ func (a *ApplicationBackupController) Init(mgr manager.Manager, backupAdminNames
 	a.execRulesCompleted = make(map[string]bool)
 	a.vmIncludeResource = make(map[string][]stork_api.ObjectInfo)
 	a.vmIncludeResourceMap = make(map[string]map[stork_api.ObjectInfo]bool)
+	a.vmNsListMap = make(map[string]map[string]bool)
 	return controllers.RegisterTo(mgr, "application-backup-controller", a, &stork_api.ApplicationBackup{})
 }
 
@@ -320,6 +322,10 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 			if _, ok := a.vmIncludeResourceMap[string(backup.UID)]; ok {
 				delete(a.vmIncludeResourceMap, string(backup.UID))
 				log.ApplicationBackupLog(backup).Infof("cleaning up vmIncludeResources for VM backupObjectType")
+			}
+			if _, ok := a.vmNsListMap[string(backup.UID)]; ok {
+				delete(a.vmNsListMap, string(backup.UID))
+				log.ApplicationBackupLog(backup).Infof("cleaning up vmNsListMap for VM backupObjectType")
 			}
 			// Calling cleanupResources which will cleanup the resources created by applicationbackup controller. Including the post exec rule CR for manual backup when created through the px-backup
 			// In the case of kdmp driver, it will cleanup the dataexport CRs.
@@ -715,6 +721,11 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 
 		var pvcCount int
 		for _, namespace := range backup.Spec.Namespaces {
+			if !a.isNsPresentForVmBackup(backup, namespace) {
+				// For VM Backup, if namespace does not have any VMs to backup we would
+				// want to skip the volumes from this namespace for backup.
+				continue
+			}
 			pvcList, err := core.Instance().GetPersistentVolumeClaims(namespace, backup.Spec.Selectors)
 			if err != nil {
 				return fmt.Errorf("error getting list of volumes to backup: %v", err)
@@ -1743,6 +1754,11 @@ func (a *ApplicationBackupController) backupResources(
 		var incResNsBatch []string
 		var resourceTypeNsBatch []string
 		for _, ns := range batch {
+			if !a.isNsPresentForVmBackup(backup, ns) {
+				// For VM Backup, if namespace does not have any VMs to backup we would
+				// want to skip resources from this namespace for backup.
+				continue
+			}
 			// As we support both includeResource and ResourceType to be mentioned
 			// match out ns for which we want to take includeResource path and
 			// for which we want to take ResourceType path
@@ -1753,7 +1769,7 @@ func (a *ApplicationBackupController) backupResources(
 					incResNsBatch = append(incResNsBatch, ns)
 				}
 			} else {
-				incResNsBatch = batch
+				incResNsBatch = append(incResNsBatch, ns)
 			}
 		}
 		if len(incResNsBatch) != 0 {
@@ -2411,13 +2427,15 @@ func (a *ApplicationBackupController) createVMIncludeResources(backup *stork_api
 	if err != nil {
 		return nil, nil, err
 	}
+	nsMap := make(map[string]bool)
 	// Second fetch VM resources from the list of filtered VMs and freeze/thaw rule for each of them.
 	vmIncludeResources, objectMap, preExecRule, postExecRule := resourcecollector.GetVMIncludeResourceInfoList(vmList,
-		objectMap, backup.Spec.SkipAutoExecRules)
+		objectMap, nsMap, backup.Spec.SkipAutoExecRules)
 
 	// update in memory data structure for later use.
 	a.vmIncludeResourceMap[string(backup.UID)] = objectMap
 	a.vmIncludeResource[string(backup.UID)] = vmIncludeResources
+	a.vmNsListMap[string(backup.UID)] = nsMap
 
 	if len(preExecRule) <= 0 || len(postExecRule) <= 0 {
 		// No VMs needed free/thaw rule, skip creating ruleCr
@@ -2434,4 +2452,15 @@ func (a *ApplicationBackupController) createVMIncludeResources(backup *stork_api
 // IsBackupObjectTypeVirtualMachine returns true if backupObjectType is VirtualMachine
 func IsBackupObjectTypeVirtualMachine(backup *stork_api.ApplicationBackup) bool {
 	return backup.Spec.BackupObjectType == resourcecollector.PxBackupObjectType_virtualMachine
+}
+
+// isNsPresentForVmBackup check if namspace had any VMs to backup.
+func (a *ApplicationBackupController) isNsPresentForVmBackup(backup *stork_api.ApplicationBackup, ns string) bool {
+
+	if !IsBackupObjectTypeVirtualMachine(backup) {
+		return true
+	}
+	nsMap := a.vmNsListMap[string(backup.UID)]
+	return nsMap[ns]
+
 }

--- a/pkg/resourcecollector/virtualmachine.go
+++ b/pkg/resourcecollector/virtualmachine.go
@@ -481,7 +481,7 @@ func GetVMIncludeListFromBackup(backup *storkapi.ApplicationBackup) (
 
 // GetVMIncludeResourceInfoList returns VMs and VM resources in IncludeResource format.
 // Also returns preExec and postExec rule Item with freeze/thaw rule for each of the filter VMs
-func GetVMIncludeResourceInfoList(vmList []kubevirtv1.VirtualMachine, objectMap map[storkapi.ObjectInfo]bool, skipAutoVMRule bool) (
+func GetVMIncludeResourceInfoList(vmList []kubevirtv1.VirtualMachine, objectMap map[storkapi.ObjectInfo]bool, nsMap map[string]bool, skipAutoVMRule bool) (
 	[]storkapi.ObjectInfo,
 	map[storkapi.ObjectInfo]bool,
 	[]storkapi.RuleItem,
@@ -503,6 +503,9 @@ func GetVMIncludeResourceInfoList(vmList []kubevirtv1.VirtualMachine, objectMap 
 			},
 			Name:      vm.Name,
 			Namespace: vm.Namespace,
+		}
+		if !nsMap[vm.Namespace] {
+			nsMap[vm.Namespace] = true
 		}
 		// We would have mapped vmInfo specified in backup.Spec.IncludeResource but,
 		// VMList from namespaces would not have been. Map them here.


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
For VM backup if a namespace provided does not have VMs in it. The VM backup takes backup of full namespace. This PR fixes the issue by filtering out namespaces that do not have VMs to backup. 
Closes PB-5779
**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: VM Backup with namespace having no VMs will take full namespace backup
User Impact: Instead of VM only backup, all resources will be backed up. 
Resolution: If namespace does not have any VMs, then the namespace will be pruned out for backup. 

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
24.1.0
