### PR TITLE
increase timeout for VM images download

### DIFF
--- a/test/integration_test/kubevirt_test.go
+++ b/test/integration_test/kubevirt_test.go
@@ -27,8 +27,8 @@ var templatePVCSpecs = map[string]string{
 const (
 	importerPodPrefix            = "importer"
 	importerPodStartTimeout      = 2 * time.Minute
-	importerPodCompletionTimeout = 20 * time.Minute
-	importerPodRetryInterval     = 10 * time.Second
+	importerPodCompletionTimeout = 60 * time.Minute
+	importerPodRetryInterval     = 30 * time.Second
 
 	kubevirtTemplates                     = "kubevirt-templates"
 	kubevirtDatadiskTemplates             = "kubevirt-datadisk-templates"


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
* The kubevirt functional test jobs are failing with timeout error when downloading images for VM templates
* Eg. https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%20Cloud%20Jobs/job/stork-ocp-kubevirt-4-13/96/consoleFull
* Increase the timeout when downloading images for VM templates
* Increase the retry interval for the same to reduce redundant logs

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
