### PR TITLE
PWX-35982: Storkctl create clusterpair will support migration and onetime-migration as mode.

### DIFF
--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -40,10 +40,9 @@ const (
 	secretNamespace        = "openstorage.io/auth-secret-namespace"
 	secretName             = "openstorage.io/auth-secret-name"
 
-	userInputCPModeAsync            = "async-dr"
-	userInputCPModeSync             = "sync-dr"
-	userInputCPModeMigration        = "migration"
-	userInputCPModeOnetimeMigration = "onetime-migration"
+	userInputCPModeAsync     = "async-dr"
+	userInputCPModeSync      = "sync-dr"
+	userInputCPModeMigration = "migration"
 
 	clusterPairDRModeDisasterRecovery = "DisasterRecovery"
 	clusterPairDRModeOnetimeMigration = "OneTimeMigration"
@@ -291,8 +290,8 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 				return
 			}
 
-			if mode != userInputCPModeAsync && mode != userInputCPModeSync && mode != userInputCPModeMigration && mode != userInputCPModeOnetimeMigration {
-				util.CheckErr(fmt.Errorf("invalid mode %s, mode value should either be %s, %s, %s or %s", mode, userInputCPModeAsync, userInputCPModeSync, userInputCPModeMigration, userInputCPModeOnetimeMigration))
+			if mode != userInputCPModeAsync && mode != userInputCPModeSync && mode != userInputCPModeMigration {
+				util.CheckErr(fmt.Errorf("invalid mode %s, mode value should either be %s, %s or %s", mode, userInputCPModeAsync, userInputCPModeSync, userInputCPModeMigration))
 				return
 			}
 
@@ -688,7 +687,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 	createClusterPairCommand.Flags().StringVarP(&srcToken, "src-token", "", "", "(Optional)Source cluster token for cluster pairing")
 	createClusterPairCommand.Flags().StringVarP(&destToken, "dest-token", "", "", "(Optional)Destination cluster token for cluster pairing")
 	createClusterPairCommand.Flags().StringVarP(&projectMappingsStr, "project-mappings", "", "", projectMappingHelpString)
-	createClusterPairCommand.Flags().StringVarP(&mode, "mode", "", userInputCPModeAsync, fmt.Sprintf("Mode of DR. [%s, %s, %s, %s]", userInputCPModeAsync, userInputCPModeSync, userInputCPModeMigration, userInputCPModeOnetimeMigration))
+	createClusterPairCommand.Flags().StringVarP(&mode, "mode", "", userInputCPModeAsync, fmt.Sprintf("Mode of DR. [%s, %s, %s]", userInputCPModeAsync, userInputCPModeSync, userInputCPModeMigration))
 	createClusterPairCommand.Flags().BoolVarP(&unidirectional, "unidirectional", "u", false, "(Optional) to create Clusterpair from source -> dest only")
 	createClusterPairCommand.Flags().StringVarP(&backupLocationName, "use-existing-objectstorelocation", "", "", "(Optional) Objectstorelocation with the provided name should be present in both source and destination cluster")
 	// New parameters for creating backuplocation secret
@@ -733,7 +732,7 @@ func generateClusterPair(
 	}
 	if mode == userInputCPModeAsync {
 		opts["mode"] = clusterPairDRModeDisasterRecovery
-	} else if mode == userInputCPModeOnetimeMigration {
+	} else if mode == userInputCPModeMigration {
 		opts["mode"] = clusterPairDRModeOnetimeMigration
 	}
 	config, err := getConfig(configFile).RawConfig()

--- a/pkg/storkctl/clusterpair_test.go
+++ b/pkg/storkctl/clusterpair_test.go
@@ -154,6 +154,9 @@ func TestCreateUniDirectionalClusterPairMissingParameters(t *testing.T) {
 	expected = "error: source kubeconfig and destination kubeconfig file should be different"
 	testCommon(t, cmdArgs, nil, expected, true)
 
+	cmdArgs = []string{"create", "clusterpair", "uni-pair1", "-n", "test", "--src-kube-file", srcConfig.Name(), "--dest-kube-file", srcConfigDuplicate.Name(), "-u", "--mode", "xyz"}
+	expected = fmt.Sprintf("error: invalid mode %s, mode value should either be %s, %s, %s or %s", "xyz", userInputCPModeAsync, userInputCPModeSync, userInputCPModeMigration, userInputCPModeOnetimeMigration)
+	testCommon(t, cmdArgs, nil, expected, true)
 }
 
 func TestGetHostPortFromEndPoint(t *testing.T) {
@@ -222,4 +225,73 @@ func createTempFile(t *testing.T, fileName string, fileContent string) *os.File 
 		require.NoError(t, err, "Error closing the file %s", fileName)
 	}
 	return f
+}
+
+func TestGenerateClusterPairForDifferentModes(t *testing.T) {
+	// a fake k8sconfig content
+	text := `
+    clusters:
+    - cluster:
+      certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJd01EUXhNekV4TkRBeU1Wb1hEVE13TURReE56RXhOREF5TVZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTmt0ClZWWGdXZ1E0eHJyNjJzUzV0N2dRM2Q4aXY4TmF3V2JHck8yTmZPeDRxMjNrd0RiMjVxK2NCVnJoN2txR1FsR2UKV2t2S1hZWDBoZz09LS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      server: https://1.2.3.4
+    name: fake-cluster
+    contexts:
+    - context:
+      cluster: fake-cluster
+      user: fake-user
+    name: fake-context
+    current-context: fake-context
+    kind: Config
+    preferences: {}
+    users:
+    - name: fake-user
+    user:
+      client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJd01EUXhNekV4TkRBeU1Wb1hEVE13TURReE56RXhOREF5TVZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTmt0ClZWWGdXZ1E0eHJyNjJzUzV0N2dRM2Q4aXY4TmF3V2JHck8yTmZPeDRxMjNrd0RiMjVxK2NCVnJoN2txR1FsR2UKV2t2S1hZWDBoZz09LS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      client-key-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FUR
+    `
+	// create a temp file with k8s config content
+	srcConfig := createTempFile(t, "src.config", text)
+	defer os.Remove(srcConfig.Name())
+
+	name := "testClusterPair"
+	ns := "testNamespace"
+	ip := "127.0.0.1"
+	port := "8080"
+	token := "abcd1234"
+	configFile := srcConfig.Name()
+	projectIDMappings := ""
+	authSecretNamespace := "authNamespace"
+	reverse := true
+	ignoreStorageOptions := false
+
+	mode := userInputCPModeAsync
+	clusterPair, err := generateClusterPair(name, ns, ip, port, token, configFile, projectIDMappings, authSecretNamespace, reverse, mode, ignoreStorageOptions)
+	require.NoError(t, err, "Error generating ClusterPair")
+
+	// Verify the generated ClusterPair object
+	require.Equal(t, clusterPairDRModeDisasterRecovery, clusterPair.Spec.Options["mode"], "ClusterPair mode mismatch")
+
+	mode = userInputCPModeSync
+	ignoreStorageOptions = true
+	clusterPair, err = generateClusterPair(name, ns, ip, port, token, configFile, projectIDMappings, authSecretNamespace, reverse, mode, ignoreStorageOptions)
+	require.NoError(t, err, "Error generating ClusterPair")
+
+	// Verify the generated ClusterPair object
+	require.Equal(t, 0, len(clusterPair.Spec.Options), "ClusterPair mode mismatch")
+
+	mode = userInputCPModeMigration
+	ignoreStorageOptions = false
+	clusterPair, err = generateClusterPair(name, ns, ip, port, token, configFile, projectIDMappings, authSecretNamespace, reverse, mode, ignoreStorageOptions)
+	require.NoError(t, err, "Error generating ClusterPair")
+
+	// Verify the generated ClusterPair object
+	require.Equal(t, "", clusterPair.Spec.Options["mode"], "ClusterPair mode mismatch")
+
+	mode = userInputCPModeOnetimeMigration
+	ignoreStorageOptions = false
+	clusterPair, err = generateClusterPair(name, ns, ip, port, token, configFile, projectIDMappings, authSecretNamespace, reverse, mode, ignoreStorageOptions)
+	require.NoError(t, err, "Error generating ClusterPair")
+
+	// Verify the generated ClusterPair object
+	require.Equal(t, clusterPairDRModeOnetimeMigration, clusterPair.Spec.Options["mode"], "ClusterPair mode mismatch")
 }

--- a/pkg/storkctl/clusterpair_test.go
+++ b/pkg/storkctl/clusterpair_test.go
@@ -155,7 +155,7 @@ func TestCreateUniDirectionalClusterPairMissingParameters(t *testing.T) {
 	testCommon(t, cmdArgs, nil, expected, true)
 
 	cmdArgs = []string{"create", "clusterpair", "uni-pair1", "-n", "test", "--src-kube-file", srcConfig.Name(), "--dest-kube-file", srcConfigDuplicate.Name(), "-u", "--mode", "xyz"}
-	expected = fmt.Sprintf("error: invalid mode %s, mode value should either be %s, %s, %s or %s", "xyz", userInputCPModeAsync, userInputCPModeSync, userInputCPModeMigration, userInputCPModeOnetimeMigration)
+	expected = fmt.Sprintf("error: invalid mode %s, mode value should either be %s, %s or %s", "xyz", userInputCPModeAsync, userInputCPModeSync, userInputCPModeMigration)
 	testCommon(t, cmdArgs, nil, expected, true)
 }
 
@@ -280,14 +280,6 @@ func TestGenerateClusterPairForDifferentModes(t *testing.T) {
 	require.Equal(t, 0, len(clusterPair.Spec.Options), "ClusterPair mode mismatch")
 
 	mode = userInputCPModeMigration
-	ignoreStorageOptions = false
-	clusterPair, err = generateClusterPair(name, ns, ip, port, token, configFile, projectIDMappings, authSecretNamespace, reverse, mode, ignoreStorageOptions)
-	require.NoError(t, err, "Error generating ClusterPair")
-
-	// Verify the generated ClusterPair object
-	require.Equal(t, "", clusterPair.Spec.Options["mode"], "ClusterPair mode mismatch")
-
-	mode = userInputCPModeOnetimeMigration
 	ignoreStorageOptions = false
 	clusterPair, err = generateClusterPair(name, ns, ip, port, token, configFile, projectIDMappings, authSecretNamespace, reverse, mode, ignoreStorageOptions)
 	require.NoError(t, err, "Error generating ClusterPair")


### PR DESCRIPTION
Also DisasterRecovery clusterpair mode gets added for async DR case in the clusterpair object.

**What type of PR is this?**
bug

**What this PR does / why we need it**:
storkctl create clusterpair now will support multiple modes like `async-dr, sync-dr, migration, onetime-migration`

**Does this PR change a user-facing CRD or CLI?**:
<!--
yes

➜  stork git:(PWX-35982) ✗ storkctl create clusterpair cp1 -n kube-system --src-kube-file /tmp/src.config --dest-kube-file /tmp/dest.config --s3-access-key ***** --s3-secret-key ***** --s3-endpoint ****** --s3-region us-east1 -p s3 --kubeconfig /tmp/src.config--mode invalid
error: invalid mode invalid, mode value should either be async-dr, sync-dr, migration or onetime-migration
-->

**Is a release note needed?**:
<!--
no
-->

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 24.2
-->

**Unit test**:
```
➜  stork git:(PWX-35982) ✗ go test -v -tags unittest -coverprofile=profile.out -covermode=atomic  github.com/libopenstorage/stork/pkg/storkctl -run TestCreateUniDirectionalClusterPairMissingParameters
=== RUN   TestCreateUniDirectionalClusterPairMissingParameters
--- PASS: TestCreateUniDirectionalClusterPairMissingParameters (0.01s)
PASS
coverage: 14.5% of statements
ok      github.com/libopenstorage/stork/pkg/storkctl    3.558s  coverage: 14.5% of statements

➜  stork git:(PWX-35982) ✗ go test -v -tags unittest -coverprofile=profile.out -covermode=atomic  github.com/libopenstorage/stork/pkg/storkctl -run TestGenerateClusterPairForDifferentModes            
=== RUN   TestGenerateClusterPairForDifferentModes
--- PASS: TestGenerateClusterPairForDifferentModes (0.01s)
PASS
coverage: 1.1% of statements
ok      github.com/libopenstorage/stork/pkg/storkctl    3.233s  coverage: 1.1% of statements
```

**Function tests**

All scenarios with tests have been updated in PWX-35982
