### PR TITLE
[PWX-32203] Adding perform failback command and unit tests

### DIFF
--- a/pkg/action/failback.go
+++ b/pkg/action/failback.go
@@ -47,7 +47,7 @@ func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv
 		return
 	}
 
-	if len(action.Spec.ActionParameter.FailbackParameter.Namespaces) > 0 {
+	if len(action.Spec.ActionParameter.FailbackParameter.FailbackNamespaces) > 0 {
 		namespaces, err := utils.GetMergedNamespacesWithLabelSelector(migrationSchedule.Spec.Template.Spec.Namespaces, migrationSchedule.Spec.Template.Spec.NamespaceSelectors)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to get list of namespaces from migrationschedule %s", migrationSchedule.Name)
@@ -60,7 +60,7 @@ func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv
 			return
 		}
 
-		if isSubList, _ := utils.IsSubList(namespaces, action.Spec.ActionParameter.FailbackParameter.Namespaces); !isSubList {
+		if isSubList, _ := utils.IsSubList(namespaces, action.Spec.ActionParameter.FailbackParameter.FailbackNamespaces); !isSubList {
 			msg := fmt.Sprintf("Namespaces provided for failback is not a subset of namespaces from migrationschedule %s", migrationSchedule.Name)
 			log.ActionLog(action).Infof(msg)
 			ac.recorder.Event(action,

--- a/pkg/apis/stork/v1alpha1/action.go
+++ b/pkg/apis/stork/v1alpha1/action.go
@@ -65,7 +65,7 @@ type FailoverParameter struct {
 }
 
 type FailbackParameter struct {
-	Namespaces                 []string `json:"failbackNamespaces"`
+	FailbackNamespaces         []string `json:"failbackNamespaces"`
 	MigrationScheduleReference string   `json:"migrationScheduleReference"`
 }
 

--- a/pkg/storkctl/action.go
+++ b/pkg/storkctl/action.go
@@ -94,7 +94,7 @@ func newFailbackCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 	var excludeNamespaceList []string
 	performFailbackCommand := &cobra.Command{
 		Use:   failbackCommand,
-		Short: "Initiate failover of the given migration schedule",
+		Short: "Initiate failback of the given migration schedule",
 		Run: func(c *cobra.Command, args []string) {
 			// namespace of the MigrationSchedule is provided by the user using the -n / --namespace global flag
 			migrationScheduleNs := cmdFactory.GetNamespace()

--- a/pkg/storkctl/action.go
+++ b/pkg/storkctl/action.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	failoverCommand                    = "failover"
+	failbackCommand                    = "failback"
 	nameTimeSuffixFormat string        = "2006-01-02-150405"
 	actionWaitTimeout    time.Duration = 10 * time.Minute
 	actionWaitInterval   time.Duration = 10 * time.Second
@@ -30,6 +31,7 @@ func newPerformCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams
 
 	performCommands.AddCommand(
 		newFailoverCommand(cmdFactory, ioStreams),
+		newFailbackCommand(cmdFactory, ioStreams),
 	)
 	return performCommands
 }
@@ -54,63 +56,17 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 	var skipDeactivateSource bool
 	var includeNamespaceList []string
 	var excludeNamespaceList []string
-	var namespaceList []string
 	performFailoverCommand := &cobra.Command{
 		Use:   failoverCommand,
 		Short: "Initiate failover of the given migration schedule",
 		Run: func(c *cobra.Command, args []string) {
-			if len(referenceMigrationSchedule) == 0 {
-				util.CheckErr(fmt.Errorf("reference MigrationSchedule name needs to be provided for failover"))
-				return
-			}
-			// namespace of the migrationSchedule is provided by user using the -n / --namespace global flag
+			// namespace of the MigrationSchedule is provided by the user using the -n / --namespace global flag
 			migrationScheduleNs := cmdFactory.GetNamespace()
-			migrSchedObj, err := storkops.Instance().GetMigrationSchedule(referenceMigrationSchedule, migrationScheduleNs)
+			namespaceList, err := validationsForPerformDRCommands(storkv1.ActionTypeFailover, migrationScheduleNs, referenceMigrationSchedule, includeNamespaceList, excludeNamespaceList)
 			if err != nil {
-				util.CheckErr(fmt.Errorf("unable to find the reference MigrationSchedule %v in the %v namespace", referenceMigrationSchedule, migrationScheduleNs))
+				util.CheckErr(err)
 				return
 			}
-			if !skipDeactivateSource {
-				clusterPair := migrSchedObj.Spec.Template.Spec.ClusterPair
-				_, err = storkops.Instance().GetClusterPair(clusterPair, migrationScheduleNs)
-				if err != nil {
-					util.CheckErr(fmt.Errorf("unable to find the cluster pair %v in the %v namespace", clusterPair, migrationScheduleNs))
-					return
-				}
-			}
-			migrationNamespaceList := migrSchedObj.Spec.Template.Spec.Namespaces
-			migrationNamespaceSelectors := migrSchedObj.Spec.Template.Spec.NamespaceSelectors
-			// update the migrationNamespaces list by fetching namespaces based on provided label selectors
-			migrationNamespaces, err := utils.GetMergedNamespacesWithLabelSelector(migrationNamespaceList, migrationNamespaceSelectors)
-			if err != nil {
-				util.CheckErr(fmt.Errorf("unable to get the namespaces based on the --namespace-selectors in the provided MigrationSchedule: %v", err))
-				return
-			}
-			// at most one of exclude-namespaces or include-namespaces can be provided
-			if len(includeNamespaceList) != 0 && len(excludeNamespaceList) != 0 {
-				util.CheckErr(fmt.Errorf("can provide only one of --include-namespaces or --exclude-namespaces values at once"))
-				return
-			} else if len(includeNamespaceList) != 0 {
-				if isSubList, nonSubsetStrings := utils.IsSubList(includeNamespaceList, migrationNamespaces); isSubList {
-					// Branch 1: Only failover some of the namespaces being migrated by the given migrationSchedule
-					namespaceList = includeNamespaceList
-				} else {
-					util.CheckErr(fmt.Errorf("provided namespaces %v are not a subset of the namespaces being migrated by the given MigrationSchedule", nonSubsetStrings))
-					return
-				}
-			} else if len(excludeNamespaceList) != 0 {
-				if isSubList, nonSubsetStrings := utils.IsSubList(excludeNamespaceList, migrationNamespaces); isSubList {
-					// Branch 2: Exclude some of the namespaces being migrated by the given migrationSchedule from failover
-					namespaceList = utils.ExcludeListAFromListB(excludeNamespaceList, migrationNamespaces)
-				} else {
-					util.CheckErr(fmt.Errorf("provided namespaces %v are not a subset of the namespaces being migrated by the given MigrationSchedule", nonSubsetStrings))
-					return
-				}
-			} else {
-				// Branch 3: Failover all the namespaces being migrated by the given migrationSchedule
-				namespaceList = migrationNamespaces
-			}
-			actionType := storkv1.ActionTypeFailover
 			actionParameters := storkv1.ActionParameter{
 				FailoverParameter: storkv1.FailoverParameter{
 					FailoverNamespaces:         namespaceList,
@@ -118,15 +74,11 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 					SkipDeactivateSource:       &skipDeactivateSource,
 				},
 			}
-			actionName := getActionName(actionType, referenceMigrationSchedule)
-			action, err := createActionCR(actionName, migrationScheduleNs, actionType, actionParameters)
-			migrationScheduleName := migrationScheduleNs + "/" + referenceMigrationSchedule
+			err = createActionCR(storkv1.ActionTypeFailover, migrationScheduleNs, referenceMigrationSchedule, actionParameters, ioStreams)
 			if err != nil {
-				util.CheckErr(fmt.Errorf("failed to start failover for MigrationSchedule %v : %v", migrationScheduleName, err))
+				util.CheckErr(err)
 				return
 			}
-			printMsg(fmt.Sprintf("Started failover for MigrationSchedule %v", migrationScheduleName), ioStreams.Out)
-			printMsg(getActionStatusMessage(action), ioStreams.Out)
 		},
 	}
 	performFailoverCommand.Flags().BoolVar(&skipDeactivateSource, "skip-deactivate-source", false, "If present, applications in the source cluster will not be scaled down as part of the failover.")
@@ -136,12 +88,96 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 	return performFailoverCommand
 }
 
-// given the name, namespace, actionType and actionParameters create an Action CR
-func createActionCR(actionName string, namespace string, actionType storkv1.ActionType, actionParameters storkv1.ActionParameter) (*storkv1.Action, error) {
-	action := storkv1.Action{
+func newFailbackCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	var referenceMigrationSchedule string
+	var includeNamespaceList []string
+	var excludeNamespaceList []string
+	performFailbackCommand := &cobra.Command{
+		Use:   failbackCommand,
+		Short: "Initiate failover of the given migration schedule",
+		Run: func(c *cobra.Command, args []string) {
+			// namespace of the MigrationSchedule is provided by the user using the -n / --namespace global flag
+			migrationScheduleNs := cmdFactory.GetNamespace()
+			namespaceList, err := validationsForPerformDRCommands(storkv1.ActionTypeFailback, migrationScheduleNs, referenceMigrationSchedule, includeNamespaceList, excludeNamespaceList)
+			if err != nil {
+				util.CheckErr(err)
+				return
+			}
+			actionParameters := storkv1.ActionParameter{
+				FailbackParameter: storkv1.FailbackParameter{
+					FailbackNamespaces:         namespaceList,
+					MigrationScheduleReference: referenceMigrationSchedule,
+				},
+			}
+			err = createActionCR(storkv1.ActionTypeFailback, migrationScheduleNs, referenceMigrationSchedule, actionParameters, ioStreams)
+			if err != nil {
+				util.CheckErr(err)
+				return
+			}
+		},
+	}
+	performFailbackCommand.Flags().StringVarP(&referenceMigrationSchedule, "migration-reference", "m", "", "Specify the MigrationSchedule to failback. Also specify the namespace of this MigrationSchedule using the -n flag")
+	performFailbackCommand.Flags().StringSliceVar(&includeNamespaceList, "include-namespaces", nil, "Specify the comma-separated list of subset namespaces to be failed back. By default, all namespaces part of the MigrationSchedule are failed back")
+	performFailbackCommand.Flags().StringSliceVar(&excludeNamespaceList, "exclude-namespaces", nil, "Specify the comma-separated list of subset namespaces to be skipped during the failback. By default, all namespaces part of the MigrationSchedule are failed back")
+	return performFailbackCommand
+}
+
+// validationsForPerformDRCommands checks the common validations for failover/failback and returns the resultant namespaceList
+func validationsForPerformDRCommands(actionType storkv1.ActionType, migrationScheduleNs string, referenceMigrationSchedule string, includeNamespaceList []string, excludeNamespaceList []string) ([]string, error) {
+	var namespaceList []string
+	if len(referenceMigrationSchedule) == 0 {
+		return nil, fmt.Errorf("reference MigrationSchedule name needs to be provided for %s", actionType)
+	}
+
+	migrSchedObj, err := storkops.Instance().GetMigrationSchedule(referenceMigrationSchedule, migrationScheduleNs)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find the reference MigrationSchedule %v in the %v namespace", referenceMigrationSchedule, migrationScheduleNs)
+	}
+
+	// clusterPair specified in the reference MigrationSchedule should exist in the destination cluster in both failover and failback
+	clusterPair := migrSchedObj.Spec.Template.Spec.ClusterPair
+	_, err = storkops.Instance().GetClusterPair(clusterPair, migrationScheduleNs)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find the ClusterPair %v in the %v namespace", clusterPair, migrationScheduleNs)
+	}
+
+	migrationNamespaceList := migrSchedObj.Spec.Template.Spec.Namespaces
+	migrationNamespaceSelectors := migrSchedObj.Spec.Template.Spec.NamespaceSelectors
+	// update the migrationNamespaces list by fetching namespaces based on provided label selectors
+	migrationNamespaces, err := utils.GetMergedNamespacesWithLabelSelector(migrationNamespaceList, migrationNamespaceSelectors)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get the namespaces based on the --namespace-selectors in the provided MigrationSchedule: %v", err)
+	}
+	// at most one of exclude-namespaces or include-namespaces can be provided
+	if len(includeNamespaceList) != 0 && len(excludeNamespaceList) != 0 {
+		return nil, fmt.Errorf("can provide only one of --include-namespaces or --exclude-namespaces values at once")
+	} else if len(includeNamespaceList) != 0 {
+		if isSubList, nonSubsetStrings := utils.IsSubList(includeNamespaceList, migrationNamespaces); isSubList {
+			// Branch 1: Only failover/failback some of the namespaces being migrated by the given migrationSchedule
+			namespaceList = includeNamespaceList
+		} else {
+			return nil, fmt.Errorf("provided namespaces %v are not a subset of the namespaces being migrated by the given MigrationSchedule", nonSubsetStrings)
+		}
+	} else if len(excludeNamespaceList) != 0 {
+		if isSubList, nonSubsetStrings := utils.IsSubList(excludeNamespaceList, migrationNamespaces); isSubList {
+			// Branch 2: Exclude some of the namespaces being migrated by the given migrationSchedule from failover/failback
+			namespaceList = utils.ExcludeListAFromListB(excludeNamespaceList, migrationNamespaces)
+		} else {
+			return nil, fmt.Errorf("provided namespaces %v are not a subset of the namespaces being migrated by the given MigrationSchedule", nonSubsetStrings)
+		}
+	} else {
+		// Branch 3: Failover/Failback all the namespaces being migrated by the given migrationSchedule
+		namespaceList = migrationNamespaces
+	}
+	return namespaceList, nil
+}
+
+func createActionCR(actionType storkv1.ActionType, migrationScheduleNs string, referenceMigrationSchedule string, actionParameters storkv1.ActionParameter, ioStreams genericclioptions.IOStreams) error {
+	actionName := getActionName(actionType, referenceMigrationSchedule)
+	actionObj := storkv1.Action{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      actionName,
-			Namespace: namespace,
+			Namespace: migrationScheduleNs,
 		},
 		Spec: storkv1.ActionSpec{
 			ActionType:      actionType,
@@ -149,11 +185,14 @@ func createActionCR(actionName string, namespace string, actionType storkv1.Acti
 		},
 		Status: storkv1.ActionStatus{Status: storkv1.ActionStatusInitial},
 	}
-	actionObj, err := storkops.Instance().CreateAction(&action)
+	action, err := storkops.Instance().CreateAction(&actionObj)
+	migrationScheduleName := migrationScheduleNs + "/" + referenceMigrationSchedule
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to start %s for MigrationSchedule %v : %v", actionType, migrationScheduleName, err)
 	}
-	return actionObj, nil
+	printMsg(fmt.Sprintf("Started %s for MigrationSchedule %v", actionType, migrationScheduleName), ioStreams.Out)
+	printMsg(getActionStatusMessage(action), ioStreams.Out)
+	return nil
 }
 
 func getActionStatusMessage(action *storkv1.Action) string {

--- a/pkg/storkctl/action_test.go
+++ b/pkg/storkctl/action_test.go
@@ -13,67 +13,100 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-func TestPerformFailoverNoMigrationSchedule(t *testing.T) {
+func TestPerformFailoverFailbackNoMigrationSchedule(t *testing.T) {
 	cmdArgs := []string{"perform", "failover"}
 	expected := "error: reference MigrationSchedule name needs to be provided for failover"
 	testCommon(t, cmdArgs, nil, expected, true)
+
+	cmdArgs = []string{"perform", "failback"}
+	expected = "error: reference MigrationSchedule name needs to be provided for failback"
+	testCommon(t, cmdArgs, nil, expected, true)
 }
 
-func TestPerformFailoverInvalidMigrationSchedule(t *testing.T) {
+func TestPerformFailoverFailbackInvalidMigrationSchedule(t *testing.T) {
 	cmdArgs := []string{"perform", "failover", "-m", "invalid-migr-sched"}
 	expected := "error: unable to find the reference MigrationSchedule invalid-migr-sched in the default namespace"
 	testCommon(t, cmdArgs, nil, expected, true)
-}
 
-func TestPerformFailoverWithInvalidNamespaces(t *testing.T) {
-	defer resetTest()
-	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
-	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--include-namespaces", "ns1", "--exclude-namespaces", "ns2", "--skip-deactivate-source", "-n", "kube-system"}
-	expected := "error: can provide only one of --include-namespaces or --exclude-namespaces values at once"
+	cmdArgs = []string{"perform", "failback", "-m", "invalid-migr-sched"}
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
-func TestPerformFailoverWithInvalidIncludeNamespaceList(t *testing.T) {
+func TestPerformFailoverFailbackWithInvalidNamespaces(t *testing.T) {
+	defer resetTest()
+	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
+	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
+	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--include-namespaces", "ns1", "--exclude-namespaces", "ns2", "--skip-deactivate-source", "-n", "kube-system"}
+	expected := "error: can provide only one of --include-namespaces or --exclude-namespaces values at once"
+	testCommon(t, cmdArgs, nil, expected, true)
+
+	cmdArgs = []string{"perform", "failback", "-m", "test-migrationschedule", "--include-namespaces", "ns1", "--exclude-namespaces", "ns2", "-n", "kube-system"}
+	testCommon(t, cmdArgs, nil, expected, true)
+}
+
+func TestPerformFailoverFailbackWithInvalidIncludeNamespaceList(t *testing.T) {
 	defer resetTest()
 	createClusterPair(t, "clusterPair1", "ns1", "async-dr")
 	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1"}, "ns1", false, t)
 	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--include-namespaces", "namespace1", "-n", "ns1"}
 	expected := "error: provided namespaces [namespace1] are not a subset of the namespaces being migrated by the given MigrationSchedule"
 	testCommon(t, cmdArgs, nil, expected, true)
+
+	cmdArgs = []string{"perform", "failback", "-m", "test-migrationschedule", "--include-namespaces", "namespace1", "-n", "ns1"}
+	testCommon(t, cmdArgs, nil, expected, true)
 }
 
-func TestPerformFailoverWithInvalidExcludeNamespaceList(t *testing.T) {
+func TestPerformFailoverFailbackWithInvalidExcludeNamespaceList(t *testing.T) {
 	defer resetTest()
 	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
 	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
 	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--exclude-namespaces", "ns3", "-n", "kube-system"}
 	expected := "error: provided namespaces [ns3] are not a subset of the namespaces being migrated by the given MigrationSchedule"
 	testCommon(t, cmdArgs, nil, expected, true)
+
+	cmdArgs = []string{"perform", "failback", "-m", "test-migrationschedule", "--exclude-namespaces", "ns3", "-n", "kube-system"}
+	testCommon(t, cmdArgs, nil, expected, true)
 }
 
-func TestPerformFailoverMissingClusterPair(t *testing.T) {
+func TestPerformFailoverFailbackMissingClusterPair(t *testing.T) {
 	defer resetTest()
 	mockTheTime()
 	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
 	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "-n", "kube-system"}
-	expected := "error: unable to find the cluster pair clusterPair1 in the kube-system namespace"
+	expected := "error: unable to find the ClusterPair clusterPair1 in the kube-system namespace"
+	testCommon(t, cmdArgs, nil, expected, true)
+
+	cmdArgs = []string{"perform", "failback", "-m", "test-migrationschedule", "-n", "kube-system"}
 	testCommon(t, cmdArgs, nil, expected, true)
 
 	//create clusterPair and try again
 	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
 	failoverActionName := "failover-test-migrationschedule-2024-01-01-000000"
+	cmdArgs = []string{"perform", "failover", "-m", "test-migrationschedule", "-n", "kube-system"}
 	expected = fmt.Sprintf("Started failover for MigrationSchedule kube-system/test-migrationschedule\nTo check failover status use the command : `storkctl get failover %v -n kube-system`\n", failoverActionName)
 	testCommon(t, cmdArgs, nil, expected, false)
 	actionObj, err := storkops.Instance().GetAction(failoverActionName, "kube-system")
 	require.NoError(t, err, "Error getting action")
 	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.FailoverNamespaces, []string{"ns1", "ns2"})
+	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.MigrationScheduleReference, "test-migrationschedule")
 	require.Equal(t, *actionObj.Spec.ActionParameter.FailoverParameter.SkipDeactivateSource, false)
+
+	failbackActionName := "failback-test-migrationschedule-2024-01-01-000000"
+	cmdArgs = []string{"perform", "failback", "-m", "test-migrationschedule", "-n", "kube-system"}
+	expected = fmt.Sprintf("Started failback for MigrationSchedule kube-system/test-migrationschedule\nTo check failback status use the command : `storkctl get failback %v -n kube-system`\n", failbackActionName)
+	testCommon(t, cmdArgs, nil, expected, false)
+	actionObj, err = storkops.Instance().GetAction(failbackActionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	require.Equal(t, actionObj.Spec.ActionParameter.FailbackParameter.FailbackNamespaces, []string{"ns1", "ns2"})
+	require.Equal(t, actionObj.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference, "test-migrationschedule")
+
 }
 
-func TestPerformFailoverWithIncludeNamespaceList(t *testing.T) {
+func TestPerformFailoverFailbackWithIncludeNamespaceList(t *testing.T) {
 	defer resetTest()
 	mockTheTime()
 	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
+	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
 	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--include-namespaces", "ns1", "--skip-deactivate-source", "-n", "kube-system"}
 	failoverActionName := "failover-test-migrationschedule-2024-01-01-000000"
 	expected := fmt.Sprintf("Started failover for MigrationSchedule kube-system/test-migrationschedule\nTo check failover status use the command : `storkctl get failover %v -n kube-system`\n", failoverActionName)
@@ -81,10 +114,21 @@ func TestPerformFailoverWithIncludeNamespaceList(t *testing.T) {
 	actionObj, err := storkops.Instance().GetAction(failoverActionName, "kube-system")
 	require.NoError(t, err, "Error getting action")
 	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.FailoverNamespaces, []string{"ns1"})
+	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.MigrationScheduleReference, "test-migrationschedule")
 	require.Equal(t, *actionObj.Spec.ActionParameter.FailoverParameter.SkipDeactivateSource, true)
+
+	failbackActionName := "failback-test-migrationschedule-2024-01-01-000000"
+	cmdArgs = []string{"perform", "failback", "-m", "test-migrationschedule", "--include-namespaces", "ns1", "-n", "kube-system"}
+	expected = fmt.Sprintf("Started failback for MigrationSchedule kube-system/test-migrationschedule\nTo check failback status use the command : `storkctl get failback %v -n kube-system`\n", failbackActionName)
+	testCommon(t, cmdArgs, nil, expected, false)
+	actionObj, err = storkops.Instance().GetAction(failbackActionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	require.Equal(t, actionObj.Spec.ActionParameter.FailbackParameter.FailbackNamespaces, []string{"ns1"})
+	require.Equal(t, actionObj.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference, "test-migrationschedule")
+
 }
 
-func TestPerformFailoverWithExcludeNamespaceList(t *testing.T) {
+func TestPerformFailoverFailbackWithExcludeNamespaceList(t *testing.T) {
 	defer resetTest()
 	mockTheTime()
 	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
@@ -96,18 +140,34 @@ func TestPerformFailoverWithExcludeNamespaceList(t *testing.T) {
 	actionObj, err := storkops.Instance().GetAction(failoverActionName, "kube-system")
 	require.NoError(t, err, "Error getting action")
 	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.FailoverNamespaces, []string{"ns2"})
+	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.MigrationScheduleReference, "test-migrationschedule")
 	require.Equal(t, *actionObj.Spec.ActionParameter.FailoverParameter.SkipDeactivateSource, false)
+
+	failbackActionName := "failback-test-migrationschedule-2024-01-01-000000"
+	cmdArgs = []string{"perform", "failback", "-m", "test-migrationschedule", "--exclude-namespaces", "ns1", "-n", "kube-system"}
+	expected = fmt.Sprintf("Started failback for MigrationSchedule kube-system/test-migrationschedule\nTo check failback status use the command : `storkctl get failback %v -n kube-system`\n", failbackActionName)
+	testCommon(t, cmdArgs, nil, expected, false)
+	actionObj, err = storkops.Instance().GetAction(failbackActionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	require.Equal(t, actionObj.Spec.ActionParameter.FailbackParameter.FailbackNamespaces, []string{"ns2"})
+	require.Equal(t, actionObj.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference, "test-migrationschedule")
 }
 
-func TestFailoverActionNameTruncation(t *testing.T) {
+func TestFailoverFailbackActionNameTruncation(t *testing.T) {
 	defer resetTest()
 	mockTheTime()
 	strWithLen253 := "utttaxvjedvxmjexmnapepwctfmjgydmidpcaantcarptudqufcpvideuttwbzgqxtexuceqnwnecxabuwaqzqypjxcvyubkwtpapziwkpdxzqfyjkyxnikfiauqvpktpkdurfzjrmyjzmhqhuqnpfjdnavfbkrrjqamtmjiphpdggcafmqugrmvqzwfchkukdeudbpxdzqqzeayjgcnphprurepjrqcwxbxrpnyhbdzkqveiukyzeghenfvp"
 	truncatedStr := strWithLen253[:validation.DNS1123SubdomainMaxLength-len("failover")-len("2024-01-01-000000")-2]
 	createTestMigrationSchedule(strWithLen253, "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", false, t)
+	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
 	cmdArgs := []string{"perform", "failover", "-m", strWithLen253, "--exclude-namespaces", "ns1", "--skip-deactivate-source", "-n", "kube-system"}
 	failoverActionName := fmt.Sprintf("failover-%v-2024-01-01-000000", truncatedStr)
 	expected := fmt.Sprintf("Started failover for MigrationSchedule kube-system/%v\nTo check failover status use the command : `storkctl get failover %v -n kube-system`\n", strWithLen253, failoverActionName)
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	failbackActionName := fmt.Sprintf("failback-%v-2024-01-01-000000", truncatedStr)
+	cmdArgs = []string{"perform", "failback", "-m", strWithLen253, "--exclude-namespaces", "ns1", "-n", "kube-system"}
+	expected = fmt.Sprintf("Started failback for MigrationSchedule kube-system/%v\nTo check failback status use the command : `storkctl get failback %v -n kube-system`\n", strWithLen253, failbackActionName)
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
>feature
>unit-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
Yes, adds a new storkctl command `storkctl perform failback`

```
[root@ip-10-13-194-37 ~]# storkctl perform failback -h
Initiate failback of the given migration schedule

Usage:
  storkctl perform failback [flags]

Flags:
      --exclude-namespaces strings   Specify the comma-separated list of subset namespaces to be skipped during the failback. By default, all namespaces part of the MigrationSchedule are failed back
  -h, --help                         help for failback
      --include-namespaces strings   Specify the comma-separated list of subset namespaces to be failed back. By default, all namespaces part of the MigrationSchedule are failed back
  -m, --migration-reference string   Specify the MigrationSchedule to failback. Also specify the namespace of this MigrationSchedule using the -n flag

```

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
24.2.0

**Testing Details**:
Have added comprehensive unit tests and tested all combinations manually as well
