### PR TITLE
Integration test fixes for backup and snapshot tests.

### DIFF
--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -1234,7 +1234,7 @@ func applicationBackupSyncControllerTest(t *testing.T) {
 	log.InfoD("Updated backup location on 2nd cluster %s: sync:%t", backupLocation2.Name, backupLocation2.Location.Sync)
 
 	backupToRestore, err := getSyncedBackupWithAnnotation(firstBackup, backupSyncAnnotation)
-	Dash.VerifyFatal(t, err != nil, true, "Backup found on the second cluster")
+	Dash.VerifyFatal(t, backupToRestore != nil, true, "Backup found on the second cluster")
 
 	// Create application restore using the backup selected, on second cluster
 	log.InfoD("Starting Restore on second cluster.")

--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -595,7 +595,9 @@ func intervalSnapshotScheduleWithSimilarLongNamesTest(t *testing.T) {
 
 	policyName := "intervalpolicy"
 	retain := 1
-	interval := 2
+	// Increasing the interval time as we have to validate multiple volumesnapshot schedules
+	// so that chances of snapshot trigerring gets reduced for verfication of later volumesnashot schedules
+	interval := 3
 	schedPolicy := &storkv1.SchedulePolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: policyName,
@@ -621,7 +623,6 @@ func intervalSnapshotScheduleWithSimilarLongNamesTest(t *testing.T) {
 	log.FailOnError(t, err, fmt.Sprintf("Error getting pvcs in namespace %s interval schedule policy", namespace))
 	log.InfoD("Found %v pvcs in namespace %s", len(pvcList.Items), namespace)
 
-	sleepTime := time.Duration((retain+1)*interval) * time.Minute
 	scheduleNames := make([]string, 0)
 	for _, pvc := range pvcList.Items {
 		scheduleName := fmt.Sprintf("intervalscheduletest-%s", pvc.Name)
@@ -647,11 +648,11 @@ func intervalSnapshotScheduleWithSimilarLongNamesTest(t *testing.T) {
 
 		_, err = storkops.Instance().CreateSnapshotSchedule(snapSched)
 		log.FailOnError(t, err, "Error creating interval snapshot schedule")
-		sleepTime := time.Duration((retain+1)*interval) * time.Minute
-		log.InfoD("Created snapshotschedule %v in namespace %v, sleeping for %v for schedule to trigger",
-			scheduleName, namespace, sleepTime)
+		log.InfoD("Created snapshotschedule %v in namespace %v", scheduleName, namespace)
 	}
 
+	sleepTime := time.Duration(interval-1) * time.Minute
+	log.InfoD("Sleeping for %v for schedule to trigger", sleepTime)
 	time.Sleep(sleepTime)
 
 	for _, scheduleName := range scheduleNames {
@@ -661,7 +662,7 @@ func intervalSnapshotScheduleWithSimilarLongNamesTest(t *testing.T) {
 			snapshotScheduleRetryInterval)
 		log.FailOnError(t, err, "Error validating interval snapshot schedule")
 		Dash.VerifyFatal(t, len(snapStatuses), 1, "Should have snapshots for only one policy type")
-		Dash.VerifyFatal(t, retain, len(snapStatuses[storkv1.SchedulePolicyTypeInterval]), fmt.Sprintf("Should have only %v snapshot for interval policy", retain))
+		Dash.VerifyFatal(t, len(snapStatuses[storkv1.SchedulePolicyTypeInterval]), retain, fmt.Sprintf("Should have only %v snapshot for interval policy", retain))
 		log.InfoD("Validated snapshotschedule %v", scheduleName)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
1. For backup tests , wrong assertion for in backup sync test.
2. In snapshot tests, choosing a bigger interval time to avoid the possibility of next snapshot trigger which may lead for sometime the old snapshot is present before it gets pruned.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no



**Does this change need to be cherry-picked to a release branch?**:
no

Test runs: 
https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2023.11.1-dev/job/application-backup-k8s-1-28-0/2162/
https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2023.11.1-dev/job/snapshot-csi-k8s-1-25/2496/