### PR TITLE
PWX-37271: Reconciling the remote migration schedule with source side changes.

### DIFF
--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -280,7 +280,7 @@ func (m *MigrationScheduleController) handle(ctx context.Context, migrationSched
 					return fmt.Errorf(msg)
 				}
 				if updatedHash != 0 {
-					// update the hash value in the source migration schedule
+					// update the hash value in the remote migration schedule along with the source migration schedule changes
 					if remoteMigrSched.Annotations == nil {
 						remoteMigrSched.Annotations = make(map[string]string)
 					}
@@ -600,6 +600,8 @@ func (m *MigrationScheduleController) reconcileRemoteMigrationSchedule(sourceMig
 		// update directly with source hash
 		updatedHash = sourceMigrationScheduleHash
 	}
+
+	// sending the default value if there is both source and destination hash value is same
 	return updatedHash, nil
 }
 

--- a/pkg/migration/controllers/migrationschedule.go
+++ b/pkg/migration/controllers/migrationschedule.go
@@ -597,11 +597,8 @@ func (m *MigrationScheduleController) reconcileRemoteMigrationSchedule(sourceMig
 			updatedHash = sourceMigrationScheduleHash
 		}
 	} else {
-		// get the hash of the dest migration schedule
-		updatedHash, err = getMigrationScheduleHash(destMigrationSchedule)
-		if err != nil {
-			return updatedHash, err
-		}
+		// update directly with source hash
+		updatedHash = sourceMigrationScheduleHash
 	}
 	return updatedHash, nil
 }


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
bug

**What this PR does / why we need it**:
Remote Migrationschedule static copy will get reconciled with the changes in the source side so that the newly added namespaces can get failed over as part of perform failover.
Kept the reconciling just before the triggering of migration as this is not very frequent operation and better to limit the remote calls to do the comparision.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
yes, 24.2.0

Test:
1. Tested new migrationschedule
2. Old migration schedule getting updated
3. changes in migrationschedule is getting updated.
4. Perform failover for later added namespaces.
Results have been updated in PWX-37271.
