### PR TITLE
Add psa support in cr status if the application backup CR

### DIFF
--- a/pkg/apis/stork/v1alpha1/applicationbackup.go
+++ b/pkg/apis/stork/v1alpha1/applicationbackup.go
@@ -98,7 +98,7 @@ type ApplicationBackupResourceInfo struct {
 
 // This object is used in VolumeInfo for PSA enabled cluster to retain the runAsUser ID and runAsGroup ID used by
 // Job pod(KDMP/NFS)during backup. We will use the same IDs to spin up Job Pods during restore.
-type VolumeJobSecurityContext struct {
+type JobSecurityContext struct {
 	RunAsUser  int64 `json:"runAsUser"`
 	RunAsGroup int64 `json:"runAsGroup"`
 }
@@ -122,7 +122,7 @@ type ApplicationBackupVolumeInfo struct {
 	VolumeSnapshot           string                      `json:"volumeSnapshot"`
 	// It preserves the uid and gid of the pod that is run by the backup job
 	// that helps in restore operation. this is required only when PSA is enforced.
-	VolumeJobSecurityContext VolumeJobSecurityContext `json:",inline"`
+	JobSecurityContext JobSecurityContext `json:",inline"`
 }
 
 // ApplicationBackupStatusType is the status of the application backup


### PR DESCRIPTION
- These data structure will be used by px-backup reconciler to sync value from CR to mongo object so that it can be used in restore path


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

