### PR TITLE
pwx-34665 | test: add tests for failover workflow in sync dr

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,12 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"strings"
 	"time"
 
 	"github.com/libopenstorage/stork/pkg/k8sutils"
-	"github.com/libopenstorage/stork/pkg/log"
 
 	"github.com/aquilax/truncate"
 	patch "github.com/evanphx/json-patch"
@@ -447,40 +445,4 @@ func DoesMigrationScheduleMigrateNamespaces(migrationSchedule stork_api.Migratio
 		}
 	}
 	return found, nil
-}
-
-// GetDestinationKubeConfigFile returns the path of the destination cluster kubeconfig file.
-func GetDestinationKubeConfigFile() (string, error) {
-	destKubeconfigPath := path.Join("/tmp", "dest_kubeconfig")
-	cm, err := core.Instance().GetConfigMap("destinationconfigmap", "kube-system")
-	if err != nil {
-		log.Error("error reading config map: %v", err)
-		return "", err
-	}
-	config := cm.Data["kubeconfig"]
-	if len(config) == 0 {
-		configErr := "error reading kubeconfig: found empty remoteConfig in config map"
-		return "", fmt.Errorf(configErr)
-	}
-	// dump to remoteFilePath
-	err = os.WriteFile(destKubeconfigPath, []byte(config), 0644)
-	return destKubeconfigPath, err
-}
-
-// GetSourceKubeConfigFile returns the path of the source cluster kubeconfig file.
-func GetSourceKubeConfigFile() (string, error) {
-	srcKubeConfigPath := path.Join("/tmp", "src_kubeconfig")
-	cm, err := core.Instance().GetConfigMap("sourceconfigmap", "kube-system")
-	if err != nil {
-		log.Error("error reading config map: %v", err)
-		return "", err
-	}
-	config := cm.Data["kubeconfig"]
-	if len(config) == 0 {
-		configErr := "error reading kubeconfig: found empty remoteConfig in config map"
-		return "", fmt.Errorf(configErr)
-	}
-	// dump to remoteFilePath
-	err = os.WriteFile(srcKubeConfigPath, []byte(config), 0644)
-	return srcKubeConfigPath, err
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -454,12 +454,12 @@ func GetDestinationKubeConfigFile() (string, error) {
 	destKubeconfigPath := path.Join("/tmp", "dest_kubeconfig")
 	cm, err := core.Instance().GetConfigMap("destinationconfigmap", "kube-system")
 	if err != nil {
-		log.Error("Error reading config map: %v", err)
+		log.Error("error reading config map: %v", err)
 		return "", err
 	}
 	config := cm.Data["kubeconfig"]
 	if len(config) == 0 {
-		configErr := "Error reading kubeconfig: found empty remoteConfig in config map"
+		configErr := "error reading kubeconfig: found empty remoteConfig in config map"
 		return "", fmt.Errorf(configErr)
 	}
 	// dump to remoteFilePath
@@ -472,12 +472,12 @@ func GetSourceKubeConfigFile() (string, error) {
 	srcKubeConfigPath := path.Join("/tmp", "src_kubeconfig")
 	cm, err := core.Instance().GetConfigMap("sourceconfigmap", "kube-system")
 	if err != nil {
-		log.Error("Error reading config map: %v", err)
+		log.Error("error reading config map: %v", err)
 		return "", err
 	}
 	config := cm.Data["kubeconfig"]
 	if len(config) == 0 {
-		configErr := "Error reading kubeconfig: found empty remoteConfig in config map"
+		configErr := "error reading kubeconfig: found empty remoteConfig in config map"
 		return "", fmt.Errorf(configErr)
 	}
 	// dump to remoteFilePath

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -2066,3 +2066,39 @@ func updateDashStats(testName string, testResult *string) {
 	stats.PushStatsToAetos(tpDash, testName, dashProductName, dashStatsType, eventStat)
 	Dash.TestCaseEnd()
 }
+
+// getDestinationKubeConfigFile returns the path of the destination cluster kubeconfig file.
+func getDestinationKubeConfigFile() (string, error) {
+	destKubeconfigPath := path.Join("/tmp", "dest_kubeconfig")
+	cm, err := core.Instance().GetConfigMap("destinationconfigmap", "kube-system")
+	if err != nil {
+		log.Error("error reading config map: %v", err)
+		return "", err
+	}
+	config := cm.Data["kubeconfig"]
+	if len(config) == 0 {
+		configErr := "error reading kubeconfig: found empty remoteConfig in config map"
+		return "", fmt.Errorf(configErr)
+	}
+	// dump to remoteFilePath
+	err = os.WriteFile(destKubeconfigPath, []byte(config), 0644)
+	return destKubeconfigPath, err
+}
+
+// getSourceKubeConfigFile returns the path of the source cluster kubeconfig file.
+func getSourceKubeConfigFile() (string, error) {
+	srcKubeConfigPath := path.Join("/tmp", "src_kubeconfig")
+	cm, err := core.Instance().GetConfigMap("sourceconfigmap", "kube-system")
+	if err != nil {
+		log.Error("error reading config map: %v", err)
+		return "", err
+	}
+	config := cm.Data["kubeconfig"]
+	if len(config) == 0 {
+		configErr := "error reading kubeconfig: found empty remoteConfig in config map"
+		return "", fmt.Errorf(configErr)
+	}
+	// dump to remoteFilePath
+	err = os.WriteFile(srcKubeConfigPath, []byte(config), 0644)
+	return srcKubeConfigPath, err
+}

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -838,7 +838,7 @@ func scheduleClusterPair(ctx *scheduler.Context, skipStorage, resetConfig bool, 
 }
 
 // Create a cluster pair from source to destination and another cluster pair from destination to source
-func scheduleBidirectionalClusterPair(cpName, cpNamespace, projectMappings string, objectStoreType storkv1.BackupLocationType, secretName string, isMetroDR bool) error {
+func scheduleBidirectionalClusterPair(cpName, cpNamespace, projectMappings string, objectStoreType storkv1.BackupLocationType, secretName string, isSyncDR bool) error {
 	//var token string
 	// Setting kubeconfig to source because we will create bidirectional cluster pair based on source as reference
 	err := setSourceKubeConfig()
@@ -937,7 +937,7 @@ func scheduleBidirectionalClusterPair(cpName, cpNamespace, projectMappings strin
 	}
 
 	// Append the sync-dr mode arg in case of metro DR.
-	if isMetroDR {
+	if isSyncDR {
 		cmdArgs = append(cmdArgs, "--mode", "sync-dr")
 	}
 
@@ -948,7 +948,7 @@ func scheduleBidirectionalClusterPair(cpName, cpNamespace, projectMappings strin
 
 	// Get external object store details and append to the command accordingily
 	objectStoreArgs := make([]string, 0)
-	if !isMetroDR {
+	if !isSyncDR {
 		objectStoreArgs, err = getObjectStoreArgs(objectStoreType, secretName)
 		if err != nil {
 			return fmt.Errorf("failed to get  %s secret in configmap secret-config in default namespace", objectStoreType)

--- a/test/integration_test/migration_dr_actions_test.go
+++ b/test/integration_test/migration_dr_actions_test.go
@@ -13,6 +13,7 @@ import (
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/storkctl"
+	"github.com/libopenstorage/stork/pkg/utils"
 	"github.com/portworx/sched-ops/k8s/apps"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/portworx/torpedo/drivers/scheduler"
@@ -34,11 +35,11 @@ func TestDRActions(t *testing.T) {
 
 	// get the destination kubeconfig from configmap in source cluster so that it can be passed to storkctl commands
 	// since both the dr cli commands run in destination cluster
-	destinationKubeConfigPath, err = getDestinationKubeConfigFile()
+	destinationKubeConfigPath, err = utils.GetDestinationKubeConfigFile()
 	log.FailOnError(t, err, "Error getting destination kubeconfig file")
 
 	// Get the source kubeconfig from configmap.
-	srcKubeConfigPath, err = getDestinationKubeConfigFile()
+	srcKubeConfigPath, err = utils.GetDestinationKubeConfigFile()
 	log.FailOnError(t, err, "Error getting destination kubeconfig file")
 
 	t.Run("testSyncDR", testSyncDR)

--- a/test/integration_test/migration_dr_actions_test.go
+++ b/test/integration_test/migration_dr_actions_test.go
@@ -13,7 +13,6 @@ import (
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/storkctl"
-	"github.com/libopenstorage/stork/pkg/utils"
 	"github.com/portworx/sched-ops/k8s/apps"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/portworx/torpedo/drivers/scheduler"
@@ -35,11 +34,11 @@ func TestDRActions(t *testing.T) {
 
 	// get the destination kubeconfig from configmap in source cluster so that it can be passed to storkctl commands
 	// since both the dr cli commands run in destination cluster
-	destinationKubeConfigPath, err = utils.GetDestinationKubeConfigFile()
+	destinationKubeConfigPath, err = getDestinationKubeConfigFile()
 	log.FailOnError(t, err, "Error getting destination kubeconfig file")
 
 	// Get the source kubeconfig from configmap.
-	srcKubeConfigPath, err = utils.GetDestinationKubeConfigFile()
+	srcKubeConfigPath, err = getDestinationKubeConfigFile()
 	log.FailOnError(t, err, "Error getting destination kubeconfig file")
 
 	t.Run("testSyncDR", testSyncDR)

--- a/test/integration_test/migration_dr_actions_test.go
+++ b/test/integration_test/migration_dr_actions_test.go
@@ -47,6 +47,7 @@ func TestDRActions(t *testing.T) {
 
 func testSyncDR(t *testing.T) {
 	t.Run("testDRActionMetroFailover", testDRActionMetroFailover)
+	t.Run("testDRActionMetroFailback", testDRActionMetroFailback)
 }
 
 func testAsyncDR(t *testing.T) {
@@ -1199,7 +1200,7 @@ func testDRActionFailbackSubsetNamespacesTest(t *testing.T) {
 func testDRActionMetroFailover(t *testing.T) {
 	// Create the apps for migration.
 	// appKeys is an array of appKeys that will be used to create the apps.
-	instanceID := "metro-multi-ns-migration-schedule-interval"
+	instanceID := "metro-failover-multi-ns-migration-schedule"
 	mysqlApp := "mysql-1-pvc"
 	mysqlNamespace := fmt.Sprintf("%s-%s", mysqlApp, instanceID)
 	elasticsearchApp := "elasticsearch"
@@ -1288,6 +1289,8 @@ func testDRActionMetroFailover(t *testing.T) {
 	// and not a part of the torpedo scheduler context.
 	_, err = storkops.Instance().ValidateMigrationSchedule(migrationScheduleName, defaultAdminNamespace, defaultWaitTimeout, defaultWaitInterval)
 	log.FailOnError(t, err, "failed to set validate migration schedule,error: %v", err)
+	err = setMockTime(nil)
+	log.FailOnError(t, err, "Error resetting mock time")
 
 	// Failover the application
 	err = setDestinationKubeConfig()
@@ -1348,6 +1351,279 @@ func testDRActionMetroFailover(t *testing.T) {
 	for _, ns := range []string{mysqlNamespace, elasticsearchNamespace} {
 		blowNamespaceForTest(t, ns, false)
 	}
+}
+
+// testDRActionMetroFailback tests the failback and failback status reporting for sync DR.
+func testDRActionMetroFailback(t *testing.T) {
+	// Create the apps for migration.
+	// appKeys is an array of appKeys that will be used to create the apps.
+	instanceID := "metro-failback-multi-ns-migration-schedule"
+	mysqlApp := "mysql-1-pvc"
+	mysqlNamespace := fmt.Sprintf("%s-%s", mysqlApp, instanceID)
+	elasticsearchApp := "elasticsearch"
+	elasticsearchNamespace := fmt.Sprintf("%s-%s", elasticsearchApp, instanceID)
+	appKeys := []string{mysqlApp, elasticsearchApp}
+
+	// Reset config in case of error
+	defer func() {
+		err := setSourceKubeConfig()
+		log.FailOnError(t, err, "Error resetting remote config")
+	}()
+
+	// Schedule multiple apps on the source cluster.
+	var preMigrationCtxs []*scheduler.Context
+	for _, appKey := range appKeys {
+		ctxs, err := schedulerDriver.Schedule(instanceID,
+			scheduler.ScheduleOptions{
+				AppKeys: []string{appKey},
+				Labels:  nil,
+			})
+		log.FailOnError(t, err, "Error scheduling task")
+		Dash.VerifyFatal(t, 1, len(ctxs), "Only one task should have started")
+		preMigrationCtxs = append(preMigrationCtxs, ctxs[0].DeepCopy())
+	}
+	for _, preMigrationCtx := range preMigrationCtxs {
+		err := schedulerDriver.WaitForRunning(preMigrationCtx, defaultWaitTimeout, defaultWaitInterval)
+		log.FailOnError(t, err, "Error waiting for app to get to running state")
+	}
+
+	// Validate the successful deployment of apps on the source cluster.
+	sourceDeployments, err := apps.Instance().ListDeployments(mysqlNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving deployments from %s namespace", mysqlNamespace)
+	Dash.VerifyFatal(t, len(sourceDeployments.Items), 1, fmt.Sprintf("Expected 1 deployment in source in %s namespace", mysqlNamespace))
+	sourceDeploymentReplicas := *sourceDeployments.Items[0].Spec.Replicas
+	sourceStatefulsets, err := apps.Instance().ListStatefulSets(elasticsearchNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving statefulsets from %s namespace", elasticsearchNamespace)
+	Dash.VerifyFatal(t, len(sourceStatefulsets.Items), 1, fmt.Sprintf("Expected 1 statefulset in source in %s namespace", elasticsearchNamespace))
+	sourceStatefulsetReplicas := *sourceStatefulsets.Items[0].Spec.Replicas
+
+	/////////////////////////////////
+	// Migrationschedule creation //
+	///////////////////////////////
+
+	// Create the clusterpair.
+	clusterPairNamespace := defaultAdminNamespace
+	log.Info("Creating bidirectional cluster pair:")
+	log.InfoD("Name: %s", remotePairName)
+	log.InfoD("Namespace: %s", clusterPairNamespace)
+	log.InfoD("Backuplocation: %s", defaultBackupLocation)
+	log.InfoD("Secret name: %s", defaultSecretName)
+	err = scheduleBidirectionalClusterPair(remotePairName, clusterPairNamespace, projectIDMappings, defaultBackupLocation, defaultSecretName, true)
+	log.FailOnError(t, err, "failed to set bidirectional cluster pair: %v", err)
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+
+	// Create the migration schedule
+	// we want to create the schedulePolicy and migrationSchedule using storkctl instead of scheduling apps using torpedo's scheduler
+	// schedulePolicyArgs is a map of schedulePolicyName : {{flag1:value1,flag2:value2,....}}
+	schedulePolicyArgs := make(map[string]map[string]string)
+	schedulePolicyArgs["migrate-every-5m"] = map[string]string{"policy-type": "Interval", "interval-minutes": "5"}
+
+	// migrationScheduleArgs is a map of migrationScheduleName : {{flag1:value1,flag2:value2,....}}
+	migrationScheduleArgs := make(map[string]map[string]string)
+	migrationScheduleArgs[instanceID] = map[string]string{
+		"purge-deleted-resources": "",
+		"schedule-policy-name":    "migrate-every-5m",
+	}
+
+	//Create schedulePolicies using storkCtl if any required
+	factory := storkctl.NewFactory()
+	var outputBuffer bytes.Buffer
+	cmd := storkctl.NewCommand(factory, os.Stdin, &outputBuffer, os.Stderr)
+	for schedulePolicyName, customArgs := range schedulePolicyArgs {
+		cmdArgs := []string{"create", "schedulepolicy", schedulePolicyName}
+		executeStorkCtlCommand(t, cmd, cmdArgs, customArgs)
+	}
+	//Create migrationSchedules using storkCtl
+	migrationScheduleName := "metro-dr-migration-schedule-multiple-ns"
+	namespacesValue := fmt.Sprintf("%s,%s", mysqlNamespace, elasticsearchNamespace)
+	cmdArgs := []string{"create", "migrationschedule", migrationScheduleName, "-c", remotePairName,
+		"--namespaces", namespacesValue, "-n", defaultAdminNamespace}
+	executeStorkCtlCommand(t, cmd, cmdArgs, migrationScheduleArgs[instanceID])
+
+	// bump time of the world by 6 minutes
+	mockNow := time.Now().Add(6 * time.Minute)
+	err = setMockTime(&mockNow)
+	log.FailOnError(t, err, "Error setting mock time")
+
+	// Need to validate the migrationSchedules separately because they are created using storkctl
+	// and not a part of the torpedo scheduler context.
+	_, err = storkops.Instance().ValidateMigrationSchedule(migrationScheduleName, defaultAdminNamespace, defaultWaitTimeout, defaultWaitInterval)
+	log.FailOnError(t, err, "failed to set validate migration schedule,error: %v", err)
+	err = setMockTime(nil)
+	log.FailOnError(t, err, "Error resetting mock time")
+
+	//////////////////////////////////////
+	// Failover to destination cluster //
+	////////////////////////////////////
+	err = setDestinationKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to destination cluster: %v", err)
+
+	// Failover the application to destination cluster.
+	failoverCmdArgs := map[string]string{
+		"migration-reference": migrationScheduleName,
+		"include-namespaces":  namespacesValue,
+		"namespace":           defaultAdminNamespace,
+	}
+	drActionName, _ := createDRAction(t, defaultAdminNamespace, storkv1.ActionTypeFailover, migrationScheduleName, failoverCmdArgs)
+
+	// Wait for failover action to complete.
+	waitTillActionComplete(t, storkv1.ActionTypeFailover, drActionName, defaultAdminNamespace)
+
+	// Verify the application is running on the destination cluster
+	destDeployments, err := apps.Instance().ListDeployments(mysqlNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving deployments from %s namespace", mysqlNamespace)
+	Dash.VerifyFatal(t, len(destDeployments.Items), 1, fmt.Sprintf("Expected 1 deployment in destination in %s namespace", mysqlNamespace))
+	Dash.VerifyFatal(t, *destDeployments.Items[0].Spec.Replicas, sourceDeploymentReplicas, fmt.Sprintf("Expected %d replica in destination in %s namespace", sourceDeploymentReplicas, mysqlNamespace))
+
+	destStatefulsets, err := apps.Instance().ListStatefulSets(elasticsearchNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving statefulsets from %s namespace", elasticsearchNamespace)
+	Dash.VerifyFatal(t, len(destStatefulsets.Items), 1, fmt.Sprintf("Expected 1 statefulset in destination in %s namespace", elasticsearchNamespace))
+	Dash.VerifyFatal(t, *destStatefulsets.Items[0].Spec.Replicas, sourceStatefulsetReplicas, fmt.Sprintf("Expected %d replica in destination in %s namespace", sourceStatefulsetReplicas, elasticsearchNamespace))
+
+	// Activate the clusterdomain again on source cluster in order to make it work for next test.
+	cmdArgs = []string{"activate", "clusterdomain", "--all", "--kubeconfig", srcKubeConfigPath, "-n", defaultAdminNamespace}
+	executeStorkCtlCommand(t, cmd, cmdArgs, nil)
+
+	// Verify the application is not running on the source cluster
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+	sourceDeployments, err = apps.Instance().ListDeployments(mysqlNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving deployments from %s namespace", mysqlNamespace)
+	Dash.VerifyFatal(t, len(sourceDeployments.Items), 1, fmt.Sprintf("Expected 1 deployment in source in %s namespace", mysqlNamespace))
+	Dash.VerifyFatal(t, *sourceDeployments.Items[0].Spec.Replicas, 0, fmt.Sprintf("Expected 0 replica in source in deployment in %s namespace", mysqlNamespace))
+
+	sourceStatefulsets, err = apps.Instance().ListStatefulSets(elasticsearchNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving statefulsets from %s namespace", elasticsearchNamespace)
+	Dash.VerifyFatal(t, len(sourceStatefulsets.Items), 1, fmt.Sprintf("Expected 1 statefulset in source in %s namespace", elasticsearchNamespace))
+	Dash.VerifyFatal(t, *sourceStatefulsets.Items[0].Spec.Replicas, 0, fmt.Sprintf("Expected 0 replica in source in sts in %s namespace", elasticsearchNamespace))
+
+	/////////////////////////////////////////////////////////
+	// Failback all namespaces back to the source cluster //
+	///////////////////////////////////////////////////////
+	err = setDestinationKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to destination cluster: %v", err)
+
+	// Create reverse migrationschedule using storkCtl.
+	// Initialize reversemigrationschedule and reverse schedule policy.
+	reverseSchedulePolicyArgs := make(map[string]map[string]string)
+	reverseSchedulePolicyArgs["reverse-migrate-every-5m"] = map[string]string{"policy-type": "Interval", "interval-minutes": "5"}
+	reverseMigrationScheduleArgs := make(map[string]map[string]string)
+	reverseMigrationScheduleArgs[instanceID] = map[string]string{
+		"purge-deleted-resources": "",
+		"schedule-policy-name":    "reverse-migrate-every-5m",
+	}
+
+	// Create schedulePolicies using storkCtl.
+	cmd = storkctl.NewCommand(factory, os.Stdin, &outputBuffer, os.Stderr)
+	for schedulePolicyName, customArgs := range reverseSchedulePolicyArgs {
+		cmdArgs := []string{"create", "schedulepolicy", schedulePolicyName, "--kubeconfig", destinationKubeConfigPath}
+		executeStorkCtlCommand(t, cmd, cmdArgs, customArgs)
+	}
+	log.Info("created reverse schedule policy")
+
+	// Create migration schedule.
+	reverseMigrationScheduleName := "reverse-metro-dr-migration-schedule-multiple-ns"
+	cmdArgs = []string{"create", "migrationschedule", reverseMigrationScheduleName, "-c", remotePairName,
+		"--namespaces", namespacesValue, "-n", defaultAdminNamespace, "--kubeconfig", destinationKubeConfigPath}
+	executeStorkCtlCommand(t, cmd, cmdArgs, reverseMigrationScheduleArgs[instanceID])
+
+	// Bump time of the world by 6 minutes.
+	mockNow = time.Now().Add(6 * time.Minute)
+	err = setMockTime(&mockNow)
+	log.FailOnError(t, err, "Error setting mock time")
+
+	// Need to validate the migrationSchedules separately because they are created using storkctl
+	// and not a part of the torpedo scheduler context.
+	_, err = storkops.Instance().ValidateMigrationSchedule(reverseMigrationScheduleName, defaultAdminNamespace, defaultWaitTimeout, defaultWaitInterval)
+	log.Info("created reverse migration schedule")
+
+	failbackCmdArgs := map[string]string{
+		"migration-reference": reverseMigrationScheduleName,
+		"include-namespaces":  namespacesValue,
+		"namespace":           defaultAdminNamespace,
+	}
+	drActionName, _ = createDRAction(t, defaultAdminNamespace, storkv1.ActionTypeFailback, reverseMigrationScheduleName, failbackCmdArgs)
+	// Wait for failback action to complete.
+	waitTillActionComplete(t, storkv1.ActionTypeFailback, drActionName, defaultAdminNamespace)
+	err = setMockTime(nil)
+	log.FailOnError(t, err, "Error resetting mock time")
+
+	/////////////////////////
+	// Failback assertion //
+	///////////////////////
+
+	// Verify the elasticsearch application is not running on the destination cluster.
+	destStatefulsets, err = apps.Instance().ListStatefulSets(elasticsearchNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving statefulsets from %s namespace", elasticsearchNamespace)
+	Dash.VerifyFatal(t, len(destStatefulsets.Items), 1, fmt.Sprintf("Expected 1 statefulset in destination in %s namespace", elasticsearchNamespace))
+	Dash.VerifyFatal(t, *destStatefulsets.Items[0].Spec.Replicas, 0, fmt.Sprintf("Expected 0 replica in destination in sts in %s namespace", elasticsearchNamespace))
+
+	// Verify the mysql application is not running on the destination cluster.
+	destDeployments, err = apps.Instance().ListDeployments(mysqlNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving deployments from %s namespace", mysqlNamespace)
+	Dash.VerifyFatal(t, len(destDeployments.Items), 1, fmt.Sprintf("Expected 1 deployment in destination in %s namespace", mysqlNamespace))
+	Dash.VerifyFatal(t, *destDeployments.Items[0].Spec.Replicas, 0, fmt.Sprintf("Expected 0 replica in destination in deployment in %s namespace", mysqlNamespace))
+
+	// Verify the elasticsearch application is running on the source cluster.
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+	expectedReplicas := int32(3)
+	sourceStatefulsets, err = apps.Instance().ListStatefulSets(elasticsearchNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving statefulsets from %s namespace", elasticsearchNamespace)
+	Dash.VerifyFatal(t, len(sourceStatefulsets.Items), 1, fmt.Sprintf("Expected 1 statefulset in source in %s namespace", elasticsearchNamespace))
+	Dash.VerifyFatal(t, *sourceStatefulsets.Items[0].Spec.Replicas, expectedReplicas, fmt.Sprintf("Expected %d replica in source in %s namespace", sourceStatefulsetReplicas, elasticsearchNamespace))
+
+	// Verify the mysql application is running on the source cluster.
+	destDeployments, err = apps.Instance().ListDeployments(mysqlNamespace, metav1.ListOptions{})
+	log.FailOnError(t, err, "error retrieving deployments from %s namespace", mysqlNamespace)
+	Dash.VerifyFatal(t, len(destDeployments.Items), 1, fmt.Sprintf("Expected 1 deployment in destination in %s namespace", mysqlNamespace))
+	Dash.VerifyFatal(t, *destDeployments.Items[0].Spec.Replicas, 1, fmt.Sprintf("Expected 1 replica in destination in deployment in %s namespace", mysqlNamespace))
+
+	// Verify that the migration schedule in destination cluster has been suspended.
+	err = setDestinationKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to destination cluster: %v", err)
+	migrSched, err := storkops.Instance().GetMigrationSchedule(reverseMigrationScheduleName, defaultAdminNamespace)
+	log.FailOnError(t, err, "failed to retrieve migration schedule: %v", err)
+
+	if migrSched.Spec.Suspend != nil && !(*migrSched.Spec.Suspend) {
+		// Fail the test as the migration schedule is not yet suspended.
+		suspendErr := fmt.Errorf("migrationschedule is not suspended on destination cluster : %s/%s", migrSched.GetName(), migrSched.GetNamespace())
+		log.FailOnError(t, err, "Failed: %v", suspendErr)
+	}
+	log.InfoD("Successfully verified suspend migration in destination cluster")
+
+	//////////////
+	// Cleanup //
+	/////////////
+
+	// Delete destination cluster cluster-pair and migration schedule.
+	err = storkops.Instance().DeleteClusterPair(remotePairName, defaultAdminNamespace)
+	log.FailOnError(t, err, "failed to delete clusterpair %s in namespace %s in destination: %v", remotePairName, defaultAdminNamespace, err)
+	DeleteAndWaitForMigrationScheduleDeletion(t, migrationScheduleName, defaultAdminNamespace)
+	DeleteAndWaitForMigrationScheduleDeletion(t, reverseMigrationScheduleName, defaultAdminNamespace)
+	for schedulePolicyName := range reverseSchedulePolicyArgs {
+		err := storkops.Instance().DeleteSchedulePolicy(schedulePolicyName)
+		log.FailOnError(t, err, "error deleting up schedule policy %s", schedulePolicyName)
+	}
+	// cleanup
+	destroyAndWait(t, preMigrationCtxs)
+
+	// Delete source cluster cluster-pair and migration schedule.
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+	err = storkops.Instance().DeleteClusterPair(remotePairName, defaultAdminNamespace)
+	log.FailOnError(t, err, "failed to delete clusterpair %s in namespace %s in source: %v", remotePairName, defaultAdminNamespace, err)
+	DeleteAndWaitForMigrationScheduleDeletion(t, migrationScheduleName, defaultAdminNamespace)
+	DeleteAndWaitForMigrationScheduleDeletion(t, reverseMigrationScheduleName, defaultAdminNamespace)
+	for schedulePolicyName := range schedulePolicyArgs {
+		err := storkops.Instance().DeleteSchedulePolicy(schedulePolicyName)
+		log.FailOnError(t, err, "error deleting up schedule policy %s", schedulePolicyName)
+	}
+	// cleanup
+	destroyAndWait(t, preMigrationCtxs)
+	blowNamespaceForTest(t, elasticsearchNamespace, false)
+	blowNamespaceForTest(t, mysqlNamespace, false)
 }
 
 func failBackWithMigrationSchedulesWithDifferentPolicies(t *testing.T, instanceID string, appName string, appNamespace string, reverseSchedulePolicyArgs map[string]map[string]string) {

--- a/test/integration_test/migration_features_test.go
+++ b/test/integration_test/migration_features_test.go
@@ -93,7 +93,7 @@ func migrationStashStrategy(t *testing.T, appName string, appPath string) {
 	err = setSourceKubeConfig()
 	log.FailOnError(t, err, "Error setting source kubeconfig")
 
-	err = scheduleBidirectionalClusterPair(clusterPairName, appData.Ns, "", storkapi.BackupLocationType(backupLocation), backupSecret)
+	err = scheduleBidirectionalClusterPair(clusterPairName, appData.Ns, "", storkapi.BackupLocationType(backupLocation), backupSecret, false)
 	log.FailOnError(t, err, "Error creating cluster pair")
 
 	err = setSourceKubeConfig()
@@ -295,7 +295,7 @@ func testMigrationStashStrategyWithStartApplication(t *testing.T) {
 	err = setSourceKubeConfig()
 	log.FailOnError(t, err, "Error setting source kubeconfig")
 
-	err = scheduleBidirectionalClusterPair(clusterPairName, appData.Ns, "", storkapi.BackupLocationType(backupLocation), backupSecret)
+	err = scheduleBidirectionalClusterPair(clusterPairName, appData.Ns, "", storkapi.BackupLocationType(backupLocation), backupSecret, false)
 	log.FailOnError(t, err, "Error creating cluster pair")
 
 	// set stashstrategy
@@ -394,7 +394,7 @@ func testMultipleTimesMigrationsWithStashStrategy(t *testing.T) {
 	err = setSourceKubeConfig()
 	log.FailOnError(t, err, "Error setting source kubeconfig")
 
-	err = scheduleBidirectionalClusterPair(clusterPairName, appData.Ns, "", storkapi.BackupLocationType(backupLocation), backupSecret)
+	err = scheduleBidirectionalClusterPair(clusterPairName, appData.Ns, "", storkapi.BackupLocationType(backupLocation), backupSecret, false)
 	log.FailOnError(t, err, "Error creating cluster pair")
 
 	// set stashstrategy
@@ -536,7 +536,7 @@ func testFailbackWithStashStrategy(t *testing.T) {
 
 	// creating migration and clusterpair in kube-system namespace as we have to delete the ns in source for failback
 	migrationNamespace := "kube-system"
-	err = scheduleBidirectionalClusterPair(clusterPairName, migrationNamespace, "", storkapi.BackupLocationType(backupLocation), backupSecret)
+	err = scheduleBidirectionalClusterPair(clusterPairName, migrationNamespace, "", storkapi.BackupLocationType(backupLocation), backupSecret, false)
 	log.FailOnError(t, err, "Error creating cluster pair")
 
 	// set stashstrategy

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -1513,7 +1513,7 @@ func bidirectionalClusterPairTest(t *testing.T) {
 	// Scheduler cluster pairs: source cluster --> destination cluster and destination cluster --> source cluster
 	for location, secret := range cmData {
 		log.InfoD("Creating a bidirectional-pair using %s as objectstore.", location)
-		err := scheduleBidirectionalClusterPair(clusterPairName, clusterPairNamespace, "", storkv1.BackupLocationType(location), secret)
+		err := scheduleBidirectionalClusterPair(clusterPairName, clusterPairNamespace, "", storkv1.BackupLocationType(location), secret, false)
 		log.FailOnError(t, err, "failed to set bidirectional cluster pair: %v", err)
 
 		err = setSourceKubeConfig()
@@ -2255,7 +2255,7 @@ func transformCRResourceTest(t *testing.T) {
 	err = setMockTime(nil)
 	log.FailOnError(t, err, "Error resetting mock time")
 
-	err = scheduleBidirectionalClusterPair(clusterPairName, appData.Ns, "", storkv1.BackupLocationType(backupLocation), backupSecret)
+	err = scheduleBidirectionalClusterPair(clusterPairName, appData.Ns, "", storkv1.BackupLocationType(backupLocation), backupSecret, false)
 	log.FailOnError(t, err, "Error creating cluster pair")
 
 	err = setSourceKubeConfig()
@@ -2825,7 +2825,7 @@ func scheduleClusterPairGeneric(t *testing.T, ctxs []*scheduler.Context,
 		log.InfoD("Namespace: %s", clusterPairNamespace)
 		log.InfoD("Backuplocation: %s", defaultBackupLocation)
 		log.InfoD("Secret name: %s", defaultSecretName)
-		err = scheduleBidirectionalClusterPair(remotePairName, clusterPairNamespace, projectIDMappings, defaultBackupLocation, defaultSecretName)
+		err = scheduleBidirectionalClusterPair(remotePairName, clusterPairNamespace, projectIDMappings, defaultBackupLocation, defaultSecretName, false)
 		log.FailOnError(t, err, "failed to set bidirectional cluster pair: %v", err)
 		err = setSourceKubeConfig()
 		log.FailOnError(t, err, "failed to set kubeconfig to source cluster: %v", err)

--- a/test/integration_test/operator_test.go
+++ b/test/integration_test/operator_test.go
@@ -81,7 +81,7 @@ func validateAndDestroyCrMigration(t *testing.T, appName string, appPath string)
 	err = asyncdr.ValidateCRD(appData.ExpectedCrdList, sourceClusterConfigPath)
 	log.FailOnError(t, err, "Error validating source crds")
 
-	err = scheduleBidirectionalClusterPair(clusterPairName, appData.Ns, "", storkv1.BackupLocationType(backupLocation), backupSecret)
+	err = scheduleBidirectionalClusterPair(clusterPairName, appData.Ns, "", storkv1.BackupLocationType(backupLocation), backupSecret, false)
 	log.FailOnError(t, err, "Error creating cluster pair")
 
 	log.InfoD("Migration Started")

--- a/test/integration_test/stork-test-pod.yaml
+++ b/test/integration_test/stork-test-pod.yaml
@@ -41,13 +41,13 @@ spec:
   - command: ["gotestsum"]
     args:
     - --format
-    - standard-verbose 
+    - standard-verbose
     - --raw-command
     - go
     - tool
     - test2json
     - -t
-    - /stork.test 
+    - /stork.test
     - -test.v
     - -test.short=SHORT_FLAG
     FOCUS_TESTS
@@ -73,27 +73,27 @@ spec:
     - name: LS_CONTROLLERS
       value: http://linstor-op-cs.default:3370/
     - name: ENABLE_CLUSTER_DOMAIN_TESTS
-      value: enable_cluster_domain 
-    - name: STORAGE_PROVISIONER 
-      value: storage_provisioner 
+      value: enable_cluster_domain
+    - name: STORAGE_PROVISIONER
+      value: storage_provisioner
     - name: AUTH_SECRET_CONFIGMAP
       value: auth_secret_configmap
     - name: PX_SHARED_SECRET
       value: px_shared_secret_key
-    - name: BACKUP_LOCATION_PATH 
-      value: backup_location_path 
+    - name: BACKUP_LOCATION_PATH
+      value: backup_location_path
     - name: AWS_ACCESS_KEY_ID
       value: aws_access_key_id
     - name: AWS_SECRET_ACCESS_KEY
       value: aws_secret_access_key
-    - name: EXTERNAL_TEST_CLUSTER 
+    - name: EXTERNAL_TEST_CLUSTER
       value: external_test_cluster
     - name: CLOUD_DELETION_VALIDATION
       value: cloud_deletion_validation
     - name: PX_NAMESPACE
       value: px_namespace
-    - name: INTERNAL_AWS_LB 
-      value: internal_aws_lb 
+    - name: INTERNAL_AWS_LB
+      value: internal_aws_lb
     - name: TESTRAIL_RUN_NAME
       value: testrail_run_name
     - name: TESTRAIL_RUN_ID

--- a/test/integration_test/storkctl_dr_action_test.go
+++ b/test/integration_test/storkctl_dr_action_test.go
@@ -13,7 +13,6 @@ import (
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/libopenstorage/stork/pkg/storkctl"
-	"github.com/libopenstorage/stork/pkg/utils"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 )
 
@@ -29,7 +28,7 @@ func TestStorkCtlAction(t *testing.T) {
 	log.FailOnError(t, err, "failed to set kubeconfig to source cluster: %v", err)
 	// get the destination kubeconfig from configmap in source cluster so that it can be passed to storkctl commands
 	// since both the dr cli commands run in destination cluster
-	destinationKubeConfigPath, err = utils.GetDestinationKubeConfigFile()
+	destinationKubeConfigPath, err = getDestinationKubeConfigFile()
 	log.FailOnError(t, err, "Error getting destination kubeconfig file")
 	err = setDestinationKubeConfig()
 	log.FailOnError(t, err, "failed to set kubeconfig to destination cluster: %v", err)

--- a/test/integration_test/storkctl_dr_action_test.go
+++ b/test/integration_test/storkctl_dr_action_test.go
@@ -23,7 +23,7 @@ const (
 	syncDR  string = "sync-dr"
 )
 
-var destinationKubeConfigPath string
+var destinationKubeConfigPath, srcKubeConfigPath string
 
 func TestStorkCtlAction(t *testing.T) {
 	err := setSourceKubeConfig()
@@ -284,6 +284,23 @@ func getDestinationKubeConfigFile() (string, error) {
 	// dump to remoteFilePath
 	err = os.WriteFile(destKubeconfigPath, []byte(config), 0644)
 	return destKubeconfigPath, err
+}
+
+func getSourceKubeConfigFile() (string, error) {
+	srcKubeConfigPath := path.Join("/tmp", "src_kubeconfig")
+	cm, err := core.Instance().GetConfigMap("sourceconfigmap", "kube-system")
+	if err != nil {
+		log.Error("Error reading config map: %v", err)
+		return "", err
+	}
+	config := cm.Data["kubeconfig"]
+	if len(config) == 0 {
+		configErr := "Error reading kubeconfig: found empty remoteConfig in config map"
+		return "", fmt.Errorf(configErr)
+	}
+	// dump to remoteFilePath
+	err = os.WriteFile(srcKubeConfigPath, []byte(config), 0644)
+	return srcKubeConfigPath, err
 }
 
 func generateDRActionObject(actionType storkv1.ActionType, migrationScheduleName string, namespaces []string, skipSourceOperations bool) *storkv1.Action {

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -169,19 +169,19 @@ case $i in
         cloud_deletion_validation=$2
         shift
         shift
-        ;;		
+        ;;
     --internal_aws_lb)
         echo "Flag to check if AWS loadbalancer is of type Internal: $2"
         internal_aws_lb=$2
         shift
         shift
-        ;;		
+        ;;
     --px_namespace)
         echo "Flag to indicate namespace PX has been deployed in: $2"
         px_namespace=$2
         shift
         shift
-        ;;		
+        ;;
     --bidirectional-cluster-pair)
         echo "Flag to indicate if bidirectional clusterpairing is intended in tests: $2"
         bidirectional_cluster_pair=$2
@@ -193,7 +193,7 @@ case $i in
         unidirectional_cluster_pair=$2
         shift
         shift
-        ;;	
+        ;;
     --enable_dash_stats)
         echo "Flag to indicate if test results should be pushed to aetos dashboard: $2"
         enable_dash_stats=$2
@@ -251,7 +251,7 @@ case $i in
       --test_description)
         echo "test_description = $2"
         test_description=$2
-        ;;	
+        ;;
     --kubevirt-scale-count)
         echo "Scale for Kubevirt tests (default 1): $2"
         kubevirt_scale=$2
@@ -352,14 +352,14 @@ done
 
 if [ "$run_cluster_domain_test" = "true" ] ; then
 	sed -i 's/'enable_cluster_domain'/'\""true"\"'/g' /testspecs/stork-test-pod.yaml
-else 
+else
 	sed -i 's/'enable_cluster_domain'/'\"\"'/g' /testspecs/stork-test-pod.yaml
 fi
 
 if [ "$focus_tests" != "" ] ; then
      echo "Running focussed test: ${focus_tests}"
 	sed -i 's|'FOCUS_TESTS'|- -test.run='"$focus_tests"'|g' /testspecs/stork-test-pod.yaml
-else 
+else
 	sed -i 's|'FOCUS_TESTS'|''|g' /testspecs/stork-test-pod.yaml
 fi
 
@@ -378,7 +378,7 @@ fi
 
 if [ "$enable_dash_stats" = "true" ] ; then
 	sed -i 's/'enable_dash'/'\""true"\"'/g' /testspecs/stork-test-pod.yaml
-else 
+else
 	sed -i 's/'enable_dash'/'\"\"'/g' /testspecs/stork-test-pod.yaml
 fi
 
@@ -467,7 +467,7 @@ sed -i 's|'aws_secret_access_key'|'"$aws_key"'|g' /testspecs/stork-test-pod.yaml
 
 if [ "$internal_aws_lb" = "true" ] ; then
 	sed -i 's/'internal_aws_lb'/'\""true"\"'/g' /testspecs/stork-test-pod.yaml
-else 
+else
 	sed -i 's/'internal_aws_lb'/'\""false"\"'/g' /testspecs/stork-test-pod.yaml
 fi
 
@@ -491,14 +491,14 @@ fi
 
 if [ "$external_test_pod" = "true" ] ; then
 	sed -i 's/'external_test_cluster'/'\""true"\"'/g' /testspecs/stork-test-pod.yaml
-else 
+else
 	sed -i 's/'external_test_cluster'/'\"\"'/g' /testspecs/stork-test-pod.yaml
 fi
 
 if [ "$stork_test_version_check" = "true" ] ; then
 	sed -i 's/'stork_test_version_check'/'\""true"\"'/g' /testspecs/stork-test-pod.yaml
 	sed -i 's/- -stork-version-check=false/- -stork-version-check='"$stork_test_version_check"'/g' /testspecs/stork-test-pod.yaml
-else 
+else
 	sed -i 's/'stork_test_version_check'/'\"\"'/g' /testspecs/stork-test-pod.yaml
 fi
 


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
The PR adds integration test for the failover workflow in the Sync/Metro DR setup.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, to `release-24.2.0` branch.

**Test runs**
- Pipeline run: https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/strivedi-cluster-domain/3/console
- Local run
![Screenshot from 2024-05-21 21-02-20](https://github.com/libopenstorage/stork/assets/156179360/8308f2eb-af82-48dd-9d4b-47c9252bc55c)


