### PR TITLE
Check vms before restart px

### DIFF
--- a/test/integration_test/kubevirt_hyperconv_test.go
+++ b/test/integration_test/kubevirt_hyperconv_test.go
@@ -308,6 +308,11 @@ func kubeVirtSimulateOCPUpgrade(t *testing.T) {
 		log.Infof("\nStart OCP upgrade simulation on node: %s", nodeName)
 		testStatesNode := getTestStatesForNode(t, ctxs, nodeName, allNodes)
 
+		if len(testStatesNode) == 0 {
+			log.Infof("No VMs are present on node: %s. Skipping this node", nodeName)
+			continue
+		}
+
 		for _, testState := range testStatesNode {
 			// start a live migration and wait for it to finish, to simulate node drain in OCP.
 			// vmPod changes after the live migration. The function below also verifies that the attachedNode


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
* The `kubeVirtSimulateOCPUpgrade` test currently restarts PX even on master node where no VMs are scheduled and PX is not installed
* This is causing the test to fail when restarting PX on those nodes
* This PR will avoid PX restarts on master node

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
