### PR TITLE
fix: fix resetting the mock time in failback subset namespace test

### DIFF
--- a/test/integration_test/migration_dr_actions_test.go
+++ b/test/integration_test/migration_dr_actions_test.go
@@ -1092,8 +1092,6 @@ func testDRActionFailbackSubsetNamespacesTest(t *testing.T) {
 	// and not a part of the torpedo scheduler context.
 	_, err = storkops.Instance().ValidateMigrationSchedule(reverseMigrationScheduleName, defaultAdminNamespace, defaultWaitTimeout, defaultWaitInterval)
 	log.Info("reverse migration schedule created")
-	err = setMockTime(nil)
-	log.FailOnError(t, err, "Error resetting mock time")
 
 	failbackCmdArgs := map[string]string{
 		"migration-reference": reverseMigrationScheduleName,
@@ -1103,6 +1101,8 @@ func testDRActionFailbackSubsetNamespacesTest(t *testing.T) {
 	drActionName, _ = createDRAction(t, defaultAdminNamespace, storkv1.ActionTypeFailback, reverseMigrationScheduleName, failbackCmdArgs)
 	// Wait for failback action to complete.
 	waitTillActionComplete(t, storkv1.ActionTypeFailback, drActionName, defaultAdminNamespace)
+	err = setMockTime(nil)
+	log.FailOnError(t, err, "Error resetting mock time")
 
 	// Verify the elasticsearch application is not running on the destination cluster.
 	destStatefulsets, err = apps.Instance().ListStatefulSets(elasticsearchNamespace, metav1.ListOptions{})


### PR DESCRIPTION
**What type of PR is this?**
>failing-test

**What this PR does / why we need it**:
Fixes the following error in the `TestDRActions/testDRActionFailbackSubsetNamespacesTest` test when ran on the jenkins pipeline:
```
Action failback-reverse-failback-migration-schedule-subset-ns-2024-05-20-200910 status fields are: Completed;Failed;Failing the failback operation because the most recent migration, reverse-failback-migration-schedule-subset-ns-interval-2024-05-20-200724, was not completed within the scheduled policy duration;"
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, `release-24.2.0` branch.

**Pipeline runs**
- Testsuite run: https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/strivedi-new-dr-workflow/14
- Individual run: https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/strivedi-new-dr-workflow/15/

