### PR TITLE
PB-5837 : DIRECT-KDMP changes from ApplicationBackup CR

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -115,10 +115,10 @@ func (a *aws) Stop() error {
 func (a *aws) OwnsPVCForBackup(
 	coreOps core.Ops,
 	pvc *v1.PersistentVolumeClaim,
-	cmBackupType string,
+	directKDMP bool,
 	crBackupType string,
 ) bool {
-	if cmBackupType == storkapi.ApplicationBackupGeneric {
+	if directKDMP {
 		// If user has forced the backupType in config map, default to generic always
 		return false
 	}

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -156,10 +156,10 @@ func (a *azure) Stop() error {
 func (a *azure) OwnsPVCForBackup(
 	coreOps core.Ops,
 	pvc *v1.PersistentVolumeClaim,
-	cmBackupType string,
+	directKDMP bool,
 	crBackupType string,
 ) bool {
-	if cmBackupType == storkapi.ApplicationBackupGeneric {
+	if directKDMP {
 		// If user has forced the backupType in config map, default to generic always
 		return false
 	}

--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -221,10 +221,10 @@ func (c *csi) Stop() error {
 func (c *csi) OwnsPVCForBackup(
 	coreOps core.Ops,
 	pvc *v1.PersistentVolumeClaim,
-	cmBackupType string,
+	directKDMP bool,
 	crBackupType string,
 ) bool {
-	if cmBackupType == storkapi.ApplicationBackupGeneric || crBackupType == storkapi.ApplicationBackupGeneric {
+	if directKDMP || crBackupType == storkapi.ApplicationBackupGeneric {
 		// If user has forced the backupType in config map or applicationBackup CR, default to generic always
 		return false
 	}

--- a/drivers/volume/gcp/gcp.go
+++ b/drivers/volume/gcp/gcp.go
@@ -97,10 +97,10 @@ func (g *gcp) Stop() error {
 func (g *gcp) OwnsPVCForBackup(
 	coreOps core.Ops,
 	pvc *v1.PersistentVolumeClaim,
-	cmBackupType string,
+	directKDMP bool,
 	crBackupType string,
 ) bool {
-	if cmBackupType == storkapi.ApplicationBackupGeneric {
+	if directKDMP {
 		// If user has forced the backupType in config map, default to generic always
 		return false
 	}

--- a/drivers/volume/linstor/linstor.go
+++ b/drivers/volume/linstor/linstor.go
@@ -338,7 +338,10 @@ func (l *linstor) GetVolumeClaimTemplates(templates []v1.PersistentVolumeClaim) 
 	return linstorTemplates, nil
 }
 
-func (l *linstor) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, cmBackupType string, crBackupType string) bool {
+func (l *linstor) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, directKDMP bool, crBackupType string) bool {
+	if directKDMP {
+		return false
+	}
 	return l.OwnsPVC(coreOps, pvc)
 }
 

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -297,7 +297,7 @@ func (m Driver) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includePend
 }
 
 // OwnsPVCForBackup returns true because it owns all PVCs created by tests
-func (m *Driver) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, cmBackupType string, crBackupType string) bool {
+func (m *Driver) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, directKDMP bool, crBackupType string) bool {
 	return m.OwnsPVC(coreOps, pvc)
 }
 

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -711,8 +711,8 @@ func (p *portworx) GetClusterID() (string, error) {
 	return cluster.Id, nil
 }
 
-func (p *portworx) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, cmBackupType string, crBackupType string) bool {
-	if enablePXGenericBackup() {
+func (p *portworx) OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, directKDMP bool, crBackupType string) bool {
+	if directKDMP || enablePXGenericBackup() {
 		logrus.Tracef("Provisioner in Storageclass is Portworx but will take generic backup")
 		return false
 	}

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -101,7 +101,7 @@ type Driver interface {
 
 	// OwnsPVCForBackup returns true if the PVC is owned by the driver
 	// Since we have extra check need to do for backup case, added separate version of API.
-	OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, cmBackupType string, crBackupType string) bool
+	OwnsPVCForBackup(coreOps core.Ops, pvc *v1.PersistentVolumeClaim, directKDMP bool, crBackupType string) bool
 
 	// OwnsPV returns true if the PV is owned by the driver
 	OwnsPV(pvc *v1.PersistentVolume) bool
@@ -343,7 +343,7 @@ func Get(name string) (Driver, error) {
 // not owned by any available driver
 func GetPVCDriverForBackup(coreOps core.Ops,
 	pvc *v1.PersistentVolumeClaim,
-	cmBackupType string,
+	directKDMP bool,
 	crBackupType string,
 ) (string, error) {
 	for _, driverName := range orderedListOfDrivers {
@@ -351,7 +351,7 @@ func GetPVCDriverForBackup(coreOps core.Ops,
 		if !ok {
 			continue
 		}
-		if d.OwnsPVCForBackup(coreOps, pvc, cmBackupType, crBackupType) {
+		if d.OwnsPVCForBackup(coreOps, pvc, directKDMP, crBackupType) {
 			return driverName, nil
 		}
 	}

--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -50,6 +50,7 @@ type ApplicationBackupSpec struct {
 	// SkipAutoExecRules is false by default, if set true will skip auto exec rules for VM specific backup.
 	// This field is unused for non VM specific Backup.
 	SkipAutoExecRules bool `json:"skipAutoExecRules"`
+	DirectKDMP        bool `json:"directKDMP"`
 }
 
 // ApplicationBackupReclaimPolicyType is the reclaim policy for the application backup

--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -135,16 +135,16 @@ func (c *csiDriver) CreateSnapshot(opts ...Option) (string, string, string, erro
 	// In case the PV does not contain CSI section itself, we will error out.
 	if pv.Spec.CSI == nil {
 		return "", "", "", fmt.Errorf("pv [%v] does not contain CSI section", pv.Name)
-	} else {
-		// If CSI Section Exist assign respective volumeSnapshotClass of its provisioner
-		if snapshotClass, ok := o.CSISnapshotMapping[pv.Spec.CSI.Driver]; ok {
-			o.SnapshotClassName = snapshotClass
-		}
+	}
+
+	// If CSI Section Exist assign respective volumeSnapshotClass of its provisioner
+	if snapshotClass, ok := o.CSISnapshotMapping[pv.Spec.CSI.Driver]; ok {
+		o.SnapshotClassName = snapshotClass
 	}
 
 	if o.SnapshotClassName == "" {
-		return "", "", "", fmt.Errorf("snapshot class cannot be empty for pvc [%s] having driver [%s] in case of "+
-			"CSI based backup or use 'default' to choose the default snapshot class, use csiSnapshotMapping in case of "+
+		return "", "", "", fmt.Errorf("volume snapshot class cannot be empty for pvc [%s] having driver [%s] "+
+			"or use 'default' to choose the default snapshot class, update/use csiSnapshotMapping in case of "+
 			"multiple provisioner", pvc.GetName(), pv.Spec.CSI.Driver)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: Before we are only allowed to force Direct KDMP on cluster level and not backup and backupschedule level now its on object level for users to take cross cloud backup restore


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
--> Yes
DirectKDMP  field added (bool -> default to false)

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: Backup Based Direct KDMP was not possible
User Impact: User can now do a direct kdmp backup on backup level and not cluster level
Resolution: BackupSchedules can have direct kdmp and another schedule can have csi native at the same time now

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

When Direct KDMP Flag is Given

```
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationBackup
metadata:
  annotations:
    portworx.io/backup-name: dkdmp-2
    portworx.io/backup-uid: edc69d3b-79df-4d66-96b2-0b59bba2963d
    portworx.io/backuplocation-name: efs
    portworx.io/cluster-name: ocp-pamathur
    portworx.io/cluster-uid: b0c730ad-827f-4eb3-9b94-c4dd70c61e21
    portworx.io/created-by: px-backup
    portworx.io/last-update: "2024-02-29T06:38:18.708381602Z"
    portworx.io/object-lock-retention-period: "0"
    portworx.io/org-id: default
    portworx.io/skip-backup-location-name-check: "true"
  creationTimestamp: "2024-02-29T06:38:18Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2024-02-29T06:41:58Z"
  finalizers:
  - stork.libopenstorage.org/finalizer-cleanup
  generation: 70
  name: dkdmp-2-edc69d3
  namespace: mysql
  resourceVersion: "9338964"
  uid: 5be61e9f-b1fa-4e23-bbae-0379d0fbc399
spec:
  backupLocation: efs-edc69d3
  backupObjectType: All
  backupType: Normal
  csiSnapshotClassMap:
    csi.vsphere.vmware.com: csi-vsphere-vsc
    openshift-storage.cephfs.csi.ceph.com: ocs-storagecluster-cephfsplugin-snapclass
    openshift-storage.rbd.csi.ceph.com: ocs-storagecluster-rbdplugin-snapclass
  directKDMP: true
  includeResources: null
  namespaceSelector: ""
  namespaces:
  - mysql
  options: {}
  platformCredential: ""
  postExecRule: ""
  preExecRule: ""
  rancherProjects: null
  reclaimPolicy: Retain
  resourceTypes: null
  selectors: null
  skipAutoExecRules: false
  skipServiceUpdate: false
status:
  backupPath: mysql/dkdmp-2-edc69d3/5be61e9f-b1fa-4e23-bbae-0379d0fbc399
  finishTimestamp: "2024-02-29T06:41:58Z"
  largeResourceEnabled: false
  lastUpdateTimestamp: "2024-02-29T06:41:58Z"
  reason: Volumes and resources were backed up successfully
  resourceCount: 39
  resources:
  - group: core
    kind: Secret
    name: mysql-ceph-rbd
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: mysql-ceph-rbd-dockercfg-d8nlp
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: mysql-ceph-rbd-token-4t6zb
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: mysql-cephfs
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: mysql-cephfs-dockercfg-l8c54
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: mysql-cephfs-token-2w5sz
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: mysql-thin
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: mysql-thin-dockercfg-mjhgx
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: mysql-thin-token-6df65
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: sh.helm.release.v1.mysql-ceph-rbd.v1
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: sh.helm.release.v1.mysql-cephfs.v1
    namespace: mysql
    version: v1
  - group: core
    kind: Secret
    name: sh.helm.release.v1.mysql-thin.v1
    namespace: mysql
    version: v1
  - group: core
    kind: ConfigMap
    name: mysql-ceph-rbd
    namespace: mysql
    version: v1
  - group: core
    kind: ConfigMap
    name: mysql-cephfs
    namespace: mysql
    version: v1
  - group: core
    kind: ConfigMap
    name: mysql-thin
    namespace: mysql
    version: v1
  - group: core
    kind: ServiceAccount
    name: mysql-ceph-rbd
    namespace: mysql
    version: v1
  - group: core
    kind: ServiceAccount
    name: mysql-cephfs
    namespace: mysql
    version: v1
  - group: core
    kind: ServiceAccount
    name: mysql-thin
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: data-mysql-ceph-rbd-0
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: data-mysql-cephfs-0
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: data-mysql-thin-0
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolumeClaim
    name: data-mysql-thin-csi-0
    namespace: mysql
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-49fd7ea0-6385-4abd-a2b5-0e49e32cd064
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-62ecbde5-2193-4786-a132-f069197f0e06
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-8eeecab5-5ed2-41e9-9883-0bb11d72485c
    namespace: ""
    version: v1
  - group: core
    kind: PersistentVolume
    name: pvc-e5947f81-0e94-469d-a8c8-0e96f927ac66
    namespace: ""
    version: v1
  - group: core
    kind: Service
    name: mysql-ceph-rbd
    namespace: mysql
    version: v1
  - group: core
    kind: Service
    name: mysql-ceph-rbd-headless
    namespace: mysql
    version: v1
  - group: core
    kind: Service
    name: mysql-cephfs
    namespace: mysql
    version: v1
  - group: core
    kind: Service
    name: mysql-cephfs-headless
    namespace: mysql
    version: v1
  - group: core
    kind: Service
    name: mysql-thin
    namespace: mysql
    version: v1
  - group: core
    kind: Service
    name: mysql-thin-headless
    namespace: mysql
    version: v1
  - group: apps
    kind: StatefulSet
    name: mysql-ceph-rbd
    namespace: mysql
    version: v1
  - group: apps
    kind: StatefulSet
    name: mysql-cephfs
    namespace: mysql
    version: v1
  - group: apps
    kind: StatefulSet
    name: mysql-thin
    namespace: mysql
    version: v1
  - group: networking.k8s.io
    kind: NetworkPolicy
    name: mysql-ceph-rbd
    namespace: mysql
    version: v1
  - group: networking.k8s.io
    kind: NetworkPolicy
    name: mysql-cephfs
    namespace: mysql
    version: v1
  - group: networking.k8s.io
    kind: NetworkPolicy
    name: mysql-thin
    namespace: mysql
    version: v1
  - group: rbac.authorization.k8s.io
    kind: RoleBinding
    name: system:openshift:scc:anyuid
    namespace: mysql
    version: v1
  stage: Final
  status: Successful
  totalSize: 3647959404
  triggerTimestamp: "2024-02-29T06:38:18Z"
  volumes:
  - Options: null
    actualSize: 3040459258
    backupID: 79dd459381777c287be8a1bef0c1454d
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: data-mysql-ceph-rbd-0
    persistentVolumeClaimUID: 49fd7ea0-6385-4abd-a2b5-0e49e32cd064
    provisioner: openshift-storage.rbd.csi.ceph.com
    reason: Backup successful for volume
    status: Successful
    storageClass: ocs-storagecluster-ceph-rbd
    totalSize: 3040459258
    volume: pvc-49fd7ea0-6385-4abd-a2b5-0e49e32cd064
    volumeSnapshot: ""
    zones: null
  - Options: null
    actualSize: 208366750
    backupID: d6b59fc7ca86ef88e97de60a3f8313a0
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: data-mysql-cephfs-0
    persistentVolumeClaimUID: e5947f81-0e94-469d-a8c8-0e96f927ac66
    provisioner: openshift-storage.cephfs.csi.ceph.com
    reason: Backup successful for volume
    status: Successful
    storageClass: ocs-storagecluster-cephfs
    totalSize: 208366750
    volume: pvc-e5947f81-0e94-469d-a8c8-0e96f927ac66
    volumeSnapshot: ""
    zones: null
  - Options: null
    actualSize: 206268443
    backupID: 123d0e321551dca62ac8db9c55fce078
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: data-mysql-thin-0
    persistentVolumeClaimUID: 8eeecab5-5ed2-41e9-9883-0bb11d72485c
    provisioner: kubernetes.io/vsphere-volume
    reason: Backup successful for volume
    status: Successful
    storageClass: thin
    totalSize: 206268443
    volume: pvc-8eeecab5-5ed2-41e9-9883-0bb11d72485c
    volumeSnapshot: ""
    zones: null
  - Options: null
    actualSize: 192864953
    backupID: b783f7a08b0e0e93a10d5ec2c58324c4
    driverName: kdmp
    namespace: mysql
    persistentVolumeClaim: data-mysql-thin-csi-0
    persistentVolumeClaimUID: 62ecbde5-2193-4786-a132-f069197f0e06
    provisioner: csi.vsphere.vmware.com
    reason: Backup successful for volume
    status: Successful
    storageClass: thin-csi
    totalSize: 192864953
    volume: pvc-62ecbde5-2193-4786-a132-f069197f0e06
    volumeSnapshot: ""
    zones: null
```

