### PR TITLE
PWX-37292: Modifying dockerfile to keep /usr/lib files of gcloud sdk.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,7 @@ RUN curl -q -o $GCLOUD_SDK https://dl.google.com/dl/cloudsdk/channels/rapid/down
     tar xf $GCLOUD_SDK -C $GCLOUD_INSTALL_DIR && rm -rf $GCLOUD_SDK && \
     rm -rf $GCLOUD_INSTALL_DIR/google-cloud-sdk/platform/gsutil \
     $GCLOUD_INSTALL_DIR/google-cloud-sdk/RELEASE_NOTES && \
-    gcloud components install gke-gcloud-auth-plugin && \
-    mv /usr/lib/google-cloud-sdk/bin google-cloud-sdk/ && \
-    rm -rf /usr/lib/google-cloud-sdk && \
-    mkdir /usr/lib/google-cloud-sdk && \
-    mv google-cloud-sdk /usr/lib/google-cloud-sdk/bin
+    gcloud components install gke-gcloud-auth-plugin
 
 #Create symlink /google-cloud-sdk/bin -> /usr/lib/google-cloud-sdk/bin for legacy cluster pair with gcp auth plugin
 RUN mkdir google-cloud-sdk


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
Reverted the changes where we were removing unused lib directories in google-cloud-sdk directory after untaring.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
<!--
TBD
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
24.2.0

**Test**
https://jenkins.pwx.dev.purestorage.com/job/Stork/job/stork-gke-migration/35/
Also Manually verified by QA.