### PR TITLE
PWX-37601: Using informer cache's event handling instead of native k8s watchers for pod monitoring and extender metrics.

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -39,7 +39,7 @@ type SharedInformerCache interface {
 	// ListTransformedPods lists the all the Pods from the cache after applying TransformFunc
 	ListTransformedPods() (*corev1.PodList, error)
 
-	// WatchPods watches registers the pod event handler with the informer cache
+	// WatchPods registers the pod event handlers with the informer cache
 	WatchPods(fn func(object interface{})) error
 }
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6,9 +6,11 @@ import (
 	"sync"
 
 	storkv1alpha1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/client-go/rest"
+	clientCache "k8s.io/client-go/tools/cache"
 	controllercache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -36,6 +38,9 @@ type SharedInformerCache interface {
 
 	// ListTransformedPods lists the all the Pods from the cache after applying TransformFunc
 	ListTransformedPods() (*corev1.PodList, error)
+
+	// WatchPods watches registers the pod event handler with the informer cache
+	WatchPods(fn func(object interface{})) error
 }
 
 type cache struct {
@@ -83,6 +88,8 @@ func CreateSharedInformerCache(mgr manager.Manager) error {
 					currPod.Spec.Volumes = append(currPod.Spec.Volumes, podVolume)
 				}
 			}
+
+			currPod.ObjectMeta.DeletionTimestamp = podResource.ObjectMeta.DeletionTimestamp
 
 			currPod.Spec.Containers = podResource.Spec.Containers
 			currPod.Spec.NodeName = podResource.Spec.NodeName
@@ -203,4 +210,24 @@ func (c *cache) ListTransformedPods() (*corev1.PodList, error) {
 		return nil, err
 	}
 	return podList, nil
+}
+
+// WatchPods uses handlers for different pod events with shared informers.
+func (c *cache) WatchPods(fn func(object interface{})) error {
+	informer, err := c.controllerCache.GetInformer(context.Background(), &corev1.Pod{})
+	if err != nil {
+		logrus.WithError(err).Error("error getting the informer for pods")
+		return err
+	}
+
+	informer.AddEventHandler(clientCache.ResourceEventHandlerFuncs{
+		AddFunc: fn,
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			// Only considering the new pod object
+			fn(newObj)
+		},
+		DeleteFunc: fn,
+	})
+
+	return nil
 }

--- a/pkg/mock/cache/cache.mock.go
+++ b/pkg/mock/cache/cache.mock.go
@@ -125,3 +125,17 @@ func (mr *MockSharedInformerCacheMockRecorder) ListTransformedPods() *gomock.Cal
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTransformedPods", reflect.TypeOf((*MockSharedInformerCache)(nil).ListTransformedPods))
 }
+
+// WatchPods mocks base method.
+func (m *MockSharedInformerCache) WatchPods(arg0 func(interface{})) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchPods", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WatchPods indicates an expected call of WatchPods.
+func (mr *MockSharedInformerCacheMockRecorder) WatchPods(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchPods", reflect.TypeOf((*MockSharedInformerCache)(nil).WatchPods), arg0)
+}


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Reducing the load by not registering for watchers with kube-api-server for pod updates. 
Instead informer cache's event handling has been used.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
<!--
yes, TBD
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 24.2.2

**Test**:
```
➜  ~ ks get nodes -o wide
NAME                                   STATUS     ROLES           AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE                KERNEL-VERSION                CONTAINER-RUNTIME
ip-10-13-192-122.pwx.purestorage.com   NotReady   <none>          84d   v1.28.0   10.13.192.122   <none>        CentOS Linux 7 (Core)   3.10.0-1160.80.1.el7.x86_64   docker://20.10.16
ip-10-13-193-24.pwx.purestorage.com    Ready      <none>          84d   v1.28.0   10.13.193.24    <none>        CentOS Linux 7 (Core)   3.10.0-1160.80.1.el7.x86_64   docker://20.10.16
ip-10-13-195-72.pwx.purestorage.com    Ready      control-plane   84d   v1.28.0   10.13.195.72    <none>        CentOS Linux 7 (Core)   3.10.0-1160.80.1.el7.x86_64   docker://20.10.16
ip-10-13-198-95.pwx.purestorage.com    Ready      <none>          84d   v1.28.0   10.13.198.95    <none>        CentOS Linux 7 (Core)   3.10.0-1160.80.1.el7.x86_64   docker://20.10.16


Stork could delete the relevant pods in node 10.13.192.122

➜  ~ ks logs -f stork-bf5868765-7fcdm | grep Force
time="2024-06-12T05:24:56Z" level=info msg="Force deleting pod as it's in unknown state." Namespace=es PodName=elasticsearch-data-2
time="2024-06-12T05:24:56Z" level=info msg="Force deleting pod as it's in unknown state." Namespace=mysql PodName=mysql-6d9f9d7947-t5jwt
time="2024-06-12T05:24:56Z" level=info msg="Force deleting csi pod as it's in unknown state." Namespace=kube-system PodName=px-csi-ext-6c89d5d4f4-7qjfn
time="2024-06-12T05:24:57Z" level=info msg="Force deleting pod as it's in unknown state." Namespace=es PodName=elasticsearch-data-2
time="2024-06-12T05:24:58Z" level=info msg="Force deleting pod as it's in unknown state." Namespace=es PodName=elasticsearch-data-2
time="2024-06-12T05:24:59Z" level=info msg="Force deleting pod as it's in unknown state." Namespace=mysql PodName=mysql-6d9f9d7947-t5jwt
time="2024-06-12T05:25:00Z" level=info msg="Force deleting pod as it's in unknown state." Namespace=mysql PodName=mysql-6d9f9d7947-t5jwt
time="2024-06-12T05:25:00Z" level=info msg="Force deleting csi pod as it's in unknown state." Namespace=kube-system PodName=px-csi-ext-6c89d5d4f4-7qjfn
time="2024-06-12T05:25:00Z" level=info msg="Force deleting csi pod as it's in unknown state." Namespace=kube-system PodName=px-csi-ext-6c89d5d4f4-7qjfn


Pod is now running in another node.
➜  ~ ks get po -n mysql -o wide
NAME                     READY   STATUS    RESTARTS   AGE   IP              NODE                                  NOMINATED NODE   READINESS GATES
mysql-6d9f9d7947-mnh5q   1/1     Running   0          12m   10.233.66.250   ip-10-13-193-24.pwx.purestorage.com   <none>           <none>

```
https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2024.2-dev/job/healthmonitor-k8s128-0/392/ 
