### PR TITLE
PWX-35856: Lastmile migration in failback workflow

### DIFF
--- a/pkg/action/actioncontroller.go
+++ b/pkg/action/actioncontroller.go
@@ -30,6 +30,12 @@ const (
 	validateCRDTimeout           time.Duration = 1 * time.Minute
 	actionExpiryTime             time.Duration = 24 * time.Hour
 	latestMigrationThresholdTime time.Duration = 1 * time.Hour
+
+	nameTimeSuffixFormat    string = "2006-01-02-150405"
+	lastmileMigrationPrefix string = "lastmile"
+	// StorkLastMileMigrationScheduleName is the annotation to keep track of
+	// from which migrationschedule last mile migration spec was generated
+	StorkLastMileMigrationScheduleName = "stork.libopenstorage.org/lastmile-migration-schedule-name"
 )
 
 func NewActionController(mgr manager.Manager, d volume.Driver, r record.EventRecorder) *ActionController {
@@ -121,7 +127,13 @@ func (ac *ActionController) handle(ctx context.Context, action *storkv1.Action) 
 		case storkv1.ActionStageInitial:
 			ac.verifyMigrationScheduleBeforeFailback(action)
 		case storkv1.ActionStageScaleDownDestination:
-			ac.performDeactivateFailBackStage(action)
+			ac.performDeactivateFailBackStageDestination(action)
+		case storkv1.ActionStageLastMileMigration:
+			ac.performLastMileMigration(action)
+		case storkv1.ActionStageScaleUpSource:
+			ac.performActivateFailBackStageSource(action)
+		case storkv1.ActionStageScaleUpDestination:
+			ac.performActivateFailBackStageDestination(action)
 		case storkv1.ActionStageFinal:
 			return nil
 		}

--- a/pkg/action/actioncontroller.go
+++ b/pkg/action/actioncontroller.go
@@ -127,13 +127,13 @@ func (ac *ActionController) handle(ctx context.Context, action *storkv1.Action) 
 		case storkv1.ActionStageInitial:
 			ac.verifyMigrationScheduleBeforeFailback(action)
 		case storkv1.ActionStageScaleDownDestination:
-			ac.performDeactivateFailBackStageDestination(action)
+			ac.deactivateDestinationDuringFailback(action)
 		case storkv1.ActionStageLastMileMigration:
 			ac.performLastMileMigration(action)
 		case storkv1.ActionStageScaleUpSource:
-			ac.performActivateFailBackStageSource(action)
+			ac.activateSourceDuringFailBack(action)
 		case storkv1.ActionStageScaleUpDestination:
-			ac.performActivateFailBackStageDestination(action)
+			ac.activateDestinationDuringFailBack(action)
 		case storkv1.ActionStageFinal:
 			return nil
 		}

--- a/pkg/action/failback.go
+++ b/pkg/action/failback.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"fmt"
+	"strings"
 
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/log"
@@ -10,7 +11,11 @@ import (
 	"github.com/libopenstorage/stork/pkg/utils"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv1.Action) {
@@ -127,7 +132,7 @@ func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv
 			log.ActionLog(action).Infof("The latest migration %s is in threshold range", latestMigration.Name)
 			// Suspend migration schedule
 			suspend := true
-			if *migrationSchedule.Spec.Suspend {
+			if !*migrationSchedule.Spec.Suspend {
 				migrationSchedule.Spec.Suspend = &suspend
 			}
 			msg := fmt.Sprintf("Suspending migration schedule %s before doing failback operation", migrationSchedule.Name)
@@ -156,7 +161,7 @@ func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv
 	}
 }
 
-func (ac *ActionController) performDeactivateFailBackStage(action *storkv1.Action) {
+func (ac *ActionController) performDeactivateFailBackStageDestination(action *storkv1.Action) {
 	if action.Status.Status == storkv1.ActionStatusSuccessful {
 		action.Status.Stage = storkv1.ActionStageLastMileMigration
 		action.Status.Status = storkv1.ActionStatusInitial
@@ -197,7 +202,7 @@ func (ac *ActionController) performDeactivateFailBackStage(action *storkv1.Actio
 	}
 
 	for _, ns := range namespaces {
-		err := resourceutils.ScaleReplicasReturningError(ns, true, true, ac.printFunc(action, "ScaleReplicas"), ac.config)
+		err := resourceutils.ScaleReplicasReturningError(ns, false, true, ac.printFunc(action, "ScaleReplicas"), ac.config)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to scale down replicas: %v", err)
 			log.ActionLog(action).Errorf(msg)
@@ -211,4 +216,270 @@ func (ac *ActionController) performDeactivateFailBackStage(action *storkv1.Actio
 			return
 		}
 	}
+	log.ActionLog(action).Infof("Going to update the action status successful for stage %s", storkv1.ActionStageScaleDownDestination)
+	action.Status.Status = storkv1.ActionStatusSuccessful
+	action.Status.Reason = ""
+	ac.updateAction(action)
+}
+
+func (ac *ActionController) performLastMileMigration(action *storkv1.Action) {
+	if action.Status.Status == storkv1.ActionStatusSuccessful {
+		action.Status.Stage = storkv1.ActionStageScaleUpSource
+		action.Status.Status = storkv1.ActionStatusInitial
+		action.Status.FinishTimestamp = metav1.Now()
+		ac.updateAction(action)
+		return
+	} else if action.Status.Status == storkv1.ActionStatusFailed {
+		action.Status.Stage = storkv1.ActionStageScaleUpDestination
+		action.Status.Status = storkv1.ActionStatusInitial
+		action.Status.FinishTimestamp = metav1.Now()
+		ac.updateAction(action)
+		return
+	}
+
+	migrationSchedule, err := storkops.Instance().GetMigrationSchedule(action.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference, action.Namespace)
+	if err != nil {
+		msg := fmt.Sprintf("error fetching migrationschedule %s/%s for failback", action.Namespace, action.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference)
+		log.ActionLog(action).Errorf(msg)
+		action.Status.Status = storkv1.ActionStatusFailed
+		action.Status.Reason = msg
+		ac.recorder.Event(action,
+			v1.EventTypeWarning,
+			string(storkv1.ActionStatusFailed),
+			msg)
+		ac.updateAction(action)
+		return
+	}
+
+	migrationName := getLastMileMigrationName(migrationSchedule.Name, string(storkv1.ActionTypeFailback), utils.GetShortUID(string(action.UID)))
+	migrationObject, err := storkops.Instance().GetMigration(migrationName, migrationSchedule.Namespace)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			// If last mile migration CR does not exist, create one
+			migration := getLastMileMigrationSpec(migrationSchedule, string(storkv1.ActionTypeFailback), utils.GetShortUID(string(action.UID)))
+			_, err := storkops.Instance().CreateMigration(migration)
+			if err != nil {
+				msg := fmt.Sprintf("Creating last mile migration from migrationschedule %s failed: %v", migrationSchedule.GetName(), err)
+				ac.recorder.Event(action,
+					v1.EventTypeWarning,
+					string(storkv1.ActionStatusFailed),
+					msg)
+				ac.updateAction(action)
+				return
+			}
+			action.Status.Status = storkv1.ActionStatusInProgress
+			ac.updateAction(action)
+			return
+		} else {
+			msg := fmt.Sprintf("Failed to get last mile migration object %s: %v", migrationName, err)
+			log.ActionLog(action).Errorf(msg)
+			ac.recorder.Event(action,
+				v1.EventTypeWarning,
+				string(storkv1.ActionStatusFailed),
+				msg)
+			ac.updateAction(action)
+			return
+		}
+	}
+
+	if migrationObject.Status.Stage == storkv1.MigrationStageFinal {
+		if migrationObject.Status.Status == storkv1.MigrationStatusSuccessful || migrationObject.Status.Status == storkv1.MigrationStatusPartialSuccess {
+			action.Status.Status = storkv1.ActionStatusSuccessful
+		} else {
+			msg := fmt.Sprintf("Failing failback operation as the last mile migration %s failed: status %s", migrationObject.Name, migrationObject.Status.Status)
+			log.ActionLog(action).Errorf(msg)
+			action.Status.Status = storkv1.ActionStatusFailed
+			action.Status.Reason = msg
+			ac.recorder.Event(action,
+				v1.EventTypeWarning,
+				string(storkv1.ActionStatusFailed),
+				msg)
+		}
+		ac.updateAction(action)
+		return
+	}
+	log.ActionLog(action).Infof("Last mile migration %s is still running, currently in stage: %s", migrationObject.Name, migrationObject.Status.Stage)
+}
+
+// getLastMileMigrationSpec will get a migration spec from the given migrationschedule spec
+func getLastMileMigrationSpec(ms *storkv1.MigrationSchedule, operation string, actionCRUID string) *storkv1.Migration {
+
+	migrationName := getLastMileMigrationName(ms.GetName(), operation, actionCRUID)
+	migrationSpec := ms.Spec.Template.Spec
+	// Make startApplications always false
+	startApplications := false
+	migrationSpec.StartApplications = &startApplications
+
+	migration := &storkv1.Migration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      migrationName,
+			Namespace: ms.Namespace,
+		},
+		Spec: migrationSpec,
+	}
+
+	if migration.Annotations == nil {
+		migration.Annotations = make(map[string]string)
+	}
+	for k, v := range ms.Annotations {
+		migration.Annotations[k] = v
+	}
+	migration.Annotations[StorkLastMileMigrationScheduleName] = ms.GetName()
+	return migration
+}
+
+func getLastMileMigrationName(migrationScheduleName string, operation string, inputUID string) string {
+	// +3 is for delimiters
+	suffixLengths := len(lastmileMigrationPrefix) + len(operation) + len(inputUID) + 3
+	// Not adding any datetime as salt to the name as the migration needs to be checked for it's status in each reconciler handler cycle.
+	if len(migrationScheduleName)+suffixLengths > validation.DNS1123SubdomainMaxLength {
+		migrationScheduleName = migrationScheduleName[:validation.DNS1123SubdomainMaxLength-suffixLengths]
+	}
+	return strings.Join([]string{migrationScheduleName,
+		lastmileMigrationPrefix,
+		strings.ToLower(operation),
+		inputUID}, "-")
+}
+
+func (ac *ActionController) performActivateFailBackStageSource(action *storkv1.Action) {
+	// Move to Final stage if this stage succeeds or fails
+	if action.Status.Status == storkv1.ActionStatusSuccessful || action.Status.Status == storkv1.ActionStatusFailed {
+		action.Status.Stage = storkv1.ActionStageFinal
+		action.Status.FinishTimestamp = metav1.Now()
+		ac.updateAction(action)
+		return
+	}
+
+	migrationSchedule, err := storkops.Instance().GetMigrationSchedule(action.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference, action.Namespace)
+	if err != nil {
+		msg := fmt.Sprintf("error fetching migrationschedule %s/%s for failback", action.Namespace, action.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference)
+		log.ActionLog(action).Errorf(msg)
+		action.Status.Status = storkv1.ActionStatusFailed
+		action.Status.Reason = msg
+		ac.recorder.Event(action,
+			v1.EventTypeWarning,
+			string(storkv1.ActionStatusFailed),
+			msg)
+		ac.updateAction(action)
+		return
+	}
+
+	namespaces, err := utils.GetMergedNamespacesWithLabelSelector(migrationSchedule.Spec.Template.Spec.Namespaces, migrationSchedule.Spec.Template.Spec.NamespaceSelectors)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to get list of namespaces from migrationschedule %s", migrationSchedule.Name)
+		log.ActionLog(action).Errorf(msg)
+		ac.recorder.Event(action,
+			v1.EventTypeWarning,
+			string(storkv1.ActionStatusScheduled),
+			msg)
+		ac.updateAction(action)
+		return
+	}
+
+	remoteConfig, err := getClusterPairSchedulerConfig(migrationSchedule.Spec.Template.Spec.ClusterPair, migrationSchedule.Namespace)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to get the remote config from the clusterpair %s", migrationSchedule.Spec.Template.Spec.ClusterPair)
+		log.ActionLog(action).Errorf(msg)
+		action.Status.Status = storkv1.ActionStatusFailed
+		action.Status.Reason = msg
+		ac.recorder.Event(migrationSchedule,
+			v1.EventTypeWarning,
+			string(storkv1.ActionStatusFailed),
+			err.Error())
+		ac.updateAction(action)
+		return
+	}
+
+	scaleupStatus := true
+	failbackSummaryList := make([]*storkv1.FailbackSummary, 0)
+	for _, ns := range namespaces {
+		err := resourceutils.ScaleReplicasReturningError(ns, true, false, ac.printFunc(action, "ScaleReplicas"), remoteConfig)
+		failbackSummary := &storkv1.FailbackSummary{
+			Namespace: ns,
+			Status:    storkv1.ActionStatusSuccessful,
+			Reason:    "",
+		}
+		if err != nil {
+			scaleupStatus = false
+			failbackSummary = &storkv1.FailbackSummary{
+				Namespace: ns,
+				Status:    storkv1.ActionStatusFailed,
+				Reason:    fmt.Sprintf("scaling up apps in namespace %s failed: %v", ns, err),
+			}
+		}
+		failbackSummaryList = append(failbackSummaryList, failbackSummary)
+	}
+	action.Status.Summary = &storkv1.ActionSummary{FailbackSummaryItem: failbackSummaryList}
+	if scaleupStatus {
+		action.Status.Status = storkv1.ActionStatusSuccessful
+	} else {
+		action.Status.Status = storkv1.ActionStatusFailed
+	}
+	ac.updateAction(action)
+
+}
+
+// performActivateFailBackStageDestination will be used for rolling back
+// in case failback operation fails to activate apps in destination cluster
+func (ac *ActionController) performActivateFailBackStageDestination(action *storkv1.Action) {
+
+	// If the status is Successful or Failed, mark the failback operation failed
+	if action.Status.Status == storkv1.ActionStatusSuccessful || action.Status.Status == storkv1.ActionStatusFailed {
+		action.Status.Stage = storkv1.ActionStageFinal
+		action.Status.Status = storkv1.ActionStatusFailed
+		action.Status.FinishTimestamp = metav1.Now()
+		ac.updateAction(action)
+		return
+	}
+
+	migrationSchedule, err := storkops.Instance().GetMigrationSchedule(action.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference, action.Namespace)
+	if err != nil {
+		msg := fmt.Sprintf("error fetching migrationschedule %s/%s for failback", action.Namespace, action.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference)
+		log.ActionLog(action).Errorf(msg)
+		action.Status.Status = storkv1.ActionStatusFailed
+		action.Status.Reason = msg
+		ac.recorder.Event(action,
+			v1.EventTypeWarning,
+			string(storkv1.ActionStatusFailed),
+			msg)
+		ac.updateAction(action)
+		return
+	}
+
+	namespaces, err := utils.GetMergedNamespacesWithLabelSelector(migrationSchedule.Spec.Template.Spec.Namespaces, migrationSchedule.Spec.Template.Spec.NamespaceSelectors)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to get list of namespaces from migrationschedule %s", migrationSchedule.Name)
+		log.ActionLog(action).Errorf(msg)
+		ac.recorder.Event(action,
+			v1.EventTypeWarning,
+			string(storkv1.ActionStatusScheduled),
+			msg)
+		ac.updateAction(action)
+		return
+	}
+
+	for _, ns := range namespaces {
+		err := resourceutils.ScaleReplicasReturningError(ns, true, false, ac.printFunc(action, "ScaleReplicas"), ac.config)
+		if err != nil {
+			msg := fmt.Sprintf("scaling up apps in namespace %s failed: %v", ns, err)
+			log.ActionLog(action).Errorf(msg)
+		}
+	}
+
+	// marking the stage's status as successful even if it hit error while activating apps up
+	action.Status.Status = storkv1.ActionStatusSuccessful
+	ac.updateAction(action)
+}
+
+func getClusterPairSchedulerConfig(clusterPairName string, namespace string) (*restclient.Config, error) {
+	clusterPair, err := storkops.Instance().GetClusterPair(clusterPairName, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("error getting clusterpair (%v/%v): %v", namespace, clusterPairName, err)
+	}
+	remoteClientConfig := clientcmd.NewNonInteractiveClientConfig(
+		clusterPair.Spec.Config,
+		clusterPair.Spec.Config.CurrentContext,
+		&clientcmd.ConfigOverrides{},
+		clientcmd.NewDefaultClientConfigLoadingRules())
+	return remoteClientConfig.ClientConfig()
 }

--- a/pkg/resourceutils/updatereplicas.go
+++ b/pkg/resourceutils/updatereplicas.go
@@ -109,7 +109,7 @@ func updateStatefulSets(namespace string, activate bool, storeOriginalReplicaCou
 	for _, statefulSet := range statefulSets.Items {
 		if replicas, update := getUpdatedReplicaCount(statefulSet.Annotations, activate, printFunc); update {
 			if storeOriginalReplicaCount {
-				statefulSet.Spec.Template.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(*statefulSet.Spec.Replicas))
+				statefulSet.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(*statefulSet.Spec.Replicas))
 			}
 			statefulSet.Spec.Replicas = &replicas
 			_, err := apps.Instance().UpdateStatefulSet(&statefulSet)
@@ -137,7 +137,7 @@ func updateDeployments(namespace string, activate bool, storeOriginalReplicaCoun
 	for _, deployment := range deployments.Items {
 		if replicas, update := getUpdatedReplicaCount(deployment.Annotations, activate, printFunc); update {
 			if storeOriginalReplicaCount {
-				deployment.Spec.Template.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(*deployment.Spec.Replicas))
+				deployment.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(*deployment.Spec.Replicas))
 			}
 			deployment.Spec.Replicas = &replicas
 			_, err := apps.Instance().UpdateDeployment(&deployment)
@@ -167,7 +167,7 @@ func updateReplicaSets(namespace string, activate bool, storeOriginalReplicaCoun
 		}
 		if replicas, update := getUpdatedReplicaCount(replicaset.Annotations, activate, printFunc); update {
 			if storeOriginalReplicaCount {
-				replicaset.Spec.Template.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(*replicaset.Spec.Replicas))
+				replicaset.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(*replicaset.Spec.Replicas))
 			}
 			replicaset.Spec.Replicas = &replicas
 			_, err := apps.Instance().UpdateReplicaSet(&replicaset)
@@ -190,13 +190,14 @@ func updateDeploymentConfigs(namespace string, activate bool, storeOriginalRepli
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			util.CheckErr(err)
+			return err
 		}
-		return err
+		return nil
 	}
 	for _, deployment := range deployments.Items {
 		if replicas, update := getUpdatedReplicaCount(deployment.Annotations, activate, printFunc); update {
 			if storeOriginalReplicaCount {
-				deployment.Spec.Template.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(deployment.Spec.Replicas))
+				deployment.Annotations[migration.StorkMigrationReplicasAnnotation] = strconv.Itoa(int(deployment.Spec.Replicas))
 			}
 			deployment.Spec.Replicas = replicas
 			_, err := openshift.Instance().UpdateDeploymentConfig(&deployment)
@@ -354,8 +355,9 @@ func updateIBPObjects(kind string, namespace string, activate bool, storeOrigina
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			util.CheckErr(err)
+			return err
 		}
-		return err
+		return nil
 	}
 	for _, o := range objects.Items {
 		if replicas, update := getUpdatedReplicaCount(o.GetAnnotations(), activate, printFunc); update {
@@ -417,8 +419,9 @@ func updateVMObjects(kind string, namespace string, activate bool, printFunc fun
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			util.CheckErr(err)
+			return err
 		}
-		return err
+		return nil
 	}
 	for _, o := range objects.Items {
 		path := []string{"spec", "running"}


### PR DESCRIPTION
PWX-35857: Also the rollback functionality where destination deactivated apps needs to be activated have been added.
                       In case of successful migration, apps in source will be activated.


**What type of PR is this?**
feature

**What this PR does / why we need it**:
Handling multiple stages of Failback workflow.
1. Doing last mile migration
2. Activating apps in source.
3. If the last mile migration fails, do rollback by activating apps back in destination cluster.

**Does this PR change a user-facing CRD or CLI?**:
<!--
no
-->

**Is a release note needed?**:
<!--
no
-->


**Does this change need to be cherry-picked to a release branch?**:
Yes, 24.2.0

Test:
Following tests were run and results have been updated in respective tickets.
1. Doing a successful failover with last mile migration and activating apps in source.
2. With failed last mile migration, doing rollback by activating apps in destination.
