### PR TITLE
pb-6459: Excluding the pods that are in completed state, even if the pod selecor label matches, to run the rules.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.1
 	github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20240320023245-5179eafab0c0
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.15.1
 	github.com/rancher/norman v0.0.0-20230222213531-275a3e921940
@@ -348,7 +348,7 @@ replace (
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240304221553-5aaf2148a210
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240327131138-e0fa03f5a66c
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240309000217-717ff5468196
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240326191238-71d38500911c
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3

--- a/go.sum
+++ b/go.sum
@@ -4059,8 +4059,8 @@ github.com/portworx/px-backup-api v1.2.2-0.20240229114136-e58baeb9fbe1/go.mod h1
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987 h1:VNBTmIPjJRZ2QP64zdsrif3ELDHiMzoyNNX74VNHgZ8=
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987/go.mod h1:g3pw2lI2AjqAixUCRhaBdKTY98znsCPR7NGRrlpimVU=
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240309000217-717ff5468196 h1:/wdB2/SdJP9PkSTxqOWhGKKd12IKFGbIdoS7WpMPCrU=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240309000217-717ff5468196/go.mod h1:aBipy9Jl9IS77SFZi2RqH2UT8MeKEmja1MYembOaZrY=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be h1:0RxnWnr0dyTfQu98r1cOwkluHofYLRJ5xnyp7LGEPl0=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be/go.mod h1:i3ImIVQMZOkmMU4nWP4kI/w6WFXsG2n/cFIGR5F1m8k=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.0.0-20240326191238-71d38500911c h1:bvttnV+Kg6pgHSY1YJKvxJSRNYmHru+tZJQL7qkprI0=

--- a/vendor/github.com/portworx/sched-ops/k8s/batch/batch.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/batch/batch.go
@@ -92,7 +92,7 @@ func (c *Client) SetConfig(cfg *rest.Config) {
 
 // initClient the k8s client if uninitialized
 func (c *Client) initClient() error {
-	if c.batch != nil && c.batchv1beta1 != nil {
+	if c.batch != nil || c.batchv1beta1 != nil {
 		return nil
 	}
 

--- a/vendor/github.com/portworx/sched-ops/k8s/common/pod.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/common/pod.go
@@ -185,3 +185,11 @@ func IsPodRunning(pod corev1.Pod) bool {
 
 	return true
 }
+
+// IsPodCompleted checks if the pod is in completed state
+func IsPodCompleted(pod corev1.Pod) bool {
+	if pod.Status.Phase == corev1.PodSucceeded {
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/core/pods.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/pods.go
@@ -62,6 +62,8 @@ type PodOps interface {
 	DeletePodsByLabels(namespace string, labelSelector map[string]string, timeout time.Duration) error
 	// IsPodRunning checks if all containers in a pod are in running state
 	IsPodRunning(corev1.Pod) bool
+	// IsPodCompleted checks if the pod is in completed state
+	IsPodCompleted(corev1.Pod) bool
 	// IsPodReady checks if all containers in a pod are ready (passed readiness probe)
 	IsPodReady(corev1.Pod) bool
 	// IsPodBeingManaged returns true if the pod is being managed by a controller
@@ -368,6 +370,11 @@ func (c *Client) DeletePodsByLabels(namespace string, listOptions map[string]str
 // IsPodRunning checks if all containers in a pod are in running state
 func (c *Client) IsPodRunning(pod corev1.Pod) bool {
 	return common.IsPodRunning(pod)
+}
+
+// IsPodCompleted checks if the pod is in completed state
+func (c *Client) IsPodCompleted(pod corev1.Pod) bool {
+	return common.IsPodCompleted(pod)
 }
 
 // IsPodReady checks if all containers in a pod are ready (passed readiness probe)

--- a/vendor/github.com/portworx/sched-ops/k8s/kubevirt/kubevirt.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/kubevirt/kubevirt.go
@@ -138,6 +138,7 @@ func (c *Client) loadClientFromServiceAccount() error {
 	return c.loadClient()
 }
 
+// loadClientFromKubeconfig loads a k8s client from a kubeconfig file
 func (c *Client) loadClientFromKubeconfig(kubeconfig string) error {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -148,6 +149,7 @@ func (c *Client) loadClientFromKubeconfig(kubeconfig string) error {
 	return c.loadClient()
 }
 
+// loadClient loads the k8s client
 func (c *Client) loadClient() error {
 	if c.config == nil {
 		return fmt.Errorf("rest config is not provided")
@@ -166,6 +168,7 @@ func (c *Client) loadClient() error {
 	return nil
 }
 
+// GetKubevirtClient get kubevirt client
 func (c *Client) GetKubevirtClient() kubecli.KubevirtClient {
 	if err := c.initClient(); err != nil {
 		return nil

--- a/vendor/github.com/portworx/sched-ops/k8s/prometheus/alertmanagerconfig.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/prometheus/alertmanagerconfig.go
@@ -9,23 +9,23 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// AlertManagerConfig adds receiver to alert manager which is responsible sending alerts
+// AlertManagerConfigOps adds receiver to alert manager which is responsible sending alerts
 type AlertManagerConfigOps interface {
-	// List of alertmanagerconfigs that match the namespace
+	// ListAlertManagerConfigs lists alertmanagerconfigs that match the namespace
 	ListAlertManagerConfigs(namespace string, labelSelectors map[string]string) (*monitoringv1alpha1.AlertmanagerConfigList, error)
-	// Get alertmanagerconfigs that matches the name
+	// GetAlertManagerConfig get alertmanagerconfigs that matches the name
 	GetAlertManagerConfig(name string, namespace string) (*monitoringv1alpha1.AlertmanagerConfig, error)
-	// Create a new alertmanagerconfig
+	// CreateAlertManagerConfig Create a new alertmanagerconfig
 	CreateAlertManagerConfig(*monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error)
-	// Update one alertmanagerconfig
+	//UpdateAlertManagerConfig  Update one alertmanagerconfig
 	UpdateAlertManagerConfig(*monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error)
-	// Delete one alertmanagerconfig
+	// DeleteAlertManagerConfig Delete one alertmanagerconfigs
 	DeleteAlertManagerConfig(name string, namespace string) error
-	// Delete a list of alertmanagerconfig based on the namespace
+	// DeleteCollectionAlertManagerConfig Delete a list of alertmanagerconfig based on the namespace
 	DeleteCollectionAlertManagerConfig(namespace string, labelSelectors map[string]string) error
 }
 
-// List of alert manager configs that match the namespace
+// ListAlertManagerConfigs  List of alert manager configs that match the namespace
 func (c *Client) ListAlertManagerConfigs(namespace string, labelSelectors map[string]string) (*monitoringv1alpha1.AlertmanagerConfigList, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (c *Client) ListAlertManagerConfigs(namespace string, labelSelectors map[st
 	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).List(context.TODO(), listOptions(labelSelectors))
 }
 
-// Get one alert manager config
+// GetAlertManagerConfig Get one alert manager config
 func (c *Client) GetAlertManagerConfig(name string, namespace string) (*monitoringv1alpha1.AlertmanagerConfig, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (c *Client) GetAlertManagerConfig(name string, namespace string) (*monitori
 	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-// Creates a new AlertmanagerConfig in the given namespace, provided the secret is provided
+// CreateAlertManagerConfig Creates a new AlertmanagerConfig in the given namespace, provided the secret is provided
 func (c *Client) CreateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func (c *Client) CreateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerCo
 	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(ns).Create(context.TODO(), amc, metav1.CreateOptions{})
 }
 
-// Updates one alert manager config
+// UpdateAlertManagerConfig  Updates one alert manager config
 func (c *Client) UpdateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerConfig) (*monitoringv1alpha1.AlertmanagerConfig, error) {
 	if err := c.initClient(); err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func (c *Client) UpdateAlertManagerConfig(amc *monitoringv1alpha1.AlertmanagerCo
 	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(amc.Namespace).Update(context.TODO(), amc, metav1.UpdateOptions{})
 }
 
-// Deletes single alert manager config
+// DeleteAlertManagerConfig Deletes single alert manager config
 func (c *Client) DeleteAlertManagerConfig(name string, namespace string) error {
 	if err := c.initClient(); err != nil {
 		return err
@@ -74,6 +74,7 @@ func (c *Client) DeleteAlertManagerConfig(name string, namespace string) error {
 	})
 }
 
+// DeleteCollectionAlertManagerConfig Deletes a list of alert manager config based on the namespace
 func (c *Client) DeleteCollectionAlertManagerConfig(namespace string, labelSelectors map[string]string) error {
 	if err := c.initClient(); err != nil {
 		return err
@@ -85,6 +86,7 @@ func (c *Client) DeleteCollectionAlertManagerConfig(namespace string, labelSelec
 	return c.prometheus.MonitoringV1alpha1().AlertmanagerConfigs(namespace).DeleteCollection(context.TODO(), deleteOpts, listOptions(labelSelectors))
 }
 
+// listOptions returns a list options with label selectors
 func listOptions(labelSelectors map[string]string) metav1.ListOptions {
 	if labelSelectors != nil {
 		return metav1.ListOptions{

--- a/vendor/github.com/portworx/sched-ops/k8s/prometheus/prometheus.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/prometheus/prometheus.go
@@ -129,6 +129,7 @@ func (c *Client) loadClientFromServiceAccount() error {
 	return c.loadClient()
 }
 
+// loadClientFromKubeconfig load client kubeconfig
 func (c *Client) loadClientFromKubeconfig(kubeconfig string) error {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -139,6 +140,7 @@ func (c *Client) loadClientFromKubeconfig(kubeconfig string) error {
 	return c.loadClient()
 }
 
+// loadClient loads the k8s client
 func (c *Client) loadClient() error {
 	if c.config == nil {
 		return fmt.Errorf("rest config is not provided")

--- a/vendor/github.com/portworx/sched-ops/k8s/storage/csidriver.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/storage/csidriver.go
@@ -1,0 +1,34 @@
+package storage
+
+import (
+	"context"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CsiDriverOps is an interface to perform k8s CsiDriver readonly operations
+type CsiDriverOps interface {
+	// ListCsiDrivers lists all CSI drivers
+	ListCsiDrivers() (*storagev1.CSIDriverList, error)
+	// GetCsiDriver returns the CSI driver for the given name
+	GetCsiDriver(name string) (*storagev1.CSIDriver, error)
+}
+
+// ListCsiDrivers lists all CSI drivers
+func (c *Client) ListCsiDrivers() (*storagev1.CSIDriverList, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.storage.CSIDrivers().List(context.TODO(), metav1.ListOptions{})
+}
+
+// GetCsiDriver returns the CSI driver for the given name
+func (c *Client) GetCsiDriver(name string) (*storagev1.CSIDriver, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.storage.CSIDrivers().Get(context.TODO(), name, metav1.GetOptions{})
+}

--- a/vendor/github.com/portworx/sched-ops/k8s/storage/storage.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/storage/storage.go
@@ -20,6 +20,7 @@ var (
 type Ops interface {
 	ScOps
 	VolumeAttachmentOps
+	CsiDriverOps
 
 	// SetConfig sets the config and resets the client
 	SetConfig(config *rest.Config)

--- a/vendor/github.com/portworx/sched-ops/k8s/tektoncd/pipeline.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/tektoncd/pipeline.go
@@ -6,6 +6,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// pipelineOps is an interface to perform pipeline related operations
 type pipelineOps interface {
 	// CreatePipeline creates a new pipeline
 	CreatePipeline(pipeline *tektonv1.Pipeline, namespace string) (*tektonv1.Pipeline, error)
@@ -19,6 +20,7 @@ type pipelineOps interface {
 	UpdatePipeline(*tektonv1.Pipeline) (*tektonv1.Pipeline, error)
 }
 
+// pipelineRunOps is an interface to perform pipeline run related operations
 type pipelineRunOps interface {
 	// CreatePipelineRun creates a new pipeline run
 	CreatePipelineRun(*tektonv1.PipelineRun) (*tektonv1.PipelineRun, error)
@@ -32,6 +34,7 @@ type pipelineRunOps interface {
 	UpdatePipelineRun(*tektonv1.PipelineRun) (*tektonv1.PipelineRun, error)
 }
 
+// CreatePipeline creates a new pipeline on a given namespace
 func (c Client) CreatePipeline(pipeline *tektonv1.Pipeline, namespace string) (*tektonv1.Pipeline, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -39,6 +42,7 @@ func (c Client) CreatePipeline(pipeline *tektonv1.Pipeline, namespace string) (*
 	return c.V1PipelineClient.Create(context.TODO(), pipeline, k8smetav1.CreateOptions{})
 }
 
+// ListPipelines lists all pipelines in a namespace
 func (c Client) ListPipelines(namespace string) (*tektonv1.PipelineList, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -46,6 +50,7 @@ func (c Client) ListPipelines(namespace string) (*tektonv1.PipelineList, error) 
 	return c.V1PipelineClient.List(context.TODO(), k8smetav1.ListOptions{})
 }
 
+// GetPipeline gets a pipeline by name on a given namespace
 func (c Client) GetPipeline(namespace, name string) (*tektonv1.Pipeline, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -53,6 +58,7 @@ func (c Client) GetPipeline(namespace, name string) (*tektonv1.Pipeline, error) 
 	return c.V1PipelineClient.Get(context.TODO(), name, k8smetav1.GetOptions{})
 }
 
+// DeletePipeline deletes a pipeline by name on a given namespace
 func (c Client) DeletePipeline(namespace, name string) error {
 	if err := c.initClient(namespace); err != nil {
 		return err
@@ -60,6 +66,7 @@ func (c Client) DeletePipeline(namespace, name string) error {
 	return c.V1PipelineClient.Delete(context.TODO(), name, k8smetav1.DeleteOptions{})
 }
 
+// UpdatePipeline updates a pipeline
 func (c Client) UpdatePipeline(pipeline *tektonv1.Pipeline) (*tektonv1.Pipeline, error) {
 	if err := c.initClient(pipeline.Namespace); err != nil {
 		return nil, err
@@ -67,6 +74,7 @@ func (c Client) UpdatePipeline(pipeline *tektonv1.Pipeline) (*tektonv1.Pipeline,
 	return c.V1PipelineClient.Update(context.TODO(), pipeline, k8smetav1.UpdateOptions{})
 }
 
+// CreatePipelineRun creates a new pipeline run
 func (c Client) CreatePipelineRun(pipelineRun *tektonv1.PipelineRun) (*tektonv1.PipelineRun, error) {
 	if err := c.initClient(pipelineRun.Namespace); err != nil {
 		return nil, err
@@ -74,6 +82,7 @@ func (c Client) CreatePipelineRun(pipelineRun *tektonv1.PipelineRun) (*tektonv1.
 	return c.V1PipelineRunClient.Create(context.TODO(), pipelineRun, k8smetav1.CreateOptions{})
 }
 
+// ListPipelineRuns lists all pipeline runs in a namespace
 func (c Client) ListPipelineRuns(namespace string) (*tektonv1.PipelineRunList, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -81,6 +90,7 @@ func (c Client) ListPipelineRuns(namespace string) (*tektonv1.PipelineRunList, e
 	return c.V1PipelineRunClient.List(context.TODO(), k8smetav1.ListOptions{})
 }
 
+// GetPipelineRun gets a pipeline run by name on a given namespace
 func (c Client) GetPipelineRun(namespace, name string) (*tektonv1.PipelineRun, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -88,6 +98,7 @@ func (c Client) GetPipelineRun(namespace, name string) (*tektonv1.PipelineRun, e
 	return c.V1PipelineRunClient.Get(context.TODO(), name, k8smetav1.GetOptions{})
 }
 
+// DeletePipelineRun deletes a pipeline run by name on a given namespace
 func (c Client) DeletePipelineRun(namespace, name string) error {
 	if err := c.initClient(namespace); err != nil {
 		return err
@@ -95,6 +106,7 @@ func (c Client) DeletePipelineRun(namespace, name string) error {
 	return c.V1PipelineRunClient.Delete(context.TODO(), name, k8smetav1.DeleteOptions{})
 }
 
+// UpdatePipelineRun updates a pipeline run
 func (c Client) UpdatePipelineRun(pipelineRun *tektonv1.PipelineRun) (*tektonv1.PipelineRun, error) {
 	if err := c.initClient(pipelineRun.Namespace); err != nil {
 		return nil, err

--- a/vendor/github.com/portworx/sched-ops/k8s/tektoncd/task.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/tektoncd/task.go
@@ -6,6 +6,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// taskOps is an interface to perform task related operations
 type taskOps interface {
 	// CreateTask creates a new task
 	CreateTask(task *tektonv1.Task, namespace string) (*tektonv1.Task, error)
@@ -19,6 +20,7 @@ type taskOps interface {
 	UpdateTask(*tektonv1.Task) (*tektonv1.Task, error)
 }
 
+// taskRunOps is an interface to perform task run related operations
 type taskRunOps interface {
 	// CreateTaskRun creates a new task run
 	CreateTaskRun(*tektonv1.TaskRun) (*tektonv1.TaskRun, error)
@@ -32,6 +34,7 @@ type taskRunOps interface {
 	UpdateTaskRun(*tektonv1.TaskRun) (*tektonv1.TaskRun, error)
 }
 
+// CreateTask creates a new task on a given namespace
 func (c *Client) CreateTask(task *tektonv1.Task, namespace string) (*tektonv1.Task, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -39,6 +42,7 @@ func (c *Client) CreateTask(task *tektonv1.Task, namespace string) (*tektonv1.Ta
 	return c.V1TaskClient.Create(context.TODO(), task, k8smetav1.CreateOptions{})
 }
 
+// ListTasks lists all tasks in a namespace
 func (c *Client) ListTasks(namespace string) (*tektonv1.TaskList, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -46,6 +50,7 @@ func (c *Client) ListTasks(namespace string) (*tektonv1.TaskList, error) {
 	return c.V1TaskClient.List(context.TODO(), k8smetav1.ListOptions{})
 }
 
+// GetTask gets a task by name on a given namespace
 func (c *Client) GetTask(namespace, name string) (*tektonv1.Task, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -53,6 +58,7 @@ func (c *Client) GetTask(namespace, name string) (*tektonv1.Task, error) {
 	return c.V1TaskClient.Get(context.TODO(), name, k8smetav1.GetOptions{})
 }
 
+// DeleteTask deletes a task by name on a given namespace
 func (c *Client) DeleteTask(namespace, name string) error {
 	if err := c.initClient(namespace); err != nil {
 		return err
@@ -60,6 +66,7 @@ func (c *Client) DeleteTask(namespace, name string) error {
 	return c.V1TaskClient.Delete(context.TODO(), name, k8smetav1.DeleteOptions{})
 }
 
+// UpdateTask updates a task
 func (c *Client) UpdateTask(task *tektonv1.Task) (*tektonv1.Task, error) {
 	if err := c.initClient(task.Namespace); err != nil {
 		return nil, err
@@ -67,6 +74,7 @@ func (c *Client) UpdateTask(task *tektonv1.Task) (*tektonv1.Task, error) {
 	return c.V1TaskClient.Update(context.TODO(), task, k8smetav1.UpdateOptions{})
 }
 
+// CreateTaskRun creates a new task run
 func (c *Client) CreateTaskRun(taskRun *tektonv1.TaskRun) (*tektonv1.TaskRun, error) {
 	if err := c.initClient(taskRun.Namespace); err != nil {
 		return nil, err
@@ -74,6 +82,7 @@ func (c *Client) CreateTaskRun(taskRun *tektonv1.TaskRun) (*tektonv1.TaskRun, er
 	return c.V1TaskRunClient.Create(context.TODO(), taskRun, k8smetav1.CreateOptions{})
 }
 
+// ListTaskRuns lists all task runs in a namespace
 func (c *Client) ListTaskRuns(namespace string) (*tektonv1.TaskRunList, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -81,6 +90,7 @@ func (c *Client) ListTaskRuns(namespace string) (*tektonv1.TaskRunList, error) {
 	return c.V1TaskRunClient.List(context.TODO(), k8smetav1.ListOptions{})
 }
 
+// GetTaskRun gets a task run by name on a given namespace
 func (c *Client) GetTaskRun(namespace, name string) (*tektonv1.TaskRun, error) {
 	if err := c.initClient(namespace); err != nil {
 		return nil, err
@@ -88,6 +98,7 @@ func (c *Client) GetTaskRun(namespace, name string) (*tektonv1.TaskRun, error) {
 	return c.V1TaskRunClient.Get(context.TODO(), name, k8smetav1.GetOptions{})
 }
 
+// DeleteTaskRun deletes a task run by name on a given namespace
 func (c *Client) DeleteTaskRun(namespace, name string) error {
 	if err := c.initClient(namespace); err != nil {
 		return err
@@ -95,6 +106,7 @@ func (c *Client) DeleteTaskRun(namespace, name string) error {
 	return c.V1TaskRunClient.Delete(context.TODO(), name, k8smetav1.DeleteOptions{})
 }
 
+// UpdateTaskRun updates a task run
 func (c *Client) UpdateTaskRun(taskRun *tektonv1.TaskRun) (*tektonv1.TaskRun, error) {
 	if err := c.initClient(taskRun.Namespace); err != nil {
 		return nil, err

--- a/vendor/github.com/portworx/sched-ops/k8s/tektoncd/tektoncd.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/tektoncd/tektoncd.go
@@ -97,10 +97,7 @@ func (c *Client) SetConfig(cfg *rest.Config) {
 
 // initClient the k8s client if uninitialized
 func (c *Client) initClient(namespace string) error {
-	if c.V1PipelineClient != nil || c.V1TaskClient != nil || c.V1TaskRunClient != nil || c.V1PipelineRunClient != nil {
-		return nil
-	}
-
+	// As the client needs to be intialized for each namespace created and passed
 	return c.setClient(namespace)
 }
 
@@ -132,6 +129,7 @@ func (c *Client) loadClientFromServiceAccount(namespace string) error {
 	return c.loadClient(namespace)
 }
 
+// loadClientFromKubeconfig loads a k8s client from a kubeconfig file
 func (c *Client) loadClientFromKubeconfig(kubeconfig string, namespace string) error {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -142,6 +140,7 @@ func (c *Client) loadClientFromKubeconfig(kubeconfig string, namespace string) e
 	return c.loadClient(namespace)
 }
 
+// loadClient loads the k8s client
 func (c *Client) loadClient(namespace string) error {
 	if c.config == nil {
 		return fmt.Errorf("rest config is not provided")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1081,7 +1081,7 @@ github.com/portworx/px-object-controller/client/listers/objectservice/v1alpha1
 github.com/portworx/px-object-controller/pkg/client
 github.com/portworx/px-object-controller/pkg/controller
 github.com/portworx/px-object-controller/pkg/utils
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20240320023245-5179eafab0c0 => github.com/portworx/sched-ops v1.20.4-rc1.0.20240309000217-717ff5468196
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be => github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -2575,7 +2575,7 @@ sigs.k8s.io/yaml/goyaml.v2
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240304221553-5aaf2148a210
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 # github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240327131138-e0fa03f5a66c
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240309000217-717ff5468196
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240326191238-71d38500911c
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3


### PR DESCRIPTION
**What type of PR is this?**
>bug


**What this PR does / why we need it**:
```
    pb-6459: Excluding the pods that are in completed state, even if the pod
    selector label matches, to run the rules.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:

```release-note
Issue: In some use-cases, completed pods are getting selected to run and execution of rule fails.
User Impact: If there are two matching pods, one in completed and another in running state, makes the rule execution to fail.
Resolution: Avoiding the pods selection to run the rules, if they are in completed state.

```

**Does this change need to be cherry-picked to a release branch?**:
release-24.1.0 branch.

**Testing:**
Tested the fix on the QA setup as mentioned in the ticket RCA.

1. When we migrate a VM (say from one node1 to node2) to another, the virt-launcher pod goes to Completed state in the current node (node1)
2. New virt-laucher pod is spawned in the new node (node2) which is up and running. Now this controls the VM ops
3. What we are doing in our backup flow is that, we are executing the default freeze rules on the pods matching the pod selector label kubevirt.io/domain=vm-name
4. But now there are 2 pods in the namespace with the same label - one is in Running state and other other is in Completed state
5. With the fix, it excluded the pod in completed state and backup completed.
