### PR TITLE
Added flag to fail cmdexecutor if no pods found

### DIFF
--- a/cmd/cmdexecutor/cmdexecutor.go
+++ b/cmd/cmdexecutor/cmdexecutor.go
@@ -255,6 +255,10 @@ func getPodNamesUsingLabelSelector(labelSelector, namespace string) ([]types.Nam
 		time.Sleep(time.Duration(retryInterval) * time.Second)
 	}
 
+	if failOnNoPodsFound && len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no pods found in namespace: %s with label selector: %s", namespace, labelSelector)
+	}
+
 	var podNames []types.NamespacedName
 	for _, pod := range pods.Items {
 		podNames = append(podNames, types.NamespacedName{
@@ -288,6 +292,7 @@ var (
 	command            string
 	statusCheckTimeout int64
 	taskID             string
+	failOnNoPodsFound  bool
 )
 
 func init() {
@@ -298,4 +303,5 @@ func init() {
 	flag.StringVar(&command, "cmd", "", "The command to run inside the pod")
 	flag.StringVar(&taskID, "taskid", "", "A unique ID the caller can provide which can be later used to clean the status files created by the command executor.")
 	flag.Int64Var(&statusCheckTimeout, "timeout", int64(defaultStatusCheckTimeout), "Time in seconds to wait for the command to succeeded on a single pod")
+	flag.BoolVar(&failOnNoPodsFound, "fail-on-no-pods", false, "If set, the command executor will fail if no pods are found in the namespace with the label selector")
 }


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Added flag `fail-on-no-pods` to fail cmdexecutor if no pods found in the namespace with the given label selector.
https://purestorage.atlassian.net/browse/DS-9703

Testing Done:
with `-fail-on-no-pods` flag set and no pods found cmdexecutor will exit with fatal error.

```
time="2024-05-15T16:54:21Z" level=info msg="Running pod command executor: 99.9.9-6198e70ff"
time="2024-05-15T16:54:21Z" level=info msg="Using timeout: 86400 seconds"
time="2024-05-15T16:54:21Z" level=info msg="no pods found yet in namespace: pg1 with label selector: deployments.pds.portworx.com/pod-type=statefulset,role=master,pds/deployment-name=pg-samore-pg-1-vr7lln"
time="2024-05-15T16:54:36Z" level=info msg="no pods found yet in namespace: pg1 with label selector: deployments.pds.portworx.com/pod-type=statefulset,role=master,pds/deployment-name=pg-samore-pg-1-vr7lln"
time="2024-05-15T16:54:52Z" level=info msg="no pods found yet in namespace: pg1 with label selector: deployments.pds.portworx.com/pod-type=statefulset,role=master,pds/deployment-name=pg-samore-pg-1-vr7lln"
time="2024-05-15T16:55:07Z" level=info msg="no pods found yet in namespace: pg1 with label selector: deployments.pds.portworx.com/pod-type=statefulset,role=master,pds/deployment-name=pg-samore-pg-1-vr7lln"
time="2024-05-15T16:55:22Z" level=info msg="no pods found yet in namespace: pg1 with label selector: deployments.pds.portworx.com/pod-type=statefulset,role=master,pds/deployment-name=pg-samore-pg-1-vr7lln"
time="2024-05-15T16:55:37Z" level=info msg="no pods found yet in namespace: pg1 with label selector: deployments.pds.portworx.com/pod-type=statefulset,role=master,pds/deployment-name=pg-samore-pg-1-vr7lln"
time="2024-05-15T16:55:52Z" level=fatal msg="no pods found in namespace: pg1 with label selector: deployments.pds.portworx.com/pod-type=statefulset,role=master,pds/deployment-name=pg-samore-pg-1-vr7lln"
```

**Does this PR change a user-facing CRD or CLI?**:

**Is a release note needed?**:


**Does this change need to be cherry-picked to a release branch?**:

