### PR TITLE
PB-6285: Remove "Use-default-volumesnapshotclass" while using snapshotClassName

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -304,12 +304,8 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		if !backup.Spec.DirectKDMP && snapshotClassRequired {
 			snapshotStorageClass := k.getSnapshotClassName(driverName, backup)
 			// In case of KDMP, if VolumeSnapshot is given and user want to use Default VolumeSnapshotClass then we need to
-			// get the default volumesnapshotclass name to populate in applicationBackup status VolumeInfo.VoluneSnapshot along with snapshot name
-
-			// Retaining "default" and "Default" because previous users who are using api based or CRD method to create Backup
-			// might be using those string, from newer version we will be using "Use-default-volumesnapshotclass" as identifier for using
-			// default volumesnapshotclass for creating volumeSnapshot
-			if snapshotStorageClass == "Default" || snapshotStorageClass == "default" || snapshotStorageClass == "Use-default-volumesnapshotclass" {
+			// get the default volumeSnapshotClass name to populate in applicationBackup status VolumeInfo.VolumeSnapshot along with snapshot name
+			if snapshotStorageClass == "Default" || snapshotStorageClass == "default" {
 				vscs, err := externalsnapshotter.Instance().ListSnapshotClasses()
 				if err != nil {
 					return nil, fmt.Errorf("unable to list volumesnapshotclasses : %+v", err.Error())
@@ -323,7 +319,7 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 					}
 				}
 
-				// if no default volumesnapshotclass found for that Provisioner we should fail backup for KDMP + LocalSnapshot Driver
+				// if no default volumeSnapshotClass found for that Provisioner we should fail backup for KDMP + LocalSnapshot Driver
 				if dataExport.Spec.SnapshotStorageClass == "" {
 					return nil, fmt.Errorf("no default volumesnapshotclass found for driver : %s", pv.Spec.CSI.Driver)
 				}

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 require (
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/golang/mock v1.6.0
-	github.com/portworx/kdmp v0.4.1-0.20240219181755-4ce81929fd25
+	github.com/portworx/kdmp v0.4.1-0.20240219181755-94bc7049f75fed7e47ca59a8bda45c827b50da16
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
 	kubevirt.io/api v1.0.0
 	kubevirt.io/client-go v0.59.2
@@ -347,7 +347,7 @@ replace (
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240304221553-5aaf2148a210
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
-	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240219181755-4ce81929fd25
+	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240322102930-94bc7049f75f
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240309000217-717ff5468196
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240312040317-20999f9df5b3
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -3510,7 +3510,7 @@ github.com/libopenstorage/operator v0.0.0-20240311222049-36e102b2df5e/go.mod h1:
 github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9 h1:pZQ5uaWky7KerHX2saBO971ti+IBDJRorHwcHwc+0aM=
 github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9/go.mod h1:gE8rSd6lwLNXNbiW3DrRZjFMs+y4fDHy/6uiOO9cdzY=
 github.com/libopenstorage/stork v1.4.1-0.20230610103146-72cf75320066/go.mod h1:Yst+fnOYjWk6SA5pXZBKm19wtiinjxQ/vgYTXI3k80Q=
-github.com/libopenstorage/stork v1.4.1-0.20240109104912-636d43cc74ca/go.mod h1:TbWc6ZiUycPSXVFm4T2O9DUbsYsljpId33UEGNroKRU=
+github.com/libopenstorage/stork v1.4.1-0.20240220121828-15cc00444a69/go.mod h1:f9CWPOsq3gxg/6bEDT+sVyafyBDouKpwd+UZZW6awk0=
 github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1 h1:5vqfYYWm4b+lbkMtvvWtWBiqLbmLN6dNvWaa7wVsz/Q=
 github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1/go.mod h1:xwNGC7xiz/BQ/wbMkvHujL8Gjgseg+x41xMek7sKRRQ=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
@@ -4052,14 +4052,13 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v1.0.5/go.mod h1:APVvOesVSAnne5SClsPxPdfvZTVDojXh1/G3qb5wjGI=
 github.com/portworx/dcos-secrets v0.0.0-20180616013705-8e8ec3f66611/go.mod h1:4hklRW/4DQpLqkcXcjtNprbH2tz/sJaNtqinfPWl/LA=
-github.com/portworx/kdmp v0.4.1-0.20240219181755-4ce81929fd25 h1:wpcR/s4cLzx1ctRAf2Vjl+L7EHgmzQFO5h85WsK2suA=
-github.com/portworx/kdmp v0.4.1-0.20240219181755-4ce81929fd25/go.mod h1:0ad65uubQO5nwlvbbSCcchtMXpDgumTHa82VDa9gKPs=
+github.com/portworx/kdmp v0.4.1-0.20240322102930-94bc7049f75f h1:WyOTl9ki0spdVgXmR30GHRQQrkJg9fDhoyEX7bro4W4=
+github.com/portworx/kdmp v0.4.1-0.20240322102930-94bc7049f75f/go.mod h1:lWsj58SHTus8KaSrir+4/8LprQSE8c6jvPWACtvv470=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200929023115-b312c7519467/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20230326003017-21a38cf82d4b h1:nP+m9tYQv2cWbN9wAwjlhJU9FZRs7GaYszhLJBLAg/I=
 github.com/portworx/kvdb v0.0.0-20230326003017-21a38cf82d4b/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
-github.com/portworx/pds-api-go-client v0.0.0-20230831092707-4faacf005c6b/go.mod h1:yn0abd9g4Q3fBpY720Eb+hwRV1OnTjROUaSb9mOlzBk=
 github.com/portworx/pds-api-go-client v0.0.0-20231102112445-993d38984eae h1:/aJSqtgpIPa9os7yOoXQzvqYdRdMoS8X+TaKC/KRPY8=
 github.com/portworx/pds-api-go-client v0.0.0-20231102112445-993d38984eae/go.mod h1:yn0abd9g4Q3fBpY720Eb+hwRV1OnTjROUaSb9mOlzBk=
 github.com/portworx/px-backup-api v1.2.2-0.20240223100835-84b57faae78f/go.mod h1:G1pn/FceOq8W6DKaYuV8LJuKowzp4/Hdgliojl9akIU=

--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -148,10 +148,7 @@ func (c *csiDriver) CreateSnapshot(opts ...Option) (string, string, string, erro
 			"multiple provisioner", pvc.GetName(), pv.Spec.CSI.Driver)
 	}
 
-	// Retaining "default" and "Default" because previous users who are using api based or CRD method to create Backup
-	// might be using those string, from newer version we will be using "Use-default-volumesnapshotclass" as identifier for using
-	// default volumesnapshotclass for creating volumeSnapshot
-	if o.SnapshotClassName == "default" || o.SnapshotClassName == "Default" || o.SnapshotClassName == "Use-default-volumesnapshotclass" {
+	if o.SnapshotClassName == "default" || o.SnapshotClassName == "Default" {
 		// Let kubernetes choose the default snapshot class to use
 		// for this snapshot. If none is set then the volume snapshot will fail
 		o.SnapshotClassName = ""

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
@@ -1531,6 +1531,11 @@ func (c *Controller) cleanUp(driver drivers.Interface, de *kdmpapi.DataExport) e
 			logrus.Errorf(errMsg)
 			return fmt.Errorf(errMsg)
 		}
+		if err := core.Instance().DeleteSecret(utils.GetImageSecretName(jobName), namespace); err != nil && !k8sErrors.IsNotFound(err) {
+			errMsg := fmt.Sprintf("deletion of image secret %s failed: %v", jobName, err)
+			logrus.Errorf(errMsg)
+			return fmt.Errorf(errMsg)
+		}
 	}
 
 	if err := core.Instance().DeleteSecret(utils.GetCredSecretName(de.Name), namespace); err != nil && !k8sErrors.IsNotFound(err) {
@@ -1857,6 +1862,7 @@ func startTransferJob(
 		return drv.StartJob(
 			drivers.WithSourcePVC(srcPVCName),
 			drivers.WithNamespace(dataExport.Spec.Destination.Namespace),
+			drivers.WithDataExportUID(string(dataExport.UID)),
 			drivers.WithDestinationPVC(dataExport.Spec.Destination.Name),
 			drivers.WithLabels(dataExport.Labels),
 		)

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/resourceexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/resourceexport/reconcile.go
@@ -280,6 +280,11 @@ func (c *Controller) cleanupResources(resourceExport *kdmpapi.ResourceExport) er
 		logrus.Errorf(errMsg)
 		return fmt.Errorf(errMsg)
 	}
+	if err := core.Instance().DeleteSecret(utils.GetImageSecretName(rbName), rbNamespace); err != nil && !k8sErrors.IsNotFound(err) {
+		errMsg := fmt.Sprintf("deletion of image secret %s failed: %v", rbName, err)
+		logrus.Errorf(errMsg)
+		return fmt.Errorf(errMsg)
+	}
 	return nil
 }
 

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/kopiamaintenance/kopiamaintenance.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/kopiamaintenance/kopiamaintenance.go
@@ -356,6 +356,7 @@ func jobFor(
 		jobV1 := &batchv1.CronJob{
 			ObjectMeta: jobObjectMeta,
 			Spec: batchv1.CronJobSpec{
+				ConcurrencyPolicy:          batchv1.ForbidConcurrent,
 				Schedule:                   scheduleInterval,
 				SuccessfulJobsHistoryLimit: &successfulJobsHistoryLimit,
 				FailedJobsHistoryLimit:     &failedJobsHistoryLimit,
@@ -388,6 +389,7 @@ func jobFor(
 	jobV1Beta1 := &batchv1beta1.CronJob{
 		ObjectMeta: jobObjectMeta,
 		Spec: batchv1beta1.CronJobSpec{
+			ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
 			Schedule:                   scheduleInterval,
 			SuccessfulJobsHistoryLimit: &successfulJobsHistoryLimit,
 			FailedJobsHistoryLimit:     &failedJobsHistoryLimit,

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
@@ -21,6 +21,7 @@ type JobOpts struct {
 	VolumeBackupDeleteName      string
 	VolumeBackupDeleteNamespace string
 	DataExportName              string
+	DataExportUID               string
 	SnapshotID                  string
 	CredSecretName              string
 	CredSecretNamespace         string
@@ -418,9 +419,20 @@ func WithLabels(l map[string]string) JobOption {
 func WithDataExportName(name string) JobOption {
 	return func(opts *JobOpts) error {
 		if strings.TrimSpace(name) == "" {
-			return fmt.Errorf("dataexport namespace should be set")
+			return fmt.Errorf("dataexport name should be set")
 		}
 		opts.DataExportName = name
+		return nil
+	}
+}
+
+// WithDataExportUID is job parameter
+func WithDataExportUID(uid string) JobOption {
+	return func(opts *JobOpts) error {
+		if strings.TrimSpace(uid) == "" {
+			return fmt.Errorf("dataexport UID should be set")
+		}
+		opts.DataExportUID = uid
 		return nil
 	}
 }

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/utils/utils.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/utils/utils.go
@@ -957,3 +957,10 @@ func SetDisableIstioLabel(labels map[string]string, jobOpts drivers.JobOpts) map
 	}
 	return labels
 }
+
+func GetShortUID(uid string) string {
+	if len(uid) < 8 {
+		return uid
+	}
+	return uid[:8]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1029,7 +1029,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20240219181755-4ce81929fd25 => github.com/portworx/kdmp v0.4.1-0.20240219181755-4ce81929fd25
+# github.com/portworx/kdmp v0.4.1-0.20240219181755-94bc7049f75fed7e47ca59a8bda45c827b50da16 => github.com/portworx/kdmp v0.4.1-0.20240322102930-94bc7049f75f
 ## explicit; go 1.21
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1
@@ -2574,7 +2574,7 @@ sigs.k8s.io/yaml/goyaml.v2
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240304221553-5aaf2148a210
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
-# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240219181755-4ce81929fd25
+# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240322102930-94bc7049f75f
 # github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240309000217-717ff5468196
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240312040317-20999f9df5b3
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
we don't need to have "Use-default-volumesnapshotclass" as value while selecting default vsc in case of csi based backup

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

