### PR TITLE
PB-7021: Fix the reason message being displayed during partial success of backup

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -2204,7 +2204,6 @@ func (a *ApplicationBackupController) backupResources(
 						backup.Status.Status = stork_api.ApplicationBackupStatusSuccessful
 						backup.Status.Reason = "Volumes and resources were backed up successfully"
 					}
-					backup.Status.Reason = "Volumes and resources were backed up successfully"
 				}
 
 				// Only on success compute the total backup size
@@ -2257,7 +2256,6 @@ func (a *ApplicationBackupController) backupResources(
 			backup.Status.Status = stork_api.ApplicationBackupStatusSuccessful
 			backup.Status.Reason = "Volumes and resources were backed up successfully"
 		}
-		backup.Status.Reason = "Volumes and resources were backed up successfully"
 	}
 	// Only on success compute the total backup size
 	for _, vInfo := range backup.Status.Volumes {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
The reason message during partial success was not showing up, as all the messages were getting overwrriten with the success message as it is outside the loop. Removed that, now the messages shouldn't be overwritten and only the correct message should be displayed.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Reason in case of partial success of backup:
<img width="620" alt="Screenshot 2024-05-22 at 2 52 54 PM" src="https://github.com/libopenstorage/stork/assets/148333439/251fe146-a811-4495-8a20-8045dc97f378">
Reason in case of success
<img width="674" alt="Screenshot 2024-05-22 at 2 53 10 PM" src="https://github.com/libopenstorage/stork/assets/148333439/65a4ec44-af9b-4977-b3b4-623053f53837">
Reason in case of failure
<img width="622" alt="Screenshot 2024-05-22 at 2 53 20 PM" src="https://github.com/libopenstorage/stork/assets/148333439/aeac7692-cbb9-4ce4-8892-5b6977105d48">

