### PR TITLE
update testrail for preferRemoteNodeFalseHyperconvergenceTest

### DIFF
--- a/test/integration_test/extender_test.go
+++ b/test/integration_test/extender_test.go
@@ -557,6 +557,10 @@ func preferRemoteNodeFalseHyperconvergenceTest(t *testing.T) {
 
 	logrus.Infof("Verifying Pods scheduling favors hyperconvergence")
 	verifyScheduledNodesMultipleReplicas(t, scheduledNodes, volumeNames)
+
+	// If we are here then the test has passed
+	testResult = testResultPass
+	logrus.Infof("Test status at end of %s test: %s", t.Name(), testResult)
 }
 
 func getNodesWithoutVolumeData(t *testing.T, volume string) []string {


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**What this PR does / why we need it**:
* Currently we don't update the test result status for preferRemoteNodeFalseHyperconvergenceTest
* So it always gets updated as `Failed` in testrail

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
