### PR TITLE
[PWX-36891] Updating ApplicationActivated to true/false in the migrationschedule 

### DIFF
--- a/pkg/action/drutils.go
+++ b/pkg/action/drutils.go
@@ -171,8 +171,7 @@ func (ac *ActionController) updateApplicationActivatedInRelevantMigrationSchedul
 	// relevant migrationSchedules are ones which are involved in migration of resources from at least one of the namespaces being activated.
 	// such migrationSchedules can reside in any of the activationNamespaces or in the adminNamespace
 	adminNs := utils.GetAdminNamespace()
-	migrationScheduleNamespaces := make([]string, 0)
-	migrationScheduleNamespaces = activationNamespaces
+	migrationScheduleNamespaces := activationNamespaces
 	if !slices.Contains(activationNamespaces, adminNs) {
 		migrationScheduleNamespaces = append(migrationScheduleNamespaces, adminNs)
 	}
@@ -196,9 +195,7 @@ func (ac *ActionController) updateApplicationActivatedInRelevantMigrationSchedul
 			logEvents(msg, "err")
 			ac.updateAction(action)
 		}
-		for _, item := range migrSchedules.Items {
-			migrationSchedules.Items = append(migrationSchedules.Items, item)
-		}
+		migrationSchedules.Items = append(migrationSchedules.Items, migrSchedules.Items...)
 	}
 
 	for _, migrSched := range migrationSchedules.Items {

--- a/pkg/action/drutils.go
+++ b/pkg/action/drutils.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"fmt"
-
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/utils"
@@ -12,6 +11,7 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"slices"
 )
 
 type DRKind string
@@ -161,4 +161,66 @@ func (ac *ActionController) remoteClusterDomainUpdate(activate bool, action *sto
 		}
 	}
 	return nil
+}
+
+func (ac *ActionController) updateApplicationActivatedInRelevantMigrationSchedules(action *storkv1.Action, config *rest.Config, namespaces []string, migrationNamespaces []string, value bool) {
+	// This is best effort only. In case we encounter an error we just log events and logs. Action will not be failed.
+
+	// Only subset of namespaces which are migrated by the reference migrationSchedule are activated / deactivated
+	_, activationNamespaces, _ := utils.IsSubList(namespaces, migrationNamespaces)
+	// relevant migrationSchedules are ones which are involved in migration of resources from at least one of the namespaces being activated.
+	// such migrationSchedules can reside in any of the activationNamespaces or in the adminNamespace
+	adminNs := utils.GetAdminNamespace()
+	migrationScheduleNamespaces := make([]string, 0)
+	migrationScheduleNamespaces = activationNamespaces
+	if !slices.Contains(activationNamespaces, adminNs) {
+		migrationScheduleNamespaces = append(migrationScheduleNamespaces, adminNs)
+	}
+
+	storkClient, err := storkops.NewForConfig(config)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to create the stork client to access cluster with the config %v", config.Host)
+		logEvents := ac.printFunc(action, "ApplicationActivatedStatus")
+		logEvents(msg, "err")
+		action.Status.Status = storkv1.ActionStatusFailed
+		ac.updateAction(action)
+		return
+	}
+
+	migrationSchedules := new(storkv1.MigrationScheduleList)
+	for _, ns := range migrationScheduleNamespaces {
+		migrSchedules, err := storkClient.ListMigrationSchedules(ns)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to fetch the list of migrationSchedules in the namespace %v", ns)
+			logEvents := ac.printFunc(action, "ApplicationActivatedStatus")
+			logEvents(msg, "err")
+			ac.updateAction(action)
+		}
+		for _, item := range migrSchedules.Items {
+			migrationSchedules.Items = append(migrationSchedules.Items, item)
+		}
+	}
+
+	for _, migrSched := range migrationSchedules.Items {
+		isMigrSchedRelevant, err := utils.DoesMigrationScheduleMigrateNamespaces(migrSched, activationNamespaces)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to determine the list of namespaces migrated by the migrationSchedule %v/%v", migrSched.Namespace, migrSched.Name)
+			logEvents := ac.printFunc(action, "ApplicationActivatedStatus")
+			logEvents(msg, "err")
+			ac.updateAction(action)
+		}
+		if isMigrSchedRelevant {
+			migrSched.Status.ApplicationActivated = value
+			_, err := storkClient.UpdateMigrationSchedule(&migrSched)
+			if err != nil {
+				msg := fmt.Sprintf("Failed to update ApplicationActivated field for the migrationSchedule %v/%v", migrSched.Namespace, migrSched.Name)
+				logEvents := ac.printFunc(action, "ApplicationActivatedStatus")
+				logEvents(msg, "err")
+				ac.updateAction(action)
+			}
+			msg := fmt.Sprintf("Setting the ApplicationActivated status in the MigrationSchedule %v/%v to %v", migrSched.Namespace, migrSched.Name, value)
+			logEvents := ac.printFunc(action, "ApplicationActivatedStatus")
+			logEvents(msg, "out")
+		}
+	}
 }

--- a/pkg/action/drutils.go
+++ b/pkg/action/drutils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/log"
+	migration "github.com/libopenstorage/stork/pkg/migration/controllers"
 	"github.com/libopenstorage/stork/pkg/utils"
 	"github.com/pborman/uuid"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
@@ -199,6 +200,10 @@ func (ac *ActionController) updateApplicationActivatedInRelevantMigrationSchedul
 	}
 
 	for _, migrSched := range migrationSchedules.Items {
+		if migrSched.GetAnnotations() == nil || migrSched.GetAnnotations()[migration.StorkMigrationScheduleCopied] != "true" {
+			// no need to update the applicationActivated filed in case the migrationSchedule is not a static copy
+			continue
+		}
 		isMigrSchedRelevant, err := utils.DoesMigrationScheduleMigrateNamespaces(migrSched, activationNamespaces)
 		if err != nil {
 			msg := fmt.Sprintf("Failed to determine the list of namespaces migrated by the migrationSchedule %v/%v", migrSched.Namespace, migrSched.Name)

--- a/pkg/action/failback.go
+++ b/pkg/action/failback.go
@@ -236,7 +236,7 @@ func (ac *ActionController) deactivateDestinationDuringFailback(action *storkv1.
 	}
 	// get destination i.e. current cluster's config
 	clusterConfig := ac.config
-	ac.deactivateClusterDuringDR(action, actualNamespaces, sourceConfig, clusterConfig)
+	ac.deactivateClusterDuringDR(action, actualNamespaces, migrationNamespaces, sourceConfig, clusterConfig)
 }
 
 func (ac *ActionController) waitAfterScaleDown(action *storkv1.Action) {

--- a/pkg/action/failover.go
+++ b/pkg/action/failover.go
@@ -217,11 +217,11 @@ func (ac *ActionController) deactivateSourceDuringFailover(action *storkv1.Actio
 	}
 	// get destination i.e. current cluster's config
 	clusterConfig := ac.config
-	ac.deactivateClusterDuringDR(action, actualNamespaces, clusterConfig, remoteConfig)
+	ac.deactivateClusterDuringDR(action, actualNamespaces, migrationNamespaces, clusterConfig, remoteConfig)
 }
 
 // deactivateClusterDuringDR will be used in both failover and failback to deactivate apps in source/destination clusters respectively
-func (ac *ActionController) deactivateClusterDuringDR(action *storkv1.Action, namespaces []string, activationClusterConfig *rest.Config, deactivationClusterConfig *rest.Config) {
+func (ac *ActionController) deactivateClusterDuringDR(action *storkv1.Action, namespaces []string, migrationNamespaces []string, activationClusterConfig *rest.Config, deactivationClusterConfig *rest.Config) {
 	// identify which resources to be scaled down by looking at which resources will be activated in the opposite cluster
 	resourcesBeingActivatedMap := make(map[string]map[metav1.GroupVersionKind]map[string]string)
 	for _, ns := range namespaces {
@@ -249,6 +249,8 @@ func (ac *ActionController) deactivateClusterDuringDR(action *storkv1.Action, na
 		ac.updateAction(action)
 		return
 	}
+	// Update ApplicationActivated value in relevant migrationSchedules
+	ac.updateApplicationActivatedInRelevantMigrationSchedules(action, deactivationClusterConfig, namespaces, migrationNamespaces, false)
 	msg := fmt.Sprintf("Scaling down of applications in cluster : %s successful. Moving to the next stage", deactivationClusterConfig.Host)
 	logEvents := ac.printFunc(action, string(storkv1.ActionStatusSuccessful))
 	logEvents(msg, "out")
@@ -328,6 +330,8 @@ func (ac *ActionController) activateClusterDuringDR(action *storkv1.Action, name
 		successStatus = storkv1.ActionStatusRollbackSuccessful
 	}
 
+	namespacesSuccessfullyActivated := make([]string, 0)
+
 	for _, ns := range namespaces {
 		logEvents := ac.printFunc(action, "ScaleReplicas")
 		logEvents(fmt.Sprintf("Scaling up apps in cluster %s", config.Host), "out")
@@ -342,6 +346,7 @@ func (ac *ActionController) activateClusterDuringDR(action *storkv1.Action, name
 				failoverSummary, failbackSummary = ac.createSummary(action, ns, failureStatus, msg)
 			} else {
 				msg := fmt.Sprintf("scaling up apps in namespace %s successful", ns)
+				namespacesSuccessfullyActivated = append(namespacesSuccessfullyActivated, ns)
 				failoverSummary, failbackSummary = ac.createSummary(action, ns, successStatus, msg)
 			}
 		} else {
@@ -355,14 +360,15 @@ func (ac *ActionController) activateClusterDuringDR(action *storkv1.Action, name
 		}
 	}
 
-	//TODO: Also mark the relevant MigrationSchedule's applicationActivated to true
-
 	if action.Spec.ActionType == storkv1.ActionTypeFailover {
 		action.Status.Summary = &storkv1.ActionSummary{FailoverSummaryItem: failoverSummaryList}
 	} else if action.Spec.ActionType == storkv1.ActionTypeFailback {
 		action.Status.Summary = &storkv1.ActionSummary{FailbackSummaryItem: failbackSummaryList}
 	}
+
 	if scaleUpStatus {
+		// Update ApplicationActivated value in relevant migrationSchedules
+		ac.updateApplicationActivatedInRelevantMigrationSchedules(action, config, namespacesSuccessfullyActivated, migrationNamespaces, true)
 		msg := fmt.Sprintf("Scaling up of applications in cluster : %s successful. Moving to the next stage", config.Host)
 		logEvents := ac.printFunc(action, string(successStatus))
 		logEvents(msg, "out")

--- a/pkg/storkctl/migration.go
+++ b/pkg/storkctl/migration.go
@@ -187,8 +187,10 @@ func newActivateMigrationsCommand(cmdFactory Factory, ioStreams genericclioption
 					util.CheckErr(err)
 					return
 				}
+				// MigrationSchedule will only be relevant if it migrates at least one of the activation namespaces
+				// Only for such migrationSchedules we will need to update applicationActivated:true
 				for _, migrSched := range migrationSchedules.Items {
-					isMigrSchedRelevant, err := doesMigrationScheduleMigrateNamespaces(migrSched, activationNamespaces)
+					isMigrSchedRelevant, err := utils.DoesMigrationScheduleMigrateNamespaces(migrSched, activationNamespaces)
 					if err != nil {
 						util.CheckErr(err)
 						return
@@ -209,29 +211,6 @@ func newActivateMigrationsCommand(cmdFactory Factory, ioStreams genericclioption
 	activateMigrationCommand.Flags().BoolVarP(&allNamespaces, "all-namespaces", "a", false, "Activate applications in all namespaces")
 
 	return activateMigrationCommand
-}
-
-// MigrationSchedule will only be relevant if it migrates at least one of the activation namespaces
-// Only for such migrationSchedules we will need to update applicationActivated:true
-func doesMigrationScheduleMigrateNamespaces(migrSched storkv1.MigrationSchedule, activationNs []string) (bool, error) {
-	namespaceList := migrSched.Spec.Template.Spec.Namespaces
-	namespaceSelectors := migrSched.Spec.Template.Spec.NamespaceSelectors
-	migrationNamespaces, err := utils.GetMergedNamespacesWithLabelSelector(namespaceList, namespaceSelectors)
-	if err != nil {
-		return false, fmt.Errorf("unable to get the namespaces based on the provided --namespace-selectors : %v", err)
-	}
-	activationNamespacesSet := make(map[string]bool)
-	for _, ns := range activationNs {
-		activationNamespacesSet[ns] = true
-	}
-	found := false
-	for _, ns := range migrationNamespaces {
-		if activationNamespacesSet[ns] {
-			found = true
-			break
-		}
-	}
-	return found, nil
 }
 
 func newDeactivateMigrationsCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
@@ -281,7 +260,7 @@ func newDeactivateMigrationsCommand(cmdFactory Factory, ioStreams genericcliopti
 					return
 				}
 				for _, migrSched := range migrationSchedules.Items {
-					isMigrSchedRelevant, err := doesMigrationScheduleMigrateNamespaces(migrSched, deactivationNamespaces)
+					isMigrSchedRelevant, err := utils.DoesMigrationScheduleMigrateNamespaces(migrSched, deactivationNamespaces)
 					if err != nil {
 						util.CheckErr(err)
 						return

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -424,3 +424,24 @@ func GetAdminNamespace() string {
 	}
 	return adminNs
 }
+
+func DoesMigrationScheduleMigrateNamespaces(migrationSchedule stork_api.MigrationSchedule, activationNs []string) (bool, error) {
+	namespaceList := migrationSchedule.Spec.Template.Spec.Namespaces
+	namespaceSelectors := migrationSchedule.Spec.Template.Spec.NamespaceSelectors
+	migrationNamespaces, err := GetMergedNamespacesWithLabelSelector(namespaceList, namespaceSelectors)
+	if err != nil {
+		return false, fmt.Errorf("unable to get the namespaces based on the provided --namespace-selectors : %v", err)
+	}
+	activationNamespacesSet := make(map[string]bool)
+	for _, ns := range activationNs {
+		activationNamespacesSet[ns] = true
+	}
+	found := false
+	for _, ns := range migrationNamespaces {
+		if activationNamespacesSet[ns] {
+			found = true
+			break
+		}
+	}
+	return found, nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -425,7 +425,7 @@ func GetAdminNamespace() string {
 	return adminNs
 }
 
-func DoesMigrationScheduleMigrateNamespaces(migrationSchedule stork_api.MigrationSchedule, activationNs []string) (bool, error) {
+func DoesMigrationScheduleMigrateNamespaces(migrationSchedule stork_api.MigrationSchedule, activatedNSList []string) (bool, error) {
 	namespaceList := migrationSchedule.Spec.Template.Spec.Namespaces
 	namespaceSelectors := migrationSchedule.Spec.Template.Spec.NamespaceSelectors
 	migrationNamespaces, err := GetMergedNamespacesWithLabelSelector(namespaceList, namespaceSelectors)
@@ -433,7 +433,7 @@ func DoesMigrationScheduleMigrateNamespaces(migrationSchedule stork_api.Migratio
 		return false, fmt.Errorf("unable to get the namespaces based on the provided --namespace-selectors : %v", err)
 	}
 	activationNamespacesSet := make(map[string]bool)
-	for _, ns := range activationNs {
+	for _, ns := range activatedNSList {
 		activationNamespacesSet[ns] = true
 	}
 	found := false


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Update the ApplicationActivated status in all the relevant migrationschedules when scaling up or scaling down namespaces during failover / failback.
Here relevant migrationschedules are those which migrate resources from atleast one of the namespaces being failed over or failed back.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 24.2.0

**Testing Details**:
Have manually verified that only the relevant migrationSchedules are picked up and updated.