### PR TITLE
pwx-37435 | fix: update the snapshotschedule post adding default reclaim policy

### DIFF
--- a/pkg/snapshot/controllers/snapshotschedule.go
+++ b/pkg/snapshot/controllers/snapshotschedule.go
@@ -107,8 +107,12 @@ func (s *SnapshotScheduleController) handle(ctx context.Context, snapshotSchedul
 	}
 
 	s.setDefaults(snapshotSchedule)
+	err := s.client.Update(context.TODO(), snapshotSchedule)
+	if err != nil {
+		return err
+	}
 	// First update the status of any pending snapshots
-	err := s.updateVolumeSnapshotStatus(snapshotSchedule)
+	err = s.updateVolumeSnapshotStatus(snapshotSchedule)
 	if err != nil {
 		msg := fmt.Sprintf("Error updating snapshot status: %v", err)
 		s.recorder.Event(snapshotSchedule,

--- a/pkg/snapshot/controllers/snapshotschedule.go
+++ b/pkg/snapshot/controllers/snapshotschedule.go
@@ -107,12 +107,8 @@ func (s *SnapshotScheduleController) handle(ctx context.Context, snapshotSchedul
 	}
 
 	s.setDefaults(snapshotSchedule)
-	err := s.client.Update(context.TODO(), snapshotSchedule)
-	if err != nil {
-		return err
-	}
 	// First update the status of any pending snapshots
-	err = s.updateVolumeSnapshotStatus(snapshotSchedule)
+	err := s.updateVolumeSnapshotStatus(snapshotSchedule)
 	if err != nil {
 		msg := fmt.Sprintf("Error updating snapshot status: %v", err)
 		s.recorder.Event(snapshotSchedule,
@@ -311,6 +307,9 @@ func (s *SnapshotScheduleController) startVolumeSnapshot(inputSnapshotSchedule *
 	if err != nil {
 		return fmt.Errorf("failed to get volumesnapshot schedule %s", inputSnapshotSchedule.Name)
 	}
+	// Set the default reclaim policy.
+	s.setDefaults(snapshotSchedule)
+
 	snapshotName := s.formatVolumeSnapshotName(snapshotSchedule, policyType)
 	if snapshotSchedule.Status.Items == nil {
 		snapshotSchedule.Status.Items = make(map[stork_api.SchedulePolicyType][]*stork_api.ScheduledVolumeSnapshotStatus)


### PR DESCRIPTION
**What type of PR is this?**
>failing test

**What this PR does / why we need it**
In the `startVolumeSnapshot` function, we were fetching the latest copy of the `snapshotschedule` from the CR however in the `handle()` function which actually calls the `startVolumeSnapshot()` function, we were not persisting the updated default `reclaimPolicy` to `Delete` in the CR. Due to this, the `ownerReference` wasn't getting added to the `volumeSnapshot` resource. This PR adds the change to persist the changed default `reclaimPolicy` to the CR as soon as it's updated in the object.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, `release-24.2.0` branch.

**Test run**
- Sample run from `snapshot-k8s-new` pipeline: https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/snapshot-k8s-new/13/console
- Sample run from `snapshot-csi` pipeline: https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/snapshot-csi/1/console
![Screenshot from 2024-05-25 21-11-22](https://github.com/libopenstorage/stork/assets/156179360/b5cdbf39-c840-451d-8b8e-7b05cc25e38f)


