### PR TITLE
Debug nilptr kubevirt

### DIFF
--- a/test/integration_test/kubevirt_hyperconv_test.go
+++ b/test/integration_test/kubevirt_hyperconv_test.go
@@ -289,6 +289,8 @@ func gatherInitialVMIInfo(t *testing.T, testState *kubevirtTestState) {
 	vols, err := schedulerDriver.GetVolumes(appCtx)
 	require.NoError(t, err, "failed to get volumes for context %s", appCtx.App.Key)
 
+	logrus.Infof("RK=> Number of volumes for test state %s: %d", testState.vmiName, len(vols))
+
 	for _, vol := range vols {
 		vmDisk := &vmDisk{volume: vol}
 		testState.vmDisks = append(testState.vmDisks, vmDisk)


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
* Stork integration test for Kubevirt One and two live VM migrations fails on OCP 4.14 
* Torpedo scheduler driver was changed to fix this

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
