### PR TITLE
wait for pods and exit gracefully if no pods found by cmdexecutor

### DIFF
--- a/cmd/cmdexecutor/cmdexecutor.go
+++ b/cmd/cmdexecutor/cmdexecutor.go
@@ -232,7 +232,7 @@ func getPodNamesUsingLabelSelector(labelSelector, namespace string) ([]types.Nam
 	for i := 0; i < maxRetries; i++ {
 		pods, err = core.Instance().GetPods(namespace, selectorsMap)
 		if err != nil {
-			return err	
+			return nil, err	
 		}
 		
 		if len(pods.Items) > 0 {

--- a/cmd/cmdexecutor/cmdexecutor.go
+++ b/cmd/cmdexecutor/cmdexecutor.go
@@ -235,11 +235,12 @@ func getPodNamesUsingLabelSelector(labelSelector, namespace string) ([]types.Nam
 			return err	
 		}
 		
-		if len(pods.Items) == 0 {
-			logrus.Infof("no pods found yet in namespace: %s with label selector: %s", namespace, labelSelector)
-			time.Sleep(time.Duration(retryInterval) * time.Second)
-			continue
+		if len(pods.Items) > 0 {
+			break	
 		}
+		
+		logrus.Infof("no pods found yet in namespace: %s with label selector: %s", namespace, labelSelector)
+		time.Sleep(time.Duration(retryInterval) * time.Second)
 	}
 
 	if len(pods.Items) == 0 {

--- a/cmd/cmdexecutor/cmdexecutor.go
+++ b/cmd/cmdexecutor/cmdexecutor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libopenstorage/stork/pkg/version"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/cmd/cmdexecutor/cmdexecutor.go
+++ b/cmd/cmdexecutor/cmdexecutor.go
@@ -232,6 +232,11 @@ func getPodNamesUsingLabelSelector(labelSelector, namespace string) ([]types.Nam
 	for i := 0; i < maxRetries; i++ {
 		pods, err = core.Instance().GetPods(namespace, selectorsMap)
 		if err != nil {
+			return err	
+		}
+		
+		if len(pods.Items) == 0 {
+			logrus.Infof("no pods found yet in namespace: %s with label selector: %s", namespace, labelSelector)
 			time.Sleep(time.Duration(retryInterval) * time.Second)
 			continue
 		}

--- a/cmd/cmdexecutor/cmdexecutor.go
+++ b/cmd/cmdexecutor/cmdexecutor.go
@@ -233,13 +233,13 @@ func getPodNamesUsingLabelSelector(labelSelector, namespace string) ([]types.Nam
 	for i := 0; i < maxRetries; i++ {
 		pods, err = core.Instance().GetPods(namespace, selectorsMap)
 		if err != nil {
-			return nil, err	
+			return nil, err
 		}
-		
+
 		if len(pods.Items) > 0 {
-			break	
+			break
 		}
-		
+
 		logrus.Infof("no pods found yet in namespace: %s with label selector: %s", namespace, labelSelector)
 		time.Sleep(time.Duration(retryInterval) * time.Second)
 	}


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
If no pods not found by cmdexecutor it is going into endless loop. 
This PR adds retry while looking for pods and eventually error out if not found any pods.
https://purestorage.atlassian.net/browse/DS-9703

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

