### PR TITLE
PB-6115 Handling label validation for Data Export CR

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -262,7 +262,7 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		labels[utils.ApplicationBackupCRUIDKey] = utils.GetValidLabel(utils.GetShortUID(string(backup.UID)))
 		labels[pvcNameKey] = utils.GetValidLabel(pvc.Name)
 		labels[pvcUIDKey] = utils.GetValidLabel(utils.GetShortUID(string(pvc.UID)))
-		labels[kdmpStorageClassKey] = volumeInfo.StorageClass
+		labels[kdmpStorageClassKey] = utils.GetValidLabel(volumeInfo.StorageClass)
 		// If backup from px-backup, update the backup object details in the label
 		if val, ok := backup.Annotations[utils.PxbackupAnnotationCreateByKey]; ok {
 			if val == utils.PxbackupAnnotationCreateByValue {
@@ -283,6 +283,7 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		dataExport.Annotations[utils.SkipResourceAnnotation] = "true"
 		dataExport.Annotations[utils.BackupObjectUIDKey] = string(backup.Annotations[utils.PxbackupObjectUIDKey])
 		dataExport.Annotations[pvcUIDKey] = string(pvc.UID)
+		dataExport.Annotations[kdmpStorageClassKey] = volumeInfo.StorageClass
 		dataExport.Name = getGenericCRName(utils.PrefixBackup, string(backup.UID), string(pvc.UID), pvc.Namespace)
 		dataExport.Namespace = pvc.Namespace
 		dataExport.Spec.Type = kdmpapi.DataExportKopia

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
@@ -267,7 +267,7 @@ func (c *Controller) sync(ctx context.Context, in *kdmpapi.DataExport) (bool, er
 		var compressionType string
 		var podDataPath string
 		var excludeFileList string
-		pvcStorageClass := dataExport.Labels[kdmpStorageClassKey]
+		pvcStorageClass := dataExport.Annotations[kdmpStorageClassKey]
 		var backupLocation *storkapi.BackupLocation
 		var data updateDataExportDetail
 		if driverName != drivers.Rsync {


### PR DESCRIPTION
- if the StorageClass name has more than 63 characters we fail to deploy the corresponding pod
- use annotation for storing SC name in DataExport CR


**What type of PR is this?**
>bug

**What this PR does / why we need it**:
This PR handles SC names with more than 64 char and succeeds the backups.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
release-24.1.0

**Test Screenshots**:
### Before Fix 
![image](https://github.com/libopenstorage/stork/assets/54888022/c5b71544-44bf-4b71-91c3-eab9c81c1662)
![image](https://github.com/libopenstorage/stork/assets/54888022/4c999160-8264-425a-afd8-782b23aeb748)
### After Fix
![image](https://github.com/libopenstorage/stork/assets/54888022/03a2d0c2-7949-46b6-8966-3e4464c64257)
![image](https://github.com/libopenstorage/stork/assets/54888022/4453911c-e735-49dc-8a2f-dbb0e947a99a)


