### PR TITLE
Pb-6675-1: adds support to use AZURE environment variable in the azure objectstore apis

### DIFF
--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -113,6 +113,16 @@ type S3Config struct {
 	SSE string `json:"sse"`
 }
 
+// AzureEnvironment is the type of the azure environment
+type AzureEnvironment string
+
+const (
+	// AzurePublicCloud - azure environment type for azure public cloud
+	AzurePublic AzureEnvironment = "AzurePublicCloud"
+	// AzureChinaCloud - azure environment type for azure china cloud
+	AzureChina AzureEnvironment = "AzureChinaCloud"
+)
+
 // AzureConfig specifies the config required to connect to Azure Blob Storage
 type AzureConfig struct {
 	StorageAccountName string `json:"storageAccountName"`
@@ -121,6 +131,9 @@ type AzureConfig struct {
 	SubscriptionID     string `json:"subscriptionID"`
 	ClientID           string `json:"clientID"`
 	ClientSecret       string `json:"clientSecret"`
+	// Azure-Environment type for azure blob storage
+	// supported option: "azure-public", "azure-china"
+	Environment AzureEnvironment `json:"environment"`
 }
 
 // GoogleConfig specifies the config required to connect to Google Cloud Storage
@@ -270,6 +283,9 @@ func (bl *BackupLocation) getMergedAzureConfig(client kubernetes.Interface) erro
 		}
 		if val, ok := secretConfig.Data["storageAccountKey"]; ok && val != nil {
 			bl.Location.AzureConfig.StorageAccountKey = strings.TrimSuffix(string(val), "\n")
+		}
+		if val, ok := secretConfig.Data["environment"]; ok && val != nil {
+			bl.Location.AzureConfig.Environment = AzureEnvironment(strings.TrimSuffix(string(val), "\n"))
 		}
 	}
 	return nil

--- a/pkg/objectstore/azure/azure.go
+++ b/pkg/objectstore/azure/azure.go
@@ -4,14 +4,20 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
+	az_autorest "github.com/Azure/go-autorest/autorest/azure"
 	stork_api "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/objectstore/common"
 	"github.com/sirupsen/logrus"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/azureblob"
+)
+
+const (
+	azureEnvKey = "AZURE_ENVIRONMENT"
 )
 
 func getPipeline(backupLocation *stork_api.BackupLocation) (pipeline.Pipeline, error) {
@@ -24,6 +30,31 @@ func getPipeline(backupLocation *stork_api.BackupLocation) (pipeline.Pipeline, e
 	return azureblob.NewPipeline(credential, azblob.PipelineOptions{}), nil
 }
 
+func getAzureURLSuffix(backupLocation *stork_api.BackupLocation) (string, error) {
+	// Give first preference to environment variable setting.
+	azureEnv := os.Getenv(azureEnvKey)
+	if len(azureEnv) == 0 {
+		// If env variable is not set, check the azure environment vaue from backuplocation CR.
+		if len(backupLocation.Location.AzureConfig.Environment) != 0 {
+			azureEnv = string(backupLocation.Location.AzureConfig.Environment)
+			logrus.Infof("Received azure environment type %s from backup location cr", azureEnv)
+		} else {
+			logrus.Infof("Both BL Cr environment type and azureEnv are empty, setting storage domain to default i.e Public")
+			return az_autorest.PublicCloud.StorageEndpointSuffix, nil
+		}
+	} else {
+		logrus.Infof("Received azure environment type as environment variable which has higher priority than environment type passed down from backup location cr %s", azureEnv)
+	}
+
+	azureClientEnv, err := az_autorest.EnvironmentFromName(azureEnv)
+	if err != nil {
+		logrus.Errorf("Failed to get azure client env for:%v, err:%v", azureEnv, err)
+		return "", err
+	}
+	// Endpoint suffix based on current cloud type
+	return azureClientEnv.StorageEndpointSuffix, nil
+}
+
 // GetBucket gets a reference to the bucket for that backup location
 func GetBucket(backupLocation *stork_api.BackupLocation) (*blob.Bucket, error) {
 	accountName := azureblob.AccountName(backupLocation.Location.AzureConfig.StorageAccountName)
@@ -31,7 +62,17 @@ func GetBucket(backupLocation *stork_api.BackupLocation) (*blob.Bucket, error) {
 	if err != nil {
 		return nil, err
 	}
-	return azureblob.OpenBucket(context.Background(), pipeline, accountName, backupLocation.Location.Path, nil)
+	urlSuffix, err := getAzureURLSuffix(backupLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	urlSuffix = fmt.Sprintf("blob.%s", urlSuffix)
+	logrus.Debugf("azure - GetBucket - urlSuffix %v", urlSuffix)
+	opts := azureblob.Options{
+		StorageDomain: azureblob.StorageDomain(urlSuffix),
+	}
+	return azureblob.OpenBucket(context.Background(), pipeline, accountName, backupLocation.Location.Path, &opts)
 }
 
 // CreateBucket creates a bucket for the bucket location
@@ -41,11 +82,16 @@ func CreateBucket(backupLocation *stork_api.BackupLocation) error {
 	if err != nil {
 		return err
 	}
-	url, err := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net", accountName))
+	urlSuffix, err := getAzureURLSuffix(backupLocation)
 	if err != nil {
 		return err
 	}
 
+	url, err := url.Parse(fmt.Sprintf("https://%s.blob.%s", accountName, urlSuffix))
+	if err != nil {
+		return err
+	}
+	logrus.Debugf("azure - CreateBucket - url %v", url)
 	_, err = azblob.NewServiceURL(*url, pipeline).
 		NewContainerURL(backupLocation.Location.Path).
 		Create(context.Background(), azblob.Metadata{}, azblob.PublicAccessNone)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
It adds support to use AZURE environment variable in the azure
objectstore apis

- Depending upon the azure environment type (AZURE_CHINA/AZURE_PUBLIC), the corresponding storage domain should be framed so that azure objectstore apis can use them to upload objects to the bucket

**Does this PR change a user-facing CRD or CLI?**:No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

**Unit Testing**

- vendored these stork changes to px-backup
- Passed the azure env type to backup location cr from px-backup and took a backup on that bl
- the backup tries to upload the object on the cloudChina url, this gives us with the storage domain 

ss
<img width="1262" alt="Screenshot 2024-04-19 at 5 02 57 PM" src="https://github.com/libopenstorage/stork/assets/141733960/cb69bdb7-aaac-4cea-b722-a77cfb6d3c83">

<img width="1249" alt="Screenshot 2024-04-19 at 5 31 38 PM" src="https://github.com/libopenstorage/stork/assets/141733960/55a005e1-6c92-48cb-8fce-52cea24733d8">

azure_public
<img width="733" alt="Screenshot 2024-04-19 at 5 37 01 PM" src="https://github.com/libopenstorage/stork/assets/141733960/dd8b7092-a8f7-497d-a7f1-1358d72a7b47">

<img width="1051" alt="Screenshot 2024-04-19 at 5 36 50 PM" src="https://github.com/libopenstorage/stork/assets/141733960/c552a22c-167d-4b0e-8c72-e124954b2868">

successful run of the test case with azure_public account
<img width="1433" alt="Screenshot 2024-04-19 at 5 39 00 PM" src="https://github.com/libopenstorage/stork/assets/141733960/5b8b0b52-0040-4318-9746-89de4195d765">

**After Addressing review comments**
<img width="1138" alt="Screenshot 2024-04-23 at 7 12 15 PM" src="https://github.com/libopenstorage/stork/assets/141733960/3b261b29-389c-43f7-854e-b8b61d29b554">

<img width="1464" alt="Screenshot 2024-04-23 at 9 03 59 PM" src="https://github.com/libopenstorage/stork/assets/141733960/8ae30903-c268-43e1-8007-8d87fa07922f">
