### PR TITLE
[PWX-36989] LastMileMigration should migrate only subset of namespaces

### DIFF
--- a/pkg/action/actioncontroller.go
+++ b/pkg/action/actioncontroller.go
@@ -121,6 +121,9 @@ func (ac *ActionController) handle(ctx context.Context, action *storkv1.Action) 
 			ac.updateStatus(action, storkv1.ActionStatusSuccessful)
 		}
 	case storkv1.ActionTypeFailover:
+		if action.Status.Stage == storkv1.ActionStageFinal {
+			return nil
+		}
 		log.ActionLog(action).Infof("in stage %s", action.Status.Stage)
 		switch action.Status.Stage {
 		case storkv1.ActionStageInitial:
@@ -135,10 +138,11 @@ func (ac *ActionController) handle(ctx context.Context, action *storkv1.Action) 
 			ac.activateClusterDuringFailover(action, false)
 		case storkv1.ActionStageScaleUpSource:
 			ac.activateClusterDuringFailover(action, true)
-		case storkv1.ActionStageFinal:
-			return nil
 		}
 	case storkv1.ActionTypeFailback:
+		if action.Status.Stage == storkv1.ActionStageFinal {
+			return nil
+		}
 		log.ActionLog(action).Infof("in stage %s", action.Status.Stage)
 		switch action.Status.Stage {
 		case storkv1.ActionStageInitial:
@@ -153,8 +157,6 @@ func (ac *ActionController) handle(ctx context.Context, action *storkv1.Action) 
 			ac.activateClusterDuringFailback(action, false)
 		case storkv1.ActionStageScaleUpDestination:
 			ac.activateClusterDuringFailback(action, true)
-		case storkv1.ActionStageFinal:
-			return nil
 		}
 	default:
 		ac.updateStatus(action, storkv1.ActionStatusFailed)

--- a/test/integration_test/migration_dr_actions_test.go
+++ b/test/integration_test/migration_dr_actions_test.go
@@ -328,9 +328,6 @@ func testDRActionFailoverSubsetNamespacesTest(t *testing.T) {
 	Dash.VerifyFatal(t, len(destStatefulsets.Items), 1, fmt.Sprintf("Expected 1 statefulset in destination in %s namespace", elasticsearchNamespace))
 	Dash.VerifyFatal(t, *destStatefulsets.Items[0].Spec.Replicas, sourceStatefulsetReplicas, fmt.Sprintf("Expected %d replica in destination in %s namespace", sourceStatefulsetReplicas, elasticsearchNamespace))
 
-	err = storkops.Instance().DeleteClusterPair(remotePairName, defaultAdminNamespace)
-	log.FailOnError(t, err, "failed to delete clusterpair %s in namespace %s in destination: %v", remotePairName, defaultAdminNamespace, err)
-
 	// Verify that mysql application is running but not elasticsearch on the source cluster
 	err = setSourceKubeConfig()
 	log.FailOnError(t, err, "failed to set kubeconfig to source cluster: %v", err)
@@ -344,7 +341,50 @@ func testDRActionFailoverSubsetNamespacesTest(t *testing.T) {
 	Dash.VerifyFatal(t, len(sourceStatefulsets.Items), 1, fmt.Sprintf("Expected 1 statefulset in source in %s namespace", elasticsearchNamespace))
 	Dash.VerifyFatal(t, *sourceStatefulsets.Items[0].Spec.Replicas, 0, fmt.Sprintf("Expected 0 replica in source in sts in %s namespace", elasticsearchNamespace))
 
-	//Delete migrationSchedules using storkCtl
+	// Failover #2 mysql ns
+	err = setDestinationKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to destination cluster: %v", err)
+
+	failoverCmdArgs = map[string]string{
+		"migration-reference": migrationScheduleName,
+		"include-namespaces":  mysqlNamespace,
+		"namespace":           defaultAdminNamespace,
+	}
+
+	drActionName, _ = createDRAction(t, defaultAdminNamespace, storkv1.ActionTypeFailover, migrationScheduleName, failoverCmdArgs)
+
+	// Wait for failover action to complete
+	waitTillActionComplete(t, storkv1.ActionTypeFailover, drActionName, defaultAdminNamespace)
+
+	// Verify that both mysql and elasticsearch applications are running on the destination cluster
+	destDeployments, err = apps.Instance().ListDeployments(mysqlNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving deployments from %s namespace", mysqlNamespace)
+	Dash.VerifyFatal(t, len(destDeployments.Items), 1, fmt.Sprintf("Expected 1 deployment in destination in %s namespace", mysqlNamespace))
+	Dash.VerifyFatal(t, *destDeployments.Items[0].Spec.Replicas, sourceDeploymentReplicas, fmt.Sprintf("Expected %d replica in destination in %s namespace", sourceDeploymentReplicas, mysqlNamespace))
+
+	destStatefulsets, err = apps.Instance().ListStatefulSets(elasticsearchNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving statefulsets from %s namespace", elasticsearchNamespace)
+	Dash.VerifyFatal(t, len(destStatefulsets.Items), 1, fmt.Sprintf("Expected 1 statefulset in destination in %s namespace", elasticsearchNamespace))
+	Dash.VerifyFatal(t, *destStatefulsets.Items[0].Spec.Replicas, sourceStatefulsetReplicas, fmt.Sprintf("Expected %d replica in destination in %s namespace", sourceStatefulsetReplicas, elasticsearchNamespace))
+
+	err = storkops.Instance().DeleteClusterPair(remotePairName, defaultAdminNamespace)
+	log.FailOnError(t, err, "failed to delete clusterpair %s in namespace %s in destination: %v", remotePairName, defaultAdminNamespace, err)
+
+	// Verify that both mysql and elasticsearch applications are not running on the source cluster
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+
+	sourceDeployments, err = apps.Instance().ListDeployments(mysqlNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving deployments from %s namespace", mysqlNamespace)
+	Dash.VerifyFatal(t, len(sourceDeployments.Items), 1, fmt.Sprintf("Expected 1 deployment in source in %s namespace", mysqlNamespace))
+	Dash.VerifyFatal(t, *sourceDeployments.Items[0].Spec.Replicas, 0, fmt.Sprintf("Expected 0 replica in source in deployment in %s namespace", mysqlNamespace))
+
+	sourceStatefulsets, err = apps.Instance().ListStatefulSets(elasticsearchNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving statefulsets from %s namespace", elasticsearchNamespace)
+	Dash.VerifyFatal(t, len(sourceStatefulsets.Items), 1, fmt.Sprintf("Expected 1 statefulset in source in %s namespace", elasticsearchNamespace))
+	Dash.VerifyFatal(t, *sourceStatefulsets.Items[0].Spec.Replicas, 0, fmt.Sprintf("Expected 0 replica in source in sts in %s namespace", elasticsearchNamespace))
+
+	// Delete migrationSchedules using storkCtl
 	cmdArgs = []string{"delete", "migrationschedule", migrationScheduleName, "-n", defaultAdminNamespace}
 	executeStorkCtlCommand(t, cmd, cmdArgs, nil)
 


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
Last Mile migration should only migrate the subset of namespaces being failed over / failed back, instead of all the namespaces part of the reference migration schedule.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 24.2.0

**Testing Details**:
Have manually tested partial failover and failbacks in sequence. LastMileMigration is picking up only the subset of namespaces being failed over / failed back.
Modified the existing subset of namespaces integration test as well and updated the PR 
https://jenkins.pwx.dev.purestorage.com/job/Users/job/dipti/job/dipti-new-dr-workflow/12/

