### PR TITLE
pb-6530: updating the CR content with the rule names, in the case of autoExecRule option.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -568,7 +568,7 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 				backup.Status.Stage = stork_api.ApplicationBackupStagePreExecRule
 				backup.Status.LastUpdateTimestamp = metav1.Now()
 				log.ApplicationBackupLog(backup).Infof("Auto exec Rules created, updating the CR")
-				//return updateCrFunction()
+				return updateCrFunction()
 
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
pb-6530: updating the CR content with the rule names, in the case of autoExecRule option.

            - In the case of autoExecRule option, we update the rule CR
              names in the applicationbackup CR in the reconciler cycle, dynamically.
            - Currently, we are not updating/persisting  the CR content initially.
              This causes issue in runPreExecRule api, where we update and
              read the CR content immediately. This client.Get actually reads from the
              cache content and the rul CR name in the applicationbackup CR was coming
              empty sometime. This makes the get rule call to fail with "resource name can not be empty."
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No, it is issue because of VM auto rule support feature.

**Does this change need to be cherry-picked to a release branch?**:
24.1.0

Tested on the QA setup, where we saw the error. Ran the schedule for 24 hours. No failures seen.


