### PR TITLE
pb-6893: Avoid calling getPVNameMappings in the applyResources api, if it is called from volume stage.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1603,10 +1603,24 @@ func (a *ApplicationRestoreController) applyResources(
 	namespacedName := types.NamespacedName{}
 	namespacedName.Namespace = restore.Namespace
 	namespacedName.Name = restore.Name
-
-	pvNameMappings, err := a.getPVNameMappings(restore, objects)
-	if err != nil {
-		return err
+	// The applyResources is getting called in both the volume stage and resource stage.
+	// In the volume stage, it is getting called for applying the preRestore object.
+	// During the volume stage, we will not have restoreVolume updated in the volumeInfo structure.
+	// In between two driver's PVC restore processing, there is a chance that applicationrestore CR will status.VolumeInfo
+	// updated with the basic information of the volume, with out restoreVolume name.
+	// List of prerestore resource for each driver is as follow:
+	// aws, azure, gke driver does not have any preRestore object.
+	// kdmp - restore PVC spec but we do not apply it in the volume stage, as we do not call applyResource for kdmp case.
+	// PXD - for px volumes, we apply the secrets of encrypted volumes.
+	// That means , we do not need to call getPVNameMappings during volume stage.
+	// So, avoiding the call to getPVNameMappings, if it getting called from volume stage.
+	var pvNameMappings map[string]string
+	var err error
+	if restore.Status.Stage != storkapi.ApplicationRestoreStageVolumes {
+		pvNameMappings, err = a.getPVNameMappings(restore, objects)
+		if err != nil {
+			return err
+		}
 	}
 	objectMap := storkapi.CreateObjectsMap(restore.Spec.IncludeResources)
 	tempObjects := make([]runtime.Unstructured, 0)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
```
   pb-6893: Avoid calling getPVNameMappings in the applyResources api, if
    it is called from volume stage.
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Issue: The restore of backup with mixed backup variant like (PXD, CSI) fails
User Impact: User was able to restore the backup which had more than one backup variant.
Resolution: Fixed the issue to allow the restore from multi variants of backup drivers.

```

**Does this change need to be cherry-picked to a release branch?**:
Yes, 24.1.0 and 24.2.0

Testing:
Validated in two setup by restore a backup taking for PXD and CSI volume.
