### PR TITLE
pb-6910: add uid & gid in each volume for psa support

### DIFF
--- a/drivers/volume/kdmp/kdmp.go
+++ b/drivers/volume/kdmp/kdmp.go
@@ -236,7 +236,7 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		}
 		// Get UID and GID from the App which is controlling this PVC.
 		getUIDFromApp := true
-		podUserId, podGroupId, err := utils.GetPsaEnabledAppUID(pvc.Name, pvc.Namespace, backup, getUIDFromApp)
+		podUserId, podGroupId, err := utils.GetAppUidGid(pvc.Name, pvc.Namespace, backup, getUIDFromApp)
 		if err != nil {
 			logrus.Errorf("failed to get the UID and GID for pvc %s %v", pvc.Name, err)
 			return nil, err
@@ -256,11 +256,9 @@ func (k *kdmp) StartBackup(backup *storkapi.ApplicationBackup,
 		volumeInfo.StorageClass = k8shelper.GetPersistentVolumeClaimClass(&pvc)
 		volumeInfo.Namespace = pvc.Namespace
 		volumeInfo.DriverName = storkvolume.KDMPDriverName
-		// if psaIsenabled then set the a UID GID in the VolumeInfo and
+		// Set the a UID GID in the VolumeInfo and
 		// set annotation in dataexport CR for updating the JOB spec
-		logrus.Infof("Setting UID in VolumeInfo for PVC %s", pvc.Name)
 		volumeInfo.JobSecurityContext.RunAsUser = podUserId
-		logrus.Infof("Setting GID in VolumeInfo for PVC %s", pvc.Name)
 		volumeInfo.JobSecurityContext.RunAsGroup = podGroupId
 
 		volume, err := core.Instance().GetVolumeForPersistentVolumeClaim(&pvc)
@@ -808,7 +806,7 @@ func (k *kdmp) StartRestore(
 			return nil, fmt.Errorf(msg)
 		}
 		getUIDFromApp := false
-		podUserId, podGroupId, err := utils.GetPsaEnabledAppUID(pvc.Name, bkpvInfo.Namespace, backup, getUIDFromApp)
+		podUserId, podGroupId, err := utils.GetAppUidGid(pvc.Name, bkpvInfo.Namespace, backup, getUIDFromApp)
 		if err != nil {
 			logrus.Errorf("failed to get the UID and GID for pvc %s %v", pvc.Name, err)
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/golang/mock v1.6.0
-	github.com/portworx/kdmp v0.4.1-0.20240514061314-e242a6c6949e
+	github.com/portworx/kdmp v0.4.1-0.20240616130645-d015322da1a8
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	kubevirt.io/api v1.0.0
 	kubevirt.io/client-go v0.59.2
@@ -354,7 +354,7 @@ replace (
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240416193513-1e07b4359307
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
-	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240527085624-8461dc1391fc
+	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240616130645-d015322da1a8
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240514213912-ff0ae32b859a
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240520065758-b58a5dd88529
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -4102,8 +4102,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v1.0.5/go.mod h1:APVvOesVSAnne5SClsPxPdfvZTVDojXh1/G3qb5wjGI=
 github.com/portworx/dcos-secrets v0.0.0-20180616013705-8e8ec3f66611/go.mod h1:4hklRW/4DQpLqkcXcjtNprbH2tz/sJaNtqinfPWl/LA=
-github.com/portworx/kdmp v0.4.1-0.20240527085624-8461dc1391fc h1:4drUD25bAMYqMnO+PrvtB2ZF4VvFw07kp2vVKee0KjQ=
-github.com/portworx/kdmp v0.4.1-0.20240527085624-8461dc1391fc/go.mod h1:E2+9UWldGJwI09tSTtZZ+CGpixPzcHgcE624G6C5uUc=
+github.com/portworx/kdmp v0.4.1-0.20240616130645-d015322da1a8 h1:fLojcTSbd9g6DYPvf7LKtDRRVARrC4QpYM4DKYKzgao=
+github.com/portworx/kdmp v0.4.1-0.20240616130645-d015322da1a8/go.mod h1:E2+9UWldGJwI09tSTtZZ+CGpixPzcHgcE624G6C5uUc=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200929023115-b312c7519467/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -582,9 +582,9 @@ func GetUIDGIDFromBackupCR(backup *stork_api.ApplicationBackup, pvcName string, 
 	return UndefinedId, UndefinedId, nil
 }
 
-// GetPsaEnabledAppUID - Get the UID/GID of the application pod which has psa enforcement in its namespace using the PVC
-func GetPsaEnabledAppUID(pvcName string, namespace string, backup *stork_api.ApplicationBackup, getUIDFromApp bool) (int64, int64, error) {
-	fn := "GetPsaEnabledAppUID"
+// GetAppUidGid - Get the UID/GID of the application pod which has psa enforcement in its namespace using the PVC
+func GetAppUidGid(pvcName string, namespace string, backup *stork_api.ApplicationBackup, getUIDFromApp bool) (int64, int64, error) {
+	fn := "GetAppUidGid"
 	uid := UndefinedId
 	gid := UndefinedId
 	var err error
@@ -598,10 +598,10 @@ func GetPsaEnabledAppUID(pvcName string, namespace string, backup *stork_api.App
 		// Get the pod which uses this PVC for backup scenario
 		pod, err = GetPodFromPVC(pvcName, namespace)
 		// Check if the error message returned is "no application pod found for PVC"
-		// that means this is astand alone PVC without any App so we don't need to look for UID/GID
+		// that means this is a stand alone PVC without any App so we don't need to look for UID/GID
 		// But other errors we must return to caller with failure
 		if err != nil && strings.Contains(err.Error(), "no application pod found for PVC") {
-			return UndefinedId, UndefinedId, err
+			return UndefinedId, UndefinedId, nil
 		} else if err != nil {
 			logrus.Errorf("%s: %v", fn, err)
 			return uid, gid, err

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/nfsbackup/nfsbackup.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/nfsbackup/nfsbackup.go
@@ -82,6 +82,13 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+	// Check whether job has violated the pod security standard
+	psaViolated := utils.IsJobPodSecurityFailed(job, namespace)
+	if psaViolated {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
+		errMsg := fmt.Sprintf("job [%v/%v] failed to meet the pod security standard, please check job pod's description for more detail", namespace, name)
+		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+	}
 
 	// Check whether mount point failure
 	mountFailed := utils.IsJobPodMountFailed(job, namespace)
@@ -199,7 +206,6 @@ func jobForBackupResource(
 	}, " ")
 
 	labels := addJobLabels(jobOption)
-
 	nfsExecutorImage, imageRegistrySecret, err := utils.GetExecutorImageAndSecret(drivers.NfsExecutorImage,
 		jobOption.NfsImageExecutorSource,
 		jobOption.NfsImageExecutorSourceNs,
@@ -216,6 +222,7 @@ func jobForBackupResource(
 		logrus.Errorf("failed to get the toleration details: %v", err)
 		return nil, fmt.Errorf("failed to get the toleration details for job [%s/%s]", jobOption.Namespace, jobOption.RestoreExportName)
 	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobOption.RestoreExportName,
@@ -270,6 +277,15 @@ func jobForBackupResource(
 			},
 		},
 	}
+
+	// The Job is intended to backup resources to  NFS backuplocation
+	// and it doesn't need a specific JOB uid/gid since it will be sqaushed at NFS server
+	// hence used a global hardcoded UID/GID.
+	job, err = utils.AddSecurityContextToJob(job, utils.KdmpJobUid, utils.KdmpJobGid)
+	if err != nil {
+		return nil, err
+	}
+
 	// Add the image secret in job spec only if it is present in the stork deployment.
 	if len(imageRegistrySecret) != 0 {
 		job.Spec.Template.Spec.ImagePullSecrets = utils.ToImagePullSecret(utils.GetImageSecretName(jobOption.RestoreExportName))

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/nfscsirestore/nfscsirestore.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/nfscsirestore/nfscsirestore.go
@@ -80,6 +80,15 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+
+	// Check whether job has violated the pod security standard
+	psaViolated := utils.IsJobPodSecurityFailed(job, namespace)
+	if psaViolated {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
+		errMsg := fmt.Sprintf("job [%v/%v] failed to meet the pod security standard, please check job pod's description for more detail", namespace, name)
+		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+	}
+
 	// Check for mount point failure
 	mountFailed := utils.IsJobPodMountFailed(job, namespace)
 	if mountFailed {
@@ -265,6 +274,13 @@ func jobForRestoreCSISnapshot(
 				},
 			},
 		},
+	}
+	// Add security Context only if the PSA is enabled.
+	if jobOption.PodUserId != "" || jobOption.PodGroupId != "" {
+		job, err = utils.AddSecurityContextToJob(job, jobOption.PodUserId, jobOption.PodGroupId)
+		if err != nil {
+			return nil, err
+		}
 	}
 	// Add the image secret in job spec only if it is present in the stork deployment.
 	if len(imageRegistrySecret) != 0 {

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/nfsrestore/nfsrestore.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/nfsrestore/nfsrestore.go
@@ -83,6 +83,14 @@ func (d Driver) JobStatus(id string) (*drivers.JobStatus, error) {
 		logrus.Errorf("%s: %v", fn, errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}
+	// Check whether job has violated the pod security standard
+	psaViolated := utils.IsJobPodSecurityFailed(job, namespace)
+	if psaViolated {
+		utils.DisplayJobpodLogandEvents(job.Name, job.Namespace)
+		errMsg := fmt.Sprintf("job [%v/%v] failed to meet the pod security standard, please check job pod's description for more detail", namespace, name)
+		return utils.ToJobStatus(0, errMsg, batchv1.JobFailed), nil
+	}
+
 	// Check for mount point failure
 	mountFailed := utils.IsJobPodMountFailed(job, namespace)
 	if mountFailed {
@@ -312,6 +320,10 @@ func jobForRestoreResource(
 				},
 			},
 		},
+	}
+	job, err = utils.AddSecurityContextToJob(job, utils.KdmpJobUid, utils.KdmpJobGid)
+	if err != nil {
+		return nil, err
 	}
 	// Add the image secret in job spec only if it is present in the stork deployment.
 	if len(imageRegistrySecret) != 0 {

--- a/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
+++ b/vendor/github.com/portworx/kdmp/pkg/drivers/options.go
@@ -59,6 +59,9 @@ type JobOpts struct {
 	ResoureBackupName          string
 	ResoureBackupNamespace     string
 	S3DisableSSL               bool
+	// psa specifc option to be used by job
+	PodUserId  string
+	PodGroupId string
 }
 
 // WithS3DisableSSL is job parameter
@@ -514,6 +517,22 @@ func WithJobConfigMapNs(jobConfigMapNs string) JobOption {
 func WithNodeAffinity(l map[string]string) JobOption {
 	return func(opts *JobOpts) error {
 		opts.NodeAffinity = l
+		return nil
+	}
+}
+
+// WithPodUserId is job parameter.
+func WithPodUserId(podUserId string) JobOption {
+	return func(opts *JobOpts) error {
+		opts.PodUserId = podUserId
+		return nil
+	}
+}
+
+// WithPodGroupId is job parameter.
+func WithPodGroupId(PodGroupId string) JobOption {
+	return func(opts *JobOpts) error {
+		opts.PodGroupId = PodGroupId
 		return nil
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1099,7 +1099,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20240514061314-e242a6c6949e => github.com/portworx/kdmp v0.4.1-0.20240527085624-8461dc1391fc
+# github.com/portworx/kdmp v0.4.1-0.20240616130645-d015322da1a8 => github.com/portworx/kdmp v0.4.1-0.20240616130645-d015322da1a8
 ## explicit; go 1.21
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1
@@ -2647,7 +2647,7 @@ sigs.k8s.io/yaml/goyaml.v2
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240416193513-1e07b4359307
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
-# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240527085624-8461dc1391fc
+# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240616130645-d015322da1a8
 # github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240514213912-ff0ae32b859a
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240520065758-b58a5dd88529
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7


### PR DESCRIPTION
- If PSA is enabled and a volume is backed-up with a specific Uid/Gid then that value need to be preserved for getting used during restore process.
- This is needed for all the job PODS to inherit above values so that no permission denied issues appear while restoring from a file backup


**What type of PR is this?** feature
> Uncomment only one and also add the corresponding label in the PR:
>bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:


**Does this PR change a user-facing CRD or CLI?**: No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: no
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Unit Test result :
Tested Portworx, portworx CSI and kdmp backup with an app which is running in PSA enabled(NS level) namespace.
![image](https://github.com/libopenstorage/stork/assets/15273500/17088f65-31f7-49d5-a28b-64211dad847b)

![image](https://github.com/libopenstorage/stork/assets/15273500/a39380bc-e0f4-4b8d-aa02-62c74ad9d2ba)

![image](https://github.com/libopenstorage/stork/assets/15273500/8b3999e6-fda4-48e7-bdbe-41ba90d934a1)

Both backup and restore passes in both PSA and non-PSA environment.
![image](https://github.com/libopenstorage/stork/assets/15273500/bbb3e7ef-6150-4b4e-97fc-6e433089ddd2)

Restore

![image](https://github.com/libopenstorage/stork/assets/15273500/56df1a53-0554-4900-af21-fc48d8a9d666)



