### PR TITLE
PWX-36885: verify initial VMI state correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/pborman/uuid v1.2.1
 	github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b
 	github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145
 	github.com/prometheus/client_golang v1.15.1
 	github.com/rancher/norman v0.0.0-20230222213531-275a3e921940
@@ -348,7 +348,7 @@ replace (
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240304221553-5aaf2148a210
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240327131138-e0fa03f5a66c
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240326191238-71d38500911c
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3

--- a/go.sum
+++ b/go.sum
@@ -4059,8 +4059,8 @@ github.com/portworx/px-backup-api v1.2.2-0.20240229114136-e58baeb9fbe1/go.mod h1
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987 h1:VNBTmIPjJRZ2QP64zdsrif3ELDHiMzoyNNX74VNHgZ8=
 github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987/go.mod h1:g3pw2lI2AjqAixUCRhaBdKTY98znsCPR7NGRrlpimVU=
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be h1:0RxnWnr0dyTfQu98r1cOwkluHofYLRJ5xnyp7LGEPl0=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be/go.mod h1:i3ImIVQMZOkmMU4nWP4kI/w6WFXsG2n/cFIGR5F1m8k=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b h1:i9MQ68H2YvpNzlU625qQFuGqQBBqFUVqVoV1ggOqK8M=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b/go.mod h1:LZkYF7Ke6gh3urQXFie1yBntpq1bINLVz05F8x314go=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/talisman v1.1.3/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.0.0-20240326191238-71d38500911c h1:bvttnV+Kg6pgHSY1YJKvxJSRNYmHru+tZJQL7qkprI0=

--- a/pkg/mock/kubevirt/kubevirt.ops.mock.go
+++ b/pkg/mock/kubevirt/kubevirt.ops.mock.go
@@ -198,6 +198,20 @@ func (mr *MockOpsMockRecorder) GetVirtualMachineInstance(arg0, arg1, arg2 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualMachineInstance", reflect.TypeOf((*MockOps)(nil).GetVirtualMachineInstance), arg0, arg1, arg2)
 }
 
+// IsKubevirtCRDInstalled mocks base method.
+func (m *MockOps) IsKubevirtCRDInstalled() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsKubevirtCRDInstalled")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IsKubevirtCRDInstalled indicates an expected call of IsKubevirtCRDInstalled.
+func (mr *MockOpsMockRecorder) IsKubevirtCRDInstalled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsKubevirtCRDInstalled", reflect.TypeOf((*MockOps)(nil).IsKubevirtCRDInstalled))
+}
+
 // IsVirtualMachineRunning mocks base method.
 func (m *MockOps) IsVirtualMachineRunning(arg0 *v10.VirtualMachine) bool {
 	m.ctrl.T.Helper()

--- a/test/integration_test/kubevirt_hyperconv_test.go
+++ b/test/integration_test/kubevirt_hyperconv_test.go
@@ -110,7 +110,12 @@ func kubeVirtHypercOneLiveMigration(t *testing.T) {
 	)
 	allNodes := node.GetNodesByVoDriverNodeID()
 
+	// Verify the initial state of the VMs before making any changes to the cluster.
+	verifyInitialHyperconvergence(t, ctxs, allNodes)
+
+	// Iterate over all VMs and simulate OCP node upgrade for each.
 	for _, appCtx := range ctxs {
+		// We need to gather the testState again because it may have changed during the previous iteration.
 		testState := &kubevirtTestState{
 			appCtx:   appCtx,
 			allNodes: allNodes,
@@ -163,6 +168,9 @@ func kubeVirtHypercTwoLiveMigrations(t *testing.T) {
 		kubevirtScale,
 	)
 	allNodes := node.GetNodesByVoDriverNodeID()
+
+	// Verify the initial state of the VMs before making any changes to the cluster.
+	verifyInitialHyperconvergence(t, ctxs, allNodes)
 
 	for _, appCtx := range ctxs {
 		testState := &kubevirtTestState{
@@ -224,6 +232,9 @@ func kubeVirtHypercHotPlugDiskCollocation(t *testing.T) {
 		kubevirtScale,
 	)
 	allNodes := node.GetNodesByVoDriverNodeID()
+
+	// Verify the initial state of the VMs before making any changes to the cluster.
+	verifyInitialHyperconvergence(t, ctxs, allNodes)
 
 	for _, appCtx := range ctxs {
 		testState := &kubevirtTestState{
@@ -300,6 +311,9 @@ func kubeVirtSimulateOCPUpgrade(t *testing.T) {
 		kubevirtScale,
 	)
 	allNodes := node.GetNodesByVoDriverNodeID()
+
+	// Verify the initial state of the VMs before making any changes to the cluster.
+	verifyInitialHyperconvergence(t, ctxs, allNodes)
 
 	nodeList := node.GetNodesByName()
 
@@ -1055,4 +1069,16 @@ func restartVolumeDriverAndWaitForReady(t *testing.T, attachedNode *node.Node) {
 	require.NoError(t, err)
 
 	log.InfoD("Volume driver is up on node %s", attachedNode.Name)
+}
+
+// Verify the initial state of the VMs before making any changes to the cluster.
+func verifyInitialHyperconvergence(t *testing.T, ctxs []*scheduler.Context, allNodes map[string]node.Node) {
+	for _, appCtx := range ctxs {
+		testState := &kubevirtTestState{
+			appCtx:   appCtx,
+			allNodes: allNodes,
+		}
+		gatherInitialVMIInfo(t, testState)
+		verifyInitialVMI(t, testState)
+	}
 }

--- a/test/integration_test/specs/kubevirt-fedora-multi-disks-wffc/fedora-multi-disks-wffc.yaml
+++ b/test/integration_test/specs/kubevirt-fedora-multi-disks-wffc/fedora-multi-disks-wffc.yaml
@@ -71,6 +71,8 @@ spec:
   dataVolumeTemplates:
   - metadata:
       name: fedora-root-disk
+      annotations:
+        cdi.kubevirt.io/storage.usePopulator: "false"
     spec:
       source:
         pvc:

--- a/test/integration_test/specs/kubevirt-fedora-wait-first-consumer/fedora-vm-wait-first-consumer.yaml
+++ b/test/integration_test/specs/kubevirt-fedora-wait-first-consumer/fedora-vm-wait-first-consumer.yaml
@@ -62,6 +62,8 @@ spec:
   dataVolumeTemplates:
   - metadata:
       name: fedora-datavolume-wffc
+      annotations:
+        cdi.kubevirt.io/storage.usePopulator: "false"
     spec:
       source:
         pvc:

--- a/test/integration_test/specs/kubevirt-windows-22k-server-wait-first-consumer/windows-vm.yaml
+++ b/test/integration_test/specs/kubevirt-windows-22k-server-wait-first-consumer/windows-vm.yaml
@@ -80,6 +80,8 @@ spec:
   dataVolumeTemplates:
     - metadata:
         name: windows-2022-datavol-wait-first-consumer
+        annotations:
+          cdi.kubevirt.io/storage.usePopulator: "false"
       spec:
         preallocation: false
         source:

--- a/vendor/github.com/portworx/sched-ops/k8s/core/pods.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/pods.go
@@ -216,7 +216,9 @@ func (c *Client) getPodsUsingPVWithListOptions(pvName string, opts metav1.ListOp
 	}
 
 	if pv.Status.Phase == corev1.VolumeBound {
-		if pv.Spec.ClaimRef != nil && pv.Spec.ClaimRef.Kind == "PersistentVolumeClaim" {
+		// In some k8s installations, we have seen that the Kind is not populated in the claim ref object. This
+		// should be ok since the kind is implicit for "ClaimRef".
+		if pv.Spec.ClaimRef != nil && (pv.Spec.ClaimRef.Kind == "PersistentVolumeClaim" || pv.Spec.ClaimRef.Kind == "") {
 			return c.getPodsUsingPVCWithListOptions(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace, opts)
 		}
 	} // else the volume is not bound so cannot rely on stale claim ref objects

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1081,7 +1081,7 @@ github.com/portworx/px-object-controller/client/listers/objectservice/v1alpha1
 github.com/portworx/px-object-controller/pkg/client
 github.com/portworx/px-object-controller/pkg/controller
 github.com/portworx/px-object-controller/pkg/utils
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be => github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b => github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/admissionregistration
 github.com/portworx/sched-ops/k8s/apiextensions
@@ -2575,7 +2575,7 @@ sigs.k8s.io/yaml/goyaml.v2
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240304221553-5aaf2148a210
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
 # github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240327131138-e0fa03f5a66c
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240331082638-605dbf61e0be
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240411193047-d17313c6c11b
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240326191238-71d38500911c
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
 # helm.sh/helm/v3 => helm.sh/helm/v3 v3.10.3


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
integration-test

**What this PR does / why we need it**:
The tests were verifying the initial VMI only for the first VM in the list. For the remaining VMs, the VMI has changed due to the testing performed on the first VM. So, we end up verifying the second or third VMI. This caused a bug to escape.

Changed the tests to verify the initial VMI correctly and verifed that they fail on OCP 4.14. Then, added an annotation to turn off cdi population to make the tests pass.

Also, vendored in the latest sched-ops to handle empty Kind in GetPodsUsingPV.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
no

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
no
