### PR TITLE
PB-7346: Adding status check for partial backup as well for deletion of backup if backup is unsuccessful

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -2285,7 +2285,7 @@ func (a *ApplicationBackupController) deleteBackup(backup *stork_api.Application
 	// Only delete the backup from the backupLocation if the ReclaimPolicy is
 	// set to Delete or if it is not successful
 	if backup.Spec.ReclaimPolicy != stork_api.ApplicationBackupReclaimPolicyDelete &&
-		backup.Status.Status == stork_api.ApplicationBackupStatusSuccessful {
+		(backup.Status.Status == stork_api.ApplicationBackupStatusSuccessful || backup.Status.Status == stork_api.ApplicationBackupStatusPartialSuccess) {
 		return true, nil
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
>bug

**What this PR does / why we need it**:
This PR fixes the bug PB-7346 - that is if the backup is in partial success state, then the clean up of backup from backuplocation by calling the `deleteBackup` function does not take place.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
As it can be seen from the below screenshots, when a backup schedule is set and the data export CR is created then the partial success status of backup remains in partial backup itself and does not move to failed due to `cloud backup missing files` as the clean up using `deleteBackup` does not take place now in case of partial backup

Please refer the ticket: https://purestorage.atlassian.net/browse/PB-7346

<img width="620" alt="Screenshot 2024-06-25 at 5 47 57 PM" src="https://github.com/libopenstorage/stork/assets/148333439/d052db79-8e09-4d4a-acf0-818a7ec648d3">
<img width="1728" alt="Screenshot 2024-06-25 at 5 47 44 PM" src="https://github.com/libopenstorage/stork/assets/148333439/d151c626-eb87-4e26-825e-0c07d8fb8bc3">

