### PR TITLE
Fixing duplicate logging

### DIFF
--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -1936,11 +1935,7 @@ func TestMain(m *testing.M) {
 		1,
 		"Number of different kubevirt VMs deployed and validated in kubevirt tests")
 	flag.Parse()
-	var once sync.Once
-	once.Do(func() {
-		doDashboardSetup()
-	})
-
+	doDashboardSetup()
 	if err := setup(); err != nil {
 		log.Error("Setup failed with error: %v", err)
 		os.Exit(1)

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -534,7 +534,6 @@ for i in $(seq 1 100) ; do
     test_status=$(kubectl get pod stork-test -n kube-system -o json | jq ".status.phase" -r)
     if [ "$test_status" = "Running" ]; then
         echo "Test is still running, status: $test_status"
-        kubectl logs stork-test  -n kube-system -f
     else
         sleep 5
         break


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
Reduced the duplicate logging. there were 12 log lines repeated. Reduced it to 6. 
https://jenkins.pwx.dev.purestorage.com/job/Stork/job/stork-ocp-kubevirt-4-13/171/consoleFull
Now thees 6 are because `kubectl logs stork-test  -n kube-system -f
for i in $(seq 1 100) ; do
    test_status=$(kubectl get pod stork-test -n kube-system -o json | jq ".status.phase" -r)
    if [ "$test_status" = "Running" ]; then
        echo "Test is still running, status: $test_status"
        kubectl logs stork-test  -n kube-system -f
    else
        sleep 5
        break
    fi
done` 


**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
no

**Does this change need to be cherry-picked to a release branch?**:
no

