### PR TITLE
Per node livemigration

### DIFF
--- a/test/integration_test/kubevirt_test.go
+++ b/test/integration_test/kubevirt_test.go
@@ -74,6 +74,7 @@ func TestKubevirt(t *testing.T) {
 	t.Run("kubeVirtHypercTwoLiveMigrations", kubeVirtHypercTwoLiveMigrations)
 	t.Run("kubeVirtHypercHotPlugDiskCollocation", kubeVirtHypercHotPlugDiskCollocation)
 	t.Run("kubeVirtHypercVPSFixJob", kubeVirtHypercVPSFixJob)
+	t.Run("kubeVirtSimulateOCPUpgrade", kubeVirtSimulateOCPUpgrade)
 }
 
 func kubevirtDeployFedoraVMWithClonePVC(t *testing.T) {
@@ -221,7 +222,7 @@ func kubevirtVMScaledDeployAndValidate(t *testing.T, instanceID string, appKeys 
 	var allCtxs []*scheduler.Context
 	logrus.Infof("Deploying %d VMs and validating them.", len(appKeys)*scale)
 	for i := 1; i <= scale; i++ {
-		logrus.Infof("Deploying VM: %d", i)
+		logrus.Infof("Deploying VM set: %d", i)
 		// Before validating the VM create required clusterrolebindings for datavolume cloning in the VM namespace
 		var testNamespaces []string
 		for _, app := range appKeys {


### PR DESCRIPTION
**What type of PR is this?**
This integration test for Kubevirt does the following:
- Deploy few VMs on the cluster
- Loop through nodes and do the below
  * Live migrate all the VMs on that node
  * restart volume driver on that node (only once)
  * wait for all attachements on that node to move to another node
  * do verification for all the VMs that were running on this node

**What this PR does / why we need it**:
https://portworx.atlassian.net/browse/PTX-22872

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
