### PR TITLE
PWX-32335 : get failover / failback cli changes

### DIFF
--- a/pkg/action/failback.go
+++ b/pkg/action/failback.go
@@ -144,7 +144,7 @@ func (ac *ActionController) verifyMigrationScheduleBeforeFailback(action *storkv
 			// Fail the action failback if latest successful migration is older than latestMigrationThresholdTime
 			// And migrationschedule is in suspended state
 			log.ActionLog(action).Infof("The latest migration %s is not in threshold range", latestMigration.Name)
-			msg := fmt.Sprintf("Failing failback operation as the latest migration %s was not completed from the scheduled policy duration from now", latestMigration.Name)
+			msg := fmt.Sprintf("Failing the failback operation because the most recent migration, %s, was not completed within the scheduled policy duration", latestMigration.Name)
 			logEvents := ac.printFunc(action, string(storkv1.ActionStatusFailed))
 			logEvents(msg, "err")
 			action.Status.Status = storkv1.ActionStatusFailed

--- a/pkg/action/failback.go
+++ b/pkg/action/failback.go
@@ -567,7 +567,7 @@ func (ac *ActionController) activateClusterDuringFailback(action *storkv1.Action
 			return
 		}
 	}
-	ac.activateClusterDuringDR(action, namespaces, migrationSchedule, config)
+	ac.activateClusterDuringDR(action, namespaces, migrationSchedule, config, rollback)
 }
 
 func getClusterPairSchedulerConfig(clusterPairName string, namespace string) (*rest.Config, error) {

--- a/pkg/action/failover.go
+++ b/pkg/action/failover.go
@@ -290,10 +290,10 @@ func (ac *ActionController) activateClusterDuringFailover(action *storkv1.Action
 	} else {
 		config = ac.config
 	}
-	ac.activateClusterDuringDR(action, namespaces, migrationSchedule, config)
+	ac.activateClusterDuringDR(action, namespaces, migrationSchedule, config, rollback)
 }
 
-func (ac *ActionController) activateClusterDuringDR(action *storkv1.Action, namespaces []string, migrationSchedule *storkv1.MigrationSchedule, config *rest.Config) {
+func (ac *ActionController) activateClusterDuringDR(action *storkv1.Action, namespaces []string, migrationSchedule *storkv1.MigrationSchedule, config *rest.Config, rollback bool) {
 	failoverSummaryList := make([]*storkv1.FailoverSummary, 0)
 	failbackSummaryList := make([]*storkv1.FailbackSummary, 0)
 	scaleUpStatus := true
@@ -311,6 +311,16 @@ func (ac *ActionController) activateClusterDuringDR(action *storkv1.Action, name
 		return
 	}
 
+	var failureStatus storkv1.ActionStatusType
+	var successStatus storkv1.ActionStatusType
+	if rollback {
+		failureStatus = storkv1.ActionStatusRollbackFailed
+		successStatus = storkv1.ActionStatusRollbackSuccessful
+	} else {
+		failureStatus = storkv1.ActionStatusFailed
+		successStatus = storkv1.ActionStatusSuccessful
+	}
+
 	for _, ns := range namespaces {
 		logEvents := ac.printFunc(action, "ScaleReplicas")
 		logEvents(fmt.Sprintf("Scaling up apps in cluster %s", config.Host), "out")
@@ -322,14 +332,14 @@ func (ac *ActionController) activateClusterDuringDR(action *storkv1.Action, name
 				scaleUpStatus = false
 				msg := fmt.Sprintf("scaling up apps in namespace %s failed: %v", ns, err)
 				log.ActionLog(action).Errorf(msg)
-				failoverSummary, failbackSummary = ac.createSummary(action, ns, storkv1.ActionStatusFailed, msg)
+				failoverSummary, failbackSummary = ac.createSummary(action, ns, failureStatus, msg)
 			} else {
 				msg := fmt.Sprintf("scaling up apps in namespace %s successful", ns)
-				failoverSummary, failbackSummary = ac.createSummary(action, ns, storkv1.ActionStatusSuccessful, msg)
+				failoverSummary, failbackSummary = ac.createSummary(action, ns, successStatus, msg)
 			}
 		} else {
 			msg := fmt.Sprintf("Skipping scaling up apps in the namespace %s since it is not one of the namespaces being migrated by the MigrationSchedule %s/%s", ns, migrationSchedule.Namespace, migrationSchedule.Name)
-			failoverSummary, failbackSummary = ac.createSummary(action, ns, storkv1.ActionStatusSuccessful, msg)
+			failoverSummary, failbackSummary = ac.createSummary(action, ns, successStatus, msg)
 		}
 		if action.Spec.ActionType == storkv1.ActionTypeFailover {
 			failoverSummaryList = append(failoverSummaryList, failoverSummary)
@@ -347,12 +357,12 @@ func (ac *ActionController) activateClusterDuringDR(action *storkv1.Action, name
 	}
 	if scaleUpStatus {
 		msg := fmt.Sprintf("Scaling up of applications in cluster : %s successful. Moving to the next stage", config.Host)
-		logEvents := ac.printFunc(action, string(storkv1.ActionStatusSuccessful))
+		logEvents := ac.printFunc(action, string(successStatus))
 		logEvents(msg, "out")
 		action.Status.Status = storkv1.ActionStatusSuccessful
 	} else {
 		msg := fmt.Sprintf("Scaling up of applications in cluster : %s failed.", config.Host)
-		logEvents := ac.printFunc(action, string(storkv1.ActionStatusFailed))
+		logEvents := ac.printFunc(action, string(failureStatus))
 		logEvents(msg, "out")
 		action.Status.Status = storkv1.ActionStatusFailed
 	}

--- a/pkg/action/failover.go
+++ b/pkg/action/failover.go
@@ -311,14 +311,11 @@ func (ac *ActionController) activateClusterDuringDR(action *storkv1.Action, name
 		return
 	}
 
-	var failureStatus storkv1.ActionStatusType
-	var successStatus storkv1.ActionStatusType
+	failureStatus := storkv1.ActionStatusFailed
+	successStatus := storkv1.ActionStatusSuccessful
 	if rollback {
 		failureStatus = storkv1.ActionStatusRollbackFailed
 		successStatus = storkv1.ActionStatusRollbackSuccessful
-	} else {
-		failureStatus = storkv1.ActionStatusFailed
-		successStatus = storkv1.ActionStatusSuccessful
 	}
 
 	for _, ns := range namespaces {

--- a/pkg/apis/stork/v1alpha1/action.go
+++ b/pkg/apis/stork/v1alpha1/action.go
@@ -83,6 +83,10 @@ const (
 	ActionStatusFailed ActionStatusType = "Failed"
 	// ActionStatusSuccessful means Action has completed successfully
 	ActionStatusSuccessful ActionStatusType = "Successful"
+	// ActionStatusRollbackSuccessful means Rollback has completed successfully
+	ActionStatusRollbackSuccessful ActionStatusType = "RollbackSuccessful"
+	// ActionStatusRollbackInProgress means Rollback failed
+	ActionStatusRollbackFailed ActionStatusType = "RollbackFailed"
 )
 
 // ActionStageType is the stage of the action

--- a/pkg/storkctl/action.go
+++ b/pkg/storkctl/action.go
@@ -24,19 +24,6 @@ const (
 	actionWaitInterval   time.Duration = 10 * time.Second
 )
 
-func newPerformCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	performCommands := &cobra.Command{
-		Use:   "perform",
-		Short: "perform actions",
-	}
-
-	performCommands.AddCommand(
-		newFailoverCommand(cmdFactory, ioStreams),
-		newFailbackCommand(cmdFactory, ioStreams),
-	)
-	return performCommands
-}
-
 var mockTime *time.Time
 
 // setMockTime is used in tests to update the time
@@ -52,7 +39,7 @@ func GetCurrentTime() time.Time {
 	return time.Now()
 }
 
-func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func newPerformFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	var referenceMigrationSchedule string
 	var skipDeactivateSource bool
 	var includeNamespaceList []string
@@ -89,7 +76,7 @@ func newFailoverCommand(cmdFactory Factory, ioStreams genericclioptions.IOStream
 	return performFailoverCommand
 }
 
-func newFailbackCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+func newPerformFailbackCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	var referenceMigrationSchedule string
 	var includeNamespaceList []string
 	var excludeNamespaceList []string

--- a/pkg/storkctl/actionstatus.go
+++ b/pkg/storkctl/actionstatus.go
@@ -1,0 +1,156 @@
+package storkctl
+
+import (
+	"fmt"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/spf13/cobra"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubernetes/pkg/printers"
+)
+
+var drActionColumns = []string{"NAME", "CREATED", "STAGE", "STATUS", "ADDITIONAL INFO"}
+
+func newGetFailoverStatusCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	getFailoverCommand := &cobra.Command{
+		Use:   failoverCommand,
+		Short: "Get the status of failover actions",
+		Run: func(c *cobra.Command, args []string) {
+			var actions *storkv1.ActionList
+			var failoverActionList *storkv1.ActionList
+			var err error
+			// user has to provide the namespace from which they want to get list of actions using -n flag
+			namespace := cmdFactory.GetNamespace()
+			if len(args) > 0 {
+				// name of action has been specified
+				actions = new(storkv1.ActionList)
+				for _, actionName := range args {
+					action, err := storkops.Instance().GetAction(actionName, namespace)
+					if err != nil {
+						util.CheckErr(err)
+						return
+					}
+					actions.Items = append(actions.Items, *action)
+				}
+			} else {
+				// fetch all the actions in the given namespace
+				actions, err = storkops.Instance().ListActions(namespace)
+				if err != nil {
+					util.CheckErr(err)
+					return
+				}
+			}
+
+			// filter it down to actions with actionType failover
+			failoverActionList = new(storkv1.ActionList)
+			for _, action := range actions.Items {
+				if action.Spec.ActionType == storkv1.ActionTypeFailover {
+					failoverActionList.Items = append(failoverActionList.Items, action)
+				}
+			}
+
+			if len(failoverActionList.Items) == 0 {
+				handleEmptyList(ioStreams.Out)
+				return
+			}
+
+			if err := printObjects(c, failoverActionList, cmdFactory, drActionColumns, drActionPrinter, ioStreams.Out); err != nil {
+				util.CheckErr(err)
+				return
+			}
+		},
+	}
+	cmdFactory.BindGetFlags(getFailoverCommand.Flags())
+	return getFailoverCommand
+}
+
+func drActionPrinter(actionList *storkv1.ActionList, options printers.GenerateOptions) ([]metav1beta1.TableRow, error) {
+	if actionList == nil {
+		return nil, nil
+	}
+
+	rows := make([]metav1beta1.TableRow, 0)
+	for _, action := range actionList.Items {
+		var row metav1beta1.TableRow
+		creationTime := toTimeString(action.CreationTimestamp.Time)
+		additionalInfo := action.Status.Reason
+		if action.Status.Summary != nil {
+			if len(action.Status.Summary.FailoverSummaryItem) > 0 {
+				// find out number of successfully scaled up namespaces
+				totalNamespaces := len(action.Status.Summary.FailoverSummaryItem)
+				successfulNamespaces := 0
+				rollbackSuccessfulNamespaces := 0
+				rollbackFailedNamespaces := 0
+				for _, item := range action.Status.Summary.FailoverSummaryItem {
+					if item.Status == storkv1.ActionStatusSuccessful {
+						successfulNamespaces++
+					} else if item.Status == storkv1.ActionStatusRollbackSuccessful {
+						rollbackSuccessfulNamespaces++
+					} else if item.Status == storkv1.ActionStatusRollbackFailed {
+						rollbackFailedNamespaces++
+					}
+				}
+				if rollbackSuccessfulNamespaces > 0 || rollbackFailedNamespaces > 0 {
+					additionalInfo = fmt.Sprintf("Rolled back Apps in : %d/%d namespaces", rollbackSuccessfulNamespaces, totalNamespaces)
+					// In case of rollback we have a failure reason as well
+					additionalInfo += " ; " + action.Status.Reason
+				} else {
+					additionalInfo = fmt.Sprintf("Scaled up Apps in : %d/%d namespaces", successfulNamespaces, totalNamespaces)
+				}
+			}
+		}
+		row = getRow(&action,
+			[]interface{}{action.Name,
+				creationTime,
+				prettyDRStageNames(action.Status.Stage, action.Spec.ActionType),
+				action.Status.Status,
+				additionalInfo,
+			},
+		)
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func prettyDRStageNames(stage storkv1.ActionStageType, actionType storkv1.ActionType) string {
+	switch stage {
+	case storkv1.ActionStageInitial:
+		return "Validations"
+	case storkv1.ActionStageScaleDownSource:
+		return "Scale Down (on source)"
+	case storkv1.ActionStageScaleDownDestination:
+		return "Scale Down (on destination)"
+	case storkv1.ActionStageWaitAfterScaleDown:
+		if actionType == storkv1.ActionTypeFailover {
+			return "Scale Down (on source)"
+		} else if actionType == storkv1.ActionTypeFailback {
+			return "Scale Down (on destination)"
+		}
+	case storkv1.ActionStageLastMileMigration:
+		if actionType == storkv1.ActionTypeFailover {
+			return "Last Mile Migration (from source -> destination)"
+		} else if actionType == storkv1.ActionTypeFailback {
+			return "Last Mile Migration (from destination -> source)"
+		}
+	case storkv1.ActionStageScaleUpSource:
+		if actionType == storkv1.ActionTypeFailover {
+			return "Rolling Back Scale Down (on source)"
+		} else if actionType == storkv1.ActionTypeFailback {
+			return "Scale Up (on source)"
+		}
+	case storkv1.ActionStageScaleUpDestination:
+		if actionType == storkv1.ActionTypeFailover {
+			return "Scale Up (on destination)"
+		} else if actionType == storkv1.ActionTypeFailback {
+			return "Rolling Back Scale Down (on destination)"
+		}
+	case storkv1.ActionStageFinal:
+		return "Completed"
+	default:
+		return string(stage)
+	}
+	return string(stage)
+}

--- a/pkg/storkctl/actionstatus.go
+++ b/pkg/storkctl/actionstatus.go
@@ -124,7 +124,9 @@ func drActionPrinter(actionList *storkv1.ActionList, options printers.GenerateOp
 			if rollbackSuccessfulNamespaces > 0 || rollbackFailedNamespaces > 0 {
 				additionalInfo = fmt.Sprintf("Rolled back Apps in : %d/%d namespaces", rollbackSuccessfulNamespaces, totalNamespaces)
 				// In case of rollback we have a failure reason as well
-				additionalInfo += " ; " + action.Status.Reason
+				if action.Status.Reason != "" {
+					additionalInfo += " ; " + action.Status.Reason
+				}
 			} else {
 				additionalInfo = fmt.Sprintf("Scaled up Apps in : %d/%d namespaces", successfulNamespaces, totalNamespaces)
 			}

--- a/pkg/storkctl/actionstatus_test.go
+++ b/pkg/storkctl/actionstatus_test.go
@@ -12,18 +12,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetFailoverNoFailoverAction(t *testing.T) {
+func TestGetFailoverFailbackNoAction(t *testing.T) {
 	cmdArgs := []string{"get", "failover"}
 	expected := "No resources found.\n"
 	var actionList storkv1.ActionList
 	testCommon(t, cmdArgs, &actionList, expected, false)
+
+	cmdArgs = []string{"get", "failback"}
+	testCommon(t, cmdArgs, &actionList, expected, false)
 }
 
-func TestGetFailoverOneSuccessfulFailoverAction(t *testing.T) {
+func TestGetFailoverSuccessfulFailoverAction(t *testing.T) {
 	defer resetTest()
 	// create a failover action
 	actionName := createFailoverActionAndVerify(t)
-	// update the status pf the action
+	// update the status of the action
 	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
 	require.NoError(t, err, "Error getting action")
 	actionObj.Status.Stage = storkv1.ActionStageFinal
@@ -44,16 +47,234 @@ func TestGetFailoverOneSuccessfulFailoverAction(t *testing.T) {
 	_, err = storkops.Instance().UpdateAction(actionObj)
 	require.NoError(t, err, "Error updating action")
 	cmdArgs := []string{"get", "failover", actionName, "-n", "kube-system"}
-	expected := "NAME                                                CREATED   STAGE       STATUS       ADDITIONAL INFO\n" +
+	expected := "NAME                                                CREATED   STAGE       STATUS       MORE INFO\n" +
 		"failover-test-migrationschedule-2024-01-01-000000             Completed   Successful   Scaled up Apps in : 2/2 namespaces\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 
-func TestGetFailoverOneFailedFailoverAction(t *testing.T) {
+func TestGetFailbackSuccessfulFailbackAction(t *testing.T) {
+	defer resetTest()
+	// create a failback action
+	actionName := createFailbackActionAndVerify(t)
+	// update the status of the action
+	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	actionObj.Status.Stage = storkv1.ActionStageFinal
+	actionObj.Status.Status = storkv1.ActionStatusSuccessful
+	actionObj.Status.Summary = &storkv1.ActionSummary{FailbackSummaryItem: []*storkv1.FailbackSummary{
+		{
+			Namespace: "ns1",
+			Status:    storkv1.ActionStatusSuccessful,
+			Reason:    "scaling up apps in namespace ns1 successful",
+		},
+		{
+			Namespace: "ns2",
+			Status:    storkv1.ActionStatusSuccessful,
+			Reason:    "scaling up apps in namespace ns2 successful",
+		},
+	}}
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	cmdArgs := []string{"get", "failback", actionName, "-n", "kube-system"}
+	expected := "NAME                                                CREATED   STAGE       STATUS       MORE INFO\n" +
+		"failback-test-migrationschedule-2024-01-01-000000             Completed   Successful   Scaled up Apps in : 2/2 namespaces\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestGetFailoverAllStages(t *testing.T) {
 	defer resetTest()
 	// create a failover action
 	actionName := createFailoverActionAndVerify(t)
-	// update the status pf the action
+	// update the status of the action
+	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+
+	cmdArgs := []string{"get", "failover", actionName, "-n", "kube-system"}
+	// Initial stage
+	actionObj.Status.Stage = storkv1.ActionStageInitial
+	actionObj.Status.Status = storkv1.ActionStatusInProgress
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected := "NAME                                                CREATED   STAGE         STATUS        MORE INFO\n" +
+		"failover-test-migrationschedule-2024-01-01-000000             Validations   In-Progress   \n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// ScaleDownSource stage
+	actionObj.Status.Stage = storkv1.ActionStageScaleDownSource
+	actionObj.Status.Status = storkv1.ActionStatusInProgress
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected = "NAME                                                CREATED   STAGE                    STATUS        MORE INFO\n" +
+		"failover-test-migrationschedule-2024-01-01-000000             Scale Down (on source)   In-Progress   \n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// WaitAfterScaleDown stage
+	actionObj.Status.Stage = storkv1.ActionStageWaitAfterScaleDown
+	actionObj.Status.Status = storkv1.ActionStatusInProgress
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected = "NAME                                                CREATED   STAGE                                        STATUS        MORE INFO\n" +
+		"failover-test-migrationschedule-2024-01-01-000000             Waiting for Apps to Scale Down (on source)   In-Progress   \n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// LastMileMigration stage
+	actionObj.Status.Stage = storkv1.ActionStageLastMileMigration
+	actionObj.Status.Status = storkv1.ActionStatusInProgress
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected = "NAME                                                CREATED   STAGE                                              STATUS        MORE INFO\n" +
+		"failover-test-migrationschedule-2024-01-01-000000             Last Mile Migration (from source -> destination)   In-Progress   \n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// ScaleUpDestination stage
+	actionObj.Status.Stage = storkv1.ActionStageScaleUpDestination
+	actionObj.Status.Status = storkv1.ActionStatusSuccessful
+	actionObj.Status.Reason = ""
+	actionObj.Status.Summary = &storkv1.ActionSummary{FailoverSummaryItem: []*storkv1.FailoverSummary{
+		{
+			Namespace: "ns1",
+			Status:    storkv1.ActionStatusSuccessful,
+			Reason:    "scaling up apps in namespace ns1 successful",
+		},
+		{
+			Namespace: "ns2",
+			Status:    storkv1.ActionStatusFailed,
+			Reason:    "scaling up apps in namespace ns2 failed",
+		},
+	}}
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected = "NAME                                                CREATED   STAGE                       STATUS       MORE INFO\n" +
+		"failover-test-migrationschedule-2024-01-01-000000             Scale Up (on destination)   Successful   Scaled up Apps in : 1/2 namespaces\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// ScaleUpSource i.e. Rollback stage
+	actionObj.Status.Stage = storkv1.ActionStageScaleUpSource
+	actionObj.Status.Status = storkv1.ActionStatusSuccessful
+	actionObj.Status.Reason = "Failing failover operation as the last mile migration test-migrationschedule-lastmile-failover-353342c failed: status Failed"
+	actionObj.Status.Summary = &storkv1.ActionSummary{FailoverSummaryItem: []*storkv1.FailoverSummary{
+		{
+			Namespace: "ns1",
+			Status:    storkv1.ActionStatusRollbackSuccessful,
+			Reason:    "scaling up apps in namespace ns1 successful",
+		},
+		{
+			Namespace: "ns2",
+			Status:    storkv1.ActionStatusRollbackSuccessful,
+			Reason:    "scaling up apps in namespace ns2 successful",
+		},
+	}}
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected = "NAME                                                CREATED   STAGE                                 STATUS       MORE INFO\n" +
+		"failover-test-migrationschedule-2024-01-01-000000             Rolling Back Scale Down (on source)   Successful   Rolled back Apps in : 2/2 namespaces ; Failing failover operation as the last mile migration test-migrationschedule-lastmile-failover-353342c failed: status Failed\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestGetFailbackAllStages(t *testing.T) {
+	defer resetTest()
+	// create a failback action
+	actionName := createFailbackActionAndVerify(t)
+	// update the status of the action
+	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+
+	cmdArgs := []string{"get", "failback", actionName, "-n", "kube-system"}
+	// Initial stage
+	actionObj.Status.Stage = storkv1.ActionStageInitial
+	actionObj.Status.Status = storkv1.ActionStatusInProgress
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected := "NAME                                                CREATED   STAGE         STATUS        MORE INFO\n" +
+		"failback-test-migrationschedule-2024-01-01-000000             Validations   In-Progress   \n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// ScaleDownDestination stage
+	actionObj.Status.Stage = storkv1.ActionStageScaleDownDestination
+	actionObj.Status.Status = storkv1.ActionStatusInProgress
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected = "NAME                                                CREATED   STAGE                         STATUS        MORE INFO\n" +
+		"failback-test-migrationschedule-2024-01-01-000000             Scale Down (on destination)   In-Progress   \n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// WaitAfterScaleDown stage
+	actionObj.Status.Stage = storkv1.ActionStageWaitAfterScaleDown
+	actionObj.Status.Status = storkv1.ActionStatusInProgress
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected = "NAME                                                CREATED   STAGE                                             STATUS        MORE INFO\n" +
+		"failback-test-migrationschedule-2024-01-01-000000             Waiting for Apps to Scale Down (on destination)   In-Progress   \n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// LastMileMigration stage
+	actionObj.Status.Stage = storkv1.ActionStageLastMileMigration
+	actionObj.Status.Status = storkv1.ActionStatusInProgress
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected = "NAME                                                CREATED   STAGE                                              STATUS        MORE INFO\n" +
+		"failback-test-migrationschedule-2024-01-01-000000             Last Mile Migration (from destination -> source)   In-Progress   \n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// ScaleUpSource stage
+	actionObj.Status.Stage = storkv1.ActionStageScaleUpSource
+	actionObj.Status.Status = storkv1.ActionStatusSuccessful
+	actionObj.Status.Reason = ""
+	actionObj.Status.Summary = &storkv1.ActionSummary{FailbackSummaryItem: []*storkv1.FailbackSummary{
+		{
+			Namespace: "ns1",
+			Status:    storkv1.ActionStatusSuccessful,
+			Reason:    "scaling up apps in namespace ns1 successful",
+		},
+		{
+			Namespace: "ns2",
+			Status:    storkv1.ActionStatusFailed,
+			Reason:    "scaling up apps in namespace ns2 failed",
+		},
+	}}
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected = "NAME                                                CREATED   STAGE                  STATUS       MORE INFO\n" +
+		"failback-test-migrationschedule-2024-01-01-000000             Scale Up (on source)   Successful   Scaled up Apps in : 1/2 namespaces\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	// ScaleUpDestination i.e. Rollback stage
+	actionObj.Status.Stage = storkv1.ActionStageScaleUpDestination
+	actionObj.Status.Status = storkv1.ActionStatusSuccessful
+	actionObj.Status.Reason = "Failing failback operation as the last mile migration test-migrationschedule-lastmile-failback-353342c failed: status Failed"
+	actionObj.Status.Summary = &storkv1.ActionSummary{FailbackSummaryItem: []*storkv1.FailbackSummary{
+		{
+			Namespace: "ns1",
+			Status:    storkv1.ActionStatusRollbackSuccessful,
+			Reason:    "scaling up apps in namespace ns1 successful",
+		},
+		{
+			Namespace: "ns2",
+			Status:    storkv1.ActionStatusRollbackSuccessful,
+			Reason:    "scaling up apps in namespace ns2 successful",
+		},
+	}}
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	expected = "NAME                                                CREATED   STAGE                                      STATUS       MORE INFO\n" +
+		"failback-test-migrationschedule-2024-01-01-000000             Rolling Back Scale Down (on destination)   Successful   Rolled back Apps in : 2/2 namespaces ; Failing failback operation as the last mile migration test-migrationschedule-lastmile-failback-353342c failed: status Failed\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestGetFailoverFailedFailoverAction(t *testing.T) {
+	defer resetTest()
+	// create a failover action
+	actionName := createFailoverActionAndVerify(t)
+	// update the status of the action
 	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
 	require.NoError(t, err, "Error getting action")
 	actionObj.Status.Stage = storkv1.ActionStageFinal
@@ -74,8 +295,38 @@ func TestGetFailoverOneFailedFailoverAction(t *testing.T) {
 	_, err = storkops.Instance().UpdateAction(actionObj)
 	require.NoError(t, err, "Error updating action")
 	cmdArgs := []string{"get", "failover", actionName, "-n", "kube-system"}
-	expected := "NAME                                                CREATED   STAGE       STATUS   ADDITIONAL INFO\n" +
+	expected := "NAME                                                CREATED   STAGE       STATUS   MORE INFO\n" +
 		"failover-test-migrationschedule-2024-01-01-000000             Completed   Failed   Rolled back Apps in : 1/2 namespaces ; Failing failover operation as the last mile migration test-migrationschedule-lastmile-failover-353342c failed: status Failed\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestGetFailbackFailedFailbackAction(t *testing.T) {
+	defer resetTest()
+	// create a failback action
+	actionName := createFailbackActionAndVerify(t)
+	// update the status of the action
+	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	actionObj.Status.Stage = storkv1.ActionStageFinal
+	actionObj.Status.Status = storkv1.ActionStatusFailed
+	actionObj.Status.Summary = &storkv1.ActionSummary{FailbackSummaryItem: []*storkv1.FailbackSummary{
+		{
+			Namespace: "ns1",
+			Status:    storkv1.ActionStatusRollbackSuccessful,
+			Reason:    "scaling up apps in namespace ns1 successful",
+		},
+		{
+			Namespace: "ns2",
+			Status:    storkv1.ActionStatusRollbackFailed,
+			Reason:    "scaling up apps in namespace ns2 failed",
+		},
+	}}
+	actionObj.Status.Reason = "Failing failback operation as the last mile migration test-migrationschedule-lastmile-failback-353342c failed: status Failed"
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	cmdArgs := []string{"get", "failback", actionName, "-n", "kube-system"}
+	expected := "NAME                                                CREATED   STAGE       STATUS   MORE INFO\n" +
+		"failback-test-migrationschedule-2024-01-01-000000             Completed   Failed   Rolled back Apps in : 1/2 namespaces ; Failing failback operation as the last mile migration test-migrationschedule-lastmile-failback-353342c failed: status Failed\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 
@@ -93,4 +344,19 @@ func createFailoverActionAndVerify(t *testing.T) string {
 	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.MigrationScheduleReference, "test-migrationschedule")
 	require.Equal(t, *actionObj.Spec.ActionParameter.FailoverParameter.SkipDeactivateSource, true)
 	return failoverActionName
+}
+
+func createFailbackActionAndVerify(t *testing.T) string {
+	mockTheTime()
+	failbackActionName := "failback-test-migrationschedule-2024-01-01-000000"
+	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", true, t)
+	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
+	cmdArgs := []string{"perform", "failback", "-m", "test-migrationschedule", "-n", "kube-system"}
+	expected := fmt.Sprintf("Started failback for MigrationSchedule kube-system/test-migrationschedule\nTo check failback status use the command : `storkctl get failback %v -n kube-system`\n", failbackActionName)
+	testCommon(t, cmdArgs, nil, expected, false)
+	actionObj, err := storkops.Instance().GetAction(failbackActionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	require.Equal(t, actionObj.Spec.ActionParameter.FailbackParameter.FailbackNamespaces, []string{"ns1", "ns2"})
+	require.Equal(t, actionObj.Spec.ActionParameter.FailbackParameter.MigrationScheduleReference, "test-migrationschedule")
+	return failbackActionName
 }

--- a/pkg/storkctl/actionstatus_test.go
+++ b/pkg/storkctl/actionstatus_test.go
@@ -1,0 +1,96 @@
+//go:build unittest
+// +build unittest
+
+package storkctl
+
+import (
+	"fmt"
+	"testing"
+
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFailoverNoFailoverAction(t *testing.T) {
+	cmdArgs := []string{"get", "failover"}
+	expected := "No resources found.\n"
+	var actionList storkv1.ActionList
+	testCommon(t, cmdArgs, &actionList, expected, false)
+}
+
+func TestGetFailoverOneSuccessfulFailoverAction(t *testing.T) {
+	defer resetTest()
+	// create a failover action
+	actionName := createFailoverActionAndVerify(t)
+	// update the status pf the action
+	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	actionObj.Status.Stage = storkv1.ActionStageFinal
+	actionObj.Status.Status = storkv1.ActionStatusSuccessful
+	actionObj.Status.Summary = &storkv1.ActionSummary{FailoverSummaryItem: []*storkv1.FailoverSummary{
+		{
+			Namespace: "ns1",
+			Status:    storkv1.ActionStatusSuccessful,
+			Reason:    "scaling up apps in namespace ns1 successful",
+		},
+		{
+			Namespace: "ns2",
+			Status:    storkv1.ActionStatusSuccessful,
+			Reason:    "scaling up apps in namespace ns2 successful",
+		},
+	}}
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	cmdArgs := []string{"get", "failover", actionName, "-n", "kube-system"}
+	expected := "NAME                                                CREATED   STAGE       STATUS       ADDITIONAL INFO\n" +
+		"failover-test-migrationschedule-2024-01-01-000000             Completed   Successful   Scaled up Apps in : 2/2 namespaces\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func TestGetFailoverOneFailedFailoverAction(t *testing.T) {
+	defer resetTest()
+	// create a failover action
+	actionName := createFailoverActionAndVerify(t)
+	// update the status pf the action
+	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	actionObj.Status.Stage = storkv1.ActionStageFinal
+	actionObj.Status.Status = storkv1.ActionStatusFailed
+	actionObj.Status.Summary = &storkv1.ActionSummary{FailoverSummaryItem: []*storkv1.FailoverSummary{
+		{
+			Namespace: "ns1",
+			Status:    storkv1.ActionStatusRollbackSuccessful,
+			Reason:    "scaling up apps in namespace ns1 successful",
+		},
+		{
+			Namespace: "ns2",
+			Status:    storkv1.ActionStatusRollbackFailed,
+			Reason:    "scaling up apps in namespace ns2 failed",
+		},
+	}}
+	actionObj.Status.Reason = "Failing failover operation as the last mile migration test-migrationschedule-lastmile-failover-353342c failed: status Failed"
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+	cmdArgs := []string{"get", "failover", actionName, "-n", "kube-system"}
+	expected := "NAME                                                CREATED   STAGE       STATUS   ADDITIONAL INFO\n" +
+		"failover-test-migrationschedule-2024-01-01-000000             Completed   Failed   Rolled back Apps in : 1/2 namespaces ; Failing failover operation as the last mile migration test-migrationschedule-lastmile-failover-353342c failed: status Failed\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
+func createFailoverActionAndVerify(t *testing.T) string {
+	mockTheTime()
+	failoverActionName := "failover-test-migrationschedule-2024-01-01-000000"
+	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", true, t)
+	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
+	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--skip-deactivate-source", "-n", "kube-system"}
+	expected := fmt.Sprintf("Started failover for MigrationSchedule kube-system/test-migrationschedule\nTo check failover status use the command : `storkctl get failover %v -n kube-system`\n", failoverActionName)
+	testCommon(t, cmdArgs, nil, expected, false)
+	actionObj, err := storkops.Instance().GetAction(failoverActionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.FailoverNamespaces, []string{"ns1", "ns2"})
+	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.MigrationScheduleReference, "test-migrationschedule")
+	require.Equal(t, *actionObj.Spec.ActionParameter.FailoverParameter.SkipDeactivateSource, true)
+	return failoverActionName
+}

--- a/pkg/storkctl/get.go
+++ b/pkg/storkctl/get.go
@@ -36,6 +36,7 @@ func newGetCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *c
 		newGetBackupLocationCommand(cmdFactory, ioStreams),
 		newGetapplicationRegistrationCommand(cmdFactory, ioStreams),
 		newGetFailoverStatusCommand(cmdFactory, ioStreams),
+		newGetFailbackStatusCommand(cmdFactory, ioStreams),
 	)
 
 	return getCommands

--- a/pkg/storkctl/get.go
+++ b/pkg/storkctl/get.go
@@ -35,6 +35,7 @@ func newGetCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *c
 		newGetApplicationCloneCommand(cmdFactory, ioStreams),
 		newGetBackupLocationCommand(cmdFactory, ioStreams),
 		newGetapplicationRegistrationCommand(cmdFactory, ioStreams),
+		newGetFailoverStatusCommand(cmdFactory, ioStreams),
 	)
 
 	return getCommands

--- a/pkg/storkctl/perform.go
+++ b/pkg/storkctl/perform.go
@@ -1,0 +1,19 @@
+package storkctl
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func newPerformCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	performCommands := &cobra.Command{
+		Use:   "perform",
+		Short: "perform actions",
+	}
+
+	performCommands.AddCommand(
+		newPerformFailoverCommand(cmdFactory, ioStreams),
+		newPerformFailbackCommand(cmdFactory, ioStreams),
+	)
+	return performCommands
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>feature
>unit-test

**What this PR does / why we need it**:
CLI command to get summary / status of failover actions.

**Does this PR change a user-facing CRD or CLI?**:
Yes, adds new CLI commands `storkctl get failover` && `storkctl get failback`

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 24.2.0

** Testing Details **:
```
[root@olavangad-92-0 ~]# kubectl describe action -n kube-system failover-ms-4-2024-04-02-135725
Name:         failover-ms-4-2024-04-02-135725
Namespace:    kube-system
Labels:       <none>
Annotations:  <none>
API Version:  stork.libopenstorage.org/v1alpha1
Kind:         Action
Metadata:
  Creation Timestamp:  2024-04-02T13:57:25Z
  Finalizers:
    stork.libopenstorage.org/finalizer-cleanup
  Generation:        13
  Resource Version:  6948049
  UID:               353342cc-e1d8-482c-ab3c-066df87a77e8
Spec:
  Action Parameter:
    Failback Parameter:
      Failback Namespaces:           <nil>
      Migration Schedule Reference:  
    Failover Parameter:
      Failover Namespaces:
        314
      Migration Schedule Reference:  ms-4
      Skip Deactivate Source:        false
  Action Type:                       failover
Status:
  Finish Timestamp:  2024-04-02T14:01:19Z
  Reason:            Failing failover operation as the last mile migration ms-4-lastmile-failover-353342c failed: status Failed
  Stage:             Final
  Status:            Failed
  Summary:
    Failover Summary:
      Namespace:  314
      Reason:     scaling up apps in namespace 314 successful
      Status:     RollbackSuccessful
Events:
  Type    Reason                      Age    From   Message
  ----    ------                      ----   ----   -------
  Normal  RemoteClusterAccessibility  5m15s  stork  Cluster Accessibility test passed. K8s version of the cluster : https://10.13.8.104:6443 is v1.28.0
  Normal  Successful                  5m14s  stork  Scaling down of applications in cluster : https://10.13.8.104:6443 successful. Moving to the next stage
  Normal  Successful                  4m14s  stork  Pods using PVCs got scaled down successfully in cluster : https://10.13.8.104:6443 successful. Moving to the next stage
  Normal  ScaleReplicas               81s    stork  Scaling up apps in cluster https://10.13.8.104:6443
  Normal  RollbackSuccessful          81s    stork  Scaling up of applications in cluster : https://10.13.8.104:6443 successful. Moving to the next stage
```

```
[root@olavangad-92-0 ~]# storkctl get failover failover-ms-4-2024-04-02-135725 -n kube-system
NAME                              CREATED               STAGE       STATUS   ADDITIONAL INFO
failover-ms-4-2024-04-02-135725   02 Apr 24 13:57 UTC   Completed   Failed   Rolled back Apps in : 1/1 namespaces ; Failing failover operation as the last mile migration ms-4-lastmile-failover-353342c failed: status Failed
```

```
[root@olavangad-92-0 ~]# kubectl get action failover-ms-4-2024-04-02-155735 -n kube-system -oyaml
apiVersion: stork.libopenstorage.org/v1alpha1
kind: Action
metadata:
  creationTimestamp: "2024-04-02T15:57:35Z"
  finalizers:
  - stork.libopenstorage.org/finalizer-cleanup
  generation: 13
  name: failover-ms-4-2024-04-02-155735
  namespace: kube-system
  resourceVersion: "6988318"
  uid: a41e95d9-40aa-4cc4-be88-574ef5a5d6d0
spec:
  actionParameter:
    failbackParameter:
      failbackNamespaces: null
      migrationScheduleReference: ""
    failoverParameter:
      failoverNamespaces:
      - "314"
      migrationScheduleReference: ms-4
      skipDeactivateSource: false
  actionType: failover
status:
  finishTimestamp: "2024-04-02T16:02:20Z"
  reason: ""
  stage: Final
  status: Successful
  summary:
    failoverSummary:
    - namespace: "314"
      reason: scaling up apps in namespace 314 successful
      status: Successful
[root@olavangad-92-0 ~]# storkctl get failover failover-ms-4-2024-04-02-155735 -n kube-system
NAME                              CREATED               STAGE       STATUS       ADDITIONAL INFO
failover-ms-4-2024-04-02-155735   02 Apr 24 15:57 UTC   Completed   Successful   Scaled up Apps in : 1/1 namespaces
```

