### PR TITLE
PB-6508: Backup to fail if all PVCs are in skipped state and making partial backup successful in backupResources stage

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -310,7 +310,6 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 					a.execRulesCompleted[string(backup.UID)] = true
 				}
 			}
-
 			canDelete, err := a.deleteBackup(backup)
 			if err != nil {
 				logrus.Errorf("%s: cleanup: %s", reflect.TypeOf(a), err)
@@ -1144,8 +1143,15 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 	}
 	// append skipped volumes
 	backup.Status.Volumes = append(backup.Status.Volumes, skipVolInfo...)
+	// add for fail and partial success
+	if len(backup.Status.Volumes) == len(skipVolInfo) {
+		// This case signifies that none of the volumes are successfully backed up
+		// hence marking it as failed
+		partialFailed = true
+	} else {
+		partialSuccess = true
+	}
 	if !partialSuccess && partialFailed {
-
 		// This case signifies that none of the volumes are successfully backed up
 		// hence marking it as failed
 		backup.Status.Stage = stork_api.ApplicationBackupStageFinal
@@ -1939,6 +1945,7 @@ func (a *ApplicationBackupController) backupResources(
 		}
 	}
 	backup.Status.FailedVolCount = len(failedVolInfoMap)
+	isPartialBackup := isPartialBackup(backup)
 	for _, obj := range allObjects {
 		objectType, err := meta.TypeAccessor(obj)
 		if err != nil {
@@ -2159,10 +2166,11 @@ func (a *ApplicationBackupController) backupResources(
 				backup.Status.BackupPath = GetObjectPath(backup)
 				backup.Status.Stage = stork_api.ApplicationBackupStageFinal
 				backup.Status.FinishTimestamp = metav1.Now()
-				if backup.Status.FailedVolCount > 0 {
-					backup.Status.Status = stork_api.ApplicationBackupStatusPartialSuccess
-					backup.Status.Reason = "Volumes and resources were backed up partially"
-				} else {
+				if isPartialBackup {
+					backup.Status.Status = stork_api.ApplicationBackupSatusPartialSuccess
+					backup.Status.Reason = "Some volumes were backed up"
+				}
+				if backup.Status.FailedVolCount == 0 {
 					backup.Status.Status = stork_api.ApplicationBackupStatusSuccessful
 					backup.Status.Reason = "Volumes and resources were backed up successfully"
 				}
@@ -2204,17 +2212,19 @@ func (a *ApplicationBackupController) backupResources(
 	backup.Status.BackupPath = GetObjectPath(backup)
 	backup.Status.Stage = stork_api.ApplicationBackupStageFinal
 	backup.Status.FinishTimestamp = metav1.Now()
-	if backup.Status.FailedVolCount > 0 {
+	if isPartialBackup {
 		backup.Status.Status = stork_api.ApplicationBackupStatusPartialSuccess
-	} else {
+	}
+	if backup.Status.FailedVolCount == 0 {
 		backup.Status.Status = stork_api.ApplicationBackupStatusSuccessful
 	}
 	if len(backup.Spec.NamespaceSelector) != 0 && len(backup.Spec.Namespaces) == 0 {
 		backup.Status.Reason = fmt.Sprintf("Namespace label selector [%s] did not find any namespaces with selected labels for backup", backup.Spec.NamespaceSelector)
 	} else {
-		if backup.Status.FailedVolCount > 0 {
-			backup.Status.Reason = "Volumes and resources were backed up partially"
-		} else {
+		if isPartialBackup {
+			backup.Status.Reason = "Some volumes were backed up"
+		}
+		if backup.Status.FailedVolCount == 0 {
 			backup.Status.Reason = "Volumes and resources were backed up successfully"
 		}
 	}
@@ -2635,4 +2645,8 @@ func (a *ApplicationBackupController) validateApplicationBackupParameters(backup
 		}
 	}
 	return nil
+}
+
+func isPartialBackup(backup *stork_api.ApplicationBackup) bool {
+	return backup.Status.FailedVolCount > 0 && backup.Status.FailedVolCount < len(backup.Status.Volumes)
 }


### PR DESCRIPTION
**What type of PR is this?**
>feature

**What this PR does / why we need it**:
When there all the PVCs to be backed up are in skipped state, then the backup is supposed to be in disabled state.
This PR implements the said above feature and also partial backup in case few PVCs are in failed or skipped state, after backing up of resources.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
**Scenario 1**: All the PVCs are kdmp and BL is in valid state:
<img width="636" alt="Screenshot 2024-04-03 at 11 43 05 AM" src="https://github.com/libopenstorage/stork/assets/148333439/670b97e6-c04e-4c71-85ee-751b26a3269f">
**Scenario 2**: BL is in active state, KDMP and 1 non KDMP PVC is successful and 1 non-KDMP is in failed state, the backup taken is in partial state
<img width="658" alt="Screenshot 2024-04-03 at 11 40 19 AM" src="https://github.com/libopenstorage/stork/assets/148333439/2c99ae48-9ab8-4643-8a3d-a97e4f4a69a7">
**Scenario 3**: The BL is in Limited Availability state and all the KDMP PVCs are skipped and the backup is in failed state.
<img width="636" alt="Screenshot 2024-04-03 at 11 24 54 AM" src="https://github.com/libopenstorage/stork/assets/148333439/f0e5b181-e999-4446-bd19-db428daeb41d">
**Scenario 4**: BL in disabled state, KDMP PVC skipped, 1 non-KDMP fail and 1 non-KDMP pass, backup is in partial state.
<img width="637" alt="Screenshot 2024-04-03 at 11 22 00 AM" src="https://github.com/libopenstorage/stork/assets/148333439/d6be0a72-46ca-472b-99bf-feb241e6528f">
<img width="636" alt="Screenshot 2024-04-03 at 11 21 50 AM" src="https://github.com/libopenstorage/stork/assets/148333439/7b9ff0e1-d17c-4ad7-ac62-e04daa6ef7e1">
