### PR TITLE
[PWX-36291] Helper functions for scaling down applications during failover/failback

### DIFF
--- a/pkg/resourceutils/listResources.go
+++ b/pkg/resourceutils/listResources.go
@@ -1,0 +1,157 @@
+package resourceutils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	migration "github.com/libopenstorage/stork/pkg/migration/controllers"
+	"github.com/libopenstorage/stork/pkg/resourcecollector"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sdynamic "k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+var statefulSetGVK = metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
+var deploymentGVK = metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+var replicaSetGVK = metav1.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}
+var deploymentConfigGVK = metav1.GroupVersionKind{Group: "apps.openshift.io", Version: "v1", Kind: "DeploymentConfig"}
+var cronJobGVK = metav1.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}
+var virtualMachineGVK = metav1.GroupVersionKind{Group: "kubevirt.io", Version: "v1", Kind: "VirtualMachine"}
+var ibpPeerGVK = metav1.GroupVersionKind{Group: "ibp.com", Version: "v1alpha1", Kind: "IBPPeer"}
+var ibpcaGVK = metav1.GroupVersionKind{Group: "ibp.com", Version: "v1alpha1", Kind: "IBPCA"}
+var ibpConsoleGVK = metav1.GroupVersionKind{Group: "ibp.com", Version: "v1alpha1", Kind: "IBPOrderer"}
+var ibpOrdererGVK = metav1.GroupVersionKind{Group: "ibp.com", Version: "v1alpha1", Kind: "IBPConsole"}
+
+func getRelevantGVKs() []metav1.GroupVersionKind {
+	return []metav1.GroupVersionKind{statefulSetGVK, deploymentGVK, replicaSetGVK, deploymentConfigGVK, cronJobGVK, virtualMachineGVK, ibpPeerGVK, ibpcaGVK, ibpOrdererGVK, ibpConsoleGVK}
+}
+
+func ListResourcesByGVK(namespace string, config *rest.Config, resourceType metav1.GroupVersionKind) (*unstructured.UnstructuredList, error) {
+	//Setup dynamic client to get resources based on gvk
+	var client k8sdynamic.ResourceInterface
+	ruleset := resourcecollector.GetDefaultRuleSet()
+	configClient, err := k8sdynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	opts := &metav1.ListOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       resourceType.Kind,
+			APIVersion: resourceType.Group + "/" + resourceType.Version},
+	}
+	gvk := schema.FromAPIVersionAndKind(opts.APIVersion, opts.Kind)
+	resourceInterface := configClient.Resource(gvk.GroupVersion().WithResource(ruleset.Pluralize(strings.ToLower(gvk.Kind))))
+	client = resourceInterface.Namespace(namespace)
+	objects, err := client.List(context.TODO(), *opts)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	for _, obj := range objects.Items {
+		fmt.Println(obj.GetName())
+	}
+	return objects, nil
+}
+
+func GenerateDynamicClientForGVK(resourceType metav1.GroupVersionKind, namespace string, config *rest.Config) (k8sdynamic.ResourceInterface, error) {
+	var client k8sdynamic.ResourceInterface
+	ruleset := resourcecollector.GetDefaultRuleSet()
+	configClient, err := k8sdynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	opts := &metav1.UpdateOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       resourceType.Kind,
+			APIVersion: resourceType.Group + "/" + resourceType.Version},
+	}
+	gvk := schema.FromAPIVersionAndKind(opts.APIVersion, opts.Kind)
+	resourceInterface := configClient.Resource(gvk.GroupVersion().WithResource(ruleset.Pluralize(strings.ToLower(gvk.Kind))))
+	client = resourceInterface.Namespace(namespace)
+	return client, nil
+}
+
+func GetResourcesBeingActivated(activationNamespaces []string, config *rest.Config) (map[string]map[metav1.GroupVersionKind]map[string]string, error) {
+	//TODO: Set correct config for storkops
+	crdList, err := storkops.Instance().ListApplicationRegistrations()
+	if err != nil {
+		return nil, err
+	}
+	resourceReplicaMap := make(map[string]map[metav1.GroupVersionKind]map[string]string)
+	for _, ns := range activationNamespaces {
+		//Initialise namespace -> resource kind maps
+		resourceReplicaMap[ns] = make(map[metav1.GroupVersionKind]map[string]string)
+
+		// 1. ApplicationResources
+		for _, gvk := range getRelevantGVKs() {
+			//Initialise namespace/resourceKind -> resources/replicas maps
+			resourceReplicaMap[ns][gvk] = make(map[string]string)
+			resources, err := ListResourcesByGVK(ns, config, gvk)
+			if err != nil {
+				return nil, err
+			}
+			for _, object := range resources.Items {
+				content := object.UnstructuredContent()
+				annotations, found, err := unstructured.NestedStringMap(content, "metadata", "annotations")
+				if err != nil {
+					return nil, err
+				}
+				if !found {
+					continue
+				}
+				//Only if replica annotation exists, we will be activating this resource
+				if val, present := annotations[migration.StorkMigrationReplicasAnnotation]; present {
+					resourceReplicaMap[ns][gvk][object.GetName()] = val
+				}
+			}
+		}
+
+		// 2. CRD Resources
+		for _, applicationRegistration := range crdList.Items {
+			for _, applicationResource := range applicationRegistration.Resources {
+				gvk := applicationResource.GroupVersionKind
+				//Initialise namespace/resourceKind -> resources/replicas maps
+				resourceReplicaMap[ns][gvk] = make(map[string]string)
+				resources, err := ListResourcesByGVK(ns, config, gvk)
+				if err != nil {
+					return nil, err
+				}
+				for _, object := range resources.Items {
+					content := object.UnstructuredContent()
+					annotations, found, err := unstructured.NestedStringMap(content, "metadata", "annotations")
+					if err != nil {
+						return nil, err
+					}
+					if !found {
+						continue
+					}
+					//Only if replica annotation exists, we will be activating this resource
+					if applicationResource.SuspendOptions.Path != "" {
+						applicationResource.NestedSuspendOptions = append(applicationResource.NestedSuspendOptions, applicationResource.SuspendOptions)
+					}
+					if len(applicationResource.NestedSuspendOptions) == 0 {
+						continue
+					}
+					for _, suspend := range applicationResource.NestedSuspendOptions {
+						specPath := strings.Split(suspend.Path, ".")
+						if len(specPath) > 1 {
+							if suspend.Type == "int" || suspend.Type == "string" {
+								if val, present := annotations[migration.StorkAnnotationPrefix+suspend.Path]; present {
+									resourceReplicaMap[ns][gvk][object.GetName()] = val
+								} else if val, present := annotations[migration.StorkMigrationCRDActivateAnnotation]; present {
+									resourceReplicaMap[ns][gvk][object.GetName()] = val
+								}
+							}
+							// for suspend.Type == "bool" we update irrespective of annotation presence
+						}
+					}
+				}
+			}
+		}
+	}
+	return resourceReplicaMap, nil
+}

--- a/pkg/resourceutils/scaleDown.go
+++ b/pkg/resourceutils/scaleDown.go
@@ -1,0 +1,190 @@
+package resourceutils
+
+import (
+	"context"
+	"fmt"
+	"github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"strconv"
+	"strings"
+
+	migration "github.com/libopenstorage/stork/pkg/migration/controllers"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sdynamic "k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+func ScaleDownGivenResources(namespaces []string, resourceMap map[string]map[metav1.GroupVersionKind]map[string]string, config *rest.Config) error {
+	//TODO: Set correct config for storkops
+	crdList, err := storkops.Instance().ListApplicationRegistrations()
+	if err != nil {
+		return err
+	}
+
+	for _, ns := range namespaces {
+		// 1. ApplicationResources
+		for _, gvk := range getRelevantGVKs() {
+			resources, err := ListResourcesByGVK(ns, config, gvk)
+			if err != nil {
+				return err
+			}
+			dynamicClient, err := GenerateDynamicClientForGVK(gvk, ns, config)
+			if err != nil {
+				return err
+			}
+			for _, object := range resources.Items {
+				if _, present := resourceMap[ns][gvk][object.GetName()]; present {
+					err := scaleDownApplicationResource(object, dynamicClient, gvk)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+		// 2. CRD Resources
+		for _, applicationRegistration := range crdList.Items {
+			for _, applicationResource := range applicationRegistration.Resources {
+				gvk := applicationResource.GroupVersionKind
+				dynamicClient, err := GenerateDynamicClientForGVK(gvk, ns, config)
+				resources, err := ListResourcesByGVK(ns, config, gvk)
+				if err != nil {
+					return err
+				}
+				for _, object := range resources.Items {
+					if _, present := resourceMap[ns][gvk][object.GetName()]; present {
+						err := ScaleDownCRDResource(object, applicationResource, dynamicClient)
+						if err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func scaleDownApplicationResource(object unstructured.Unstructured, dynamicClient k8sdynamic.ResourceInterface, resourceType metav1.GroupVersionKind) error {
+	content := object.UnstructuredContent()
+	currentReplicas, found, err := unstructured.NestedInt64(content, "spec", "replicas")
+	if err != nil {
+		return err
+	}
+	if !found {
+		currentReplicas = 1
+	}
+	annotations, found, err := unstructured.NestedStringMap(content, "metadata", "annotations")
+	if err != nil {
+		return err
+	}
+	if !found {
+		annotations = make(map[string]string)
+	}
+	migrationReplicasAnnotationValue, replicaAnnotationIsPresent := annotations[migration.StorkMigrationReplicasAnnotation]
+	if currentReplicas == 0 && replicaAnnotationIsPresent {
+		//If the actual replica count is 0 and migrationReplicas annotation is more than 0, then don't override the migrationReplicaAnnotation value.
+		migrationReplicas, err := strconv.ParseInt(migrationReplicasAnnotationValue, 10, 64)
+		if err != nil {
+			return err
+		}
+		if migrationReplicas > 0 {
+			currentReplicas = migrationReplicas
+		}
+	}
+	//we set the actual replica count to 0 to scale down the resource on target cluster
+	err = unstructured.SetNestedField(content, int64(0), "spec", "replicas")
+	if err != nil {
+		return err
+	}
+	annotations[migration.StorkMigrationReplicasAnnotation] = strconv.FormatInt(currentReplicas, 10)
+	err = unstructured.SetNestedStringMap(content, annotations, "metadata", "annotations")
+	if err != nil {
+		return err
+	}
+	_, err = dynamicClient.Update(context.TODO(), &object, metav1.UpdateOptions{}, "")
+	if err != nil {
+		return fmt.Errorf("unable to update resource %v %v/%v: %v", strings.ToLower(resourceType.String()), object.GetNamespace(), object.GetName(), err)
+	}
+	return nil
+}
+
+func ScaleDownCRDResource(object unstructured.Unstructured, applicationResource v1alpha1.ApplicationResource, dynamicClient k8sdynamic.ResourceInterface) error {
+	content := object.UnstructuredContent()
+	annotations, found, err := unstructured.NestedStringMap(content, "metadata", "annotations")
+	if err != nil {
+		return err
+	}
+	if !found {
+		annotations = make(map[string]string)
+	}
+	if applicationResource.SuspendOptions.Path != "" {
+		applicationResource.NestedSuspendOptions = append(applicationResource.NestedSuspendOptions, applicationResource.SuspendOptions)
+	}
+	if len(applicationResource.NestedSuspendOptions) == 0 {
+		return nil
+	}
+	for _, suspend := range applicationResource.NestedSuspendOptions {
+		specPath := strings.Split(suspend.Path, ".")
+		if len(specPath) > 1 {
+			var val string
+			SuspendAnnotationValue, suspendAnnotationIsPresent := annotations[migration.StorkAnnotationPrefix+suspend.Path]
+			var disableVersion interface{}
+			if suspend.Type == "int" {
+				currentValue, found, err := unstructured.NestedInt64(content, specPath...)
+				if err != nil || !found {
+					return fmt.Errorf("unable to find suspend path, err: %v", err)
+				}
+				disableVersion = int64(0)
+				if currentValue == 0 && suspendAnnotationIsPresent {
+					//suspendAnnotation has value set as {currVal + "," + suspend.Value}
+					//we need to extract only the currVal from it
+					annotationValue := strings.Split(SuspendAnnotationValue, ",")[0]
+					intValue, err := strconv.ParseInt(annotationValue, 10, 64)
+					if err != nil {
+						return err
+					}
+					if intValue > 0 {
+						//If the actual suspend path value is 0 and suspend annotation value is more than 0,
+						//then don't override the annotation.
+						currentValue = intValue
+					}
+				}
+				val = fmt.Sprintf("%v", currentValue)
+			} else if suspend.Type == "string" {
+				currentValue, _, err := unstructured.NestedString(content, specPath...)
+				if err != nil {
+					return fmt.Errorf("unable to find suspend path, err: %v", err)
+				}
+				disableVersion = suspend.Value
+				if currentValue == suspend.Value && suspendAnnotationIsPresent {
+					annotationValue := strings.Split(SuspendAnnotationValue, ",")[0]
+					if annotationValue != "" {
+						//If the actual value is equal to suspend.Value and suspend path annotation value is not an empty string,
+						//then don't override the annotation
+						currentValue = annotationValue
+					}
+				}
+				val = currentValue
+			} else {
+				return fmt.Errorf("invalid type %v to suspend cr", suspend.Type)
+			}
+			//scale down the CRD resource by setting the suspendPath value to disableVersion
+			if err := unstructured.SetNestedField(content, disableVersion, specPath...); err != nil {
+				return err
+			}
+
+			// path : activate/deactivate value
+			annotations[migration.StorkAnnotationPrefix+suspend.Path] = val + "," + suspend.Value
+		}
+	}
+	err = unstructured.SetNestedStringMap(content, annotations, "metadata", "annotations")
+	if err != nil {
+		return err
+	}
+	_, err = dynamicClient.Update(context.TODO(), &object, metav1.UpdateOptions{}, "")
+	if err != nil {
+		return fmt.Errorf("unable to update resource %v %v/%v: %v", strings.ToLower(applicationResource.GroupVersionKind.String()), object.GetNamespace(), object.GetName(), err)
+	}
+	return nil
+}

--- a/pkg/resourceutils/scaleDown.go
+++ b/pkg/resourceutils/scaleDown.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/portworx/sched-ops/k8s/core"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 
@@ -133,7 +134,7 @@ func scaleDownApplicationResource(dynamicClient k8sdynamic.ResourceInterface, ob
 	if err != nil {
 		return fmt.Errorf("unable to update resource %v %v/%v: %v", strings.ToLower(resourceType.Kind), object.GetNamespace(), object.GetName(), err)
 	}
-	fmt.Printf("successfully updated resource %v %v/%v \n", strings.ToLower(resourceType.Kind), object.GetNamespace(), object.GetName())
+	log.Infof("successfully updated resource %v %v/%v \n", strings.ToLower(resourceType.Kind), object.GetNamespace(), object.GetName())
 	return nil
 }
 
@@ -152,7 +153,7 @@ func scaleDownCronJob(dynamicClient k8sdynamic.ResourceInterface, object unstruc
 	if err != nil {
 		return fmt.Errorf("unable to update resource %v %v/%v: %v", strings.ToLower(cronJobGVK.Kind), object.GetNamespace(), object.GetName(), err)
 	}
-	fmt.Printf("successfully updated resource %v %v/%v \n", strings.ToLower(cronJobGVK.Kind), object.GetNamespace(), object.GetName())
+	log.Infof("successfully updated resource %v %v/%v \n", strings.ToLower(cronJobGVK.Kind), object.GetNamespace(), object.GetName())
 	return nil
 }
 
@@ -217,6 +218,7 @@ func scaleDownCRDResource(dynamicClient k8sdynamic.ResourceInterface, object uns
 				if val, err := strconv.ParseBool(suspend.Value); err != nil {
 					disableVersion = true
 				} else {
+					log.Warnf("failed to parse suspend.Value %v. going ahead with default bool disable value of true", suspend.Value)
 					disableVersion = val
 				}
 			} else {
@@ -242,7 +244,7 @@ func scaleDownCRDResource(dynamicClient k8sdynamic.ResourceInterface, object uns
 	if err != nil {
 		return fmt.Errorf("unable to update resource %v %v/%v: %v", strings.ToLower(crd.Kind), object.GetNamespace(), object.GetName(), err)
 	}
-	fmt.Printf("successfully updated resource %v %v/%v \n", strings.ToLower(crd.Kind), object.GetNamespace(), object.GetName())
+	log.Infof("successfully updated resource %v %v/%v \n", strings.ToLower(crd.Kind), object.GetNamespace(), object.GetName())
 
 	// Delete pods corresponding to the CRD as well
 	if crd.PodsPath == "" {


### PR DESCRIPTION
**What type of PR is this?**
>feature

**What this PR does / why we need it**:
This PR deals with the methods required for scaling down applications during failover and failback. 
Note: These functions are not being used yet. The upcoming PR will use these methods.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 24.2.0

**Testing Details**
For failover, we will first find out the resources which will be activated in the destination cluster and scale down the corresponding resources in the source cluster.
To simulate this for testing I used the below code in one of the storkctl commands and verified that a deployment,replicaSet & a mongocommunitydb resource (CRD) are scaled down in source cluster as expected and required annotations are added as well.
```
srcConf, _ := getConfig(srcConfig).ClientConfig()
destConf, _ := cmdFactory.GetConfig()
activationNamespaces := []string{cmdFactory.GetNamespace()}
resourceBeingActivated, _ := resourceutils.GetResourcesBeingActivated(activationNamespaces, destConf)
_ = resourceutils.ScaleDownGivenResources(activationNamespaces, resourceBeingActivated, srcConf)
```
