### PR TITLE
feat: backup.Spec.Namepace to contain only NS with vms for allns sche…

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -243,9 +243,15 @@ func (a *ApplicationBackupController) updateWithAllNamespaces(backup *stork_api.
 	}
 	namespacesToBackup := make([]string, 0)
 	for _, ns := range namespaces.Items {
-		if _, found := utils.IgnoreNamespaces[ns.Name]; !found {
-			namespacesToBackup = append(namespacesToBackup, ns.Name)
+		if _, found := utils.IgnoreNamespaces[ns.Name]; found {
+			continue
 		}
+		//For VM backup include only if there exist atleast 1 VM in the NS
+		if IsBackupObjectTypeVirtualMachine(backup) && !resourcecollector.IsVmPresentInNS(ns.Name) {
+			continue
+		}
+		namespacesToBackup = append(namespacesToBackup, ns.Name)
+
 	}
 	backup.Spec.Namespaces = namespacesToBackup
 	err = a.client.Update(context.TODO(), backup)

--- a/pkg/resourcecollector/virtualmachine.go
+++ b/pkg/resourcecollector/virtualmachine.go
@@ -564,3 +564,17 @@ func GetVMIncludeResourceInfoList(vmList []kubevirtv1.VirtualMachine, objectMap 
 	return vmResourceInfoList, objectMap, freezeRulesItems, unFreezeRulesItems
 
 }
+
+// ISVmPresentInNS returns true if a given name space at least has one VM in it
+func IsVmPresentInNS(ns string) bool {
+	kv := kubevirtops.Instance()
+
+	listOptions := &metav1.ListOptions{
+		Limit: 1,
+	}
+	blist, err := kv.BatchListVirtualMachines(ns, listOptions)
+	if err == nil && len(blist.Items) > 0 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
backup.Spec.Namepace to contain only NS with vms for allns scheduleBackup


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
For allNamespace i.e * backup, only add those NS which has atleast 1 vm. 

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
release-24.1.0
