### PR TITLE
pwx-37386 | chore: get action status for all namespaces

### DIFF
--- a/pkg/storkctl/actionstatus.go
+++ b/pkg/storkctl/actionstatus.go
@@ -42,6 +42,7 @@ func getDRActionStatus(cmdFactory Factory, ioStreams genericclioptions.IOStreams
 	var actions *storkv1.ActionList
 	var filteredActionList *storkv1.ActionList
 	var err error
+
 	// Check all namespaces else user has to provide the namespace from which they want to get list of actions using -n flag.
 	namespaces, err := cmdFactory.GetAllNamespaces()
 	if err != nil {
@@ -62,13 +63,15 @@ func getDRActionStatus(cmdFactory Factory, ioStreams genericclioptions.IOStreams
 			}
 		}
 	} else {
+		actions = new(storkv1.ActionList)
 		// fetch all the actions in the given namespace
 		for _, ns := range namespaces {
-			actions, err = storkops.Instance().ListActions(ns)
+			actionsList, err := storkops.Instance().ListActions(ns)
 			if err != nil {
 				util.CheckErr(err)
 				return
 			}
+			actions.Items = append(actions.Items, actionsList.Items...)
 		}
 	}
 

--- a/pkg/storkctl/actionstatus_test.go
+++ b/pkg/storkctl/actionstatus_test.go
@@ -8,8 +8,11 @@ import (
 	"testing"
 
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/portworx/sched-ops/k8s/core"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetFailoverFailbackNoAction(t *testing.T) {
@@ -25,7 +28,7 @@ func TestGetFailoverFailbackNoAction(t *testing.T) {
 func TestGetFailoverSuccessfulFailoverAction(t *testing.T) {
 	defer resetTest()
 	// create a failover action
-	actionName := createFailoverActionAndVerify(t)
+	actionName := createFailoverActionAndVerify(t, "failover-test-migrationschedule-2024-01-01-000000", "test-migrationschedule", "clusterPair1", "kube-system")
 	// update the status of the action
 	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
 	require.NoError(t, err, "Error getting action")
@@ -82,10 +85,48 @@ func TestGetFailbackSuccessfulFailbackAction(t *testing.T) {
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 
+func TestGetFailoverAllNamespaces(t *testing.T) {
+	defer resetTest()
+	_, err := core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}})
+	require.NoError(t, err, "error creating namespace")
+
+	_, err = core.Instance().CreateNamespace(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "dummy-ns"}})
+	require.NoError(t, err, "error creating namespace")
+
+	// Create first failover.
+	actionName := createFailoverActionAndVerify(t, "failover-test-migrationschedule-2024-01-01-000000", "test-migrationschedule", "clusterPair1", "kube-system")
+	// Update the status of the action.
+	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
+	require.NoError(t, err, "Error getting action")
+
+	// Update the status of the failover action.
+	actionObj.Status.Stage = storkv1.ActionStageInitial
+	actionObj.Status.Status = storkv1.ActionStatusInProgress
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+
+	// Create another failover in another namespace.
+	actionName = createFailoverActionAndVerify(t, "failover-test-migrationschedule-new-2024-01-01-000000", "test-migrationschedule-new", "clusterPair2", "dummy-ns")
+	actionObj, err = storkops.Instance().GetAction(actionName, "dummy-ns")
+	require.NoError(t, err, "Error getting action")
+
+	// Update the status of the failover action.
+	actionObj.Status.Stage = storkv1.ActionStageInitial
+	actionObj.Status.Status = storkv1.ActionStatusInProgress
+	actionObj.Status.Reason = ""
+	_, err = storkops.Instance().UpdateAction(actionObj)
+	require.NoError(t, err, "Error updating action")
+
+	cmdArgs := []string{"get", "failover", "--all-namespaces"}
+	expected := "NAMESPACE     NAME                                                    CREATED   STAGE         STATUS        MORE INFO\ndummy-ns      failover-test-migrationschedule-new-2024-01-01-000000             Validations   In-Progress   \nkube-system   failover-test-migrationschedule-2024-01-01-000000                 Validations   In-Progress   \n"
+	testCommon(t, cmdArgs, nil, expected, false)
+}
+
 func TestGetFailoverAllStages(t *testing.T) {
 	defer resetTest()
 	// create a failover action
-	actionName := createFailoverActionAndVerify(t)
+	actionName := createFailoverActionAndVerify(t, "failover-test-migrationschedule-2024-01-01-000000", "test-migrationschedule", "clusterPair1", "kube-system")
 	// update the status of the action
 	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
 	require.NoError(t, err, "Error getting action")
@@ -273,7 +314,8 @@ func TestGetFailbackAllStages(t *testing.T) {
 func TestGetFailoverFailedFailoverAction(t *testing.T) {
 	defer resetTest()
 	// create a failover action
-	actionName := createFailoverActionAndVerify(t)
+
+	actionName := createFailoverActionAndVerify(t, "failover-test-migrationschedule-2024-01-01-000000", "test-migrationschedule", "clusterPair1", "kube-system")
 	// update the status of the action
 	actionObj, err := storkops.Instance().GetAction(actionName, "kube-system")
 	require.NoError(t, err, "Error getting action")
@@ -330,18 +372,17 @@ func TestGetFailbackFailedFailbackAction(t *testing.T) {
 	testCommon(t, cmdArgs, nil, expected, false)
 }
 
-func createFailoverActionAndVerify(t *testing.T) string {
+func createFailoverActionAndVerify(t *testing.T, failoverActionName, migrationScheduleName, cpair, namespace string) string {
 	mockTheTime()
-	failoverActionName := "failover-test-migrationschedule-2024-01-01-000000"
-	createTestMigrationSchedule("test-migrationschedule", "default-migration-policy", "clusterPair1", []string{"ns1", "ns2"}, "kube-system", true, t)
-	createClusterPair(t, "clusterPair1", "kube-system", "async-dr")
-	cmdArgs := []string{"perform", "failover", "-m", "test-migrationschedule", "--skip-source-operations", "-n", "kube-system"}
-	expected := fmt.Sprintf("Started failover for MigrationSchedule kube-system/test-migrationschedule\nTo check failover status use the command : `storkctl get failover %v -n kube-system`\n", failoverActionName)
+	createClusterPair(t, cpair, namespace, "async-dr")
+	createTestMigrationSchedule(migrationScheduleName, "default-migration-policy", cpair, []string{namespace}, namespace, true, t)
+	cmdArgs := []string{"perform", "failover", "-m", migrationScheduleName, "--skip-source-operations", "-n", namespace, "--include-namespaces", namespace}
+	expected := fmt.Sprintf("Started failover for MigrationSchedule %s/%s\nTo check failover status use the command : `storkctl get failover %v -n %s`\n", namespace, migrationScheduleName, failoverActionName, namespace)
 	testCommon(t, cmdArgs, nil, expected, false)
-	actionObj, err := storkops.Instance().GetAction(failoverActionName, "kube-system")
+	actionObj, err := storkops.Instance().GetAction(failoverActionName, namespace)
 	require.NoError(t, err, "Error getting action")
-	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.FailoverNamespaces, []string{"ns1", "ns2"})
-	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.MigrationScheduleReference, "test-migrationschedule")
+	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.FailoverNamespaces, []string{namespace})
+	require.Equal(t, actionObj.Spec.ActionParameter.FailoverParameter.MigrationScheduleReference, migrationScheduleName)
 	require.Equal(t, *actionObj.Spec.ActionParameter.FailoverParameter.SkipSourceOperations, true)
 	return failoverActionName
 }

--- a/pkg/storkctl/common_test.go
+++ b/pkg/storkctl/common_test.go
@@ -5,11 +5,12 @@ package storkctl
 
 import (
 	"fmt"
-	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	"maps"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/libopenstorage/stork/pkg/resourcecollector"
 
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 	v1alpha1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"

--- a/pkg/storkctl/common_test.go
+++ b/pkg/storkctl/common_test.go
@@ -10,12 +10,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/libopenstorage/stork/pkg/resourcecollector"
-
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 	v1alpha1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/appregistration"
 	fakeclient "github.com/libopenstorage/stork/pkg/client/clientset/versioned/fake"
+	"github.com/libopenstorage/stork/pkg/resourcecollector"
 	fakeocpclient "github.com/openshift/client-go/apps/clientset/versioned/fake"
 	fakeocpconfigclient "github.com/openshift/client-go/config/clientset/versioned/fake"
 	fakeocpsecurityclient "github.com/openshift/client-go/security/clientset/versioned/fake"


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Closes [PWX-37386](https://purestorage.atlassian.net/browse/PWX-37386). Adds the `--all-namespaces` flag for `get failover` and `get failback` commands in storkctl.

**Does this PR change a user-facing CRD or CLI?**:
Yes, adds a flag to the `get failover/failback` commands.

**Is a release note needed?**:
No

**Screenshots**
![Screenshot from 2024-05-22 20-54-58](https://github.com/libopenstorage/stork/assets/156179360/717946b9-ba2e-4d58-87cd-2454b3fc5ca3)
![Screenshot from 2024-05-22 20-52-14](https://github.com/libopenstorage/stork/assets/156179360/732423f9-02e5-4dff-a05f-206f85a8680a)
![Screenshot from 2024-05-28 12-20-32](https://github.com/libopenstorage/stork/assets/156179360/dc73ef9d-9348-49af-bb44-9ca77a53500a)

