### PR TITLE
PWX-34790: Enabling support for resourcetransformation for all objects including CRs.

### DIFF
--- a/pkg/migration/controllers/resourcetransformation.go
+++ b/pkg/migration/controllers/resourcetransformation.go
@@ -154,13 +154,7 @@ func (r *ResourceTransformationController) validateSpecPath(transform *stork_api
 		if err != nil {
 			return err
 		}
-		if !resourcecollector.GetSupportedK8SResources(kind, []string{}) {
-			return fmt.Errorf("unsupported resource kind for transformation: %s", kind)
-		}
 		for _, path := range spec.Paths {
-			// TODO: this can be validated via CRDs as well, when we have defined schema
-			// for stork crds
-			// https://portworx.atlassian.net/browse/PWX-26465
 			if path.Operation == stork_api.JsonResourcePatch {
 				return fmt.Errorf("json patch for resources is not supported, operation: %s", path.Operation)
 			}

--- a/pkg/migration/controllers/resourcetransformation_test.go
+++ b/pkg/migration/controllers/resourcetransformation_test.go
@@ -1,0 +1,90 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateSpecPath(t *testing.T) {
+	// Create a new ResourceTransformation object
+	transform := &v1alpha1.ResourceTransformation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-transform",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.ResourceTransformationSpec{
+			Objects: []v1alpha1.TransformSpecs{
+				{
+					Resource: "apps/v1/Deployment",
+					Paths: []v1alpha1.ResourcePaths{
+						{
+							Operation: v1alpha1.AddResourcePath,
+							Type:      v1alpha1.StringResourceType,
+							Path:      "/spec/template/spec/containers/0/image",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create a new ResourceTransformationController
+	controller := &ResourceTransformationController{
+		client: nil, // Replace with your own implementation of the client
+	}
+
+	// Call the validateSpecPath function
+	err := controller.validateSpecPath(transform)
+	assert.NoError(t, err, "Failed to validate spec path")
+
+	// Create a new ResourceTransformation object for a custom resource like elasticsearch
+	transform = &v1alpha1.ResourceTransformation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cr-transform",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.ResourceTransformationSpec{
+			Objects: []v1alpha1.TransformSpecs{
+				{
+					Resource: "elasticsearch/v1/Cluster",
+					Paths: []v1alpha1.ResourcePaths{
+						{
+							Operation: v1alpha1.AddResourcePath,
+							Type:      v1alpha1.StringResourceType,
+							Path:      "/spec/template/spec/containers/0/image",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Call the validateSpecPath function
+	err = controller.validateSpecPath(transform)
+	assert.NoError(t, err, "Failed to validate spec path")
+
+	// Update the ResourceTransformation object with json patch operation
+	transform.Spec.Objects[0].Paths[0].Operation = v1alpha1.JsonResourcePatch
+
+	// validateSpecPath function should fail for json patch operation
+	err = controller.validateSpecPath(transform)
+	assert.Error(t, err, "Spec path validation should fail for operation %s", v1alpha1.JsonResourcePatch)
+
+	// Update the ResourceTransformation object with an unsupported operation
+	transform.Spec.Objects[0].Paths[0].Operation = "invalid-operation"
+
+	// Call the validateSpecPath function again
+	err = controller.validateSpecPath(transform)
+	assert.Error(t, err, "Spec path validation should fail for operation %s", "invalid-operation")
+
+	// Update the ResourceTransformation object with an unsupported type
+	transform.Spec.Objects[0].Paths[0].Operation = v1alpha1.AddResourcePath
+	transform.Spec.Objects[0].Paths[0].Type = "invalid-type"
+
+	// Call the validateSpecPath function again
+	err = controller.validateSpecPath(transform)
+	assert.Error(t, err, "Spec path validation should fail for type %s", "invalid-type")
+}


### PR DESCRIPTION
Signed-off-by: Diptiranjan

**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Now resourcetransformation is supported for CRs.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes
```release-note
Issue: Resourcetransformation for CRs were not supported.
User Impact: It was blocking some of the necessary transformations for resources required in destination site.
Resolution: Now resourcetransformation for CRs is supported.

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 24.2.0

**Test**:
1. Transformed elasticsearch CR during migration.
2. Checked resourcetransformation for an invalid resource.

Test results have been updated in the ticket.
The integration test will be raised in another PR.