### PR TITLE
PWX-35626: Add a last 4 digit UID string from volumesnapshotschedule to volumesnapshot name to avoid name collision.

### DIFF
--- a/pkg/snapshot/controllers/snapshotschedule.go
+++ b/pkg/snapshot/controllers/snapshotschedule.go
@@ -290,12 +290,15 @@ func (s *SnapshotScheduleController) shouldStartVolumeSnapshot(snapshotSchedule 
 }
 
 func (s *SnapshotScheduleController) formatVolumeSnapshotName(snapshotSchedule *stork_api.VolumeSnapshotSchedule, policyType stork_api.SchedulePolicyType) string {
-	snapSuffix := strings.Join([]string{strings.ToLower(string(policyType)), time.Now().Format(nameTimeSuffixFormat)}, "-")
+	// get a random 4 character suffix from the snapshotschedule's UID
+	randSuffix := string(snapshotSchedule.UID)[len(snapshotSchedule.UID)-4:]
+
+	snapSuffix := strings.Join([]string{strings.ToLower(string(policyType)), randSuffix, time.Now().Format(nameTimeSuffixFormat)}, "-")
 	scheduleName := snapshotSchedule.Name
 	if len(scheduleName) >= validation.LabelValueMaxLength-len(snapSuffix) {
 		scheduleName = scheduleName[:validation.LabelValueMaxLength-len(snapSuffix)-1]
 	}
-	return strings.Join([]string{scheduleName, strings.ToLower(string(policyType)), time.Now().Format(nameTimeSuffixFormat)}, "-")
+	return strings.Join([]string{scheduleName, snapSuffix}, "-")
 }
 
 func (s *SnapshotScheduleController) startVolumeSnapshot(inputSnapshotSchedule *stork_api.VolumeSnapshotSchedule, policyType stork_api.SchedulePolicyType) error {


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
bug

**What this PR does / why we need it**:
Adding the last 4 digit of UID to volumesnapshot names to avoid name collision in case of long volumesnapshotschedule with similar names resulting in similar volumesnapshot names if time frequency matches.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
<!--
yes
-->
```release-note
Issue: Similar volumesnapshot names were getting created if volumesnapshotschedule frequency matches and after trimming produces similar substrings.
User Impact: For one volume snapshot might not be taken and be already marked as successful.
Resolution: Adding a 4 digit randomness to the name to avoid name collision for volumesnapshots resulting from different volumesnapshotschedules.

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
no
-->

**Test**
```
Volumesnapshotschedule names with after trim should have given output

➜  elasticsearch git:(PWX-35626) ✗ storkctl get volumesnapshotschedule -n es
NAME                                                     PVC                                    POLICYNAME   PRE-EXEC-RULE   POST-EXEC-RULE   RECLAIM-POLICY   SUSPEND   LAST-SUCCESS-TIME
elasticdata-vol-elasticsearch-data-0-interval-1-minute   elasticdata-vol-elasticsearch-data-0   every-1m                                      Delete           false     26 Mar 24 10:42 UTC
elasticdata-vol-elasticsearch-data-1-interval-1-minute   elasticdata-vol-elasticsearch-data-1   every-1m                                      Delete           false     26 Mar 24 10:42 UTC
elasticdata-vol-elasticsearch-data-2-interval-1-minute   elasticdata-vol-elasticsearch-data-2   every-1m                                      Delete           false     26 Mar 24 10:42 UTC

But with the last 4 digits of UID as suffix to create random  string, volume snapshots are coming like
➜  elasticsearch git:(PWX-35626) ✗ storkctl get volumesnapshots -n es
NAME                                                              PVC                                    STATUS   CREATED               COMPLETED             TYPE
elasticdata-vol-elasticsearch-d-interval-22e7-2024-03-26-104052   elasticdata-vol-elasticsearch-data-0   Ready    26 Mar 24 10:40 UTC   26 Mar 24 10:40 UTC   local
elasticdata-vol-elasticsearch-d-interval-22e7-2024-03-26-104152   elasticdata-vol-elasticsearch-data-0   Ready    26 Mar 24 10:41 UTC   26 Mar 24 10:41 UTC   local
elasticdata-vol-elasticsearch-d-interval-22e7-2024-03-26-104252   elasticdata-vol-elasticsearch-data-0   Ready    26 Mar 24 10:42 UTC   26 Mar 24 10:42 UTC   local
elasticdata-vol-elasticsearch-d-interval-5313-2024-03-26-104058   elasticdata-vol-elasticsearch-data-2   Ready    26 Mar 24 10:40 UTC   26 Mar 24 10:40 UTC   local
elasticdata-vol-elasticsearch-d-interval-5313-2024-03-26-104158   elasticdata-vol-elasticsearch-data-2   Ready    26 Mar 24 10:41 UTC   26 Mar 24 10:41 UTC   local
elasticdata-vol-elasticsearch-d-interval-5313-2024-03-26-104258   elasticdata-vol-elasticsearch-data-2   Ready    26 Mar 24 10:42 UTC   26 Mar 24 10:42 UTC   local
elasticdata-vol-elasticsearch-d-interval-d305-2024-03-26-104055   elasticdata-vol-elasticsearch-data-1   Ready    26 Mar 24 10:40 UTC   26 Mar 24 10:40 UTC   local
elasticdata-vol-elasticsearch-d-interval-d305-2024-03-26-104155   elasticdata-vol-elasticsearch-data-1   Ready    26 Mar 24 10:41 UTC   26 Mar 24 10:41 UTC   local
elasticdata-vol-elasticsearch-d-interval-d305-2024-03-26-104255   elasticdata-vol-elasticsearch-data-1   Ready    26 Mar 24 10:42 UTC   26 Mar 24 10:42 UTC   local


Integration test: https://jenkins.pwx.dev.purestorage.com/job/Users/job/dipti/job/dipti-snapshot-k8s-1-25-0/4/
```

