### PR TITLE
changing the image used for elasticsearch

### DIFF
--- a/test/integration_test/specs/elasticsearch/elasticsearch.yaml
+++ b/test/integration_test/specs/elasticsearch/elasticsearch.yaml
@@ -50,7 +50,7 @@ spec:
           capabilities:
             add:
               - IPC_LOCK
-        image: quay.io/pires/docker-elasticsearch-kubernetes:5.5.0
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.5.0
         imagePullPolicy: Always
         env:
         - name: NAMESPACE


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
extender job is failing in statefulsetTest due to ImagePullBackoff when trying to pull elasticsearch image. Have changede the image used.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

Jenkins job to test whether issue is fixed in progress. Will merge PR post successful run
https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2023.11.1-dev/job/extender-op-k8s-1-25-0/348
