### PR TITLE
PWX-35855: Action CR reconciler changes with multiple stages.

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -140,10 +140,9 @@ func main() {
 			Value: 120,
 			Usage: "The interval in seconds to monitor the health of the storage driver (min: 30)",
 		},
-		cli.BoolFlag{
-			Name:   "action-controller",
-			Usage:  "Start the Action controller (default: false)",
-			Hidden: true,
+		cli.BoolTFlag{
+			Name:  "action-controller",
+			Usage: "Start the Action controller (default: false)",
 		},
 		cli.BoolTFlag{
 			Name:  "migration-controller",

--- a/pkg/action/actioncontroller.go
+++ b/pkg/action/actioncontroller.go
@@ -205,7 +205,8 @@ func getLatestMigrationPolicyAndStatus(migrationSchedule storkv1.MigrationSchedu
 }
 
 func isMigrationComplete(status storkv1.MigrationStatusType) bool {
-	if status == storkv1.MigrationStatusPending ||
+	if status == storkv1.MigrationStatusInitial ||
+		status == storkv1.MigrationStatusPending ||
 		status == storkv1.MigrationStatusInProgress {
 		return false
 	}

--- a/pkg/action/actioncontroller.go
+++ b/pkg/action/actioncontroller.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	validateCRDInterval time.Duration = 5 * time.Second
-	validateCRDTimeout  time.Duration = 1 * time.Minute
-	actionExpiryTime    time.Duration = 24 * time.Hour
+	validateCRDInterval          time.Duration = 5 * time.Second
+	validateCRDTimeout           time.Duration = 1 * time.Minute
+	actionExpiryTime             time.Duration = 24 * time.Hour
+	latestMigrationThresholdTime time.Duration = 1 * time.Hour
 )
 
 func NewActionController(mgr manager.Manager, d volume.Driver, r record.EventRecorder) *ActionController {
@@ -69,30 +70,61 @@ func (ac *ActionController) Reconcile(ctx context.Context, request reconcile.Req
 		return reconcile.Result{RequeueAfter: controllers.DefaultRequeueError}, err
 	}
 
-	if action.Status.Status == storkv1.ActionStatusScheduled {
-		if err = ac.handle(context.TODO(), action); err != nil {
-			log.ActionLog(action).Errorf("ActionController handle failed with %s", err)
-			ac.recorder.Event(action, v1.EventTypeWarning, "ActionController", err.Error())
-			return reconcile.Result{RequeueAfter: controllers.DefaultRequeueError}, err
-		}
+	if action.Status.Stage == storkv1.ActionStageFinal {
+		// Will not requeue once action is in final stage
+		return reconcile.Result{}, nil
 	}
-	ac.pruneActionIfExpired(action)
+
+	if !controllers.ContainsFinalizer(action, controllers.FinalizerCleanup) {
+		controllers.SetFinalizer(action, controllers.FinalizerCleanup)
+		return reconcile.Result{Requeue: true}, ac.client.Update(context.TODO(), action)
+	}
+
+	if err = ac.handle(context.TODO(), action); err != nil {
+		log.ActionLog(action).Errorf("ActionController handle failed with %s", err)
+		ac.recorder.Event(action, v1.EventTypeWarning, "ActionController", err.Error())
+		return reconcile.Result{RequeueAfter: controllers.DefaultRequeueError}, err
+	}
+
+	if action.Spec.ActionType == storkv1.ActionTypeNearSyncFailover {
+		ac.pruneActionIfExpired(action)
+	}
 
 	return reconcile.Result{RequeueAfter: controllers.DefaultRequeue}, nil
 }
 
 func (ac *ActionController) handle(ctx context.Context, action *storkv1.Action) error {
-	ac.updateStatus(action, storkv1.ActionStatusInProgress)
+	if action.DeletionTimestamp != nil {
+		if action.GetFinalizers() != nil {
+			controllers.RemoveFinalizer(action, controllers.FinalizerCleanup)
+			return ac.client.Update(ctx, action)
+		}
+		return nil
+	}
+
 	switch action.Spec.ActionType {
 	case storkv1.ActionTypeNearSyncFailover:
-		log.ActionLog(action).Info("started failover")
-		err := ac.volDriver.Failover(action)
-		if err != nil {
-			ac.updateStatus(action, storkv1.ActionStatusFailed)
-			return err
+		ac.updateStatus(action, storkv1.ActionStatusInProgress)
+		if action.Status.Status == storkv1.ActionStatusScheduled {
+			log.ActionLog(action).Info("started failover")
+			err := ac.volDriver.Failover(action)
+			if err != nil {
+				ac.updateStatus(action, storkv1.ActionStatusFailed)
+				return err
+			}
+			resourceutils.ScaleReplicas(action.Namespace, true, ac.printFunc(action, "ScaleReplicas"), ac.config)
+			ac.updateStatus(action, storkv1.ActionStatusSuccessful)
 		}
-		resourceutils.ScaleReplicas(action.Namespace, true, ac.printFunc(action, "ScaleReplicas"), ac.config)
-		ac.updateStatus(action, storkv1.ActionStatusSuccessful)
+	case storkv1.ActionTypeFailback:
+		log.ActionLog(action).Infof("in stage %s", action.Status.Stage)
+		switch action.Status.Stage {
+		case storkv1.ActionStageInitial:
+			ac.verifyMigrationScheduleBeforeFailback(action)
+		case storkv1.ActionStageScaleDownDestination:
+			ac.performDeactivateFailBackStage(action)
+		case storkv1.ActionStageFinal:
+			return nil
+		}
 	default:
 		ac.updateStatus(action, storkv1.ActionStatusFailed)
 		return fmt.Errorf("invalid value received for Action.Spec.ActionType")
@@ -126,6 +158,15 @@ func (ac *ActionController) updateStatus(action *storkv1.Action, actionStatus st
 	}
 }
 
+func (ac *ActionController) updateAction(action *storkv1.Action) error {
+	err := ac.client.Update(context.TODO(), action)
+	if err != nil {
+		log.ActionLog(action).Errorf("failed to update action status to %v with error %v", action.Status, err)
+		return err
+	}
+	return nil
+}
+
 // delete any action older than actionExpiryTime
 func (ac *ActionController) pruneActionIfExpired(action *storkv1.Action) {
 	if action.Status.Status == storkv1.ActionStatusFailed || action.Status.Status == storkv1.ActionStatusSuccessful {
@@ -148,4 +189,25 @@ func (ac *ActionController) createCRD() error {
 		Kind:    reflect.TypeOf(storkv1.Action{}).Name(),
 	}
 	return k8sutils.CreateCRD(resource, validateCRDInterval, validateCRDTimeout)
+}
+
+// getLatestMigrationStatus returns the a migrationschedule's latest migration's policy type and status
+func getLatestMigrationPolicyAndStatus(migrationSchedule storkv1.MigrationSchedule) (storkv1.SchedulePolicyType, *storkv1.ScheduledMigrationStatus) {
+	var lastMigrationStatus *storkv1.ScheduledMigrationStatus
+	var schedulePolicyType storkv1.SchedulePolicyType
+	for schedulePolicyType, policyMigration := range migrationSchedule.Status.Items {
+		if len(policyMigration) > 0 {
+			lastMigrationStatus = policyMigration[len(policyMigration)-1]
+			return schedulePolicyType, lastMigrationStatus
+		}
+	}
+	return schedulePolicyType, lastMigrationStatus
+}
+
+func isMigrationComplete(status storkv1.MigrationStatusType) bool {
+	if status == storkv1.MigrationStatusPending ||
+		status == storkv1.MigrationStatusInProgress {
+		return false
+	}
+	return true
 }

--- a/pkg/action/actioncontroller.go
+++ b/pkg/action/actioncontroller.go
@@ -205,10 +205,7 @@ func getLatestMigrationPolicyAndStatus(migrationSchedule storkv1.MigrationSchedu
 }
 
 func isMigrationComplete(status storkv1.MigrationStatusType) bool {
-	if status == storkv1.MigrationStatusInitial ||
+	return !(status == storkv1.MigrationStatusInitial ||
 		status == storkv1.MigrationStatusPending ||
-		status == storkv1.MigrationStatusInProgress {
-		return false
-	}
-	return true
+		status == storkv1.MigrationStatusInProgress)
 }

--- a/pkg/action/failback.go
+++ b/pkg/action/failback.go
@@ -1,0 +1,216 @@
+package action
+
+import (
+	"fmt"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/log"
+	"github.com/libopenstorage/stork/pkg/resourceutils"
+	"github.com/libopenstorage/stork/pkg/schedule"
+	"github.com/libopenstorage/stork/pkg/utils"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv1.Action) {
+
+	if action.Status.Status == storkv1.ActionStatusSuccessful {
+		action.Status.Stage = storkv1.ActionStageScaleDownDestination
+		action.Status.Status = storkv1.ActionStatusInitial
+		action.Status.FinishTimestamp = metav1.Now()
+		ac.updateAction(action)
+		return
+	} else if action.Status.Status == storkv1.ActionStatusFailed {
+		action.Status.Stage = storkv1.ActionStageFinal
+		action.Status.Status = storkv1.ActionStatusInitial
+		action.Status.FinishTimestamp = metav1.Now()
+		ac.updateAction(action)
+		return
+	}
+
+	migrationSchedule, err := storkops.Instance().GetMigrationSchedule(action.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference, action.Namespace)
+	if err != nil {
+		msg := fmt.Sprintf("error fetching migrationschedule %s/%s for failback", action.Namespace, action.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference)
+		log.ActionLog(action).Errorf(msg)
+		action.Status.Status = storkv1.ActionStatusFailed
+		action.Status.Reason = msg
+		ac.recorder.Event(action,
+			v1.EventTypeWarning,
+			string(storkv1.ActionStatusFailed),
+			msg)
+		ac.updateAction(action)
+		return
+	}
+
+	if len(action.Spec.ActionParameter.FailbackParameter.Namespaces) > 0 {
+		namespaces, err := utils.GetMergedNamespacesWithLabelSelector(migrationSchedule.Spec.Template.Spec.Namespaces, migrationSchedule.Spec.Template.Spec.NamespaceSelectors)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to get list of namespaces from migrationschedule %s", migrationSchedule.Name)
+			log.ActionLog(action).Infof(msg)
+			ac.recorder.Event(action,
+				v1.EventTypeWarning,
+				string(storkv1.ActionStatusScheduled),
+				msg)
+			ac.updateAction(action)
+			return
+		}
+
+		if !utils.IsSubList(namespaces, action.Spec.ActionParameter.FailbackParameter.Namespaces) {
+			msg := fmt.Sprintf("Namespaces provided for failback is not a subset of namespaces from migrationschedule %s", migrationSchedule.Name)
+			log.ActionLog(action).Infof(msg)
+			ac.recorder.Event(action,
+				v1.EventTypeWarning,
+				string(storkv1.ActionStatusScheduled),
+				msg)
+			ac.updateAction(action)
+			return
+		}
+
+	}
+
+	// Return if any migration is ongoing
+	for _, policyType := range storkv1.GetValidSchedulePolicyTypes() {
+		policyMigration, present := migrationSchedule.Status.Items[policyType]
+		if present {
+			for _, migration := range policyMigration {
+				if !isMigrationComplete(migration.Status) {
+					msg := fmt.Sprintf("Waiting for the completion of migration %s", migration.Name)
+					log.ActionLog(action).Infof(msg)
+					ac.recorder.Event(action,
+						v1.EventTypeWarning,
+						string(storkv1.ActionStatusScheduled),
+						msg)
+					ac.updateAction(action)
+					return
+				}
+			}
+		}
+	}
+
+	// check if it has any latest successful migration
+	schedulePolicyType, latestMigration := getLatestMigrationPolicyAndStatus(*migrationSchedule)
+	if latestMigration.Status == storkv1.MigrationStatusFailed {
+		msg := fmt.Sprintf("The latest migration %s is in %s state, hence aborting failback", latestMigration.Name, storkv1.MigrationStatusFailed)
+		log.ActionLog(action).Errorf(msg)
+		action.Status.Status = storkv1.ActionStatusFailed
+		action.Status.Reason = msg
+		ac.recorder.Event(action,
+			v1.EventTypeWarning,
+			string(storkv1.ActionStatusFailed),
+			msg)
+		ac.updateAction(action)
+		return
+	}
+
+	if latestMigration.Status == storkv1.MigrationStatusSuccessful ||
+		latestMigration.Status == storkv1.MigrationStatusPartialSuccess {
+		// Check if the latest migration has run with in the policy time
+		alreadyTriggered, err := schedule.AlreadyTriggered(
+			migrationSchedule.Spec.SchedulePolicyName,
+			migrationSchedule.Namespace,
+			schedulePolicyType,
+			latestMigration.FinishTimestamp,
+		)
+		if err != nil {
+			msg := fmt.Sprintf("Error while checking if the latest migration %s has been successful: %v", latestMigration.Name, err)
+			log.ActionLog(action).Errorf(msg)
+			action.Status.Status = storkv1.ActionStatusFailed
+			action.Status.Reason = msg
+			ac.recorder.Event(action,
+				v1.EventTypeWarning,
+				string(storkv1.ActionStatusFailed),
+				msg)
+			ac.updateAction(action)
+			return
+		}
+		if alreadyTriggered {
+			log.ActionLog(action).Infof("The latest migration %s is in threshold range", latestMigration.Name)
+			// Suspend migration schedule
+			log.ActionLog(action).Infof("Suspending the migration schedule %s", migrationSchedule.Name)
+			suspend := true
+			if *migrationSchedule.Spec.Suspend {
+				migrationSchedule.Spec.Suspend = &suspend
+			}
+			msg := fmt.Sprintf("Suspending migration schedule %s before doing failback operation", migrationSchedule.Name)
+			log.ActionLog(action).Infof(msg)
+			_, err := storkops.Instance().UpdateMigrationSchedule(migrationSchedule)
+			if err != nil {
+				log.ActionLog(action).Errorf("Error suspending migration schedule %s: %v", migrationSchedule.Name, err)
+			}
+			action.Status.Status = storkv1.ActionStatusSuccessful
+			ac.updateAction(action)
+		} else {
+			// Fail the action failback if latest successful migration is older than latestMigrationThresholdTime
+			// And migrationschedule is in suspended state
+			log.ActionLog(action).Infof("The latest migration %s is not in threshold range", latestMigration.Name)
+			msg := fmt.Sprintf("Failing failback operation as the latest migration %s is not in threshold range", latestMigration.Name)
+			log.ActionLog(action).Errorf(msg)
+			action.Status.Status = storkv1.ActionStatusFailed
+			action.Status.Reason = msg
+			ac.recorder.Event(action,
+				v1.EventTypeWarning,
+				string(storkv1.ActionStatusFailed),
+				msg)
+			ac.updateAction(action)
+		}
+	}
+}
+
+func (ac *ActionController) performDeactivateFailBackStage(action *storkv1.Action) {
+	if action.Status.Status == storkv1.ActionStatusSuccessful {
+		action.Status.Stage = storkv1.ActionStageLastMileMigration
+		action.Status.Status = storkv1.ActionStatusInitial
+		action.Status.FinishTimestamp = metav1.Now()
+		ac.updateAction(action)
+		return
+	} else if action.Status.Status == storkv1.ActionStatusFailed {
+		action.Status.Stage = storkv1.ActionStageFinal
+		action.Status.Status = storkv1.ActionStatusInitial
+		action.Status.FinishTimestamp = metav1.Now()
+		ac.updateAction(action)
+		return
+	}
+
+	migrationSchedule, err := storkops.Instance().GetMigrationSchedule(action.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference, action.Namespace)
+	if err != nil {
+		msg := fmt.Sprintf("error fetching migrationschedule %s/%s for failback", action.Namespace, action.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference)
+		log.ActionLog(action).Errorf(msg)
+		action.Status.Status = storkv1.ActionStatusFailed
+		action.Status.Reason = msg
+		ac.recorder.Event(action,
+			v1.EventTypeWarning,
+			string(storkv1.ActionStatusFailed),
+			msg)
+		ac.updateAction(action)
+		return
+	}
+
+	namespaces, err := utils.GetMergedNamespacesWithLabelSelector(migrationSchedule.Spec.Template.Spec.Namespaces, migrationSchedule.Spec.Template.Spec.NamespaceSelectors)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to get list of namespaces from migrationschedule %s", migrationSchedule.Name)
+		log.ActionLog(action).Infof(msg)
+		ac.recorder.Event(action,
+			v1.EventTypeWarning,
+			string(storkv1.ActionStatusScheduled),
+			msg)
+		ac.updateAction(action)
+		return
+	}
+
+	for _, ns := range namespaces {
+		err := resourceutils.ScaleReplicasReturningError(ns, true, true, ac.printFunc(action, "ScaleReplicas"), ac.config)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to scale down replicas: %v", err)
+			log.ActionLog(action).Errorf(msg)
+			action.Status.Status = storkv1.ActionStatusFailed
+			action.Status.Reason = msg
+			ac.recorder.Event(action,
+				v1.EventTypeWarning,
+				string(storkv1.ActionStatusFailed),
+				msg)
+			ac.updateAction(action)
+			return
+		}
+	}
+}

--- a/pkg/action/failback.go
+++ b/pkg/action/failback.go
@@ -23,7 +23,6 @@ func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv
 		return
 	} else if action.Status.Status == storkv1.ActionStatusFailed {
 		action.Status.Stage = storkv1.ActionStageFinal
-		action.Status.Status = storkv1.ActionStatusInitial
 		action.Status.FinishTimestamp = metav1.Now()
 		ac.updateAction(action)
 		return
@@ -127,7 +126,6 @@ func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv
 		if alreadyTriggered {
 			log.ActionLog(action).Infof("The latest migration %s is in threshold range", latestMigration.Name)
 			// Suspend migration schedule
-			log.ActionLog(action).Infof("Suspending the migration schedule %s", migrationSchedule.Name)
 			suspend := true
 			if *migrationSchedule.Spec.Suspend {
 				migrationSchedule.Spec.Suspend = &suspend
@@ -166,7 +164,6 @@ func (ac *ActionController) performDeactivateFailBackStage(action *storkv1.Actio
 		return
 	} else if action.Status.Status == storkv1.ActionStatusFailed {
 		action.Status.Stage = storkv1.ActionStageFinal
-		action.Status.Status = storkv1.ActionStatusInitial
 		action.Status.FinishTimestamp = metav1.Now()
 		ac.updateAction(action)
 		return

--- a/pkg/action/failback.go
+++ b/pkg/action/failback.go
@@ -135,6 +135,7 @@ func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv
 			_, err := storkops.Instance().UpdateMigrationSchedule(migrationSchedule)
 			if err != nil {
 				log.ActionLog(action).Errorf("Error suspending migration schedule %s: %v", migrationSchedule.Name, err)
+				return
 			}
 			action.Status.Status = storkv1.ActionStatusSuccessful
 			ac.updateAction(action)
@@ -142,7 +143,7 @@ func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv
 			// Fail the action failback if latest successful migration is older than latestMigrationThresholdTime
 			// And migrationschedule is in suspended state
 			log.ActionLog(action).Infof("The latest migration %s is not in threshold range", latestMigration.Name)
-			msg := fmt.Sprintf("Failing failback operation as the latest migration %s is not in threshold range", latestMigration.Name)
+			msg := fmt.Sprintf("Failing failback operation as the latest migration %s was not completed from the scheduled policy duration from now", latestMigration.Name)
 			log.ActionLog(action).Errorf(msg)
 			action.Status.Status = storkv1.ActionStatusFailed
 			action.Status.Reason = msg

--- a/pkg/apis/stork/v1alpha1/action.go
+++ b/pkg/apis/stork/v1alpha1/action.go
@@ -34,8 +34,8 @@ type Action struct {
 
 // ActionSpec specifies the type of Action
 type ActionSpec struct {
-	ActionType      ActionType       `json:"actionType"`
-	ActionParameter *ActionParameter `json:"actionParameter"`
+	ActionType      ActionType      `json:"actionType"`
+	ActionParameter ActionParameter `json:"actionParameter"`
 }
 
 // ActionType lists the various actions that can be performed
@@ -54,18 +54,18 @@ const (
 type ActionParameter ActionParameterItem
 
 type ActionParameterItem struct {
-	FailoverParameter *FailoverParameter `json:"failoverParameter,omitempty"`
-	FailbackParameter *FailbackParameter `json:"failbackParameter,omitempty"`
+	FailoverParameter FailoverParameter `json:"failoverParameter,omitempty"`
+	FailbackParameter FailbackParameter `json:"failbackParameter,omitempty"`
 }
 
 type FailoverParameter struct {
 	FailoverNamespaces         []string `json:"failoverNamespaces"`
 	MigrationScheduleReference string   `json:"migrationScheduleReference"`
-	DeactivateSource           bool     `json:"deactivateSource"`
+	SkipDeactivateSource       *bool    `json:"skipDeactivateSource"`
 }
 
 type FailbackParameter struct {
-	Namespaces                 []string `json:"namespaces"`
+	Namespaces                 []string `json:"failbackNamespaces"`
 	MigrationScheduleReference string   `json:"migrationScheduleReference"`
 }
 
@@ -99,6 +99,8 @@ const (
 	ActionStageScaleUpDestination ActionStageType = "ScaleUpDestination"
 	// ActionStageScaleUpSource for scaling apps in source
 	ActionStageScaleUpSource ActionStageType = "ScaleUpSource"
+	// ActionStageLastMileMigration for doing a last migration before failover/failback to ensure data integrity
+	ActionStageLastMileMigration ActionStageType = "LastMileMigration"
 	// ActionStageFinal is the final stage for action
 	ActionStageFinal ActionStageType = "Final"
 )

--- a/pkg/resourceutils/updatereplicas.go
+++ b/pkg/resourceutils/updatereplicas.go
@@ -31,113 +31,199 @@ const (
 )
 
 func ScaleReplicas(namespace string, activate bool, printFunc func(string, string), config *rest.Config) {
-	updateStatefulSets(namespace, activate, printFunc)
-	updateDeployments(namespace, activate, printFunc)
-	updateReplicaSets(namespace, activate, printFunc)
-	updateDeploymentConfigs(namespace, activate, printFunc)
-	updateIBPObjects("IBPPeer", namespace, activate, printFunc)
-	updateIBPObjects("IBPCA", namespace, activate, printFunc)
-	updateIBPObjects("IBPOrderer", namespace, activate, printFunc)
-	updateIBPObjects("IBPConsole", namespace, activate, printFunc)
+	updateStatefulSets(namespace, activate, false, false, printFunc)
+	updateDeployments(namespace, activate, false, false, printFunc)
+	updateReplicaSets(namespace, activate, false, false, printFunc)
+	updateDeploymentConfigs(namespace, activate, false, false, printFunc)
+	updateIBPObjects("IBPPeer", namespace, activate, false, false, printFunc)
+	updateIBPObjects("IBPCA", namespace, activate, false, false, printFunc)
+	updateIBPObjects("IBPOrderer", namespace, activate, false, false, printFunc)
+	updateIBPObjects("IBPConsole", namespace, activate, false, false, printFunc)
 	updateVMObjects("VirtualMachine", namespace, true, printFunc)
-	updateCRDObjects(namespace, activate, printFunc, config)
-	updateCronJobObjects(namespace, activate, printFunc)
+	updateCRDObjects(namespace, activate, false, printFunc, config)
+	updateCronJobObjects(namespace, activate, false, printFunc)
 	// This is unique for migration cases to support stash stratgery for CRs managed by clusterwide operators
-	updateStashedCMObjects(namespace, activate, printFunc, config)
+	updateStashedCMObjects(namespace, activate, false, printFunc, config)
 }
 
-func updateStatefulSets(namespace string, activate bool, printFunc func(string, string)) {
+func ScaleReplicasReturningError(namespace string, activate bool, storeOriginalReplicaCount bool, printFunc func(string, string), config *rest.Config) error {
+	err := updateStatefulSets(namespace, activate, storeOriginalReplicaCount, true, printFunc)
+	if err != nil {
+		return err
+	}
+	err = updateDeployments(namespace, activate, storeOriginalReplicaCount, true, printFunc)
+	if err != nil {
+		return err
+	}
+	err = updateReplicaSets(namespace, activate, storeOriginalReplicaCount, true, printFunc)
+	if err != nil {
+		return err
+	}
+	err = updateDeploymentConfigs(namespace, activate, storeOriginalReplicaCount, true, printFunc)
+	if err != nil {
+		return err
+	}
+	err = updateIBPObjects("IBPPeer", namespace, activate, storeOriginalReplicaCount, true, printFunc)
+	if err != nil {
+		return err
+	}
+	err = updateIBPObjects("IBPCA", namespace, activate, storeOriginalReplicaCount, true, printFunc)
+	if err != nil {
+		return err
+	}
+	err = updateIBPObjects("IBPOrderer", namespace, activate, storeOriginalReplicaCount, true, printFunc)
+	if err != nil {
+		return err
+	}
+	err = updateIBPObjects("IBPConsole", namespace, activate, storeOriginalReplicaCount, true, printFunc)
+	if err != nil {
+		return err
+	}
+	err = updateVMObjects("VirtualMachine", namespace, true, printFunc)
+	if err != nil {
+		return err
+	}
+	err = updateCRDObjects(namespace, activate, false, printFunc, config)
+	if err != nil {
+		return err
+	}
+	err = updateCronJobObjects(namespace, activate, true, printFunc)
+	if err != nil {
+		return err
+	}
+
+	// This is unique for migration cases to support stash stratgery for CRs managed by clusterwide operators
+	err = updateStashedCMObjects(namespace, activate, true, printFunc, config)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func updateStatefulSets(namespace string, activate bool, storeOriginalReplicaCount bool, returnOnError bool, printFunc func(string, string)) error {
 	statefulSets, err := apps.Instance().ListStatefulSets(namespace, metav1.ListOptions{})
 	if err != nil {
 		util.CheckErr(err)
-		return
+		return err
 	}
 	for _, statefulSet := range statefulSets.Items {
 		if replicas, update := getUpdatedReplicaCount(statefulSet.Annotations, activate, printFunc); update {
+			if storeOriginalReplicaCount {
+				statefulSet.Spec.Template.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(*statefulSet.Spec.Replicas))
+			}
 			statefulSet.Spec.Replicas = &replicas
 			_, err := apps.Instance().UpdateStatefulSet(&statefulSet)
 			if err != nil {
-				printFunc(fmt.Sprintf("Error updating replicas for statefulset %v/%v : %v", statefulSet.Namespace, statefulSet.Name, err), "err")
+				msg := fmt.Sprintf("Error updating replicas for statefulset %v/%v : %v", statefulSet.Namespace, statefulSet.Name, err)
+				printFunc(msg, "err")
+				if returnOnError {
+					return fmt.Errorf(msg)
+				}
 				continue
 			}
 			printFunc(fmt.Sprintf("Updated replicas for statefulset %v/%v to %v", statefulSet.Namespace, statefulSet.Name, replicas), "out")
 		}
 
 	}
+	return nil
 }
 
-func updateDeployments(namespace string, activate bool, printFunc func(string, string)) {
+func updateDeployments(namespace string, activate bool, storeOriginalReplicaCount bool, returnOnError bool, printFunc func(string, string)) error {
 	deployments, err := apps.Instance().ListDeployments(namespace, metav1.ListOptions{})
 	if err != nil {
 		util.CheckErr(err)
-		return
+		return err
 	}
 	for _, deployment := range deployments.Items {
 		if replicas, update := getUpdatedReplicaCount(deployment.Annotations, activate, printFunc); update {
+			if storeOriginalReplicaCount {
+				deployment.Spec.Template.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(*deployment.Spec.Replicas))
+			}
 			deployment.Spec.Replicas = &replicas
 			_, err := apps.Instance().UpdateDeployment(&deployment)
 			if err != nil {
-				printFunc(fmt.Sprintf("Error updating replicas for deployment %v/%v : %v", deployment.Namespace, deployment.Name, err), "err")
+				msg := fmt.Sprintf("Error updating replicas for deployment %v/%v : %v", deployment.Namespace, deployment.Name, err)
+				printFunc(msg, "err")
+				if returnOnError {
+					return fmt.Errorf(msg)
+				}
 				continue
 			}
 			printFunc(fmt.Sprintf("Updated replicas for deployment %v/%v to %v", deployment.Namespace, deployment.Name, replicas), "out")
 		}
 	}
+	return nil
 }
 
-func updateReplicaSets(namespace string, activate bool, printFunc func(string, string)) {
+func updateReplicaSets(namespace string, activate bool, storeOriginalReplicaCount bool, returnOnError bool, printFunc func(string, string)) error {
 	replicasets, err := apps.Instance().ListReplicaSets(namespace, metav1.ListOptions{})
 	if err != nil {
 		util.CheckErr(err)
-		return
+		return err
 	}
 	for _, replicaset := range replicasets {
 		if replicaset.OwnerReferences != nil {
 			continue
 		}
 		if replicas, update := getUpdatedReplicaCount(replicaset.Annotations, activate, printFunc); update {
+			if storeOriginalReplicaCount {
+				replicaset.Spec.Template.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(*replicaset.Spec.Replicas))
+			}
 			replicaset.Spec.Replicas = &replicas
 			_, err := apps.Instance().UpdateReplicaSet(&replicaset)
 			if err != nil {
-				printFunc(fmt.Sprintf("Error updating replicas for replicaset %v/%v : %v", replicaset.Namespace, replicaset.Name, err), "err")
+				msg := fmt.Sprintf("Error updating replicas for replicaset %v/%v : %v", replicaset.Namespace, replicaset.Name, err)
+				printFunc(msg, "err")
+				if returnOnError {
+					return fmt.Errorf(msg)
+				}
 				continue
 			}
 			printFunc(fmt.Sprintf("Updated replicas for replicaset %v/%v to %v", replicaset.Namespace, replicaset.Name, replicas), "out")
 		}
 	}
+	return nil
 }
 
-func updateDeploymentConfigs(namespace string, activate bool, printFunc func(string, string)) {
+func updateDeploymentConfigs(namespace string, activate bool, storeOriginalReplicaCount bool, returnOnError bool, printFunc func(string, string)) error {
 	deployments, err := openshift.Instance().ListDeploymentConfigs(namespace)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			util.CheckErr(err)
 		}
-		return
+		return err
 	}
 	for _, deployment := range deployments.Items {
 		if replicas, update := getUpdatedReplicaCount(deployment.Annotations, activate, printFunc); update {
+			if storeOriginalReplicaCount {
+				deployment.Spec.Template.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(deployment.Spec.Replicas))
+			}
 			deployment.Spec.Replicas = replicas
 			_, err := openshift.Instance().UpdateDeploymentConfig(&deployment)
 			if err != nil {
-				printFunc(fmt.Sprintf("Error updating replicas for deploymentconfig %v/%v : %v", deployment.Namespace, deployment.Name, err), "err")
+				msg := fmt.Sprintf("Error updating replicas for deploymentconfig %v/%v : %v", deployment.Namespace, deployment.Name, err)
+				printFunc(msg, "err")
+				if returnOnError {
+					return fmt.Errorf(msg)
+				}
 				continue
 			}
 			printFunc(fmt.Sprintf("Updated replicas for deploymentconfig %v/%v to %v", deployment.Namespace, deployment.Name, replicas), "out")
 		}
 	}
+	return nil
 }
 
-func updateCRDObjects(ns string, activate bool, printFunc func(string, string), config *rest.Config) {
+func updateCRDObjects(ns string, activate bool, returnOnError bool, printFunc func(string, string), config *rest.Config) error {
 	crdList, err := storkops.Instance().ListApplicationRegistrations()
 	if err != nil {
 		util.CheckErr(err)
-		return
+		return err
 	}
 	configClient, err := k8sdynamic.NewForConfig(config)
 	if err != nil {
 		util.CheckErr(err)
-		return
+		return err
 	}
 
 	ruleset := resourcecollector.GetDefaultRuleSet()
@@ -159,7 +245,7 @@ func updateCRDObjects(ns string, activate bool, printFunc func(string, string), 
 					continue
 				}
 				util.CheckErr(err)
-				return
+				return err
 			}
 			for _, o := range objects.Items {
 				annotations := o.GetAnnotations()
@@ -193,23 +279,31 @@ func updateCRDObjects(ns string, activate bool, printFunc func(string, string), 
 							suspend, err := getSuspendStringOpts(o.GetAnnotations(), activate, suspend.Path, printFunc)
 							if err != nil {
 								util.CheckErr(err)
-								return
+								return err
 							}
 							disableVersion = suspend
 						} else {
 							util.CheckErr(fmt.Errorf("invalid type %v to suspend cr", crd.SuspendOptions.Type))
-							return
+							return err
 						}
 						err := unstructured.SetNestedField(o.Object, disableVersion, specPath...)
 						if err != nil {
-							printFunc(fmt.Sprintf("Error updating \"%v\" for %v %v/%v to %v : %v", suspend.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), disableVersion, err), "err")
+							msg := fmt.Sprintf("Error updating \"%v\" for %v %v/%v to %v : %v", suspend.Path, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), disableVersion, err)
+							printFunc(msg, "err")
+							if returnOnError {
+								return fmt.Errorf(msg)
+							}
 							continue
 						}
 					}
 				}
 				_, err = client.Update(context.TODO(), &o, metav1.UpdateOptions{}, "")
 				if err != nil {
-					printFunc(fmt.Sprintf("Error updating CR %v %v/%v: %v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), "err")
+					msg := fmt.Sprintf("Error updating CR %v %v/%v: %v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err)
+					printFunc(msg, "err")
+					if returnOnError {
+						return fmt.Errorf(msg)
+					}
 					continue
 				}
 				printFunc(fmt.Sprintf("Updated CR for %v %v/%v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName()), "out")
@@ -220,7 +314,11 @@ func updateCRDObjects(ns string, activate bool, printFunc func(string, string), 
 					podpath := strings.Split(crd.PodsPath, ".")
 					pods, found, err := unstructured.NestedStringSlice(o.Object, podpath...)
 					if err != nil {
-						printFunc(fmt.Sprintf("Error getting pods for %v %v/%v : %v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), "err")
+						msg := fmt.Sprintf("Error getting pods for %v %v/%v : %v", strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err)
+						printFunc(msg, "err")
+						if returnOnError {
+							return fmt.Errorf(msg)
+						}
 						continue
 					}
 					if !found {
@@ -228,7 +326,13 @@ func updateCRDObjects(ns string, activate bool, printFunc func(string, string), 
 					}
 					for _, pod := range pods {
 						err = core.Instance().DeletePod(o.GetNamespace(), pod, true)
-						printFunc(fmt.Sprintf("Error deleting pod %v for %v %v/%v : %v", pod, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err), "err")
+						if err != nil {
+							msg := fmt.Sprintf("Error deleting pod %v for %v %v/%v : %v", pod, strings.ToLower(crd.Kind), o.GetNamespace(), o.GetName(), err)
+							printFunc(msg, "err")
+							if returnOnError {
+								return fmt.Errorf(msg)
+							}
+						}
 						continue
 					}
 				}
@@ -236,9 +340,10 @@ func updateCRDObjects(ns string, activate bool, printFunc func(string, string), 
 
 		}
 	}
+	return nil
 }
 
-func updateIBPObjects(kind string, namespace string, activate bool, printFunc func(string, string)) {
+func updateIBPObjects(kind string, namespace string, activate bool, storeOriginalReplicaCount bool, returnOnError bool, printFunc func(string, string)) error {
 	objects, err := dynamic.Instance().ListObjects(
 		&metav1.ListOptions{
 			TypeMeta: metav1.TypeMeta{
@@ -250,26 +355,58 @@ func updateIBPObjects(kind string, namespace string, activate bool, printFunc fu
 		if !errors.IsNotFound(err) {
 			util.CheckErr(err)
 		}
-		return
+		return err
 	}
 	for _, o := range objects.Items {
 		if replicas, update := getUpdatedReplicaCount(o.GetAnnotations(), activate, printFunc); update {
+			if storeOriginalReplicaCount {
+				curReplicas, found, err := unstructured.NestedInt64(o.Object, "spec", "replicas")
+				if err != nil {
+					msg := fmt.Sprintf("Error getting replicas for %v %v/%v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), err)
+					printFunc(msg, "err")
+					if returnOnError {
+						return fmt.Errorf(msg)
+					}
+					continue
+				}
+				if !found {
+					msg := fmt.Sprintf("Could not get replicas for %v %v/%v", strings.ToLower(kind), o.GetNamespace(), o.GetName())
+					printFunc(msg, "err")
+					if returnOnError {
+						return fmt.Errorf(msg)
+					}
+					continue
+				}
+				curAnnotations := o.GetAnnotations()
+				curAnnotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(curReplicas))
+				o.SetAnnotations(curAnnotations)
+			}
 			err := unstructured.SetNestedField(o.Object, int64(replicas), "spec", "replicas")
 			if err != nil {
-				printFunc(fmt.Sprintf("Error updating replicas for %v %v/%v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), err), "err")
+				msg := fmt.Sprintf("Error updating replicas for %v %v/%v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), err)
+				printFunc(msg, "err")
+				if returnOnError {
+					return fmt.Errorf(msg)
+				}
 				continue
 			}
+
 			_, err = dynamic.Instance().UpdateObject(&o)
 			if err != nil {
-				printFunc(fmt.Sprintf("Error updating replicas for %v %v/%v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), err), "err")
+				msg := fmt.Sprintf("Error updating replicas for %v %v/%v : %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), err)
+				printFunc(msg, "err")
+				if returnOnError {
+					return fmt.Errorf(msg)
+				}
 				continue
 			}
 			printFunc(fmt.Sprintf("Updated replicas for %v %v/%v to %v", strings.ToLower(kind), o.GetNamespace(), o.GetName(), replicas), "out")
 		}
 	}
+	return nil
 }
 
-func updateVMObjects(kind string, namespace string, activate bool, printFunc func(string, string)) {
+func updateVMObjects(kind string, namespace string, activate bool, printFunc func(string, string)) error {
 	objects, err := dynamic.Instance().ListObjects(
 		&metav1.ListOptions{
 			TypeMeta: metav1.TypeMeta{
@@ -281,33 +418,39 @@ func updateVMObjects(kind string, namespace string, activate bool, printFunc fun
 		if !errors.IsNotFound(err) {
 			util.CheckErr(err)
 		}
-		return
+		return err
 	}
 	for _, o := range objects.Items {
 		path := []string{"spec", "running"}
 		unstructured.RemoveNestedField(o.Object, path...)
 		printFunc(fmt.Sprintf("Removed field for %v %v/%v", strings.ToLower(kind), o.GetNamespace(), o.GetName()), "out")
 	}
+	return nil
 }
 
-func updateCronJobObjects(namespace string, activate bool, printFunc func(string, string)) {
+func updateCronJobObjects(namespace string, activate bool, returnOnError bool, printFunc func(string, string)) error {
 	cronJobs, err := batch.Instance().ListCronJobs(namespace, metav1.ListOptions{})
 	if err != nil {
 		util.CheckErr(err)
-		return
+		return err
 	}
 
 	for _, cronJob := range cronJobs.Items {
 		*cronJob.Spec.Suspend = !activate
 		_, err = batch.Instance().UpdateCronJob(&cronJob)
 		if err != nil {
-			printFunc(fmt.Sprintf("Error updating suspend option for cronJob %v/%v : %v", cronJob.Namespace, cronJob.Name, err), "err")
+			msg := fmt.Sprintf("Error updating suspend option for cronJob %v/%v : %v", cronJob.Namespace, cronJob.Name, err)
+			printFunc(msg, "err")
+			if returnOnError {
+				return fmt.Errorf(msg)
+			}
 			continue
 		}
 		printFunc(fmt.Sprintf("Updated suspend option for cronjob %v/%v to %v", cronJob.Namespace, cronJob.Name, !activate), "out")
 	}
-
+	return nil
 }
+
 func getSuspendStringOpts(annotations map[string]string, activate bool, path string, printFunc func(string, string)) (string, error) {
 	if val, present := annotations[migration.StorkAnnotationPrefix+path]; present {
 		suspend := strings.Split(val, ",")
@@ -374,16 +517,16 @@ func getUpdatedReplicaCount(annotations map[string]string, activate bool, printF
 	return 0, false
 }
 
-func updateStashedCMObjects(namespace string, activate bool, printFunc func(string, string), config *rest.Config) {
+func updateStashedCMObjects(namespace string, activate bool, returnOnError bool, printFunc func(string, string), config *rest.Config) error {
 	if !activate {
-		return
+		return nil
 	}
 	pvcToPVCOwnerMapping := make(map[string][]metav1.OwnerReference)
 	// List the configmaps with label "stash-cr" enabled
 	configMaps, err := core.Instance().ListConfigMap(namespace, metav1.ListOptions{LabelSelector: StashCRLabel})
 	if err != nil {
 		util.CheckErr(err)
-		return
+		return err
 	}
 	ruleset := resourcecollector.GetDefaultRuleSet()
 	// Create the CRs in the same namespace if those don't exist
@@ -392,12 +535,19 @@ func updateStashedCMObjects(namespace string, activate bool, printFunc func(stri
 		unstructuredObj := &unstructured.Unstructured{}
 		err := unstructuredObj.UnmarshalJSON(objBytes)
 		if err != nil {
-			printFunc(fmt.Sprintf("Error converting string to Unstructured object: %s\n", err.Error()), "err")
+			msg := fmt.Sprintf("Error converting string to Unstructured object: %s\n", err.Error())
+			printFunc(msg, "err")
+			if returnOnError {
+				return fmt.Errorf(msg)
+			}
 			continue
 		}
 		configClient, err := k8sdynamic.NewForConfig(config)
 		if err != nil {
 			util.CheckErr(err)
+			if returnOnError {
+				return err
+			}
 			continue
 		}
 		resource := &metav1.APIResource{
@@ -422,6 +572,9 @@ func updateStashedCMObjects(namespace string, activate bool, printFunc func(stri
 			} else {
 				printFunc(fmt.Sprintf("Error creating resource %s/%s from stashed configmap : %v\n", unstructuredObj.GetKind(), unstructuredObj.GetName(), err), "err")
 				util.CheckErr(err)
+				if returnOnError {
+					return err
+				}
 				continue
 			}
 		}
@@ -430,6 +583,9 @@ func updateStashedCMObjects(namespace string, activate bool, printFunc func(stri
 		newResourceUnstructured, err := resourceClient.Get(context.TODO(), unstructuredObj.GetName(), metav1.GetOptions{})
 		if err != nil {
 			util.CheckErr(err)
+			if returnOnError {
+				return err
+			}
 			continue
 		}
 
@@ -439,6 +595,9 @@ func updateStashedCMObjects(namespace string, activate bool, printFunc func(stri
 		err = json.Unmarshal([]byte(ownedPVCs), &nestedMap)
 		if err != nil {
 			util.CheckErr(err)
+			if returnOnError {
+				return err
+			}
 			continue
 		}
 
@@ -453,7 +612,7 @@ func updateStashedCMObjects(namespace string, activate bool, printFunc func(stri
 	pvcList, err := core.Instance().GetPersistentVolumeClaims(namespace, nil)
 	if err != nil {
 		util.CheckErr(err)
-		return
+		return err
 	}
 
 	for _, pvc := range pvcList.Items {
@@ -464,8 +623,12 @@ func updateStashedCMObjects(namespace string, activate bool, printFunc func(stri
 			_, err = core.Instance().UpdatePersistentVolumeClaim(&pvc)
 			if err != nil {
 				util.CheckErr(err)
+				if returnOnError {
+					return err
+				}
 				continue
 			}
 		}
 	}
+	return nil
 }

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -148,6 +148,88 @@ func checkTrigger(
 	return false, nil
 }
 
+func hasTriggered(
+	lastTrigger time.Time,
+	lastTriggerEarliest time.Time,
+	now time.Time,
+) (bool, error) {
+	// If the last trigger is before the  we had triggered before the scheduled time this month, don't
+	// triggered again
+	if lastTrigger.Before(lastTriggerEarliest) || lastTrigger.After(now) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func AlreadyTriggered(
+	policyName string,
+	namespace string,
+	policyType stork_api.SchedulePolicyType,
+	lastTrigger meta.Time,
+) (bool, error) {
+	schedulePolicy, err := getSchedulePolicy(policyName, namespace)
+	if err != nil {
+		return false, err
+	}
+
+	if err := ValidateSchedulePolicy(schedulePolicy); err != nil {
+		return false, err
+	}
+
+	now := GetCurrentTime()
+	switch policyType {
+	case stork_api.SchedulePolicyTypeInterval:
+		if schedulePolicy.Policy.Interval == nil {
+			return false, nil
+		}
+		duration := time.Duration(schedulePolicy.Policy.Interval.IntervalMinutes) * time.Minute
+		// Triggerred if last trigger is within the duration from now
+		earliestTrigger := now.Add(-duration)
+		return hasTriggered(lastTrigger.Time, earliestTrigger, now)
+
+	case stork_api.SchedulePolicyTypeDaily:
+		if schedulePolicy.Policy.Daily == nil {
+			return false, nil
+		}
+
+		policyHour, policyMinute, err := schedulePolicy.Policy.Daily.GetHourMinute()
+		if err != nil {
+			return false, err
+		}
+
+		nextTrigger := time.Date(now.Year(), now.Month(), now.Day(), policyHour, policyMinute, 0, 0, time.Local)
+		earliestTrigger := nextTrigger.AddDate(0, 0, -1)
+		return hasTriggered(lastTrigger.Time, earliestTrigger, now)
+
+	case stork_api.SchedulePolicyTypeWeekly:
+		if schedulePolicy.Policy.Weekly == nil {
+			return false, nil
+		}
+		policyHour, policyMinute, err := schedulePolicy.Policy.Weekly.GetHourMinute()
+		if err != nil {
+			return false, err
+		}
+		nextTrigger := time.Date(now.Year(), now.Month(), now.Day(), policyHour, policyMinute, 0, 0, time.Local)
+		earliestTrigger := nextTrigger.AddDate(0, 0, -7)
+
+		return hasTriggered(lastTrigger.Time, earliestTrigger, now)
+
+	case stork_api.SchedulePolicyTypeMonthly:
+		if schedulePolicy.Policy.Monthly == nil {
+			return false, nil
+		}
+		policyHour, policyMinute, err := schedulePolicy.Policy.Monthly.GetHourMinute()
+		if err != nil {
+			return false, err
+		}
+		nextTrigger := time.Date(now.Year(), now.Month(), schedulePolicy.Policy.Monthly.Date, policyHour, policyMinute, 0, 0, time.Local)
+		earliestTrigger := nextTrigger.AddDate(0, -1, 0)
+		return hasTriggered(lastTrigger.Time, earliestTrigger, now)
+
+	}
+	return false, nil
+}
+
 // ValidateSchedulePolicy Validate if a given schedule policy is valid
 func ValidateSchedulePolicy(policy *stork_api.SchedulePolicy) error {
 	if policy == nil {

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -153,8 +153,7 @@ func hasTriggered(
 	lastTriggerEarliest time.Time,
 	now time.Time,
 ) (bool, error) {
-	// If the last trigger is before the  we had triggered before the scheduled time this month, don't
-	// triggered again
+	// Check if the last trigger falls between the allowed earliest trigger time and now
 	if lastTrigger.Before(lastTriggerEarliest) || lastTrigger.After(now) {
 		return false, nil
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/utils/strings/slices"
 )
 
 const (
@@ -333,4 +334,39 @@ func addResourceVersion(patchBytes []byte, resourceVersion string) ([]byte, erro
 		return nil, fmt.Errorf("error marshalling json patch: %v", err)
 	}
 	return versionBytes, nil
+}
+
+func GetMergedNamespacesWithLabelSelector(namespaceList []string, namespaceSelectors map[string]string) ([]string, error) {
+	if len(namespaceSelectors) == 0 {
+		return namespaceList, nil
+	}
+	uniqueNamespaces := make(map[string]bool)
+	for _, ns := range namespaceList {
+		uniqueNamespaces[ns] = true
+	}
+
+	for key, val := range namespaceSelectors {
+		namespaces, err := core.Instance().ListNamespaces(map[string]string{key: val})
+		if err != nil {
+			return nil, err
+		}
+		for _, namespace := range namespaces.Items {
+			uniqueNamespaces[namespace.GetName()] = true
+		}
+	}
+
+	migrationNamespaces := make([]string, 0, len(uniqueNamespaces))
+	for namespace := range uniqueNamespaces {
+		migrationNamespaces = append(migrationNamespaces, namespace)
+	}
+	return migrationNamespaces, nil
+}
+
+func IsSubList(list1 []string, list2 []string) bool {
+	for _, element := range list2 {
+		if !slices.Contains(list1, element) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
feature

**What this PR does / why we need it**:
1. Added action CR reconciler workflow with respect to different actions and multiple stages.
2. Added the code for DeactivateDestination of failback action.
3. Unit tests

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->

**Does this change need to be cherry-picked to a release branch?**:
<!--
no
-->

Tests:
Manually run following cases and results have been updated in the ticket.
```
1. With an old successful migration.
2. With the latest migration failed.
3. With migration is in progress.
4. With more namespaces in action CR with reference to migration schedule (not a subset).
5. With latest successful migration within the schedule policy interval range.

```
