### PR TITLE
chore: upgrade go to v1.21.11 for cve fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ STORK_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_IMAGE):$(DOCKER_HUB_STORK_TAG)
 CMD_EXECUTOR_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_CMD_EXECUTOR_IMAGE):$(DOCKER_HUB_CMD_EXECUTOR_TAG)
 STORK_TEST_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORK_TEST_IMAGE):$(DOCKER_HUB_STORK_TEST_TAG)
 
-DOCK_BUILD_CNT := golang:1.21.4
+DOCK_BUILD_CNT := golang:1.21.11
 
 # DO NOT update this to the latest version. We need to keep this old enough so that
 # px_statfs.so can be loaded on OCP 4.12 which uses RHEL8. Use "ldd -r -v ./bin/px_statfs.so" to


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Upgrade Go to v1.2.11 to fix https://github.com/advisories/GHSA-49gw-vxvf-fc2g reported in security assessment.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 24.2.3 and 24.3.0 branch.
