### PR TITLE
PB-6687 :: Skipping pvc as per RetainPolicy in case of nfs and pxd

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -665,6 +665,7 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 		for driverName, vInfos := range backupVolumeInfoMappings {
 			// Portworx driver restore is not supported via job as it can be a secured px volume
 			// to access the token, we need to run the restore in the same pod as the stork controller
+			// this check is equivalent to (if !nfs || (nfs && driverName == volume.PortworxDriverName))
 			if !nfs || driverName == volume.PortworxDriverName {
 				backupVolInfos := vInfos
 				driver, err := volume.Get(driverName)
@@ -676,8 +677,18 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 				if err != nil {
 					return err
 				}
-				var preRestoreObjects []runtime.Unstructured
-				if !nfs {
+				var preRestoreObjects, objects []runtime.Unstructured
+				// this check is equivalent to (if nfs && driverName == volume.PortworxDriverName)
+				if nfs {
+					if restore.Spec.ReplacePolicy == storkapi.ApplicationRestoreReplacePolicyRetain {
+						// Skip pv/pvc if replacepolicy is set to retain to avoid creating with empty object
+						backupVolInfos, existingRestoreVolInfos, err = a.skipVolumesFromRestoreList(restore, objects, driver, vInfos)
+						if err != nil {
+							log.ApplicationRestoreLog(restore).Errorf("Error while checking pvcs: %v", err)
+							return err
+						}
+					}
+				} else {
 					// For each driver, check if it needs any additional resources to be
 					// restored before starting the volume restore
 					objects, err := a.downloadResources(backup, restore.Spec.BackupLocation, restore.Namespace)
@@ -1411,21 +1422,26 @@ func (a *ApplicationRestoreController) skipVolumesFromRestoreList(
 			logrus.Infof("skipping namespace %s for restore", bkupVolInfo.Namespace)
 			continue
 		}
-
-		// get corresponding pvc object from objects list
-		pvcObject, err := volume.GetPVCFromObjects(objects, bkupVolInfo)
-		if err != nil {
-			return newVolInfos, existingInfos, err
-		}
-
 		ns := val
-		pvc, err := core.Instance().GetPersistentVolumeClaim(pvcObject.Name, ns)
+		var pvcName string // Declare the pvcName variable
+		if objects != nil {
+			// get corresponding pvc object from objects list
+			pvcObject, err := volume.GetPVCFromObjects(objects, bkupVolInfo)
+			if err != nil {
+				return newVolInfos, existingInfos, err
+			}
+			pvcName = pvcObject.Name
+
+		} else {
+			pvcName = bkupVolInfo.PersistentVolumeClaim
+		}
+		pvc, err := core.Instance().GetPersistentVolumeClaim(pvcName, ns)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
 				newVolInfos = append(newVolInfos, bkupVolInfo)
 				continue
 			}
-			return newVolInfos, existingInfos, fmt.Errorf("erorr getting pvc %s/%s: %v", ns, pvcObject.Name, err)
+			return newVolInfos, existingInfos, fmt.Errorf("error getting pvc %s/%s: %v", ns, pvcName, err) // Update the error message
 		}
 		pvName := pvc.Spec.VolumeName
 		var zones []string


### PR DESCRIPTION
**What type of PR is this?**
>failing-test


**What this PR does / why we need it**:
This handles pvc creation as per reatin policy in case of nfs as BL and pxd as driver combination

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
release-24.1.0

