### PR TITLE
PWX-36282: Improve the GetPodVolumes() implementation for the Portworx Driver.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -252,15 +251,16 @@ var restoreStateCallBackoff = wait.Backoff{
 }
 
 type portworx struct {
-	store           cache.Store
-	stopChannel     chan struct{}
-	sdkConn         *portworxGrpcConnection
-	id              string
-	endpoint        string
-	tlsConfig       *tls.Config
-	jwtSharedSecret string
-	jwtIssuer       string
-	initDone        bool
+	store             cache.Store
+	stopChannel       chan struct{}
+	sdkConn           *portworxGrpcConnection
+	id                string
+	endpoint          string
+	tlsConfig         *tls.Config
+	jwtSharedSecret   string
+	jwtIssuer         string
+	initDone          bool
+	getAdminVolDriver func() (volume.VolumeDriver, error)
 }
 
 type portworxGrpcConnection struct {
@@ -506,35 +506,76 @@ func (p *portworx) inspectVolume(volDriver volume.VolumeDriver, volumeID string)
 			Type: "Volume",
 		}
 	}
+	return p.constructStorkVolume(vols[0]), nil
+}
 
+func (p *portworx) constructStorkVolume(vol *api.Volume) *storkvolume.Info {
 	info := &storkvolume.Info{}
-	info.VolumeID = vols[0].Id
+	info.VolumeID = vol.Id
 
-	info.VolumeName = vols[0].Locator.Name
-	for _, rset := range vols[0].ReplicaSets {
+	info.VolumeName = vol.Locator.Name
+	for _, rset := range vol.ReplicaSets {
 		info.DataNodes = append(info.DataNodes, rset.Nodes...)
 	}
-	if vols[0].Source != nil {
-		info.ParentID = vols[0].Source.Parent
+	if vol.Source != nil {
+		info.ParentID = vol.Source.Parent
 	}
 
 	info.Labels = make(map[string]string)
-	for k, v := range vols[0].Spec.GetVolumeLabels() {
+	for k, v := range vol.Spec.GetVolumeLabels() {
 		info.Labels[k] = v
 	}
 
-	for k, v := range vols[0].Locator.GetVolumeLabels() {
+	for k, v := range vol.Locator.GetVolumeLabels() {
 		info.Labels[k] = v
 	}
-	info.NeedsAntiHyperconvergence = vols[0].Spec.Sharedv4 && vols[0].Spec.Sharedv4ServiceSpec != nil
+	info.NeedsAntiHyperconvergence = vol.Spec.Sharedv4 && vol.Spec.Sharedv4ServiceSpec != nil
 
 	info.WindowsVolume = p.volumePrefersWindowsNodes(info)
 
-	info.VolumeSourceRef = vols[0]
+	info.VolumeSourceRef = vol
 
-	info.AttachedOn = vols[0].AttachedOn
+	info.AttachedOn = vol.AttachedOn
 
-	return info, nil
+	return info
+
+}
+
+func (p *portworx) enumerateVolumes(volumeNameList []string) (map[string]*storkvolume.Info, error) {
+	if !p.initDone {
+		if err := p.initPortworxClients(); err != nil {
+			return nil, err
+		}
+	}
+
+	volDriver, err := p.getAdminVolDriver()
+	if err != nil {
+		return nil, err
+	}
+	volMap := make(map[string]*storkvolume.Info)
+	vols, err := volDriver.Enumerate(
+		&api.VolumeLocator{
+			VolumeIds: volumeNameList,
+		},
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for _, volName := range volumeNameList {
+		storkVol := &storkvolume.Info{
+			VolumeID: volName,
+		}
+		for _, vol := range vols {
+			if vol.Locator.Name == volName || vol.Id == volName {
+				storkVol = p.constructStorkVolume(vol)
+				break
+			}
+		}
+		volMap[volName] = storkVol
+	}
+
+	return volMap, nil
 }
 
 // volumePrefersWindowsNodes checks if "winshare" label is applied to the volume
@@ -745,7 +786,7 @@ func (p *portworx) IsSupportedPVC(coreOps core.Ops, pvc *v1.PersistentVolumeClai
 	if storageClassName != "" {
 		var storageClass *storagev1.StorageClass
 		var err error
-		if !reflect.ValueOf(storkcache.Instance()).IsNil() {
+		if storkcache.Instance() != nil {
 			storageClass, err = storkcache.Instance().GetStorageClass(storageClassName)
 		} else {
 			storageClass, err = storage.Instance().GetStorageClass(storageClassName)
@@ -813,6 +854,8 @@ func (p *portworx) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includeP
 	// includePendingWFFC - Includes pending volumes in the second return value if they are using WaitForFirstConsumer binding mode
 	var volumes []*storkvolume.Info
 	var pendingWFFCVolumes []*storkvolume.Info
+	pvcMap := make(map[string]*v1.PersistentVolumeClaim)
+	var volumeNameList []string
 	for _, volume := range podSpec.Volumes {
 		volumeName := ""
 		isPendingWFFC := false
@@ -835,6 +878,18 @@ func (p *portworx) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includeP
 			if pvc.Status.Phase == v1.ClaimPending {
 				// Only include pending volume if requested and storage class has WFFC
 				if includePendingWFFC && isWaitingForFirstConsumer(pvc) {
+					// For pending volumes we won't query Portworx.
+					// Populate at lease something about these volumes
+					wffcVol := &storkvolume.Info{
+						// this would be empty for pending volumes, but the callers are simply
+						// checking for the existence of such a volume and not its contents
+						VolumeName: pvc.Spec.VolumeName,
+					}
+					wffcVol.Labels = make(map[string]string)
+					for k, v := range pvc.ObjectMeta.Annotations {
+						wffcVol.Labels[k] = v
+					}
+					pendingWFFCVolumes = append(pendingWFFCVolumes, wffcVol)
 					isPendingWFFC = true
 				} else {
 					return nil, nil, &storkvolume.ErrPVCPending{
@@ -843,37 +898,49 @@ func (p *portworx) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includeP
 				}
 			}
 			volumeName = pvc.Spec.VolumeName
+			pvcMap[volumeName] = pvc
 		} else if volume.PortworxVolume != nil {
 			volumeName = volume.PortworxVolume.VolumeID
 		}
-
-		if volumeName != "" {
-			volumeInfo, err := p.InspectVolume(volumeName)
-			if err != nil {
-				logrus.Warnf("Failed to inspect volume %v: %v", volumeName, err)
-				// If the inspect volume fails return with atleast some info
-				volumeInfo = &storkvolume.Info{
+		// If a volume is pending and WFFC, it doesn't exist in Portworx.
+		// No need of querying it.
+		if !isPendingWFFC {
+			volumeNameList = append(volumeNameList, volumeName)
+		}
+	}
+	var (
+		volInfos map[string]*storkvolume.Info
+		err      error
+	)
+	if len(volumeNameList) > 0 {
+		// Lets get all the volumes in one shot
+		volInfos, err = p.enumerateVolumes(volumeNameList)
+		if err != nil {
+			logrus.Warnf("Failed to enumerate volumes %v: %v", volumeNameList, err)
+			volInfos = make(map[string]*storkvolume.Info)
+			for _, volumeName := range volumeNameList {
+				// Populate at lease something about the volumes
+				volInfos[volumeName] = &storkvolume.Info{
 					VolumeName: volumeName,
 				}
 			}
-			// Add the annotations as volume labels
-			if len(volumeInfo.Labels) == 0 {
-				volumeInfo.Labels = make(map[string]string)
-			}
-
-			if pvc != nil {
-				for k, v := range pvc.ObjectMeta.Annotations {
-					volumeInfo.Labels[k] = v
-				}
-			}
-
-			if isPendingWFFC {
-				pendingWFFCVolumes = append(pendingWFFCVolumes, volumeInfo)
-			} else {
-				volumes = append(volumes, volumeInfo)
-			}
 		}
 	}
+
+	for volumeName, volumeInfo := range volInfos {
+		// Add the annotations as volume labels
+		if len(volumeInfo.Labels) == 0 {
+			volumeInfo.Labels = make(map[string]string)
+		}
+		pvc, ok := pvcMap[volumeName]
+		if ok && pvc != nil {
+			for k, v := range pvc.ObjectMeta.Annotations {
+				volumeInfo.Labels[k] = v
+			}
+		}
+		volumes = append(volumes, volumeInfo)
+	}
+
 	return volumes, pendingWFFCVolumes, nil
 }
 
@@ -1063,7 +1130,7 @@ func (p *portworx) getUserVolDriver(annotations map[string]string, namespace str
 	return volDriver, err
 }
 
-func (p *portworx) getAdminVolDriver() (volume.VolumeDriver, error) {
+func (p *portworx) adminVolDriver() (volume.VolumeDriver, error) {
 	if len(p.jwtSharedSecret) != 0 {
 		claims := &auth.Claims{
 			Issuer: p.jwtIssuer,
@@ -2762,7 +2829,7 @@ func (p *portworx) UpdateMigratedPersistentVolumeSpec(
 	if len(pv.Spec.StorageClassName) != 0 {
 		var sc *storagev1.StorageClass
 		var err error
-		if !reflect.ValueOf(storkcache.Instance()).IsNil() {
+		if storkcache.Instance() != nil {
 			sc, err = storkcache.Instance().GetStorageClass(pv.Spec.StorageClassName)
 		} else {
 			sc, err = storage.Instance().GetStorageClass(pv.Spec.StorageClassName)
@@ -3718,7 +3785,7 @@ func (p *portworx) getCloudBackupRestoreSpec(
 	var sc *storagev1.StorageClass
 	var err error
 	if len(destStorageClass) != 0 {
-		if !reflect.ValueOf(storkcache.Instance()).IsNil() {
+		if storkcache.Instance() != nil {
 			sc, err = storkcache.Instance().GetStorageClass(destStorageClass)
 		} else {
 			sc, err = storage.Instance().GetStorageClass(destStorageClass)
@@ -4404,6 +4471,8 @@ func (p *portworx) statfsConfigMapNeedsUpdate(existing *v1.ConfigMap, expectedSu
 
 func init() {
 	p := &portworx{}
+	// Defining this override helps in UTs
+	p.getAdminVolDriver = p.adminVolDriver
 	err := p.Init(nil)
 	if err != nil {
 		logrus.Debugf("Error init'ing portworx driver: %v", err)

--- a/drivers/volume/portworx/portworx_test.go
+++ b/drivers/volume/portworx/portworx_test.go
@@ -1,0 +1,382 @@
+package portworx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/volume"
+	storkvolume "github.com/libopenstorage/stork/drivers/volume"
+	"github.com/libopenstorage/stork/pkg/cache"
+	mockcache "github.com/libopenstorage/stork/pkg/mock/cache"
+	mockosd "github.com/libopenstorage/stork/pkg/mock/osd"
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetes "k8s.io/client-go/kubernetes/fake"
+
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+const (
+	scName      = "sc1"
+	pvcAnnKey   = "ann1"
+	pvcAnnValue = "val1"
+)
+
+func TestGetPodVolumesSinglePVC(t *testing.T) {
+	// Setup
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockDriver := mockosd.NewMockVolumeDriver(mockCtrl)
+	mockCache := mockcache.NewMockSharedInformerCache(mockCtrl)
+	p := setup(mockDriver, mockCache)
+
+	// Create a sample pod with volumes
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "volume1",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "claim1",
+						},
+					},
+				},
+			},
+		},
+	}
+	createPVAndPVC("claim1", "ns1", "pv1", v1.ClaimBound)
+
+	bindingMode := storagev1.VolumeBindingImmediate
+	mockCache.EXPECT().GetStorageClass(scName).Return(&storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: scName,
+		},
+		VolumeBindingMode: &bindingMode,
+	}, nil).Times(1)
+
+	mockDriver.EXPECT().Enumerate(
+		&api.VolumeLocator{
+			VolumeIds: []string{"pv1"},
+		}, nil).Return([]*api.Volume{
+		{
+			Id: "id1",
+			Locator: &api.VolumeLocator{
+				Name:         "pv1",
+				VolumeLabels: map[string]string{"k": "v"},
+			},
+			Spec: &api.VolumeSpec{
+				Sharedv4:            true,
+				Sharedv4ServiceSpec: &api.Sharedv4ServiceSpec{},
+				VolumeLabels:        map[string]string{"k1": "v1"},
+			},
+		},
+	}, nil)
+	// Call the GetPodVolumes function
+	volumes, volumesWFFC, err := p.GetPodVolumes(&pod.Spec, "ns1", true)
+	require.NoError(t, err, "failed to get pod volumes")
+	require.Len(t, volumes, 1, "incorrect volume count")
+
+	// Make sure constructStorkVolume returns the correct values
+	require.Equal(t, "id1", volumes[0].VolumeID, "incorrect volume id")
+	require.Equal(t, "pv1", volumes[0].VolumeName, "incorrect volume name")
+	require.Equal(t, "v", volumes[0].Labels["k"], "incorrect volume labels from locator")
+	require.Equal(t, pvcAnnValue, volumes[0].Labels[pvcAnnKey], "annotations not found")
+	require.True(t, volumes[0].NeedsAntiHyperconvergence, "incorrect anti-hyperconvergence flag")
+	require.Equal(t, "v1", volumes[0].Labels["k1"], "incorrect volume labels from spec")
+
+	require.Len(t, volumesWFFC, 0, "volumesWFFC should not be found")
+
+	// Change a few return parameters from Enumerate
+
+	mockCache.EXPECT().GetStorageClass(scName).Return(&storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: scName,
+		},
+		VolumeBindingMode: &bindingMode,
+	}, nil).Times(1)
+	mockDriver.EXPECT().Enumerate(
+		&api.VolumeLocator{
+			VolumeIds: []string{"pv1"},
+		}, nil).Return([]*api.Volume{
+		{
+			Id: "id1",
+			Locator: &api.VolumeLocator{
+				Name: "pv1",
+			},
+			Spec: &api.VolumeSpec{},
+		},
+	}, nil)
+	// Call the GetPodVolumes function
+	volumes, volumesWFFC, err = p.GetPodVolumes(&pod.Spec, "ns1", true)
+	require.NoError(t, err, "failed to get pod volumes")
+	require.Len(t, volumes, 1, "incorrect volume count")
+
+	// Make sure constructStorkVolume returns the correct values
+	require.Equal(t, "id1", volumes[0].VolumeID, "incorrect volume id")
+	require.Equal(t, "pv1", volumes[0].VolumeName, "incorrect volume name")
+	require.Len(t, volumes[0].Labels, 1, "incorrect volume labels")
+	require.Equal(t, pvcAnnValue, volumes[0].Labels[pvcAnnKey], "annotations not found")
+	require.False(t, volumes[0].NeedsAntiHyperconvergence, "incorrect anti-hyperconvergence flag")
+
+	require.Len(t, volumesWFFC, 0, "volumesWFFC should not be found")
+
+	// Enumerate fails
+	mockCache.EXPECT().GetStorageClass(scName).Return(&storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: scName,
+		},
+		VolumeBindingMode: &bindingMode,
+	}, nil).Times(1)
+	mockDriver.EXPECT().Enumerate(
+		&api.VolumeLocator{
+			VolumeIds: []string{"pv1"},
+		}, nil).Return(nil, fmt.Errorf("some error"))
+	// Call the GetPodVolumes function
+	volumes, volumesWFFC, err = p.GetPodVolumes(&pod.Spec, "ns1", true)
+	require.NoError(t, err, "failed to get pod volumes")
+	require.Len(t, volumes, 1, "incorrect volume count")
+
+	require.Empty(t, volumes[0].VolumeID, "volume id should be empty")
+	require.Equal(t, "pv1", volumes[0].VolumeName, "incorrect volume name")
+	require.Len(t, volumes[0].Labels, 1, "incorrect volume labels")
+	require.Equal(t, pvcAnnValue, volumes[0].Labels[pvcAnnKey], "annotations should be returned even if enumerate fails")
+
+	require.Len(t, volumesWFFC, 0, "volumesWFFC should not be found")
+}
+
+func TestGetPodVolumesMultiplePVC(t *testing.T) {
+	// Setup
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockDriver := mockosd.NewMockVolumeDriver(mockCtrl)
+	mockCache := mockcache.NewMockSharedInformerCache(mockCtrl)
+	p := setup(mockDriver, mockCache)
+
+	// Create a sample pod with volumes
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "volume1",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "claim1",
+						},
+					},
+				},
+				{
+					Name: "volume2",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "claim2",
+						},
+					},
+				},
+			},
+		},
+	}
+	createPVAndPVC("claim1", "ns1", "pv1", v1.ClaimBound)
+	createPVAndPVC("claim2", "ns1", "pv2", v1.ClaimBound)
+
+	bindingMode := storagev1.VolumeBindingImmediate
+	mockCache.EXPECT().GetStorageClass(scName).Return(&storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: scName,
+		},
+		VolumeBindingMode: &bindingMode,
+	}, nil).Times(2)
+
+	mockDriver.EXPECT().Enumerate(
+		&api.VolumeLocator{
+			VolumeIds: []string{"pv1", "pv2"},
+		}, nil).Return([]*api.Volume{
+		{
+			Id: "id1",
+			Locator: &api.VolumeLocator{
+				Name: "pv1",
+			},
+			Spec: &api.VolumeSpec{},
+		},
+		{
+			Id: "id2",
+			Locator: &api.VolumeLocator{
+				Name: "pv2",
+			},
+			Spec: &api.VolumeSpec{},
+		},
+	}, nil)
+	// Call the GetPodVolumes function
+	volumes, volumesWFFC, err := p.GetPodVolumes(&pod.Spec, "ns1", true)
+	require.NoError(t, err, "failed to get pod volumes")
+	require.Len(t, volumes, 2, "incorrect volume count")
+	require.Len(t, volumesWFFC, 0, "volumesWFFC should not be found")
+}
+
+func TestGetPodVolumesMultiplePVCWFFC(t *testing.T) {
+	// Setup
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockDriver := mockosd.NewMockVolumeDriver(mockCtrl)
+	mockCache := mockcache.NewMockSharedInformerCache(mockCtrl)
+	p := setup(mockDriver, mockCache)
+
+	// Create a sample pod with volumes
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "volume1",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "claim1",
+						},
+					},
+				},
+				{
+					Name: "volume2",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "claim2",
+						},
+					},
+				},
+			},
+		},
+	}
+	createPVAndPVC("claim1", "ns1", "pv1", v1.ClaimPending)
+	createPVAndPVC("claim2", "ns1", "pv2", v1.ClaimBound)
+
+	// Enumerate should be called only for one PVC which is Bound
+	mockDriver.EXPECT().Enumerate(
+		&api.VolumeLocator{
+			VolumeIds: []string{"pv2"},
+		}, nil).Return([]*api.Volume{
+		{
+			Id: "id2",
+			Locator: &api.VolumeLocator{
+				Name: "pv2",
+			},
+			Spec: &api.VolumeSpec{},
+		},
+	}, nil)
+
+	bindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+	mockCache.EXPECT().GetStorageClass(scName).Return(&storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: scName,
+		},
+		VolumeBindingMode: &bindingMode,
+	}, nil).Times(3)
+	// Call the GetPodVolumes function
+	volumes, volumesWFFC, err := p.GetPodVolumes(&pod.Spec, "ns1", true)
+	require.NoError(t, err, "failed to get pod volumes")
+	require.Len(t, volumes, 1, "incorrect volume count")
+	require.Equal(t, "id2", volumes[0].VolumeID, "incorrect volume id")
+	require.Equal(t, "pv2", volumes[0].VolumeName, "incorrect volume name")
+	require.Len(t, volumesWFFC, 1, "volumesWFFC should not be found")
+	require.Equal(t, "", volumesWFFC[0].VolumeID, "volume id should be empty")
+	require.Equal(t, pvcAnnValue, volumes[0].Labels[pvcAnnKey], "annotations should be returned for WFFC volumes")
+}
+
+func TestGetPodVolumesPendingPVCs(t *testing.T) {
+	// Setup
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockDriver := mockosd.NewMockVolumeDriver(mockCtrl)
+	mockCache := mockcache.NewMockSharedInformerCache(mockCtrl)
+	p := setup(mockDriver, mockCache)
+
+	// Create a sample pod with volumes
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "volume1",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "claim1",
+						},
+					},
+				},
+				{
+					Name: "volume2",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "claim2",
+						},
+					},
+				},
+			},
+		},
+	}
+	createPVAndPVC("claim1", "ns1", "pv1", v1.ClaimPending)
+	createPVAndPVC("claim2", "ns1", "pv2", v1.ClaimBound)
+
+	bindingMode := storagev1.VolumeBindingImmediate
+	mockCache.EXPECT().GetStorageClass(scName).Return(&storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: scName,
+		},
+		VolumeBindingMode: &bindingMode,
+	}, nil).Times(2)
+
+	// Enumerate should not be called
+	// Call the GetPodVolumes function
+	volumes, volumesWFFC, err := p.GetPodVolumes(&pod.Spec, "ns1", true)
+	require.Error(t, err, "GetPodVolumes should fail")
+	require.Equal(t, err.Error(), "PVC is pending for claim1", "incorrect error message")
+	require.Len(t, volumes, 0, "incorrect volume count")
+	require.Len(t, volumesWFFC, 0, "volumesWFFC should not be found")
+}
+
+func createPVAndPVC(name, namespace, pvName string, status v1.PersistentVolumeClaimPhase) {
+	sc := scName
+	core.Instance().CreatePersistentVolumeClaim(&v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				pvcAnnKey: pvcAnnValue,
+			},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName:       pvName,
+			StorageClassName: &sc,
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: status,
+		},
+	})
+	core.Instance().CreatePersistentVolume(&v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pvName,
+			Annotations: map[string]string{
+				pvProvisionedByAnnotation: provisionerName,
+			},
+		}})
+}
+
+func setup(mockDriver volume.VolumeDriver, mockCache cache.SharedInformerCache) storkvolume.Driver {
+	p := &portworx{
+		initDone: true,
+	}
+
+	p.getAdminVolDriver = func() (volume.VolumeDriver, error) {
+		return mockDriver, nil
+	}
+
+	fakeKubeClient := kubernetes.NewSimpleClientset()
+
+	scheme.AddToScheme(scheme.Scheme)
+
+	// setup fake k8s instances
+	core.SetInstance(core.New(fakeKubeClient))
+	cache.SetTestInstance(mockCache)
+	return p
+}

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -3,7 +3,6 @@ package resourcecollector
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -241,7 +240,7 @@ func (r *ResourceCollector) GetResourceTypes(
 	var crdResources []metav1.GroupVersionKind
 	var crdList *stork_api.ApplicationRegistrationList
 	storkcache.Instance()
-	if !reflect.ValueOf(storkcache.Instance()).IsNil() {
+	if storkcache.Instance() != nil {
 		crdList, err = storkcache.Instance().ListApplicationRegistrations()
 	} else {
 		crdList, err = r.storkOps.ListApplicationRegistrations()
@@ -359,7 +358,7 @@ func (r *ResourceCollector) GetResourcesForType(
 		return nil, nil, err
 	}
 	var crdList *stork_api.ApplicationRegistrationList
-	if !reflect.ValueOf(storkcache.Instance()).IsNil() {
+	if storkcache.Instance() != nil {
 		crdList, err = storkcache.Instance().ListApplicationRegistrations()
 	} else {
 		crdList, err = r.storkOps.ListApplicationRegistrations()
@@ -407,7 +406,7 @@ func (r *ResourceCollector) GetResourcesExcludingTypes(
 	resourceMap := make(map[types.UID]bool)
 	var crdResources []metav1.GroupVersionKind
 	var crdList *stork_api.ApplicationRegistrationList
-	if !reflect.ValueOf(storkcache.Instance()).IsNil() {
+	if storkcache.Instance() != nil {
 		crdList, err = storkcache.Instance().ListApplicationRegistrations()
 	} else {
 		crdList, err = r.storkOps.ListApplicationRegistrations()
@@ -508,7 +507,7 @@ func (r *ResourceCollector) GetResources(
 	resourceMap := make(map[types.UID]bool)
 	var crdResources []metav1.GroupVersionKind
 	var crdList *stork_api.ApplicationRegistrationList
-	if !reflect.ValueOf(storkcache.Instance()).IsNil() {
+	if storkcache.Instance() != nil {
 		crdList, err = storkcache.Instance().ListApplicationRegistrations()
 	} else {
 		crdList, err = r.storkOps.ListApplicationRegistrations()

--- a/test/integration_test/health_monitor_test.go
+++ b/test/integration_test/health_monitor_test.go
@@ -47,7 +47,7 @@ func stopDriverTest(t *testing.T) {
 	defer updateDashStats(t.Name(), &testResult)
 
 	ctxs, err := schedulerDriver.Schedule(generateInstanceID(t, "stopdrivertest"),
-		scheduler.ScheduleOptions{AppKeys: []string{"mysql-1-pvc"}})
+		scheduler.ScheduleOptions{AppKeys: []string{"mysql-2-pvc"}})
 	log.FailOnError(t, err, "Error scheduling task")
 	Dash.VerifyFatal(t, 1, len(ctxs), "Only one task should have started")
 
@@ -59,7 +59,7 @@ func stopDriverTest(t *testing.T) {
 	Dash.VerifyFatal(t, 1, len(scheduledNodes), "App should be scheduled on one node")
 
 	volumeNames := getVolumeNames(t, ctxs[0])
-	Dash.VerifyFatal(t, 1, len(volumeNames), "Should have one volume")
+	Dash.VerifyFatal(t, 2, len(volumeNames), "Should have two volumes")
 
 	verifyScheduledNode(t, scheduledNodes[0], volumeNames)
 


### PR DESCRIPTION


**What type of PR is this?**

>improvement

**What this PR does / why we need it**:

- Instead of sending individual Inspect() requests for each volume in a pod send a single Enumerate() request with all volumes in it. This is also less intensive on the Portworx side.
- Modify the Transform function in the SharedInformerCache to only store pod volumes which are relevant for stork.
- Added a framework to unit test the Portworx driver. Added UTs for GetPodVolumes() implementation.
- Modify the health monitor integration test to use mysql spec that has two volumes.


**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:

```release-note
Improvement: The Portworx driver has optimized the API calls it makes to reduce the time taken for scheduling pods and monitoring pods if they need to be rescheduled if Portworx is down on nodes. 
```

**Does this change need to be cherry-picked to a release branch?**:
Yes - 24.2.0

