### PR TITLE
PB-6013 :: Handling multiple ns having portworx-service

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -534,7 +534,7 @@ func (a *ApplicationRestoreController) updateRestoreCRInVolumeStage(
 			}
 			return restore, nil
 		}
-		logrus.Infof("Updating restore  %s/%s in stage/stagus: %s/%s to volume stage", restore.Namespace, restore.Name, restore.Status.Stage, restore.Status.Status)
+		logrus.Infof("Updating restore  %s/%s in stage/status: %s/%s to volume stage", restore.Namespace, restore.Name, restore.Status.Stage, restore.Status.Status)
 		if namespacemapping != nil {
 			restore.Spec.NamespaceMapping = namespacemapping
 		}


### PR DESCRIPTION
- if you run Portworx in a namespace other than kube-system and not using the default 9001 start port
- if annotation is not set to portworx.io/portworx-proxy: "false"


**What type of PR is this?**
>improvement


**What this PR does / why we need it**:
We don't want to backup NS having portworx csi and hence we were ignoring the NS having portworx-service installed.
We found out that if you run Portworx in a namespace other than kube-system and not using the default 9001 start port then portworx-proxy pods are deployed by default and it has another set of portworx-service installed which was masking the NS actually having portworx service

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**: release-24.1.0
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

**Test Screenshots**
<img width="659" alt="Screenshot 2024-03-12 at 12 12 09 AM" src="https://github.com/libopenstorage/stork/assets/54888022/f2241646-08f2-4a7e-9ff4-6f3a03f688fa">
<img width="1437" alt="Screenshot 2024-03-11 at 11 50 33 PM" src="https://github.com/libopenstorage/stork/assets/54888022/32ca4290-a38c-4ddd-9abb-f0c18a91d29c">
<img width="1564" alt="Screenshot 2024-03-11 at 11 51 04 PM" src="https://github.com/libopenstorage/stork/assets/54888022/ce518ce9-5114-418d-87cb-1a58e240f498">


