### PR TITLE
pb-6910: add uid & gid in each volume for psa support

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -234,6 +234,13 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		if err != nil {
 			return nil, fmt.Errorf("error getting pv %v: %v", pvName, err)
 		}
+		// Get UID and GID from the App which is controlling this PVC.
+		getUIDFromApp := true
+		podUserId, podGroupId, psaIsEnabled, err := utils.GetPsaEnabledAppUID(pvc.Name, pvc.Namespace, backup, getUIDFromApp)
+		if err != nil {
+			logrus.Errorf("failed to get the UID and GID for pvc %s %v", pvc.Name, err)
+			return nil, err
+		}
 		volumeInfo := &storkapi.ApplicationBackupVolumeInfo{}
 		zones, err := getZones(pv)
 		if err != nil {
@@ -249,6 +256,14 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		volumeInfo.StorageClass = k8shelper.GetPersistentVolumeClaimClass(&pvc)
 		volumeInfo.Namespace = pvc.Namespace
 		volumeInfo.DriverName = storkvolume.KDMPDriverName
+		// if psaIsenabled then set the a UID GID in the VolumeInfo and
+		// set annotation in dataexport CR for updating the JOB spec
+		if psaIsEnabled && podUserId != utils.UndefinedId {
+			logrus.Infof("Setting UID and GID in VolumeInfo for PVC %s", pvc.Name)
+			volumeInfo.JobSecurityContext.RunAsUser = podUserId
+			volumeInfo.JobSecurityContext.RunAsGroup = podGroupId
+		}
+
 		volume, err := core.Instance().GetVolumeForPersistentVolumeClaim(&pvc)
 		if err != nil {
 			return nil, fmt.Errorf("error getting volume for PVC: %v", err)
@@ -285,6 +300,11 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		dataExport.Annotations[utils.BackupObjectUIDKey] = string(backup.Annotations[utils.PxbackupObjectUIDKey])
 		dataExport.Annotations[pvcUIDKey] = string(pvc.UID)
 		dataExport.Annotations[kdmpStorageClassKey] = volumeInfo.StorageClass
+		if psaIsEnabled && podUserId != utils.UndefinedId {
+			dataExport.Annotations[utils.PsaEnabledKey] = "true"
+			dataExport.Annotations[utils.PsaUIDKey] = fmt.Sprintf("%d", podUserId)
+			dataExport.Annotations[utils.PsaGIDKey] = fmt.Sprintf("%d", podGroupId)
+		}
 		dataExport.Name = getGenericCRName(utils.PrefixBackup, string(backup.UID), string(pvc.UID), pvc.Namespace)
 		dataExport.Namespace = pvc.Namespace
 		dataExport.Spec.Type = kdmpapi.DataExportKopia
@@ -778,6 +798,12 @@ func (k *kdmp) StartRestore(
 			msg := fmt.Sprintf("unable to find backup uid from applicationbackup %s/%s", restore.Namespace, restore.Spec.BackupName)
 			return nil, fmt.Errorf(msg)
 		}
+		getUIDFromApp := false
+		podUserId, podGroupId, psaIsEnabled, err := utils.GetPsaEnabledAppUID("", restoreNamespace, backup, getUIDFromApp)
+		if err != nil {
+			logrus.Errorf("failed to get the UID and GID for pvc %s %v", pvc.Name, err)
+			return nil, err
+		}
 		backupUID = backup.Annotations[backupUIDKey]
 		// create kdmp cr
 		dataExport := &kdmpapi.DataExport{}
@@ -793,6 +819,11 @@ func (k *kdmp) StartRestore(
 		dataExport.Annotations[utils.SkipResourceAnnotation] = "true"
 		dataExport.Annotations[utils.BackupObjectUIDKey] = backupUID
 		dataExport.Annotations[pvcUIDKey] = bkpvInfo.PersistentVolumeClaimUID
+		if psaIsEnabled && podUserId != utils.UndefinedId {
+			dataExport.Annotations[utils.PsaEnabledKey] = "true"
+			dataExport.Annotations[utils.PsaUIDKey] = fmt.Sprintf("%d", podUserId)
+			dataExport.Annotations[utils.PsaGIDKey] = fmt.Sprintf("%d", podGroupId)
+		}
 		dataExport.Name = getGenericCRName(prefixRestore, string(restore.UID), bkpvInfo.PersistentVolumeClaimUID, restoreNamespace)
 		dataExport.Namespace = restoreNamespace
 		dataExport.Status.TransferID = volBackup.Namespace + "/" + volBackup.Name

--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -95,7 +95,7 @@ type ApplicationBackupResourceInfo struct {
 
 // This object is used in VolumeInfo for PSA enabled cluster to retain the runAsUser ID and runAsGroup ID used by
 // Job pod(KDMP/NFS)during backup. We will use the same IDs to spin up Job Pods during restore.
-type VolumeJobSecurityContext struct {
+type JobSecurityContext struct {
 	RunAsUser  int64 `json:"runAsUser"`
 	RunAsGroup int64 `json:"runAsGroup"`
 }
@@ -119,7 +119,7 @@ type ApplicationBackupVolumeInfo struct {
 	VolumeSnapshot           string                      `json:"volumeSnapshot"`
 	// It preserves the uid and gid of the pod that is run by the backup job
 	// that helps in restore operation. this is required only when PSA is enforced.
-	VolumeJobSecurityContext VolumeJobSecurityContext `json:",inline"`
+	JobSecurityContext JobSecurityContext `json:",inline"`
 }
 
 // ApplicationBackupStatusType is the status of the application backup

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -2019,6 +2019,16 @@ func (a *ApplicationBackupController) backupResources(
 				resourceExport.Labels = labels
 				resourceExport.Annotations = make(map[string]string)
 				resourceExport.Annotations[utils.SkipResourceAnnotation] = "true"
+				// Add psa enabled annotation in resource export cr only if the
+				// the namespace has the PSA labels set
+				psaIsEnforced, _, err := utils.GetPsaDetail(backup.Namespace)
+				if err != nil {
+					log.ApplicationBackupLog(backup).Errorf("%v", err)
+					return err
+				}
+				if psaIsEnforced {
+					resourceExport.Annotations[utils.PsaEnabledKey] = "true"
+				}
 				resourceExport.Name = getResourceExportCRName(utils.PrefixNFSBackup, string(backup.UID), backup.Namespace)
 				resourceExport.Namespace = backup.Namespace
 				resourceExport.Spec.Type = kdmpapi.ResourceExportBackup

--- a/pkg/applicationmanager/controllers/applicationrestore.go
+++ b/pkg/applicationmanager/controllers/applicationrestore.go
@@ -903,6 +903,16 @@ func (a *ApplicationRestoreController) restoreVolumes(restore *storkapi.Applicat
 					resourceExport.Labels = labels
 					resourceExport.Annotations = make(map[string]string)
 					resourceExport.Annotations[utils.SkipResourceAnnotation] = "true"
+					// Add psa enabled annotation in resource export cr only if the
+					// the namespace has the PSA labels set
+					psaIsEnforced, _, err := utils.GetPsaDetail(backup.Namespace)
+					if err != nil {
+						log.ApplicationBackupLog(backup).Errorf("%v", err)
+						return err
+					}
+					if psaIsEnforced {
+						resourceExport.Annotations[utils.PsaEnabledKey] = "true"
+					}
 					resourceExport.Name = crName
 					resourceExport.Namespace = restore.Namespace
 					resourceExport.Spec.Type = kdmpapi.ResourceExportBackup
@@ -1902,6 +1912,16 @@ func (a *ApplicationRestoreController) restoreResources(
 				resourceExport.Labels = labels
 				resourceExport.Annotations = make(map[string]string)
 				resourceExport.Annotations[utils.SkipResourceAnnotation] = "true"
+				// Add psa enabled annotation in resource export cr only if the
+				// the namespace has the PSA labels set
+				psaIsEnforced, _, err := utils.GetPsaDetail(backup.Namespace)
+				if err != nil {
+					log.ApplicationBackupLog(backup).Errorf("%v", err)
+					return err
+				}
+				if psaIsEnforced {
+					resourceExport.Annotations[utils.PsaEnabledKey] = "true"
+				}
 				resourceExport.Name = crName
 				resourceExport.Namespace = restore.Namespace
 				resourceExport.Spec.Type = kdmpapi.ResourceExportBackup


### PR DESCRIPTION
- If PSA is enabled and a volume is backed-up with a specific Uid/Gid then that value need to be preserved for getting used during restore process.
- This is needed for all the job PODS to inherit above valuec so that no permission denied issues appear while restoring from a file backup


**What type of PR is this?** feature
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: This PR adds support for k8s PSA feature. It enables the Job pod to run gracefully in a restricted environment.


**Does this PR change a user-facing CRD or CLI?**: No, it changes the status of the AB CR not the spec
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: NA
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: 24.2.1
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

Will update unit test result before EOD tomorrow.