### PR TITLE
pwx-37485 | feat: add support for nfs backup location in async disaster recovery

### DIFF
--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -552,6 +552,9 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 						util.CheckErr(getMissingParameterError("nfs-export-path", "Export Path to be mounted missing for NFS"))
 						return
 					}
+					if nfsTimeoutSeconds < 1 || nfsTimeoutSeconds > 30 {
+						util.CheckErr(fmt.Errorf("--nfs-timeout-seconds valid range is [1 30]"))
+					}
 
 					// Note: Store the export path of NFS server in `subPath` field
 					// and the subpath of NFS server in `path` field.
@@ -712,7 +715,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 	createClusterPairCommand.Flags().BoolVarP(&unidirectional, "unidirectional", "u", false, "(Optional) to create Clusterpair from source -> dest only")
 	createClusterPairCommand.Flags().StringVarP(&backupLocationName, "use-existing-objectstorelocation", "", "", "(Optional) Objectstorelocation with the provided name should be present in both source and destination cluster")
 	// New parameters for creating backuplocation secret
-	createClusterPairCommand.Flags().StringVarP(&provider, "provider", "p", "", "External objectstore provider name. [nfs, s3, azure, google]")
+	createClusterPairCommand.Flags().StringVarP(&provider, "provider", "p", "", "External objectstore provider name. [s3, azure, google, nfs]")
 	createClusterPairCommand.Flags().StringVar(&bucket, "bucket", "", "Bucket name")
 	createClusterPairCommand.Flags().StringVar(&encryptionKey, "encryption-key", "", "Encryption key for encrypting the data stored in the objectstore.")
 	// AWS
@@ -733,7 +736,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 	createClusterPairCommand.Flags().StringVar(&nfsExportPath, "nfs-export-path", "", "mount path exported by the NFS server")
 	createClusterPairCommand.Flags().StringVar(&nfsSubPath, "nfs-sub-path", "", "sub-path to use in mount")
 	createClusterPairCommand.Flags().StringVar(&nfsMountOpts, "nfs-mount-opts", "", "optional NFS mount options")
-	createClusterPairCommand.Flags().IntVar(&nfsTimeoutSeconds, "nfs-timeout-seconds", 5, "optional nfs IO timeout in seconds")
+	createClusterPairCommand.Flags().IntVar(&nfsTimeoutSeconds, "nfs-timeout-seconds", 5, "optional nfs IO timeout in seconds (Valid Range: [1 30]) (default 5)")
 
 	return createClusterPairCommand
 }

--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -553,9 +553,11 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 						return
 					}
 
+					// Note: Store the export path of NFS server in `subPath` field
+					// and the subpath of NFS server in `path` field.
+					credentialData["subPath"] = []byte(nfsExportPath)
 					credentialData["path"] = []byte(nfsSubPath)
 					credentialData["serverAddr"] = []byte(nfsServer)
-					credentialData["subPath"] = []byte(nfsExportPath)
 					credentialData["mountOptions"] = []byte(nfsMountOpts)
 					credentialData["nfsIOTimeoutInSecs"] = []byte(strconv.Itoa(nfsTimeoutSeconds))
 					backupLocation.Location.Type = storkv1.BackupLocationNFS

--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path"
 	"reflect"
 	"strconv"
 	"strings"
@@ -259,6 +260,8 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 	var disableSSL bool
 	var azureAccountName, azureAccountKey string
 	var googleProjectID, googleJSONKey string
+	var nfsServer, nfsExportPath, nfsSubPath, nfsMountOpts string
+	var nfsTimeoutSeconds int
 	var syncDR bool
 	var pxAuthTokenSrc, pxAuthSecretNamespaceSrc string
 	var pxAuthTokenDest, pxAuthSecretNamespaceDest string
@@ -502,6 +505,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 						util.CheckErr(getMissingParameterError("s3-region", "Region missing for S3"))
 						return
 					}
+					credentialData["path"] = []byte(bucket)
 					credentialData["endpoint"] = []byte(s3EndPoint)
 					credentialData["accessKeyID"] = []byte(s3AccessKey)
 					credentialData["secretAccessKey"] = []byte(s3SecretKey)
@@ -517,6 +521,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 						util.CheckErr(getMissingParameterError("azure-account-key", "Account Key missing for Azure"))
 						return
 					}
+					credentialData["path"] = []byte(bucket)
 					credentialData["storageAccountName"] = []byte(azureAccountName)
 					credentialData["storageAccountKey"] = []byte(azureAccountKey)
 					backupLocation.Location.Type = storkv1.BackupLocationAzure
@@ -535,15 +540,33 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 						util.CheckErr(fmt.Errorf("failed to read json key file: %v", err))
 						return
 					}
+					credentialData["path"] = []byte(bucket)
 					credentialData["accountKey"] = keyData
 					credentialData["projectID"] = []byte(googleProjectID)
 					backupLocation.Location.Type = storkv1.BackupLocationGoogle
+				case "nfs":
+					if len(nfsServer) == 0 {
+						util.CheckErr(getMissingParameterError("nfs-server", "Server address missing for NFS"))
+						return
+					}
+					if len(nfsExportPath) == 0 {
+						util.CheckErr(getMissingParameterError("nfs-export-path", "Export Path to be mounted missing for NFS"))
+						return
+					}
+
+					nfsPath := ""
+					if nfsSubPath != "" {
+						nfsPath = path.Join(nfsExportPath, nfsSubPath)
+					}
+					credentialData["serverAddr"] = []byte(nfsServer)
+					credentialData["subPath"] = []byte(nfsPath)
+					credentialData["mountOptions"] = []byte(nfsMountOpts)
+					credentialData["nfsIOTimeoutInSecs"] = []byte(strconv.Itoa(nfsTimeoutSeconds))
+					backupLocation.Location.Type = storkv1.BackupLocationNFS
 				default:
-					util.CheckErr(getMissingParameterError("provider", "External objectstore provider needs to be either of azure, google, s3"))
+					util.CheckErr(getMissingParameterError("provider", "External objectstore provider needs to be either of azure, google, s3, nfs"))
 					return
 				}
-
-				credentialData["path"] = []byte(bucket)
 				credentialData["type"] = []byte(provider)
 				credentialData["encryptionKey"] = []byte(encryptionKey)
 				backupLocationName = backupLocation.Name
@@ -691,7 +714,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 	createClusterPairCommand.Flags().BoolVarP(&unidirectional, "unidirectional", "u", false, "(Optional) to create Clusterpair from source -> dest only")
 	createClusterPairCommand.Flags().StringVarP(&backupLocationName, "use-existing-objectstorelocation", "", "", "(Optional) Objectstorelocation with the provided name should be present in both source and destination cluster")
 	// New parameters for creating backuplocation secret
-	createClusterPairCommand.Flags().StringVarP(&provider, "provider", "p", "", "External objectstore provider name. [s3, azure, google]")
+	createClusterPairCommand.Flags().StringVarP(&provider, "provider", "p", "", "External objectstore provider name. [nfs, s3, azure, google]")
 	createClusterPairCommand.Flags().StringVar(&bucket, "bucket", "", "Bucket name")
 	createClusterPairCommand.Flags().StringVar(&encryptionKey, "encryption-key", "", "Encryption key for encrypting the data stored in the objectstore.")
 	// AWS
@@ -707,6 +730,12 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 	// Google
 	createClusterPairCommand.Flags().StringVar(&googleProjectID, "google-project-id", "", "Project ID for Google")
 	createClusterPairCommand.Flags().StringVar(&googleJSONKey, "google-key-file-path", "", "Json key file path for Google")
+	// NFS
+	createClusterPairCommand.Flags().StringVar(&nfsServer, "nfs-server", "", "NFS server address")
+	createClusterPairCommand.Flags().StringVar(&nfsExportPath, "nfs-export-path", "", "mount path exported by the NFS server")
+	createClusterPairCommand.Flags().StringVar(&nfsSubPath, "nfs-sub-path", "", "sub-path to use in mount")
+	createClusterPairCommand.Flags().StringVar(&nfsMountOpts, "nfs-mount-opts", "", "optional NFS mount options")
+	createClusterPairCommand.Flags().IntVar(&nfsTimeoutSeconds, "nfs-timeout-seconds", 5, "optional nfs IO timeout in seconds")
 
 	return createClusterPairCommand
 }

--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"path"
 	"reflect"
 	"strconv"
 	"strings"
@@ -554,12 +553,9 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 						return
 					}
 
-					nfsPath := ""
-					if nfsSubPath != "" {
-						nfsPath = path.Join(nfsExportPath, nfsSubPath)
-					}
+					credentialData["path"] = []byte(nfsSubPath)
 					credentialData["serverAddr"] = []byte(nfsServer)
-					credentialData["subPath"] = []byte(nfsPath)
+					credentialData["subPath"] = []byte(nfsExportPath)
 					credentialData["mountOptions"] = []byte(nfsMountOpts)
 					credentialData["nfsIOTimeoutInSecs"] = []byte(strconv.Itoa(nfsTimeoutSeconds))
 					backupLocation.Location.Type = storkv1.BackupLocationNFS

--- a/pkg/storkctl/clusterpair.go
+++ b/pkg/storkctl/clusterpair.go
@@ -554,6 +554,7 @@ func newCreateClusterPairCommand(cmdFactory Factory, ioStreams genericclioptions
 					}
 					if nfsTimeoutSeconds < 1 || nfsTimeoutSeconds > 30 {
 						util.CheckErr(fmt.Errorf("--nfs-timeout-seconds valid range is [1 30]"))
+						return
 					}
 
 					// Note: Store the export path of NFS server in `subPath` field

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -1267,7 +1267,8 @@ func getObjectStoreArgs(objectStoreType storkv1.BackupLocationType, secretName s
 		objectStoreArgs = append(objectStoreArgs,
 			[]string{"--provider", "nfs",
 				"--nfs-server", string(secretData.Data["serverAddr"]),
-				"--nfs-sub-path", string(secretData.Data["subPath"]),
+				"--nfs-export-path", string(secretData.Data["subPath"]),
+				"--nfs-sub-path", string(secretData.Data["path"]),
 				"--nfs-mount-ops", string(secretData.Data["mountOptions"]),
 				"--nfs-timeout-seconds", string(secretData.Data["nfsIOTimeoutInSecs"])}...)
 	}

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -117,15 +117,19 @@ const (
 	defaultWaitInterval      time.Duration = 10 * time.Second
 	backupWaitInterval       time.Duration = 2 * time.Second
 
-	enableClusterDomainTests = "ENABLE_CLUSTER_DOMAIN_TESTS"
-	storageProvisioner       = "STORAGE_PROVISIONER"
-	authSecretConfigMap      = "AUTH_SECRET_CONFIGMAP"
-	backupPathVar            = "BACKUP_LOCATION_PATH"
-	externalTestCluster      = "EXTERNAL_TEST_CLUSTER"
-	cloudDeletionValidation  = "CLOUD_DELETION_VALIDATION"
-	internalLBAws            = "INTERNAL_AWS_LB"
-	portworxNamespace        = "PX_NAMESPACE"
-	enableDashStats          = "ENABLE_DASH"
+	enableClusterDomainTests   = "ENABLE_CLUSTER_DOMAIN_TESTS"
+	storageProvisioner         = "STORAGE_PROVISIONER"
+	authSecretConfigMap        = "AUTH_SECRET_CONFIGMAP"
+	backupPathVar              = "BACKUP_LOCATION_PATH"
+	externalTestCluster        = "EXTERNAL_TEST_CLUSTER"
+	cloudDeletionValidation    = "CLOUD_DELETION_VALIDATION"
+	internalLBAws              = "INTERNAL_AWS_LB"
+	portworxNamespace          = "PX_NAMESPACE"
+	enableDashStats            = "ENABLE_DASH"
+	nfsServerAddressEnv        = "NFS_SERVER_ADDRESS"
+	nfsServerExportPathEnv     = "NFS_EXPORT_PATH"
+	defaultNFSServerAddress    = "10.13.248.14"
+	defaultNFSServerExportPath = "stork-nfs"
 
 	tokenKey    = "token"
 	clusterIP   = "ip"
@@ -181,6 +185,9 @@ var bidirectionalClusterpair bool
 var unidirectionalClusterpair bool
 var currentTestSuite string
 var kubevirtScale int
+
+// NFS location config variables.
+var nfsSrvAddr, nfsSrvExpPath string
 
 func TestSnapshot(t *testing.T) {
 	currentTestSuite = t.Name()
@@ -384,6 +391,15 @@ func setup() error {
 			return fmt.Errorf("failed to change PX service to LoadBalancer on source cluster: %v", err)
 		}
 	}
+
+	set := false
+	if nfsSrvAddr, set = os.LookupEnv(nfsServerAddressEnv); !set {
+		nfsSrvAddr = defaultNFSServerAddress
+	}
+	if nfsSrvExpPath, set = os.LookupEnv(nfsServerExportPathEnv); !set {
+		nfsSrvExpPath = defaultNFSServerExportPath
+	}
+
 	err = setDestinationKubeConfig()
 	if err != nil {
 		return fmt.Errorf("while PX service to LoadBalancer, setting kubeconfig to destination failed %v", err)
@@ -1228,7 +1244,8 @@ func getObjectStoreArgs(objectStoreType storkv1.BackupLocationType, secretName s
 	if err != nil {
 		return objectStoreArgs, fmt.Errorf("error getting secret %s in default namespace: %v", secretName, err)
 	}
-	if objectStoreType == storkv1.BackupLocationS3 {
+	switch objectStoreType {
+	case storkv1.BackupLocationS3:
 		objectStoreArgs = append(objectStoreArgs,
 			[]string{"--provider", "s3",
 				"--s3-access-key", string(secretData.Data["accessKeyID"]),
@@ -1239,25 +1256,26 @@ func getObjectStoreArgs(objectStoreType storkv1.BackupLocationType, secretName s
 		if val, ok := secretData.Data["disableSSL"]; ok && string(val) == "true" {
 			objectStoreArgs = append(objectStoreArgs, "--disable-ssl")
 		}
-		if val, ok := secretData.Data["encryptionKey"]; ok && len(val) > 0 {
-			objectStoreArgs = append(objectStoreArgs, "--encryption-key")
-			objectStoreArgs = append(objectStoreArgs, string(val))
-		}
-	} else if objectStoreType == storkv1.BackupLocationAzure {
+	case storkv1.BackupLocationAzure:
 		objectStoreArgs = append(objectStoreArgs,
 			[]string{"--provider", "azure", "--azure-account-name", string(secretData.Data["storageAccountName"]),
 				"--azure-account-key", string(secretData.Data["storageAccountKey"])}...)
-		if val, ok := secretData.Data["encryptionKey"]; ok && len(val) > 0 {
-			objectStoreArgs = append(objectStoreArgs, "--encryption-key")
-			objectStoreArgs = append(objectStoreArgs, string(val))
-		}
-	} else if objectStoreType == storkv1.BackupLocationGoogle {
+	case storkv1.BackupLocationGoogle:
 		objectStoreArgs = append(objectStoreArgs,
 			[]string{"--provider", "google", "--google-project-id", string(secretData.Data["projectID"]), "--google-key-file-path", string(secretData.Data["accountKey"])}...)
-		if val, ok := secretData.Data["encryptionKey"]; ok && len(val) > 0 {
-			objectStoreArgs = append(objectStoreArgs, "--encryption-key")
-			objectStoreArgs = append(objectStoreArgs, string(val))
-		}
+	case storkv1.BackupLocationNFS:
+		objectStoreArgs = append(objectStoreArgs,
+			[]string{"--provider", "nfs",
+				"--nfs-server", string(secretData.Data["serverAddr"]),
+				"--nfs-sub-path", string(secretData.Data["subPath"]),
+				"--nfs-mount-ops", string(secretData.Data["mountOptions"]),
+				"--nfs-timeout-seconds", string(secretData.Data["nfsIOTimeoutInSecs"])}...)
+	}
+
+	// Handle the encryption case.
+	if val, ok := secretData.Data["encryptionKey"]; ok && len(val) > 0 {
+		objectStoreArgs = append(objectStoreArgs, "--encryption-key")
+		objectStoreArgs = append(objectStoreArgs, string(val))
 	}
 
 	return objectStoreArgs, nil

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -111,7 +111,7 @@ const (
 	zoneScore   = 25
 	regionScore = 10
 
-	defaultWaitTimeout       time.Duration = 10 * time.Minute
+	defaultWaitTimeout       time.Duration = 15 * time.Minute
 	clusterDomainWaitTimeout time.Duration = 10 * time.Minute
 	groupSnapshotWaitTimeout time.Duration = 15 * time.Minute
 	defaultWaitInterval      time.Duration = 10 * time.Second

--- a/test/integration_test/operator_test.go
+++ b/test/integration_test/operator_test.go
@@ -18,9 +18,7 @@ import (
 var (
 	kubeconfigDirectory   = "/tmp"
 	backupLocation        = "s3"
-	backupLocationNFS     = "nfs"
 	backupSecret          = "s3secret"
-	backupSecretNFS       = "nfssecret"
 	clusterPairName       = "bid-pair"
 	migNamePref           = "operator-"
 	includeVolumesFlag    = true

--- a/test/integration_test/operator_test.go
+++ b/test/integration_test/operator_test.go
@@ -18,7 +18,9 @@ import (
 var (
 	kubeconfigDirectory   = "/tmp"
 	backupLocation        = "s3"
+	backupLocationNFS     = "nfs"
 	backupSecret          = "s3secret"
+	backupSecretNFS       = "nfssecret"
 	clusterPairName       = "bid-pair"
 	migNamePref           = "operator-"
 	includeVolumesFlag    = true

--- a/test/integration_test/storkctl_clusterpair_test.go
+++ b/test/integration_test/storkctl_clusterpair_test.go
@@ -1,0 +1,141 @@
+//go:build integrationtest
+// +build integrationtest
+
+package integrationtest
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/libopenstorage/stork/pkg/log"
+	"github.com/libopenstorage/stork/pkg/storkctl"
+	"github.com/pborman/uuid"
+	"github.com/portworx/sched-ops/k8s/stork"
+)
+
+func TestStorkCtlClusterPair(t *testing.T) {
+	// Reset mock time before running any tests.
+	err := setMockTime(nil)
+	log.FailOnError(t, err, "Error resetting mock time")
+
+	// Switch context to source cluster.
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "failed to set kubeconfig to source cluster: %v", err)
+	destinationKubeConfigPath, err = getDestinationKubeConfigFile()
+	log.FailOnError(t, err, "Error getting destination kubeconfig file")
+	srcKubeConfigPath, err = getSourceKubeConfigFile()
+	log.FailOnError(t, err, "Error getting source kubeconfig file")
+
+	t.Run("testStorkCtlClusterPairNFSBidirectional", testStorkCtlClusterPairNFSBidirectional)
+	t.Run("testStorkCtlClusterPairNFSUnidirectional", testStorkCtlClusterPairNFSUnidirectional)
+}
+
+// testClusterPairNFSBidirectional tests the bidirectional clusterpair creation workflow.
+func testStorkCtlClusterPairNFSBidirectional(t *testing.T) {
+	var err error
+	// Reset config in case of error
+	defer func() {
+		err = setSourceKubeConfig()
+		log.FailOnError(t, err, "Error resetting source config")
+	}()
+	cpName := fmt.Sprintf("testclusterpair-%s", uuid.New())
+	cmdFlags := map[string]string{
+		"namespace":       defaultAdminNamespace,
+		"src-kube-file":   srcKubeConfigPath,
+		"dest-kube-file":  destinationKubeConfigPath,
+		"provider":        "nfs",
+		"nfs-server":      nfsSrvAddr,
+		"nfs-export-path": nfsSrvExpPath,
+		"nfs-sub-path":    fmt.Sprintf("test-%s", uuid.New()),
+	}
+
+	// Execute the storkctl command.
+	factory := storkctl.NewFactory()
+	var outputBuffer bytes.Buffer
+	cmd := storkctl.NewCommand(factory, os.Stdin, &outputBuffer, os.Stderr)
+	cmdArgs := []string{"create", "clusterpair", cpName}
+
+	// Add the custom flags to the command arguments.
+	for key, value := range cmdFlags {
+		cmdArgs = append(cmdArgs, "--"+key)
+		if value != "" {
+			cmdArgs = append(cmdArgs, value)
+		}
+	}
+	cmd.SetArgs(cmdArgs)
+
+	// Execute the command.
+	log.InfoD("The storkctl command being executed is %v", cmdArgs)
+	if err := cmd.Execute(); err != nil {
+		log.Error("Storkctl execution failed: %v", err)
+		return
+	}
+
+	// Get the captured output as a string.
+	actualOutput := outputBuffer.String()
+	log.InfoD("Actual output is: %s", actualOutput)
+	// expectedOutput := fmt.Sprintf("MigrationSchedule %v created successfully\n", migrationScheduleName)
+	if !strings.Contains(actualOutput, "Cluster pair test created successfully. Direction Destination -> Source") {
+		t.Errorf("cluster pair creation failed, expected success got=%s", actualOutput)
+	}
+
+	// Cleanup created resource.
+	err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace)
+}
+
+// testStorkCtlClusterPairNFSUnidirectional tests the unidirectional clusterpair creation workflow.
+func testStorkCtlClusterPairNFSUnidirectional(t *testing.T) {
+	var err error
+	// Reset config in case of error
+	defer func() {
+		err = setSourceKubeConfig()
+		log.FailOnError(t, err, "Error resetting source config")
+	}()
+	cpName := fmt.Sprintf("testclusterpair-%s", uuid.New())
+	cmdFlags := map[string]string{
+		"namespace":       defaultAdminNamespace,
+		"src-kube-file":   srcKubeConfigPath,
+		"dest-kube-file":  destinationKubeConfigPath,
+		"provider":        "nfs",
+		"nfs-server":      nfsSrvAddr,
+		"nfs-export-path": nfsSrvExpPath,
+		"nfs-sub-path":    fmt.Sprintf("test-%s", uuid.New()),
+	}
+
+	// Execute the storkctl command.
+	factory := storkctl.NewFactory()
+	var outputBuffer bytes.Buffer
+	cmd := storkctl.NewCommand(factory, os.Stdin, &outputBuffer, os.Stderr)
+	cmdArgs := []string{"create", "clusterpair", cpName}
+
+	// Add the custom flags to the command arguments.
+	for key, value := range cmdFlags {
+		cmdArgs = append(cmdArgs, "--"+key)
+		if value != "" {
+			cmdArgs = append(cmdArgs, value)
+		}
+	}
+	cmdArgs = append(cmdArgs, "--unidirectional")
+	cmd.SetArgs(cmdArgs)
+
+	// Execute the command.
+	log.InfoD("The storkctl command being executed is %v", cmdArgs)
+	if err := cmd.Execute(); err != nil {
+		log.Error("Storkctl execution failed: %v", err)
+		return
+	}
+
+	// Get the captured output as a string.
+	actualOutput := outputBuffer.String()
+	log.InfoD("Actual output is: %s", actualOutput)
+	// expectedOutput := fmt.Sprintf("MigrationSchedule %v created successfully\n", migrationScheduleName)
+	if !strings.Contains(actualOutput, "Cluster pair test created successfully. Direction Source -> Destination") {
+		t.Errorf("cluster pair creation failed, expected success got=%s", actualOutput)
+	}
+
+	// Cleanup created resource.
+	err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace)
+}

--- a/test/integration_test/storkctl_clusterpair_test.go
+++ b/test/integration_test/storkctl_clusterpair_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/stork"
+	"github.com/portworx/torpedo/drivers/scheduler"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -61,6 +62,7 @@ func testStorkCtlClusterPairNFSBidirectional(t *testing.T) {
 		"nfs-server":      nfsSrvAddr,
 		"nfs-export-path": nfsSrvExpPath,
 		"nfs-sub-path":    fmt.Sprintf("test-%s", uuid.New()),
+		"mode":            "migration",
 	}
 
 	// Execute the storkctl command.
@@ -91,11 +93,36 @@ func testStorkCtlClusterPairNFSBidirectional(t *testing.T) {
 		Dash.Fatal("cluster pair creation failed, expected success got=%s", actualOutput)
 	}
 
+	///////////////////////////////////////
+	// Deploy app for running migration //
+	//////////////////////////////////////
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "Error resetting source config")
+	instanceID := "nfs-bidirectional-cp-test"
+	appKey := "mysql-1-pvc"
+
+	// Schedule mysql replicas.
+	ctxs, err := schedulerDriver.Schedule(instanceID,
+		scheduler.ScheduleOptions{AppKeys: []string{appKey}, Namespace: instanceID})
+	log.FailOnError(t, err, "Error scheduling task")
+	Dash.VerifyFatal(t, len(ctxs), 1, "Only one task should have started")
+
+	err = schedulerDriver.WaitForRunning(ctxs[0], defaultWaitTimeout, defaultWaitInterval)
+	log.FailOnError(t, err, "Error waiting for app to get to running state")
+	defer blowNamespaceForTest(t, instanceID, false)
+
+	//////////////////////
+	// Start migration //
+	////////////////////
+	migrationName := fmt.Sprintf("%s-%s", instanceID, uuid.New())
+	err = startAndValidateMigration(migrationName, cpName, []string{instanceID}, true)
+	log.FailOnError(t, err, "failed to validate migration")
+
 	////////////////////////////////
 	// Cleanup created resources //
 	//////////////////////////////
-	if err = cleanUpClusterPairTestResources(cpName, defaultAdminNamespace); err != nil {
-		Dash.Fatal("cluster pair resources cleanup failed, error=", err)
+	if err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace); err != nil && !k8s_errors.IsNotFound(err) {
+		Dash.Fatal("failed to delete cluster pair", err)
 	}
 
 	// If we are here then the test has passed
@@ -128,6 +155,7 @@ func testStorkCtlClusterPairNFSUnidirectional(t *testing.T) {
 		"nfs-server":      nfsSrvAddr,
 		"nfs-export-path": nfsSrvExpPath,
 		"nfs-sub-path":    fmt.Sprintf("test-%s", uuid.New()),
+		"mode":            "migration",
 	}
 
 	// Execute the storkctl command.
@@ -159,11 +187,36 @@ func testStorkCtlClusterPairNFSUnidirectional(t *testing.T) {
 		Dash.Fatal("cluster pair creation failed, expected success got=%s", actualOutput)
 	}
 
+	///////////////////////////////////////
+	// Deploy app for running migration //
+	//////////////////////////////////////
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "Error resetting source config")
+	instanceID := "nfs-unidirectional-cp-test"
+	appKey := "mysql-1-pvc"
+
+	// Schedule mysql replicas.
+	ctxs, err := schedulerDriver.Schedule(instanceID,
+		scheduler.ScheduleOptions{AppKeys: []string{appKey}, Namespace: instanceID})
+	log.FailOnError(t, err, "Error scheduling task")
+	Dash.VerifyFatal(t, len(ctxs), 1, "Only one task should have started")
+
+	err = schedulerDriver.WaitForRunning(ctxs[0], defaultWaitTimeout, defaultWaitInterval)
+	log.FailOnError(t, err, "Error waiting for app to get to running state")
+	defer blowNamespaceForTest(t, instanceID, false)
+
+	//////////////////////
+	// Start migration //
+	////////////////////
+	migrationName := fmt.Sprintf("%s-%s", instanceID, uuid.New())
+	err = startAndValidateMigration(migrationName, cpName, []string{instanceID}, true)
+	log.FailOnError(t, err, "failed to validate migration")
+
 	////////////////////////////////
 	// Cleanup created resources //
 	//////////////////////////////
-	if err = cleanUpClusterPairTestResources(cpName, defaultAdminNamespace); err != nil {
-		Dash.Fatal("cluster pair resources cleanup failed, error=", err)
+	if err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace); err != nil && !k8s_errors.IsNotFound(err) {
+		Dash.Fatal("failed to delete cluster pair", err)
 	}
 
 	// If we are here then the test has passed
@@ -196,6 +249,7 @@ func testStorkCtlClusterPairNFSSecretCreation(t *testing.T) {
 		"provider":            "nfs",
 		"nfs-server":          nfsSrvAddr,
 		"nfs-export-path":     nfsSrvExpPath,
+		"mode":                "migration",
 		"nfs-sub-path":        fmt.Sprintf("test-%s", uuid.New()),
 		"nfs-timeout-seconds": "10",
 		"nfs-mount-opts":      "hard,timeo=10",
@@ -238,11 +292,38 @@ func testStorkCtlClusterPairNFSSecretCreation(t *testing.T) {
 	Dash.VerifyFatal(t, string(secretData.Data["nfsIOTimeoutInSecs"]), "10", "invalid timeout seconds value")
 	Dash.VerifyFatal(t, string(secretData.Data["mountOptions"]), "hard,timeo=10", "invalid mount option")
 
+	///////////////////////////////////////
+	// Deploy app for running migration //
+	//////////////////////////////////////
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "Error resetting source config")
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "Error resetting source config")
+	instanceID := "nfs-verify-secret"
+	appKey := "mysql-1-pvc"
+
+	// Schedule mysql replicas.
+	ctxs, err := schedulerDriver.Schedule(instanceID,
+		scheduler.ScheduleOptions{AppKeys: []string{appKey}, Namespace: instanceID})
+	log.FailOnError(t, err, "Error scheduling task")
+	Dash.VerifyFatal(t, len(ctxs), 1, "Only one task should have started")
+
+	err = schedulerDriver.WaitForRunning(ctxs[0], defaultWaitTimeout, defaultWaitInterval)
+	log.FailOnError(t, err, "Error waiting for app to get to running state")
+	defer blowNamespaceForTest(t, instanceID, false)
+
+	//////////////////////
+	// Start migration //
+	////////////////////
+	migrationName := fmt.Sprintf("%s-%s", instanceID, uuid.New())
+	err = startAndValidateMigration(migrationName, cpName, []string{instanceID}, true)
+	log.FailOnError(t, err, "failed to validate migration")
+
 	////////////////////////////////
 	// Cleanup created resources //
 	//////////////////////////////
-	if err = cleanUpClusterPairTestResources(cpName, defaultAdminNamespace); err != nil {
-		Dash.Fatal("cluster pair resources cleanup failed, error=", err)
+	if err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace); err != nil && !k8s_errors.IsNotFound(err) {
+		Dash.Fatal("failed to delete cluster pair", err)
 	}
 
 	// If we are here then the test has passed
@@ -250,29 +331,49 @@ func testStorkCtlClusterPairNFSSecretCreation(t *testing.T) {
 	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
 }
 
-// cleanUpClusterPairTestResources cleans up the resources that get created during the cluster pair integration
-// test execution across both the source and destination cluster.
-func cleanUpClusterPairTestResources(name, namespace string) (err error) {
-	for i := 0; i < 2; i++ {
-		switch i {
-		case 0:
-			if err = setDestinationKubeConfig(); err != nil {
-				return err
-			}
-		case 1:
-			if err = setSourceKubeConfig(); err != nil {
-				return err
-			}
+// startAndValidateMigration starts the migration and validates the status if the migration was successful or not.
+func startAndValidateMigration(migrationName, cpName string, namespaces []string, expectSuccess bool) (err error) {
+	ns := strings.Join(namespaces, ",")
+	cmdFlags := map[string]string{
+		"namespace":   defaultAdminNamespace,
+		"clusterPair": cpName,
+		"namespaces":  ns,
+	}
+
+	factory := storkctl.NewFactory()
+	var outputBuffer bytes.Buffer
+	cmd := storkctl.NewCommand(factory, os.Stdin, &outputBuffer, os.Stderr)
+	cmdArgs := []string{"create", "migration", migrationName}
+	// add the custom args to the command
+	for key, value := range cmdFlags {
+		cmdArgs = append(cmdArgs, "--"+key)
+		if value != "" {
+			cmdArgs = append(cmdArgs, value)
 		}
-		if err = stork.Instance().DeleteClusterPair(name, namespace); err != nil && !k8s_errors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete cluster pair,error=%s", err)
-		}
-		if err = stork.Instance().DeleteBackupLocation(name, namespace); err != nil && !k8s_errors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete backuplocation,error=%s", err)
-		}
-		if err = core.Instance().DeleteSecret(name, namespace); err != nil && !k8s_errors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete secret,error=%s", err)
-		}
+	}
+	cmd.SetArgs(cmdArgs)
+	// execute the command
+	log.InfoD("The storkctl command being executed is %v", cmdArgs)
+	if err = cmd.Execute(); err != nil {
+		err = fmt.Errorf("Storkctl execution failed: %v", err)
+		return err
+	}
+	// Get the captured output as a string
+	actualOutput := outputBuffer.String()
+	log.InfoD("Actual output is: %s", actualOutput)
+	expectedOutput := fmt.Sprintf("Migration %v created successfully\n", migrationName)
+	if actualOutput != expectedOutput {
+		return fmt.Errorf("Output mismatch,expected=%s,got=%s", expectedOutput, actualOutput)
+	}
+
+	// Check the status of the migration.
+	if err = stork.Instance().ValidateMigration(migrationName, defaultAdminNamespace, defaultWaitTimeout, defaultWaitInterval); err != nil && expectSuccess {
+		return fmt.Errorf("failed to validate migration %s,error=%v", migrationName, err)
+	}
+
+	// Cleanup the created migration.
+	if err = deleteAndwaitForMigrationDeletion(migrationName, defaultAdminNamespace, migrationRetryTimeout); err != nil {
+		return fmt.Errorf("failed to delete migration %s,error=%v", migrationName, err)
 	}
 	return
 }

--- a/test/integration_test/storkctl_clusterpair_test.go
+++ b/test/integration_test/storkctl_clusterpair_test.go
@@ -84,6 +84,11 @@ func testStorkCtlClusterPairNFSBidirectional(t *testing.T) {
 	if err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace); err != nil {
 		Dash.Fatal("failed to delete cluster pair,error=", err)
 	}
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "Error resetting source config")
+	if err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace); err != nil {
+		Dash.Fatal("failed to delete cluster pair,error=", err)
+	}
 }
 
 // testStorkCtlClusterPairNFSUnidirectional tests the unidirectional clusterpair creation workflow.
@@ -135,6 +140,11 @@ func testStorkCtlClusterPairNFSUnidirectional(t *testing.T) {
 	}
 
 	// Cleanup created resource.
+	if err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace); err != nil {
+		Dash.Fatal("failed to delete cluster pair,error=", err)
+	}
+	err = setSourceKubeConfig()
+	log.FailOnError(t, err, "Error resetting source config")
 	if err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace); err != nil {
 		Dash.Fatal("failed to delete cluster pair,error=", err)
 	}

--- a/test/integration_test/storkctl_clusterpair_test.go
+++ b/test/integration_test/storkctl_clusterpair_test.go
@@ -76,14 +76,14 @@ func testStorkCtlClusterPairNFSBidirectional(t *testing.T) {
 
 	// Get the captured output as a string.
 	actualOutput := outputBuffer.String()
-	log.InfoD("Actual output is: %s", actualOutput)
-	// expectedOutput := fmt.Sprintf("MigrationSchedule %v created successfully\n", migrationScheduleName)
-	if !strings.Contains(actualOutput, "Cluster pair test created successfully. Direction Destination -> Source") {
-		t.Errorf("cluster pair creation failed, expected success got=%s", actualOutput)
+	if !strings.Contains(actualOutput, fmt.Sprintf("Cluster pair %s created successfully. Direction: Destination -> Source", cpName)) {
+		Dash.Fatal("cluster pair creation failed, expected success got=%s", actualOutput)
 	}
 
 	// Cleanup created resource.
-	err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace)
+	if err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace); err != nil {
+		Dash.Fatal("failed to delete cluster pair,error=", err)
+	}
 }
 
 // testStorkCtlClusterPairNFSUnidirectional tests the unidirectional clusterpair creation workflow.
@@ -130,12 +130,12 @@ func testStorkCtlClusterPairNFSUnidirectional(t *testing.T) {
 
 	// Get the captured output as a string.
 	actualOutput := outputBuffer.String()
-	log.InfoD("Actual output is: %s", actualOutput)
-	// expectedOutput := fmt.Sprintf("MigrationSchedule %v created successfully\n", migrationScheduleName)
-	if !strings.Contains(actualOutput, "Cluster pair test created successfully. Direction Source -> Destination") {
-		t.Errorf("cluster pair creation failed, expected success got=%s", actualOutput)
+	if !strings.Contains(actualOutput, fmt.Sprintf("ClusterPair %s created successfully. Direction Source -> Destination", cpName)) {
+		Dash.Fatal("cluster pair creation failed, expected success got=%s", actualOutput)
 	}
 
 	// Cleanup created resource.
-	err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace)
+	if err = stork.Instance().DeleteClusterPair(cpName, defaultAdminNamespace); err != nil {
+		Dash.Fatal("failed to delete cluster pair,error=", err)
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
>feature

**What this PR does / why we need it**:
Adds support for NFS location while creating clusterpair for async DR.

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
Yes, adds support creating clusterpair with NFS in storkctl.

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
Yes, `release-24.4.0` branch.

**Pipeline run**
https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/storkctl-test/43/console