### PR TITLE
pb-7108: Updating the TenantID, ClientID, ClientSecret and SubscriptionID from backuplocation cred object,     if cluster object is not aassociated with the cred object.

### DIFF
--- a/pkg/apis/stork/v1alpha1/backuplocation.go
+++ b/pkg/apis/stork/v1alpha1/backuplocation.go
@@ -289,6 +289,21 @@ func (bl *BackupLocation) getMergedAzureConfig(client kubernetes.Interface) erro
 		if val, ok := secretConfig.Data["environment"]; ok && val != nil {
 			bl.Location.AzureConfig.Environment = AzureEnvironment(strings.TrimSuffix(string(val), "\n"))
 		}
+		if val, ok := secretConfig.Data["resourceGroupName"]; ok && val != nil {
+			bl.Location.AzureConfig.ResourceGroupName = strings.TrimSuffix(string(val), "\n")
+		}
+		if val, ok := secretConfig.Data["tenantID"]; ok && val != nil {
+			bl.Location.AzureConfig.TenantID = strings.TrimSuffix(string(val), "\n")
+		}
+		if val, ok := secretConfig.Data["clientID"]; ok && val != nil {
+			bl.Location.AzureConfig.ClientID = strings.TrimSuffix(string(val), "\n")
+		}
+		if val, ok := secretConfig.Data["clientSecret"]; ok && val != nil {
+			bl.Location.AzureConfig.ClientSecret = strings.TrimSuffix(string(val), "\n")
+		}
+		if val, ok := secretConfig.Data["subscriptionID"]; ok && val != nil {
+			bl.Location.AzureConfig.SubscriptionID = strings.TrimSuffix(string(val), "\n")
+		}
 	}
 	return nil
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
```
pb-7108: Updating the TenantID, ClientID, ClientSecret and SubscriptionID from backuplocation cred object,
    if cluster object is not aassociated with the cred object.
```

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
N.A

**Does this change need to be cherry-picked to a release branch?**:
No

Testing Notes
<img width="1936" alt="Screenshot 2024-05-27 at 6 40 07 AM" src="https://github.com/libopenstorage/stork/assets/52188641/86ceecb0-103f-4ba0-9049-ca5a30c295a1">


Tested scheduled backup with the azure immutable container.
