### PR TITLE
revert change for torpedo dash variable

### DIFF
--- a/vendor/github.com/portworx/torpedo/pkg/stats/stats.go
+++ b/vendor/github.com/portworx/torpedo/pkg/stats/stats.go
@@ -52,7 +52,6 @@ type EventStat struct {
 	DashStats map[string]string
 }
 
-var Dash = aetosutil.Get()
 func getRebootStats(rebootTime, nodeID, pxVersion string) (map[string]string, error) {
 	rebootStats := &NodeRebootStatsType{
 		RebootTime: rebootTime,


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Unneccessary variable was introduced in torpedo vendor directory, which needs to be reverted

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

