### PR TITLE
PB-6903: Fix Cloud Native Restore Path

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -1334,7 +1334,6 @@ func getNamespacedPVCLocation(pvc *v1.PersistentVolumeClaim) string {
 
 // getPVCToPVMapping constructs a mapping of PVC name/namespace to PV objects
 func getPVCToPVMapping(allObjects []runtime.Unstructured) (map[string]*v1.PersistentVolume, error) {
-
 	// Get mapping of PVC name to PV name
 	pvNameToPVCName := make(map[string]string)
 	for _, o := range allObjects {
@@ -1380,7 +1379,7 @@ func getPVCToPVMapping(allObjects []runtime.Unstructured) (map[string]*v1.Persis
 }
 
 func isGenericCSIPersistentVolume(pv *v1.PersistentVolume) (bool, error) {
-	driverName, err := volume.GetPVDriver(pv)
+	driverName, err := volume.GetPVDriverForRestore(pv)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/resourcecollector/persistentvolume.go
+++ b/pkg/resourcecollector/persistentvolume.go
@@ -207,7 +207,7 @@ func (r *ResourceCollector) preparePVResourceForApply(
 	// checks proper driver by looking at pv name
 	if driverName == "" {
 		var err error
-		driverName, err = volume.GetPVDriver(&pv)
+		driverName, err = volume.GetPVDriverForRestore(&pv)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: In case of Old Cloud Native Backups when we restore in 24.1.0 we were facing issue with cloud native backups as they were going as native csi and in resource phase we skip csi based pv and pvc because we apply them later on 


**Does this PR change a user-facing CRD or CLI?**: no 
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

<img width="1721" alt="Screenshot 2024-05-06 at 5 17 45 PM" src="https://github.com/libopenstorage/stork/assets/125460878/59707de4-d22d-4feb-82c1-b4db16f6ed55">

<img width="1711" alt="Screenshot 2024-05-06 at 5 17 55 PM" src="https://github.com/libopenstorage/stork/assets/125460878/c2f809fa-2ca7-4a78-9056-c71bef109aa8">


<img width="1692" alt="Screenshot 2024-05-06 at 5 18 15 PM" src="https://github.com/libopenstorage/stork/assets/125460878/e7ef04a3-32d1-4936-941d-d925e86e971e">


<img width="1728" alt="Screenshot 2024-05-06 at 5 18 24 PM" src="https://github.com/libopenstorage/stork/assets/125460878/945be4d6-0892-490a-926f-8a41f7a8a3fd">



