### PR TITLE
pb-5861: application-clone cr apply caused stork pod crash

### DIFF
--- a/pkg/applicationmanager/controllers/applicationclone.go
+++ b/pkg/applicationmanager/controllers/applicationclone.go
@@ -705,9 +705,13 @@ func (a *ApplicationCloneController) applyResources(
 
 		log.ApplicationCloneLog(clone).Infof("Applying %v %v", objectType.GetKind(), metadata.GetName())
 		retained := false
+		// clone path doesn't need any options to be set yet,
+		// hence creating an empty structure for preventing any
+		// accidental panic while accesing the elements of it deep down.
+		var opts resourcecollector.Options
 		err = a.resourceCollector.ApplyResource(
 			a.dynamicInterface,
-			o, nil)
+			o, &opts)
 		if err != nil && errors.IsAlreadyExists(err) {
 			switch clone.Spec.ReplacePolicy {
 			case stork_api.ApplicationCloneReplacePolicyDelete:

--- a/pkg/resourcecollector/networkpolicy.go
+++ b/pkg/resourcecollector/networkpolicy.go
@@ -2,8 +2,9 @@ package resourcecollector
 
 import (
 	"fmt"
-	"github.com/libopenstorage/stork/pkg/utils"
 	"strings"
+
+	"github.com/libopenstorage/stork/pkg/utils"
 
 	v1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -111,7 +112,7 @@ func (r *ResourceCollector) mergeAndUpdateNetworkPolicy(
 	opts *Options,
 ) error {
 
-	if len(opts.RancherProjectMappings) == 0 {
+	if (opts == nil) || len(opts.RancherProjectMappings) == 0 {
 		return nil
 	}
 

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -1212,7 +1212,7 @@ func (r *ResourceCollector) mergeSupportedForRancherResource(
 	opts *Options,
 ) bool {
 	// return false if there is no project mapping
-	if len(opts.RancherProjectMappings) == 0 {
+	if (opts == nil) || len(opts.RancherProjectMappings) == 0 {
 		return false
 	}
 
@@ -1434,7 +1434,7 @@ func (r *ResourceCollector) mergeAndUpdateApplicationResource(
 	dynamicClient dynamic.ResourceInterface,
 	opts *Options) error {
 
-	if len(opts.RancherProjectMappings) == 0 {
+	if (opts == nil) || len(opts.RancherProjectMappings) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
- Cloning from one namespace to another target namespace if there are resources pre-exist in the target namespace then stork pod crashes for a nil pointer dereference
- Added relevant nil check and passed an empty struct for any accidental nil pointer access in that path.


**What type of PR is this?** BUG
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**: No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: Yes
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: Cloning application to a namespace which has the same resource in it can cause stork pod crash
User Impact: stork pod will keep restarting unless the duplicate resource is removed explicitly
Resolution : Added necessary checks so that we don't panic if same resource exist in target namespace 

```

**Does this change need to be cherry-picked to a release branch?**: 24.1.0
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

Unit test : 
tested by applying a application clone CR which clones a ngnix application to a target namesapce which has already same PVC exist which used to present in source namespace.

```
THE CLONE CR IS As below
--------------
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationClone
metadata:
  name: clone-test
  namespace: kube-system
spec:
  sourceNamespace: test
  destinationNamespace: test-clone
-------------
root@matser-ld:~# kubectl get applicationclone -n kube-system
NAME         AGE
clone-test   82s
root@matser-ld:~# kubectl get applicationclone -n kube-system -oyaml
apiVersion: v1
items:
- apiVersion: stork.libopenstorage.org/v1alpha1
  kind: ApplicationClone
  metadata:
    creationTimestamp: "2024-02-28T09:21:23Z"
    finalizers:
    - stork.libopenstorage.org/finalizer-cleanup
    generation: 7
    name: clone-test
    namespace: kube-system
    resourceVersion: "1811854"
    uid: f18cba79-8615-404b-b157-8cae7c4b95ae
  spec:
    destinationNamespace: test-clone
    includeOptionalResourceTypes: null
    postExecRule: ""
    preExecRule: ""
    replacePolicy: Retain
    selectors: null
    sourceNamespace: test
  status:
    finishTimestamp: "2024-02-28T09:21:26Z"
    resources:
    - group: core
      kind: PersistentVolumeClaim
      name: pvc1
      reason: Resource clone skipped as it was already present and ReplacePolicy is
        set to Retain
      status: Retained
      version: v1
    - group: core
      kind: PersistentVolumeClaim
      name: pvc2
      reason: Resource clone skipped as it was already present and ReplacePolicy is
        set to Retain
      status: Retained
      version: v1
    - group: core
      kind: PersistentVolumeClaim
      name: pvc3
      reason: Resource clone skipped as it was already present and ReplacePolicy is
        set to Retain
      status: Retained
      version: v1
    - group: core
      kind: PersistentVolume
      name: pvc-241377ef-b490-4cf2-b690-aebf941e8c58
      reason: Resource cloned successfully for namespace test-clone
      status: Successful
      version: v1
    - group: core
      kind: PersistentVolume
      name: pvc-647ffe48-2d55-495e-905e-449dabd47e86
      reason: Resource cloned successfully for namespace test-clone
      status: Successful
      version: v1
    - group: core
      kind: PersistentVolume
      name: pvc-e9b51a8b-0ba5-487f-879d-a49d89c48616
      reason: Resource cloned successfully for namespace test-clone
      status: Successful
      version: v1
    - group: apps
      kind: Deployment
      name: stork-issue-pod1-pvc1
      reason: Resource cloned successfully for namespace test-clone
      status: Successful
      version: v1
    - group: apps
      kind: Deployment
      name: stork-issue-pod2-pvc2
      reason: Resource cloned successfully for namespace test-clone
      status: Successful
      version: v1
    - group: apps
      kind: Deployment
      name: stork-issue-pod3-pvc3
      reason: Resource cloned successfully for namespace test-clone
      status: Successful
      version: v1
    stage: Final
    status: PartialSuccess
    volumes:
    - cloneVolume: pvc-241377ef-b490-4cf2-b690-aebf941e8c58
      persistentVolumeClaim: pvc1
      reason: Volume cloned succesfully
      status: Successful
      volume: pvc-2ed80e8e-5ba4-427b-ae78-d8f6820699cf
    - cloneVolume: pvc-e9b51a8b-0ba5-487f-879d-a49d89c48616
      persistentVolumeClaim: pvc2
      reason: Volume cloned succesfully
      status: Successful
      volume: pvc-b92edd4d-7a0f-435f-99bb-482d85065d8e
    - cloneVolume: pvc-647ffe48-2d55-495e-905e-449dabd47e86
      persistentVolumeClaim: pvc3
      reason: Volume cloned succesfully
      status: Successful
      volume: pvc-58ccb195-ebe0-4215-89a3-4b7812acaa3f
kind: List
metadata:
  resourceVersion: ""


------------------------------------------------


root@matser-ld:~# kubectl get po -n portworx -l name=stork -owide
NAME                    READY   STATUS    RESTARTS   AGE     IP             NODE         NOMINATED NODE   READINESS GATES
stork-d694cd788-8c7rl   1/1     Running   0          7m25s   10.244.192.1   worker1-ld   <none>           <none>
stork-d694cd788-8qt6r   1/1     Running   0          9m23s   10.244.64.4    worker3-ld   <none>           <none>
stork-d694cd788-ct8w6   1/1     Running   0          9m23s   10.244.160.6   worker2-ld   <none>           <none>


------------------------------------------------


root@matser-ld:~# kubectl get deploy stork -n portworx -owide
NAME    READY   UP-TO-DATE   AVAILABLE   AGE     CONTAINERS   IMAGES                                                                         SELECTOR
stork   3/3     3            3           3d22h   stork        pure-artifactory.dev.purestorage.com/px-docker-dev-virtual/ldas/stork:pvtImg   name=stork,tier=control-plane

------------------------------------------------

Destination Namespace:

root@matser-ld:~# kubectl get pvc -n test-clone
NAME   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pvc1   Bound    pvc-1f976df8-6afd-4983-adc2-ae4671451033   3Gi        RWO            px-csi-db      10h
pvc2   Bound    pvc-c16ea890-2a00-4138-a554-2d0a71f5ba97   4Gi        RWO            px-csi-db      10h
pvc3   Bound    pvc-b6614f83-b0d4-4466-a0a3-ccd60cb40878   5Gi        RWO            px-csi-db      10h
root@matser-ld:~# kubectl get all -n test-clone
NAME                                         READY   STATUS    RESTARTS   AGE
pod/stork-issue-pod1-pvc1-7cbc47b4ff-bzz6b   1/1     Running   0          3m7s
pod/stork-issue-pod2-pvc2-ffbcc98b4-5k85p    1/1     Running   0          3m7s
pod/stork-issue-pod3-pvc3-5db66b9b94-987lk   1/1     Running   0          3m7s

NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/stork-issue-pod1-pvc1   1/1     1            1           3m7s
deployment.apps/stork-issue-pod2-pvc2   1/1     1            1           3m7s
deployment.apps/stork-issue-pod3-pvc3   1/1     1            1           3m7s

NAME                                               DESIRED   CURRENT   READY   AGE
replicaset.apps/stork-issue-pod1-pvc1-7cbc47b4ff   1         1         1       3m7s
replicaset.apps/stork-issue-pod2-pvc2-ffbcc98b4    1         1         1       3m7s
replicaset.apps/stork-issue-pod3-pvc3-5db66b9b94   1         1         1       3m7s

-----------------------------------------------------

Source Namespace:

root@matser-ld:~# kubectl get pvc -n test
NAME   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pvc1   Bound    pvc-2ed80e8e-5ba4-427b-ae78-d8f6820699cf   3Gi        RWO            px-csi-db      12h
pvc2   Bound    pvc-b92edd4d-7a0f-435f-99bb-482d85065d8e   4Gi        RWO            px-csi-db      12h
pvc3   Bound    pvc-58ccb195-ebe0-4215-89a3-4b7812acaa3f   5Gi        RWO            px-csi-db      12h
root@matser-ld:~# 
root@matser-ld:~# 
root@matser-ld:~# kubectl get all -n test
NAME                                         READY   STATUS    RESTARTS   AGE
pod/stork-issue-pod1-pvc1-7cbc47b4ff-j7ncp   1/1     Running   0          10h
pod/stork-issue-pod2-pvc2-ffbcc98b4-zf2rr    1/1     Running   0          10h
pod/stork-issue-pod3-pvc3-5db66b9b94-gqc8j   1/1     Running   0          10h

NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/stork-issue-pod1-pvc1   1/1     1            1           10h
deployment.apps/stork-issue-pod2-pvc2   1/1     1            1           10h
deployment.apps/stork-issue-pod3-pvc3   1/1     1            1           10h

NAME                                               DESIRED   CURRENT   READY   AGE
replicaset.apps/stork-issue-pod1-pvc1-7cbc47b4ff   1         1         1       10h
replicaset.apps/stork-issue-pod2-pvc2-ffbcc98b4    1         1         1       10h
replicaset.apps/stork-issue-pod3-pvc3-5db66b9b94   1         1         1       10h

```