### PR TITLE
PB-7173: Bug fix - Backup to not fail when there are non-PVC resources to be backed up

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1174,7 +1174,7 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 			backup.Status.FailedVolCount++
 		}
 	}
-	if len(backup.Status.Volumes) == backup.Status.FailedVolCount {
+	if (len(backup.Status.Volumes) != 0) && (len(backup.Status.Volumes) == backup.Status.FailedVolCount) {
 		// This case signifies that none of the volumes are successfully backed up
 		// hence marking it as failed
 		backup.Status.Stage = stork_api.ApplicationBackupStageFinal


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
Earlier when there were only non-PVC resources were present for the backup we were entering the loop `backup.Status.Volumes) == backup.Status.FailedVolCount` and failing the backup. Now the entry into this loop is changed and backup does not fail if only non-PVC resources are backed up

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
After the fix: As it can be seen in the screenshot, we have taken backup of only non-PVC resources and backup is successful.
<img width="313" alt="Screenshot 2024-05-30 at 5 01 34 PM" src="https://github.com/libopenstorage/stork/assets/148333439/b07cc842-0259-4a29-8e4c-aea92c806b8c">
<img width="651" alt="Screenshot 2024-05-30 at 5 02 07 PM" src="https://github.com/libopenstorage/stork/assets/148333439/243d2e90-f68e-4e6e-a97e-8337b6d8afba">

Before this PR:
<img width="478" alt="Screenshot 2024-05-30 at 5 11 01 PM" src="https://github.com/libopenstorage/stork/assets/148333439/5b9d510c-d9b8-40b7-abed-ba8d3d87175e">
