### PR TITLE
pwx-37280 | test: use spec.storageClassName instead of annotation for storageclass

### DIFF
--- a/test/integration_test/specs/cassandra/cassandra.yaml
+++ b/test/integration_test/specs/cassandra/cassandra.yaml
@@ -91,9 +91,8 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: cassandra-data
-      annotations:
-        volume.beta.kubernetes.io/storage-class: mysql-sc
     spec:
+      storageClassName: "mysql-sc"
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:

--- a/test/integration_test/specs/elasticsearch/elasticsearch.yaml
+++ b/test/integration_test/specs/elasticsearch/elasticsearch.yaml
@@ -81,9 +81,8 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: elasticdata-vol
-      annotations:
-        volume.beta.kubernetes.io/storage-class: elasticdata-sc
     spec:
+      storageClassName: "elasticdata-sc"
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:

--- a/test/integration_test/specs/endpoint/mysql.yaml
+++ b/test/integration_test/specs/endpoint/mysql.yaml
@@ -4,9 +4,8 @@ metadata:
    name: mysql-data
    labels:
      app: mysql 
-   annotations:
-     volume.beta.kubernetes.io/storage-class: mysql-sc
 spec:
+   storageClassName: "mysql-sc"
    accessModes:
      - ReadWriteOnce
    resources:

--- a/test/integration_test/specs/mysql-1-pvc/mysql.yaml
+++ b/test/integration_test/specs/mysql-1-pvc/mysql.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 metadata:
    name: mysql-data
    labels:
-     app: mysql 
+     app: mysql
    annotations:
-     volume.beta.kubernetes.io/storage-class: mysql-sc
 spec:
+   storageClassName: "mysql-sc"
    accessModes:
      - ReadWriteOnce
    resources:
@@ -18,7 +18,7 @@ kind: Deployment
 metadata:
   name: mysql
   labels:
-    app: mysql 
+    app: mysql
 spec:
   strategy:
     rollingUpdate:

--- a/test/integration_test/specs/mysql-2-pvc/mysql.yaml
+++ b/test/integration_test/specs/mysql-2-pvc/mysql.yaml
@@ -2,12 +2,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
    name: mysql-data
-   annotations:
-     volume.beta.kubernetes.io/storage-class: mysql-sc
    labels:
      type: db
      app: mysql
 spec:
+   storageClassName: "mysql-sc"
    accessModes:
      - ReadWriteOnce
    resources:
@@ -18,12 +17,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
    name: mysql-temp
-   annotations:
-     volume.beta.kubernetes.io/storage-class: mysql-sc
    labels:
      type: db
      app: mysql
 spec:
+   storageClassName: "mysql-sc"
    accessModes:
      - ReadWriteOnce
    resources:

--- a/test/integration_test/specs/mysql-cloudsnap-group-restore/mysql.yaml
+++ b/test/integration_test/specs/mysql-cloudsnap-group-restore/mysql.yaml
@@ -2,12 +2,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-data-1
-  annotations:
-    volume.beta.kubernetes.io/storage-class: px-mysql-sc
   labels:
     type: db
     app: mysql
 spec:
+  storageClassName: "px-mysql-sc"
   accessModes:
     - ReadWriteOnce
   resources:
@@ -18,12 +17,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-data-2
-  annotations:
-    volume.beta.kubernetes.io/storage-class: px-mysql-sc
   labels:
     type: db
     app: mysql
 spec:
+  storageClassName: "px-mysql-sc"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/test/integration_test/specs/mysql-cloudsnap-group/mysql.yaml
+++ b/test/integration_test/specs/mysql-cloudsnap-group/mysql.yaml
@@ -2,12 +2,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-data-1
-  annotations:
-    volume.beta.kubernetes.io/storage-class: px-mysql-sc
   labels:
     type: db
     app: mysql
 spec:
+  storageClassName: "px-mysql-sc"
   accessModes:
     - ReadWriteOnce
   resources:
@@ -18,12 +17,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-data-2
-  annotations:
-    volume.beta.kubernetes.io/storage-class: px-mysql-sc
   labels:
     type: db
     app: mysql
 spec:
+  storageClassName: "px-mysql-sc"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/test/integration_test/specs/mysql-cloudsnap-restore/mysql.yaml
+++ b/test/integration_test/specs/mysql-cloudsnap-restore/mysql.yaml
@@ -2,9 +2,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-data
-  annotations:
-    volume.beta.kubernetes.io/storage-class: px-mysql-sc
 spec:
+  storageClassName: "px-mysql-sc"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/test/integration_test/specs/mysql-enc-pvc-rancher/mysql.yaml
+++ b/test/integration_test/specs/mysql-enc-pvc-rancher/mysql.yaml
@@ -45,12 +45,12 @@ spec:
   - metadata:
       name: mysql-data
       annotations:
-        volume.beta.kubernetes.io/storage-class: mysql-sc
         px/secret-name: volume-secrets
         px/secret-namespace: kube-system
         px/secret-key: mysql-secret
         field.cattle.io/projectId: "project-A"
     spec:
+      storageClassName: "mysql-sc"
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:

--- a/test/integration_test/specs/mysql-enc-pvc/mysql.yaml
+++ b/test/integration_test/specs/mysql-enc-pvc/mysql.yaml
@@ -45,11 +45,11 @@ spec:
   - metadata:
       name: mysql-data
       annotations:
-        volume.beta.kubernetes.io/storage-class: mysql-sc
         px/secret-name: volume-secrets
         px/secret-namespace: kube-system
         px/secret-key: mysql-secret
     spec:
+      storageClassName: "mysql-sc"
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:

--- a/test/integration_test/specs/mysql-localsnap-rule/mysql-1.yaml
+++ b/test/integration_test/specs/mysql-localsnap-rule/mysql-1.yaml
@@ -2,11 +2,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-data-1
-  annotations:
-    volume.beta.kubernetes.io/storage-class: px-mysql-sc
   labels:
     app: mysql
 spec:
+  storageClassName: "px-mysql-sc"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/test/integration_test/specs/mysql-localsnap-rule/mysql-2.yaml
+++ b/test/integration_test/specs/mysql-localsnap-rule/mysql-2.yaml
@@ -2,11 +2,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-data-2
-  annotations:
-    volume.beta.kubernetes.io/storage-class: px-mysql-sc
   labels:
     app: mysql
 spec:
+  storageClassName: "px-mysql-sc"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/test/integration_test/specs/mysql-nearsync/mysql.yaml
+++ b/test/integration_test/specs/mysql-nearsync/mysql.yaml
@@ -45,11 +45,11 @@ spec:
   - metadata:
       name: mysql-data
       annotations:
-        volume.beta.kubernetes.io/storage-class: px-sc
         px/secret-name: volume-secrets
         px/secret-namespace: kube-system
         px/secret-key: mysql-secret
     spec:
+      storageClassName: "px-sc"
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:

--- a/test/integration_test/specs/mysql-repl-1/mysql.yaml
+++ b/test/integration_test/specs/mysql-repl-1/mysql.yaml
@@ -4,9 +4,8 @@ metadata:
    name: mysql-data
    labels:
      app: mysql
-   annotations:
-     volume.beta.kubernetes.io/storage-class: mysql-sc-repl-1
 spec:
+   storageClassName: "mysql-sc-repl-1"
    accessModes:
      - ReadWriteOnce
    resources:

--- a/test/integration_test/specs/mysql-service-account/mysql.yaml
+++ b/test/integration_test/specs/mysql-service-account/mysql.yaml
@@ -3,10 +3,9 @@ apiVersion: v1
 metadata:
    name: mysql-data
    labels:
-     app: mysql 
-   annotations:
-     volume.beta.kubernetes.io/storage-class: mysql-sc
+     app: mysql
 spec:
+   storageClassName: "mysql-sc"
    accessModes:
      - ReadWriteOnce
    resources:
@@ -18,7 +17,7 @@ kind: Deployment
 metadata:
   name: mysql
   labels:
-    app: mysql 
+    app: mysql
 spec:
   strategy:
     rollingUpdate:

--- a/test/integration_test/specs/mysql-snap-group-fail/mysql.yaml
+++ b/test/integration_test/specs/mysql-snap-group-fail/mysql.yaml
@@ -2,12 +2,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-data-1
-  annotations:
-    volume.beta.kubernetes.io/storage-class: px-mysql-sc
   labels:
     type: db
     app: mysql
 spec:
+  storageClassName: "px-mysql-sc"
   accessModes:
     - ReadWriteOnce
   resources:
@@ -18,12 +17,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-data-2
-  annotations:
-    volume.beta.kubernetes.io/storage-class: px-mysql-sc
   labels:
     type: db
     app: mysql
 spec:
+  storageClassName: "px-mysql-sc"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/test/integration_test/specs/mysql-snap-restore/mysql.yaml
+++ b/test/integration_test/specs/mysql-snap-restore/mysql.yaml
@@ -2,9 +2,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: mysql-data
-  annotations:
-    volume.beta.kubernetes.io/storage-class: px-mysql-sc
 spec:
+  storageClassName: "px-mysql-sc"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/test/integration_test/specs/mysql-ss/mysql-ss.yaml
+++ b/test/integration_test/specs/mysql-ss/mysql-ss.yaml
@@ -74,9 +74,8 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: mysql-vol
-      annotations:
-        volume.beta.kubernetes.io/storage-class: portworx-repl2
     spec:
+      storageClassName: "portworx-repl2"
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:

--- a/test/integration_test/specs/nearsync-cassandra/cassandra.yaml
+++ b/test/integration_test/specs/nearsync-cassandra/cassandra.yaml
@@ -89,9 +89,8 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: cassandra-data
-      annotations:
-        volume.beta.kubernetes.io/storage-class: px-sc
     spec:
+      storageClassName: "px-sc"
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:

--- a/test/integration_test/specs/networkpolicy/mysql.yaml
+++ b/test/integration_test/specs/networkpolicy/mysql.yaml
@@ -4,9 +4,8 @@ metadata:
    name: mysql-data
    labels:
      app: mysql 
-   annotations:
-     volume.beta.kubernetes.io/storage-class: mysql-sc
 spec:
+   storageClassName: "mysql-sc"
    accessModes:
      - ReadWriteOnce
    resources:

--- a/test/integration_test/specs/snapshot-storageclass/autosnapsched.yaml
+++ b/test/integration_test/specs/snapshot-storageclass/autosnapsched.yaml
@@ -13,9 +13,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
    name: autosnap
-   annotations:
-     volume.beta.kubernetes.io/storage-class: autosnap-sc
 spec:
+   storageClassName: "autosnap-sc"
    accessModes:
      - ReadWriteOnce
    resources:


### PR DESCRIPTION
**What type of PR is this?**
>failing-test
>integration-test

**What this PR does / why we need it**:
Addresses [PWX-37280](https://purestorage.atlassian.net/browse/PWX-37280). The PX volume provisioning has been failing in the Bidirectional Migration test job latelya and it was suggested to replace the annotation `volume.beta.kubernetes.io/storage-class: "mysql-sc"` from the PVC and instead use the field `spec.storageClassName : "mysql-sc"`. Post this, the volume provisioning for the pvc is successful. It is better for us to remove the annotation since it is deprecated according to kubernetes [docs](https://kubernetes.io/docs/reference/labels-annotations-taints/#volume-beta-kubernetes-io-storage-class-deprecated).

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
`release-24.2.0` branch.

**Successful job run**
Link to the successful job with the changes on the fork: https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/strivedi-bidirectional-migration/1/
