### PR TITLE
pwx-36876 | feat: add update command to modify volumesnapshotschedule pvc

### DIFF
--- a/pkg/storkctl/snapshotschedule.go
+++ b/pkg/storkctl/snapshotschedule.go
@@ -193,7 +193,7 @@ func newUpdateSnapShotScheduleCommand(cmdFactory Factory, ioStreams genericcliop
 			printMsg(msg, ioStreams.Out)
 		},
 	}
-	updateSnapshotScheduleCommand.Flags().StringVar(&newPVCName, "new-pvc-name", "", "Specify new PVC name of the volume snapshot schedule")
+	updateSnapshotScheduleCommand.Flags().StringVar(&newPVCName, "new-pvc-name", "", "Specify the PVC name to be updated in the volumesnapshotschedule")
 
 	return updateSnapshotScheduleCommand
 }

--- a/pkg/storkctl/snapshotschedule.go
+++ b/pkg/storkctl/snapshotschedule.go
@@ -185,8 +185,8 @@ func newUpdateSnapShotScheduleCommand(cmdFactory Factory, ioStreams genericcliop
 			}
 		},
 	}
-	updateSnapshotScheduleCommand.Flags().StringVarP(&pvc, "pvc", "p", "", "Name of the PVC for which to update snapshot schedules")
-	updateSnapshotScheduleCommand.Flags().StringVarP(&newPVCName, "newpvcname", "", "", "New name of PVC of the volume snapshot schedule")
+	updateSnapshotScheduleCommand.Flags().StringVarP(&pvc, "pvc", "p", "", "Name of the PVC whose volume snapshot schedules need to be updated")
+	updateSnapshotScheduleCommand.Flags().StringVarP(&newPVCName, "new-pvc-name", "", "", "Specify new PVC name of the volume snapshot schedule")
 
 	return updateSnapshotScheduleCommand
 }
@@ -205,7 +205,7 @@ func updateSnapshotSchedules(name string, namespace string, ioStreams genericcli
 		util.CheckErr(err)
 		return
 	}
-	msg := fmt.Sprintf("VolumeSnapshotSchedule %v updated successfully", name)
+	msg := fmt.Sprintf("VolumeSnapshotSchedule %v updated successfully with new PVC name %s", name, newPVCName)
 	printMsg(msg, ioStreams.Out)
 }
 

--- a/pkg/storkctl/snapshotschedule_test.go
+++ b/pkg/storkctl/snapshotschedule_test.go
@@ -288,7 +288,7 @@ func TestUpdateSnapshotSchedulePVCName(t *testing.T) {
 
 	// Verify the `storkctl update volumesnapshotschedule <vss name> --newpvcname <new-pvc-name>` workflow.
 	cmdArgs := []string{"update", "volumesnapshotschedule", name, "--new-pvc-name", "pvcname2"}
-	expected := "VolumeSnapshotSchedule " + name + " updated successfully with new PVC name pvcname2\n"
+	expected := "VolumeSnapshotSchedule " + name + " updated successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
 	snapshotSchedule, err := storkops.Instance().GetSnapshotSchedule(name, namespace)
@@ -300,11 +300,22 @@ func TestUpdateSnapshotSchedulePVCName(t *testing.T) {
 	name = "testupdatesnapshotschedule1"
 	createSnapshotScheduleAndVerify(t, name, "pvcname1", "testpolicy", namespace, "preExec", "postExec", false)
 	cmdArgs = []string{"update", "volumesnapshotschedule", "--pvc", "pvcname1", "--new-pvc-name", "pvcname2"}
-	expected = "VolumeSnapshotSchedule " + name + " updated successfully with new PVC name pvcname2\n"
+	expected = "VolumeSnapshotSchedule " + name + " updated successfully\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
 	snapshotSchedule, err = storkops.Instance().GetSnapshotSchedule(name, namespace)
 	require.NoError(t, err, "Error getting snapshotschedule")
 	newPVCName = snapshotSchedule.Spec.Template.Spec.PersistentVolumeClaimName
 	require.Equal(t, "pvcname2", newPVCName, "snapshot schedule not updated with the new pvc name")
+
+	// Verify that `storkctl update volumesnapshotschedule` without args and pvc flag fails.
+	cmdArgs = []string{"update", "volumesnapshotschedule"}
+	expected = "error: argument needs to be provided for snapshot schedule name if pvc isn't provided"
+	testCommon(t, cmdArgs, nil, expected, true)
+
+	// Verify the `storkctl update volumesnapshotschedule` with invalid volumesnapshotschedule failure.
+	cmdArgs = []string{"update", "volumesnapshotschedule", "non-existing-schedule", "--new-pvc-name", "pvcname1"}
+	expected = "Error from server (NotFound): volumesnapshotschedules.stork.libopenstorage.org \"non-existing-schedule\" not found"
+	testCommon(t, cmdArgs, nil, expected, true)
+
 }

--- a/pkg/storkctl/snapshotschedule_test.go
+++ b/pkg/storkctl/snapshotschedule_test.go
@@ -296,21 +296,9 @@ func TestUpdateSnapshotSchedulePVCName(t *testing.T) {
 	newPVCName := snapshotSchedule.Spec.Template.Spec.PersistentVolumeClaimName
 	require.Equal(t, "pvcname2", newPVCName, "snapshot schedule not updated with the new pvc name")
 
-	// Verify the `storkctl update volumesnapshotschedule --pvc <pvc-name> --newpvcname <new-pvc-name>` workflow.
-	name = "testupdatesnapshotschedule1"
-	createSnapshotScheduleAndVerify(t, name, "pvcname1", "testpolicy", namespace, "preExec", "postExec", false)
-	cmdArgs = []string{"update", "volumesnapshotschedule", "--pvc", "pvcname1", "--new-pvc-name", "pvcname2"}
-	expected = "VolumeSnapshotSchedule " + name + " updated successfully\n"
-	testCommon(t, cmdArgs, nil, expected, false)
-
-	snapshotSchedule, err = storkops.Instance().GetSnapshotSchedule(name, namespace)
-	require.NoError(t, err, "Error getting snapshotschedule")
-	newPVCName = snapshotSchedule.Spec.Template.Spec.PersistentVolumeClaimName
-	require.Equal(t, "pvcname2", newPVCName, "snapshot schedule not updated with the new pvc name")
-
 	// Verify that `storkctl update volumesnapshotschedule` without args and pvc flag fails.
 	cmdArgs = []string{"update", "volumesnapshotschedule"}
-	expected = "error: argument needs to be provided for snapshot schedule name if pvc isn't provided"
+	expected = "error: argument needs to be provided for snapshot schedule name"
 	testCommon(t, cmdArgs, nil, expected, true)
 
 	// Verify the `storkctl update volumesnapshotschedule` with invalid volumesnapshotschedule failure.

--- a/pkg/storkctl/snapshotschedule_test.go
+++ b/pkg/storkctl/snapshotschedule_test.go
@@ -287,8 +287,8 @@ func TestUpdateSnapshotSchedulePVCName(t *testing.T) {
 	createSnapshotScheduleAndVerify(t, name, "pvcname1", "testpolicy", namespace, "preExec", "postExec", false)
 
 	// Verify the `storkctl update volumesnapshotschedule <vss name> --newpvcname <new-pvc-name>` workflow.
-	cmdArgs := []string{"update", "volumesnapshotschedule", name, "--newpvcname", "pvcname2"}
-	expected := "VolumeSnapshotSchedule " + name + " updated successfully\n"
+	cmdArgs := []string{"update", "volumesnapshotschedule", name, "--new-pvc-name", "pvcname2"}
+	expected := "VolumeSnapshotSchedule " + name + " updated successfully with new PVC name pvcname2\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
 	snapshotSchedule, err := storkops.Instance().GetSnapshotSchedule(name, namespace)
@@ -299,8 +299,8 @@ func TestUpdateSnapshotSchedulePVCName(t *testing.T) {
 	// Verify the `storkctl update volumesnapshotschedule --pvc <pvc-name> --newpvcname <new-pvc-name>` workflow.
 	name = "testupdatesnapshotschedule1"
 	createSnapshotScheduleAndVerify(t, name, "pvcname1", "testpolicy", namespace, "preExec", "postExec", false)
-	cmdArgs = []string{"update", "volumesnapshotschedule", "--pvc", "pvcname1", "--newpvcname", "pvcname2"}
-	expected = "VolumeSnapshotSchedule " + name + " updated successfully\n"
+	cmdArgs = []string{"update", "volumesnapshotschedule", "--pvc", "pvcname1", "--new-pvc-name", "pvcname2"}
+	expected = "VolumeSnapshotSchedule " + name + " updated successfully with new PVC name pvcname2\n"
 	testCommon(t, cmdArgs, nil, expected, false)
 
 	snapshotSchedule, err = storkops.Instance().GetSnapshotSchedule(name, namespace)

--- a/pkg/storkctl/snapshotschedule_test.go
+++ b/pkg/storkctl/snapshotschedule_test.go
@@ -277,3 +277,34 @@ func TestSuspendResumeSnapshotSchedule(t *testing.T) {
 	cmdArgs = []string{"resume", "volumesnapshotschedule", "invalidschedule"}
 	testCommon(t, cmdArgs, nil, expected, true)
 }
+
+// TestUpdateSnapshotSchedulePVCName tests the functionality of storkctl to update the
+// volumesnapshotschedule's PVC name through the `storkctl update volumesnapshotschedule` command.
+func TestUpdateSnapshotSchedulePVCName(t *testing.T) {
+	name := "testupdatesnapshotschedule"
+	namespace := "default"
+	defer resetTest()
+	createSnapshotScheduleAndVerify(t, name, "pvcname1", "testpolicy", namespace, "preExec", "postExec", false)
+
+	// Verify the `storkctl update volumesnapshotschedule <vss name> --newpvcname <new-pvc-name>` workflow.
+	cmdArgs := []string{"update", "volumesnapshotschedule", name, "--newpvcname", "pvcname2"}
+	expected := "VolumeSnapshotSchedule " + name + " updated successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	snapshotSchedule, err := storkops.Instance().GetSnapshotSchedule(name, namespace)
+	require.NoError(t, err, "Error getting snapshotschedule")
+	newPVCName := snapshotSchedule.Spec.Template.Spec.PersistentVolumeClaimName
+	require.Equal(t, "pvcname2", newPVCName, "snapshot schedule not updated with the new pvc name")
+
+	// Verify the `storkctl update volumesnapshotschedule --pvc <pvc-name> --newpvcname <new-pvc-name>` workflow.
+	name = "testupdatesnapshotschedule1"
+	createSnapshotScheduleAndVerify(t, name, "pvcname1", "testpolicy", namespace, "preExec", "postExec", false)
+	cmdArgs = []string{"update", "volumesnapshotschedule", "--pvc", "pvcname1", "--newpvcname", "pvcname2"}
+	expected = "VolumeSnapshotSchedule " + name + " updated successfully\n"
+	testCommon(t, cmdArgs, nil, expected, false)
+
+	snapshotSchedule, err = storkops.Instance().GetSnapshotSchedule(name, namespace)
+	require.NoError(t, err, "Error getting snapshotschedule")
+	newPVCName = snapshotSchedule.Spec.Template.Spec.PersistentVolumeClaimName
+	require.Equal(t, "pvcname2", newPVCName, "snapshot schedule not updated with the new pvc name")
+}

--- a/pkg/storkctl/storkctl.go
+++ b/pkg/storkctl/storkctl.go
@@ -31,6 +31,7 @@ func NewCommand(cmdFactory Factory, in io.Reader, out io.Writer, errOut io.Write
 		newCreateCommand(cmdFactory, ioStreams),
 		newDeleteCommand(cmdFactory, ioStreams),
 		newGetCommand(cmdFactory, ioStreams),
+		newUpdateCommand(cmdFactory, ioStreams),
 		newActivateCommand(cmdFactory, ioStreams),
 		newDeactivateCommand(cmdFactory, ioStreams),
 		newGenerateCommand(cmdFactory, ioStreams),

--- a/pkg/storkctl/update.go
+++ b/pkg/storkctl/update.go
@@ -1,0 +1,17 @@
+package storkctl
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func newUpdateCommand(cmdFactory Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	updateCommands := &cobra.Command{
+		Use:   "update",
+		Short: "Update stork resources",
+	}
+	updateCommands.AddCommand(
+		newUpdateSnapShotScheduleCommand(cmdFactory, ioStreams),
+	)
+	return updateCommands
+}

--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.17.0
+FROM golang:1.21.10
 
 # Install dependancies
-RUN apt-get update && \ 
+RUN apt-get update && \
     /usr/local/go/bin/go install -v  gotest.tools/gotestsum@latest
 
 RUN apt-get update && apt-get install -y python3-pip && apt-get install -y jq

--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -4,9 +4,9 @@ FROM golang:1.21.10
 RUN apt-get update && \
     /usr/local/go/bin/go install -v  gotest.tools/gotestsum@latest
 
-RUN apt-get update && apt-get install -y python3-pip && apt-get install -y jq
-
-RUN pip3 install --upgrade pip
+RUN apt-get update && \
+	apt-get install -y pipx jq && \
+	pipx ensurepath
 
 #Install Google Cloud SDK
 ARG GCLOUD_SDK=google-cloud-sdk-418.0.0-linux-x86_64.tar.gz
@@ -20,14 +20,13 @@ ENV PATH "${PATH}:$GCLOUD_INSTALL_DIR/google-cloud-sdk/bin"
 RUN gcloud components install gke-gcloud-auth-plugin
 
 RUN wget -O /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
-    chmod +x /usr/local/bin/aws-iam-authenticator
-
-RUN pip3 install awscli
+    chmod +x /usr/local/bin/aws-iam-authenticator && \
+    pipx install awscli
 
 # Install kubectl
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-RUN chmod +x ./kubectl
-RUN mv ./kubectl /usr/local/bin
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+	chmod +x ./kubectl && \
+	mv ./kubectl /usr/local/bin
 
 WORKDIR /
 

--- a/test/integration_test/migration_dr_actions_test.go
+++ b/test/integration_test/migration_dr_actions_test.go
@@ -1198,6 +1198,11 @@ func testDRActionFailbackSubsetNamespacesTest(t *testing.T) {
 
 // testDRActionMetroFailover tests the failover and failover status reporting for sync DR.
 func testDRActionMetroFailover(t *testing.T) {
+	var testrailID, testResult = 257174, testResultFail
+	runID := testrailSetupForTest(testrailID, &testResult, t.Name())
+	defer updateTestRail(&testResult, testrailID, runID)
+	defer updateDashStats(t.Name(), &testResult)
+
 	// Create the apps for migration.
 	// appKeys is an array of appKeys that will be used to create the apps.
 	instanceID := "metro-failover-multi-ns-migration-schedule"
@@ -1351,10 +1356,19 @@ func testDRActionMetroFailover(t *testing.T) {
 	for _, ns := range []string{mysqlNamespace, elasticsearchNamespace} {
 		blowNamespaceForTest(t, ns, false)
 	}
+
+	// If we are here then the test has passed
+	testResult = testResultPass
+	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
 }
 
 // testDRActionMetroFailback tests the failback and failback status reporting for sync DR.
 func testDRActionMetroFailback(t *testing.T) {
+	var testrailID, testResult = 257172, testResultFail
+	runID := testrailSetupForTest(testrailID, &testResult, t.Name())
+	defer updateTestRail(&testResult, testrailID, runID)
+	defer updateDashStats(t.Name(), &testResult)
+
 	// Create the apps for migration.
 	// appKeys is an array of appKeys that will be used to create the apps.
 	instanceID := "metro-failback-multi-ns-migration-schedule"
@@ -1624,6 +1638,10 @@ func testDRActionMetroFailback(t *testing.T) {
 	destroyAndWait(t, preMigrationCtxs)
 	blowNamespaceForTest(t, elasticsearchNamespace, false)
 	blowNamespaceForTest(t, mysqlNamespace, false)
+
+	// If we are here then the test has passed
+	testResult = testResultPass
+	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
 }
 
 func failBackWithMigrationSchedulesWithDifferentPolicies(t *testing.T, instanceID string, appName string, appNamespace string, reverseSchedulePolicyArgs map[string]map[string]string) {

--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -517,7 +517,6 @@ func deletePolicyAndSnapshotSchedule(t *testing.T, namespace string, policyName 
 }
 
 func intervalSnapshotScheduleTest(t *testing.T) {
-	// TODO: Check if the testrail ID is being rightly used here.
 	var testrailID, testResult = 50797, testResultFail
 	runID := testrailSetupForTest(testrailID, &testResult, t.Name())
 	defer updateTestRail(&testResult, testrailID, runID)

--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -517,6 +517,7 @@ func deletePolicyAndSnapshotSchedule(t *testing.T, namespace string, policyName 
 }
 
 func intervalSnapshotScheduleTest(t *testing.T) {
+	// TODO: Check if the testrail ID is being rightly used here.
 	var testrailID, testResult = 50797, testResultFail
 	runID := testrailSetupForTest(testrailID, &testResult, t.Name())
 	defer updateTestRail(&testResult, testrailID, runID)

--- a/test/integration_test/storkctl_snapshotschedule_test.go
+++ b/test/integration_test/storkctl_snapshotschedule_test.go
@@ -1,0 +1,154 @@
+//go:build integrationtest
+// +build integrationtest
+
+package integrationtest
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	crdv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
+	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/log"
+	"github.com/libopenstorage/stork/pkg/storkctl"
+	storkops "github.com/portworx/sched-ops/k8s/stork"
+	"github.com/portworx/torpedo/drivers/scheduler"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStorkCtlSnapshotSchedule(t *testing.T) {
+	err := setSourceKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+	currentTestSuite = t.Name()
+	t.Run("testSnapShotScheduleModifyPVCName", testSnapShotScheduleModifyPVCName)
+
+	err = setRemoteConfig("")
+	log.FailOnError(t, err, "setting kubeconfig to default failed")
+}
+
+/*
+testSnapShotScheduleModifyPVCName tests the `storkctl update` utility to update the volumesnapshotschedule
+with a certain PVC name.
+
+Steps:
+1. Deploy a test mysql application with PVC.
+2. Deploy a schedulepolicy and volumesnapshotschedule corresponding to the app's PVC.
+3. Use storkctl to update the volumesnapshotschedule's PVC.
+4. Verify if the change got reflected in the actual volumesnapshotschedule.
+*/
+func testSnapShotScheduleModifyPVCName(t *testing.T) {
+	// TODO: Add testrail id here for this test.
+	// var testrailID, testResult = 50797, testResultFail
+	// runID := testrailSetupForTest(testrailID, &testResult, t.Name())
+	// defer updateTestRail(&testResult, testrailID, runID)
+	// defer updateDashStats(t.Name(), &testResult)
+
+	/////////////////////////////////////////////////
+	// Deploy test application and schedulepolicy //
+	///////////////////////////////////////////////
+	ctx := createApp(t, "storkctl-snapshot-schedule-pvc-update")
+	policyName := "intervalpolicy"
+	retain := 2
+	interval := 2
+	schedPolicy := &storkv1.SchedulePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Policy: storkv1.SchedulePolicyItem{
+			Interval: &storkv1.IntervalPolicy{
+				Retain:          storkv1.Retain(retain),
+				IntervalMinutes: interval,
+			},
+		}}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(schedPolicy)
+		log.FailOnError(t, err, "Error adding annotations to interval schedule policy")
+	}
+
+	_, err := storkops.Instance().CreateSchedulePolicy(schedPolicy)
+	log.FailOnError(t, err, "Error creating interval schedule policy")
+	log.InfoD("Created schedulepolicy %v with %v minute interval and retain at %v", policyName, interval, retain)
+
+	////////////////////////////////////////////////////////////////////////////////
+	// Deploy volumesnapshotschedule corresponding to the test application's PVC //
+	//////////////////////////////////////////////////////////////////////////////
+	scheduleName := "snapshotschedule-pvc-update-test"
+	namespace := ctx.GetID()
+	snapSched := &storkv1.VolumeSnapshotSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scheduleName,
+			Namespace: namespace,
+		},
+		Spec: storkv1.VolumeSnapshotScheduleSpec{
+			Template: storkv1.VolumeSnapshotTemplateSpec{
+				Spec: crdv1.VolumeSnapshotSpec{
+					PersistentVolumeClaimName: "mysql-data"},
+			},
+			SchedulePolicyName: policyName,
+		},
+	}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(snapSched)
+		log.FailOnError(t, err, "Error adding annotations to interval schedule policy")
+	}
+
+	_, err = storkops.Instance().CreateSnapshotSchedule(snapSched)
+	log.FailOnError(t, err, "Error creating snapshot schedule")
+	sleepTime := time.Duration((retain+1)*interval) * time.Minute
+	log.InfoD("Created snapshotschedule %v in namespace %v, sleeping for %v for schedule to trigger",
+		scheduleName, namespace, sleepTime)
+	time.Sleep(sleepTime)
+
+	_, err = storkops.Instance().ValidateSnapshotSchedule(scheduleName,
+		namespace,
+		snapshotScheduleRetryTimeout,
+		snapshotScheduleRetryInterval)
+	log.FailOnError(t, err, "Error validating snapshot schedule")
+	log.InfoD("Validated snapshotschedule %v", scheduleName)
+
+	/////////////////////////////////////////////////////////////////
+	// Update PVC name of volumesnapshotschedule through storkctl //
+	////////////////////////////////////////////////////////////////
+
+	factory := storkctl.NewFactory()
+	var outputBuffer bytes.Buffer
+	cmd := storkctl.NewCommand(factory, os.Stdin, &outputBuffer, os.Stderr)
+	cmdArgs := []string{"update", "volumesnapshotschedule", scheduleName, "--new-pvc-name", "new-pvc", "-n", namespace}
+	cmd.SetArgs(cmdArgs)
+
+	// Execute the command.
+	log.InfoD("The storkctl command being executed is %v", cmdArgs)
+	err = cmd.Execute()
+	log.FailOnError(t, err, "Storkctl execution failed: %v", err)
+
+	////////////////////////////////////////////
+	// Assert the command output and results //
+	//////////////////////////////////////////
+
+	// Get the captured output as a string and validate it with the expected output.
+	actualOutput := outputBuffer.String()
+	log.InfoD("Actual output is: %s\n", actualOutput)
+	expectedOutput := fmt.Sprintf("VolumeSnapshotSchedule %v updated successfully with new PVC name new-pvc\n", scheduleName)
+	Dash.VerifyFatal(t, expectedOutput, actualOutput, "Error validating the output of the command")
+
+	// Validate the snapshotschedule CR modification through the command.
+	snapshotSchedule, err := storkops.Instance().GetSnapshotSchedule(scheduleName, namespace)
+	log.FailOnError(t, err, "failed to get snapshotschedule %s from %s namespace : %v", scheduleName, namespace, err)
+	Dash.VerifyFatal(t, snapshotSchedule.Spec.Template.Spec.PersistentVolumeClaimName, "new-pvc", "snapshotschedule pvc name should be updated")
+
+	//////////////
+	// Cleanup //
+	////////////
+
+	deletePolicyAndSnapshotSchedule(t, namespace, policyName, scheduleName)
+	destroyAndWait(t, []*scheduler.Context{ctx})
+
+	// If we are here then the test has passed
+	// testResult = testResultPass
+	// log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
+}

--- a/test/integration_test/storkctl_snapshotschedule_test.go
+++ b/test/integration_test/storkctl_snapshotschedule_test.go
@@ -133,7 +133,7 @@ func testSnapShotScheduleModifyPVCName(t *testing.T) {
 	// Get the captured output as a string and validate it with the expected output.
 	actualOutput := outputBuffer.String()
 	log.InfoD("Actual output is: %s\n", actualOutput)
-	expectedOutput := fmt.Sprintf("VolumeSnapshotSchedule %v updated successfully with new PVC name new-pvc\n", scheduleName)
+	expectedOutput := fmt.Sprintf("VolumeSnapshotSchedule %v updated successfully\n", scheduleName)
 	Dash.VerifyFatal(t, expectedOutput, actualOutput, "Error validating the output of the command")
 
 	// Validate the snapshotschedule CR modification through the command.

--- a/test/integration_test/storkctl_snapshotschedule_test.go
+++ b/test/integration_test/storkctl_snapshotschedule_test.go
@@ -40,11 +40,10 @@ Steps:
 4. Verify if the change got reflected in the actual volumesnapshotschedule.
 */
 func testSnapShotScheduleModifyPVCName(t *testing.T) {
-	// TODO: Add testrail id here for this test.
-	// var testrailID, testResult = 50797, testResultFail
-	// runID := testrailSetupForTest(testrailID, &testResult, t.Name())
-	// defer updateTestRail(&testResult, testrailID, runID)
-	// defer updateDashStats(t.Name(), &testResult)
+	var testrailID, testResult = 298854, testResultFail
+	runID := testrailSetupForTest(testrailID, &testResult, t.Name())
+	defer updateTestRail(&testResult, testrailID, runID)
+	defer updateDashStats(t.Name(), &testResult)
 
 	/////////////////////////////////////////////////
 	// Deploy test application and schedulepolicy //
@@ -149,6 +148,6 @@ func testSnapShotScheduleModifyPVCName(t *testing.T) {
 	destroyAndWait(t, []*scheduler.Context{ctx})
 
 	// If we are here then the test has passed
-	// testResult = testResultPass
-	// log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
+	testResult = testResultPass
+	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
 }


### PR DESCRIPTION
**What type of PR is this?**
>feature

**What this PR does / why we need it**:
Adds the `update volumesnapshotschedule` command to `storkctl` to update the PVC name in the specified `volumesnapshotschedule`.

**Does this PR change a user-facing CRD or CLI?**:
Yes

**Does this change need to be cherry-picked to a release branch?**:
Would be required to be cherry-picked later once the release branch is finalized.

**Pipeline run**
- `TestStorkCtl` pipeline run: https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/storkctl-test/3/

**Test run screenshots**
- Integration test:
![Screenshot from 2024-05-30 14-46-06](https://github.com/libopenstorage/stork/assets/156179360/88267c6f-e6f3-4856-9b48-8e7955ed7957)

- Unit test:
![Screenshot from 2024-05-30 14-57-37](https://github.com/libopenstorage/stork/assets/156179360/6766e07a-61c8-47a0-bd3a-3cdbcc752767)
