### PR TITLE
pwx-37596 | fix: add kubectl log command to follow log in case of failure

### DIFF
--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.17.0
+FROM golang:1.21.10
 
 # Install dependancies
-RUN apt-get update && \ 
+RUN apt-get update && \
     /usr/local/go/bin/go install -v  gotest.tools/gotestsum@latest
 
-RUN apt-get update && apt-get install -y python3-pip && apt-get install -y jq
-
-RUN pip3 install --upgrade pip
+RUN apt-get update && \
+	apt-get install -y pipx jq && \
+	pipx ensurepath
 
 #Install Google Cloud SDK
 ARG GCLOUD_SDK=google-cloud-sdk-418.0.0-linux-x86_64.tar.gz
@@ -20,14 +20,13 @@ ENV PATH "${PATH}:$GCLOUD_INSTALL_DIR/google-cloud-sdk/bin"
 RUN gcloud components install gke-gcloud-auth-plugin
 
 RUN wget -O /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
-    chmod +x /usr/local/bin/aws-iam-authenticator
-
-RUN pip3 install awscli
+    chmod +x /usr/local/bin/aws-iam-authenticator && \
+    pipx install awscli
 
 # Install kubectl
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-RUN chmod +x ./kubectl
-RUN mv ./kubectl /usr/local/bin
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+	chmod +x ./kubectl && \
+	mv ./kubectl /usr/local/bin
 
 WORKDIR /
 

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -102,7 +102,9 @@ func testMigration(t *testing.T) {
 	t.Run("excludeMultipleResourceTypesTest", excludeMultipleResourceTypesTest)
 	t.Run("excludeResourceTypesWithSelectorsTest", excludeResourceTypesWithSelectorsTest)
 	t.Run("excludeNonExistingResourceTypesTest", excludeNonExistingResourceTypesTest)
-	t.Run("transformCRResourceTest", transformCRResourceTest)
+	if authTokenConfigMap == "" {
+		t.Run("transformCRResourceTest", transformCRResourceTest)
+	}
 
 	err = setRemoteConfig("")
 	log.FailOnError(t, err, "setting kubeconfig to default failed")

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -533,7 +533,9 @@ kubectl logs stork-test  -n kube-system -f
 for i in $(seq 1 100) ; do
     test_status=$(kubectl get pod stork-test -n kube-system -o json | jq ".status.phase" -r)
     if [ "$test_status" = "Running" ]; then
-        echo "Test is still running, status: $test_status"
+	sleep 5
+        echo "Test is still running, resuming logs from past 5 seconds, status: $test_status"
+	kubectl logs stork-test -n kube-system -f --since=10s
     else
         sleep 5
         break

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -534,7 +534,7 @@ for i in $(seq 1 100) ; do
     test_status=$(kubectl get pod stork-test -n kube-system -o json | jq ".status.phase" -r)
     if [ "$test_status" = "Running" ]; then
 	sleep 5
-        echo "Test is still running, resuming logs from past 5 seconds, status: $test_status"
+	echo "Test is still running, status: $test_status, resuming logs from past 10 seconds"
 	kubectl logs stork-test -n kube-system -f --since=10s
     else
         sleep 5


### PR DESCRIPTION
**What type of PR is this?**
>failing-test

**What this PR does / why we need it**:
Addresses [PWX-37596](https://purestorage.atlassian.net/browse/PWX-37596). Handles the failure of `kubectl log` command inside a retry loop and uses `--since` flag of `kubectl log` command to reduce duplication of logs.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No
