### PR TITLE
pb-6910: add uid & gid in each volume for psa support

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -93,6 +93,13 @@ type ApplicationBackupResourceInfo struct {
 	ObjectInfo `json:",inline"`
 }
 
+// This object is used in VolumeInfo for PSA enabled cluster to retain the runAsUser ID and runAsGroup ID used by
+// Job pod(KDMP/NFS)during backup. We will use the same IDs to spin up Job Pods during restore.
+type VolumeJobSecurityContext struct {
+	RunAsUser  int64 `json:"runAsUser"`
+	RunAsGroup int64 `json:"runAsGroup"`
+}
+
 // ApplicationBackupVolumeInfo is the info for the backup of a volume
 type ApplicationBackupVolumeInfo struct {
 	PersistentVolumeClaim    string                      `json:"persistentVolumeClaim"`
@@ -110,6 +117,9 @@ type ApplicationBackupVolumeInfo struct {
 	StorageClass             string                      `json:"storageClass"`
 	Provisioner              string                      `json:"provisioner"`
 	VolumeSnapshot           string                      `json:"volumeSnapshot"`
+	// It preserves the uid and gid of the pod that is run by the backup job
+	// that helps in restore operation. this is required only when PSA is enforced.
+	VolumeJobSecurityContext VolumeJobSecurityContext `json:",inline"`
 }
 
 // ApplicationBackupStatusType is the status of the application backup


### PR DESCRIPTION
- If PSA is enabled and a volume is backed-up with a specific Uid/Gid then that value need to be preserved for getting used during restore process.
- This is needed for all the job PODS to inherit above valuec so that no permission denied issues appear while restoring from a file backup


**What type of PR is this?** feature
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: This is needed to support PSA for backup and restore.


**Does this PR change a user-facing CRD or CLI?**: No, it updates the status of Application Backup CR
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: Nope
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: 24.2.2
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

