### PR TITLE
fix: PB-5878 - Handle freeze/thaw for case with two VMs with same nam…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -335,7 +335,7 @@ replace (
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v0.0.0-20230511212757-41751b27d69f
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240219181755-4ce81929fd25
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240213085633-9253e7ad248f
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240124200451-5928195f61c0
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3

--- a/go.sum
+++ b/go.sum
@@ -3041,8 +3041,8 @@ github.com/portworx/px-backup-api v1.2.2-0.20231011130438-812370c309e7/go.mod h1
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987 h1:VNBTmIPjJRZ2QP64zdsrif3ELDHiMzoyNNX74VNHgZ8=
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987/go.mod h1:g3pw2lI2AjqAixUCRhaBdKTY98znsCPR7NGRrlpimVU=
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27 h1:1Q50KWDMei8O+ckB2UzUKC6eRT6Aiwxg6u99C9wtrK0=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240213085633-9253e7ad248f h1:z2pqLq27ezNQezFhqWoLj6RbxKOc9m///+HjnmKLhU4=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240213085633-9253e7ad248f/go.mod h1:wZnNzyY7B/cuWwYZ6XysdbwsXPC8DjfJ1YGg6MdyefU=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.0.0-20240124200451-5928195f61c0 h1:fHlHlS9+tMlc/nMTRLzeI6cCTYjSAxTAiLHIf0rheUQ=

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/kubevirt.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/kubevirt.go
@@ -19,6 +19,7 @@ var (
 // Ops is an interface to perform kubernetes related operations on the core resources.
 type Ops interface {
 	VirtualMachineOps
+	VirtualMachineInstanceOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachineinstance.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/virtualmachineinstance.go
@@ -1,0 +1,22 @@
+package kubevirt
+
+import (
+	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+// VirtualMachineInstanceOps is an interface to perform kubevirt operations on virtual machine instances
+type VirtualMachineInstanceOps interface {
+	// GetVirtualMachineInstance gets updated Virtual Machine Instance from client matching name and namespace
+	GetVirtualMachineInstance(context.Context, string, string) (*kubevirtv1.VirtualMachineInstance, error)
+}
+
+// GetVirtualMachineInstance gets updated Virtual Machine Instance from client matching name and namespace
+func (c *Client) GetVirtualMachineInstance(ctx context.Context, name string, namespace string) (*kubevirtv1.VirtualMachineInstance, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubevirt.VirtualMachineInstance(namespace).Get(ctx, name, &metav1.GetOptions{})
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/prometheus/alertmanagerconfig.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/prometheus/alertmanagerconfig.go
@@ -1,0 +1,95 @@
+package prometheus
+
+import (
+	"context"
+
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// AlertManagerConfig adds receiver to alert manager which is responsible sending alerts
+type AlertManagerConfigOps interface {
+	// List of alertmanagerconfigs that match the namespace
+	ListAlertManagerConfigs(namespace string, labelSelectors map[string]string) (*monitoringv1alpha1.AlertmanagerConfigList, error)
+	// Get alertmanagerconfigs that matches the name
+	GetAlertManagerConfig(name string, namespace string) (*monitoringv1alpha1.AlertmanagerConfig, error)
+	// Create a new alertmanagerconfig
+	CreateAlertManagerConfig(*monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error)
+	// Update one alertmanagerconfig
+	UpdateAlertManagerConfig(*monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error)
+	// Delete one alertmanagerconfig
+	DeleteAlertManagerConfig(name string, namespace string) error
+	// Delete a list of alertmanagerconfig based on the namespace
+	DeleteCollectionAlertManagerConfig(namespace string, labelSelectors map[string]string) error
+}
+
+// List of alert manager configs that match the namespace
+func (c *Client) ListAlertManagerConfigs(namespace string, labelSelectors map[string]string) (*monitoringv1alpha1.AlertmanagerConfigList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).List(context.TODO(), listOptions(labelSelectors))
+}
+
+// Get one alert manager config
+func (c *Client) GetAlertManagerConfig(name string, namespace string) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// Creates a new AlertmanagerConfig in the given namespace, provided the secret is provided
+func (c *Client) CreateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	ns := amc.Namespace
+	if len(ns) == 0 {
+		ns = corev1.NamespaceDefault
+	}
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(ns).Create(context.TODO(), amc, metav1.CreateOptions{})
+}
+
+// Updates one alert manager config
+func (c *Client) UpdateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(amc.Namespace).Update(context.TODO(), amc, metav1.UpdateOptions{})
+}
+
+// Deletes single alert manager config
+func (c *Client) DeleteAlertManagerConfig(name string, namespace string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{
+		PropagationPolicy: &deleteForegroundPolicy,
+	})
+}
+
+func (c *Client) DeleteCollectionAlertManagerConfig(namespace string, labelSelectors map[string]string) error {
+	if err := c.initClient(); err != nil {
+		return err
+	}
+	deleteOpts := metav1.DeleteOptions{
+		PropagationPolicy: &deleteForegroundPolicy,
+	}
+
+	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).DeleteCollection(context.TODO(), deleteOpts, listOptions(labelSelectors))
+}
+
+func listOptions(labelSelectors map[string]string) metav1.ListOptions {
+	if labelSelectors != nil {
+		return metav1.ListOptions{
+			LabelSelector: labels.Set(labelSelectors).String(),
+		}
+	}
+	return metav1.ListOptions{}
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/prometheus/prometheus.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/prometheus/prometheus.go
@@ -25,6 +25,7 @@ type Ops interface {
 	PodOps
 	RuleOps
 	AlertManagerOps
+	AlertManagerConfigOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)

--- a/vendor/github.com/portworx/torpedo/pkg/stats/stats.go
+++ b/vendor/github.com/portworx/torpedo/pkg/stats/stats.go
@@ -52,7 +52,6 @@ type EventStat struct {
 	DashStats map[string]string
 }
 
-var Dash = aetosutil.Get()
 func getRebootStats(rebootTime, nodeID, pxVersion string) (map[string]string, error) {
 	rebootStats := &NodeRebootStatsType{
 		RebootTime: rebootTime,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1096,7 +1096,7 @@ github.com/portworx/px-object-controller/client/listers/objectservice/v1alpha1
 github.com/portworx/px-object-controller/pkg/client
 github.com/portworx/px-object-controller/pkg/controller
 github.com/portworx/px-object-controller/pkg/utils
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27 => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27 => github.com/portworx/sched-ops v1.20.4-rc1.0.20240213085633-9253e7ad248f
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -2486,7 +2486,7 @@ sigs.k8s.io/yaml
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v0.0.0-20230511212757-41751b27d69f
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 # github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240219181755-4ce81929fd25
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240124012200-74280fbb6e27
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240213085633-9253e7ad248f
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240124200451-5928195f61c0
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3


### PR DESCRIPTION
Handle freeze/thaw for case with two VMs with same nam


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
Fixes Bug PB-5878 where autoExecRules fail if there are more than one vm with same name but different namespace

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no
**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: execRules fails to run if there are two VMs with same name during backup
User Impact: px-backup will fail.
Resolution: Fix 

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

release-24.1.0