### PR TITLE
add new VM spec for datavolume based root and data-disk, without WFFC

### DIFF
--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -1729,7 +1729,7 @@ func addTestModeEnvironmentVar() error {
 
 func IsCloud() bool {
 	stc, err := operator.Instance().ListStorageClusters(defaultAdminNamespace)
-	if err == nil {
+	if len(stc.Items) > 0 && err == nil {
 		log.InfoD("Storage cluster name: %s", stc.Items[0].Name)
 		if len(stc.Items) > 0 {
 			if oputils.IsEKS(&stc.Items[0]) {

--- a/test/integration_test/kubevirt_hyperconv_test.go
+++ b/test/integration_test/kubevirt_hyperconv_test.go
@@ -105,6 +105,7 @@ func kubeVirtHypercOneLiveMigration(t *testing.T) {
 		[]string{
 			"kubevirt-fedora", "kubevirt-fedora-wait-first-consumer", "kubevirt-fedora-multi-disks-wffc",
 			"kubevirt-windows-22k-server", "kubevirt-windows-22k-server-wait-first-consumer",
+			"kubevirt-fedora-multiple-disks-datavol-only",
 		},
 		kubevirtScale,
 	)
@@ -164,6 +165,7 @@ func kubeVirtHypercTwoLiveMigrations(t *testing.T) {
 		[]string{
 			"kubevirt-fedora", "kubevirt-fedora-wait-first-consumer", "kubevirt-fedora-multi-disks-wffc",
 			"kubevirt-windows-22k-server", "kubevirt-windows-22k-server-wait-first-consumer",
+			"kubevirt-fedora-multiple-disks-datavol-only",
 		},
 		kubevirtScale,
 	)
@@ -307,6 +309,7 @@ func kubeVirtSimulateOCPUpgrade(t *testing.T) {
 		[]string{
 			"kubevirt-fedora", "kubevirt-fedora-wait-first-consumer", "kubevirt-fedora-multi-disks-wffc",
 			"kubevirt-windows-22k-server", "kubevirt-windows-22k-server-wait-first-consumer",
+			"kubevirt-fedora-multiple-disks-datavol-only",
 		},
 		kubevirtScale,
 	)
@@ -712,7 +715,7 @@ func startAndWaitForVMIMigration(t *testing.T, testState *kubevirtTestState, mig
 func restartVolumeDriverAndWaitForAttachmentToMove(t *testing.T, testState *kubevirtTestState) {
 	verifyDisksAttachedOnSameNode(t, testState)
 	attachedNode := testState.vmDisks[0].attachedNode
-	log.InfoD("Restarting volume driver on node %s", attachedNode)
+	log.InfoD("Restarting volume driver on node %s", attachedNode.Name)
 	restartVolumeDriverAndWaitForReady(t, attachedNode)
 	waitForVolumeAttachmentsToMove(t, testState, attachedNode)
 }
@@ -876,7 +879,7 @@ func verifyVMProperties(
 		// verify replica node
 		replicaNodeIDs := getReplicaNodeIDs(vmDisk.apiVol)
 		if expectReplicaNode {
-			Dash.VerifyFatal(t, replicaNodeIDs[podNodeID], true, fmt.Sprintf("pod is running on node %s (%s) which is a replica node for %s", vmPod.Spec.NodeName, podNodeID, vmDisk))
+			Dash.VerifyFatal(t, replicaNodeIDs[podNodeID], true, fmt.Sprintf("pod is running on node %s (%s) which is NOT a replica node for %s", vmPod.Spec.NodeName, podNodeID, vmDisk))
 		} else {
 			Dash.VerifyFatal(t, replicaNodeIDs[podNodeID], false, fmt.Sprintf("pod is running on node %s (%s) which is a replica node for %s", vmPod.Spec.NodeName, podNodeID, vmDisk))
 		}

--- a/test/integration_test/specs/kubevirt-fedora-multiple-disks-datavol-only/fedora-vm-multidisk-datavol-only.yaml
+++ b/test/integration_test/specs/kubevirt-fedora-multiple-disks-datavol-only/fedora-vm-multidisk-datavol-only.yaml
@@ -1,0 +1,111 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    app: fedora-vm-multidisk-datavol-only
+    vm.kubevirt.io/template: fedora-server-small
+    vm.kubevirt.io/template.namespace: openshift
+  name: fedora-vm-multidisk-datavol-only
+spec:
+  running: true
+  template:
+    metadata:
+      annotations:
+        vm.kubevirt.io/flavor: small
+        vm.kubevirt.io/os: fedora
+        vm.kubevirt.io/workload: server
+      labels:
+        kubevirt.io/size: small
+    spec:
+      domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
+        devices:
+          disks:
+          - bootOrder: 1
+            disk:
+              bus: virtio
+            name: rootdisk
+          - bootOrder: 2
+            disk:
+              bus: virtio
+            name: cloudinitdisk
+          networkInterfaceMultiqueue: true
+          rng: {}
+        features:
+          acpi: {}
+          smm:
+            enabled: true
+        firmware:
+          bootloader:
+            efi: {}
+        machine:
+          type: pc-q35-rhel9.2.0
+        resources:
+          requests:
+            memory: 2Gi
+      evictionStrategy: LiveMigrate
+      terminationGracePeriodSeconds: 180
+      volumes:
+      - dataVolume:
+          name: fedora-root-disk-datavol-only
+        name: rootdisk
+      - dataVolume:
+          name: fedora-data-disk-datavol-only
+        name: fedora-datavol-disk
+      - dataVolume:
+          name: fedora-data-disk-datavol-only-blank
+        name: fedora-datavol-disk-2
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            user: fedora
+            password: password1
+            chpasswd: { expire: False }
+        name: cloudinitdisk
+  dataVolumeTemplates:
+  - metadata:
+      name: fedora-root-disk-datavol-only
+    spec:
+      source:
+        pvc:
+          name: fedora-template-pvc
+          namespace: openshift-virtualization-os-images
+      pvc:
+        accessModes:
+        - ReadWriteMany
+        resources:
+          requests:
+            storage: 50Gi
+        storageClassName: sc-sharedv4svc-nolock
+        volumeMode: Filesystem
+  - metadata:
+      name: fedora-data-disk-datavol-only
+    spec:
+      source:
+        pvc:
+          name: fedora-template-datadisk
+          namespace: openshift-virtualization-datadisk-templates
+      pvc:
+        accessModes:
+        - ReadWriteMany
+        resources:
+          requests:
+            storage: 25Gi
+        storageClassName: sc-sharedv4svc-nolock
+        volumeMode: Filesystem
+  - metadata:
+      name: fedora-data-disk-datavol-only-blank
+    spec:
+      source:
+        blank: {}
+      pvc:
+        accessModes:
+        - ReadWriteMany
+        resources:
+          requests:
+            storage: 25Gi
+        storageClassName: sc-sharedv4svc-nolock
+        volumeMode: Filesystem


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
* Adding a new VM spec that uses only datavolume based root and datadisks, that don't use WFFC
* This way co-location will always be achieved

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no
