### PR TITLE
fix a nil pointer dereference error in the tests

### DIFF
--- a/test/integration_test/kubevirt_hyperconv_test.go
+++ b/test/integration_test/kubevirt_hyperconv_test.go
@@ -481,7 +481,7 @@ func kubeVirtUpdatePXBlocked(t *testing.T) {
 	// Select a node to pin the VM to.
 	nodeToPinVMTo := ""
 	for _, n := range allNodes {
-		if node.IsMasterNode(n) || !node.IsStorageNode(n) {
+		if node.IsMasterNode(n) || n.StorageNode == nil || !node.IsStorageNode(n) {
 			continue
 		}
 		nodeToPinVMTo = n.Name


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
integration-test

**What this PR does / why we need it**:
Ensure that the embedded n.StorageNode pointer is non-nil before dereferencing.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
no

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
no
