### PR TITLE
PB-6908: Fix Default VSC CSISnapshotName to CSISnapshotMap Conversion

### DIFF
--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -532,7 +532,7 @@ func (a *ApplicationRestoreController) updateRestoreCRInVolumeStage(
 	restore := &storkapi.ApplicationRestore{}
 	var err error
 	for i := 0; i < maxRetry; i++ {
-		err := a.client.Get(context.TODO(), namespacedName, restore)
+		err = a.client.Get(context.TODO(), namespacedName, restore)
 		if err != nil {
 			time.Sleep(retrySleep)
 			continue


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
We need to Migrate the CSISnapshotName to CSISnapshotMap in case "default" is given to convert and find the default VSC for all provisioner in case user has not updated the PX Backup to 2.7.0

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no. 
--> no 

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
--> yes
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
--> yes 24.2.1

<img width="1728" alt="Screenshot 2024-05-08 at 1 38 21 PM" src="https://github.com/libopenstorage/stork/assets/125460878/5fe400f8-59c8-4811-9fbe-35be35f612a5">

<img width="1728" alt="Screenshot 2024-05-08 at 1 38 41 PM" src="https://github.com/libopenstorage/stork/assets/125460878/49b9fa22-31a4-4e44-997b-c6c3a5b83b9a">

<img width="1728" alt="Screenshot 2024-05-08 at 1 38 57 PM" src="https://github.com/libopenstorage/stork/assets/125460878/1faf2842-0622-4b74-a263-8bb38c392843">






