### PR TITLE
PWX-36256: handle no bootOrder in kubevirt vmi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.1
 	github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20240225203035-f1f1b532c6a1
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rancher/norman v0.0.0-20230222213531-275a3e921940
@@ -334,7 +334,7 @@ replace (
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v0.0.0-20230511212757-41751b27d69f
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20231204032720-337bcd4db162
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240225203035-f1f1b532c6a1
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3

--- a/go.sum
+++ b/go.sum
@@ -2907,8 +2907,8 @@ github.com/portworx/px-backup-api v1.2.2-0.20230904054048-eb1f23dd7431/go.mod h1
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987 h1:VNBTmIPjJRZ2QP64zdsrif3ELDHiMzoyNNX74VNHgZ8=
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987/go.mod h1:g3pw2lI2AjqAixUCRhaBdKTY98znsCPR7NGRrlpimVU=
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27 h1:1Q50KWDMei8O+ckB2UzUKC6eRT6Aiwxg6u99C9wtrK0=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240225203035-f1f1b532c6a1 h1:EO2pOM5ejctwi2sHyHW7CS3MuXqvR0yrNxeh0D534Fs=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240225203035-f1f1b532c6a1/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0 h1:KXN6ublTdb+tSfEwmrS7rxIjC0ys3w6agfm5CnyTdb0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1092,7 +1092,7 @@ github.com/portworx/px-object-controller/client/listers/objectservice/v1alpha1
 github.com/portworx/px-object-controller/pkg/client
 github.com/portworx/px-object-controller/pkg/controller
 github.com/portworx/px-object-controller/pkg/utils
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27 => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20240225203035-f1f1b532c6a1 => github.com/portworx/sched-ops v1.20.4-rc1.0.20240225203035-f1f1b532c6a1
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -2481,7 +2481,7 @@ sigs.k8s.io/yaml
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v0.0.0-20230511212757-41751b27d69f
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 # github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20231204032720-337bcd4db162
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240225203035-f1f1b532c6a1
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20231013194137-84e2957806f0
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3


### PR DESCRIPTION
**What this PR does / why we need it**:

Pull in the bootOrder VMI fix from sched-ops repo.

Used branch "for-stork-23.11-kubevirt-ea" to work around the incompatibility below when vendoring in from the master:

k8s.go:5992:67: cannot use obj (variable of type *"k8s.io/api/policy/v1beta1".PodDisruptionBudget) as *"k8s.io/api/policy/v1".PodDisruptionBudget value in argument to k8sPolicy.CreatePodDisruptionBudget


**What type of PR is this?**
>bug

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
no
