### PR TITLE
pwx-37111: add stork argument to disable preloading statfs

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -183,6 +183,10 @@ func main() {
 			Usage: "Application annotation to be used to disable auto updating app scheduler as stork",
 		},
 		cli.BoolTFlag{
+			Name:  "kubevirt-skip-preload-statfs",
+			Usage: "Skip preloading statfs shared library for kubevirt vm live migration",
+		},
+		cli.BoolTFlag{
 			Name:  "enable-metrics",
 			Usage: "Enable stork metrics collection for stork resources (default: true)",
 		},
@@ -426,9 +430,10 @@ func run(c *cli.Context) {
 		}
 		if c.Bool("webhook-controller") {
 			webhook = &webhookadmission.Controller{
-				Driver:       d,
-				Recorder:     recorder,
-				SkipResource: c.String("webhook-skip-resources-annotation"),
+				Driver:                    d,
+				Recorder:                  recorder,
+				SkipResource:              c.String("webhook-skip-resources-annotation"),
+				KubevirtSkipPreloadStatFS: c.Bool("kubevirt-skip-preload-statfs"),
 			}
 			if err := webhook.Start(); err != nil {
 				log.Fatalf("error starting webhook controller: %v", err)

--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -184,7 +184,7 @@ func main() {
 		},
 		cli.BoolTFlag{
 			Name:  "kubevirt-skip-preload-statfs",
-			Usage: "Skip preloading statfs shared library for kubevirt vm live migration",
+			Usage: "Skip preloading statfs shared library for Kubevirt VM live migration",
 		},
 		cli.BoolTFlag{
 			Name:  "enable-metrics",

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -4345,7 +4345,7 @@ func (p *portworx) IsVirtualMachineSupported() bool {
 }
 
 func (p *portworx) getVirtLauncherPatches(podNamespace string, pod *v1.Pod) ([]k8sutils.JSONPatchOp, error) {
-	if pod.Labels["kubevirt.io"] != "virt-launcher" {
+	if pod.Labels["kubevirt.io"] != "virt-launcher" || storkvolume.SkipKubevirtPreloadStatfs {
 		return nil, nil
 	}
 

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -77,6 +77,12 @@ var (
 		CSIDriverName,
 		KDMPDriverName,
 	}
+
+	// `kubevirt-skip-preload-statfs=true` stork argument can be configured
+	// by the user as per their need through which stork can get to know if to
+	// actually create the configmap and mount the ld.so.preload and px_statfs.so
+	// shared lib onto the virt-launcher container.
+	SkipKubevirtPreloadStatfs bool
 )
 
 // Driver defines an external volume driver interface.

--- a/pkg/webhookadmission/webhook.go
+++ b/pkg/webhookadmission/webhook.go
@@ -43,12 +43,13 @@ const (
 // with stork as scheduler, if given resources are using driver supported
 // by stork
 type Controller struct {
-	Recorder     record.EventRecorder
-	Driver       volume.Driver
-	server       *http.Server
-	lock         sync.Mutex
-	started      bool
-	SkipResource string
+	Recorder                  record.EventRecorder
+	Driver                    volume.Driver
+	server                    *http.Server
+	lock                      sync.Mutex
+	started                   bool
+	SkipResource              string
+	KubevirtSkipPreloadStatFS bool
 }
 
 // Serve method for webhook server
@@ -126,7 +127,6 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 	// by the user as per their need through which stork can get to know if to
 	// actually create the configmap and mount the ld.so.preload and px_statfs.so
 	// files onto the virt-launcher container.
-	skipPreloadStatFS := os.Getenv("KUBEVIRT_SKIP_LD_PRELOAD_STATFS")
 	if !isStorkResource {
 		admissionResponse = &v1beta1.AdmissionResponse{
 			Result: &metav1.Status{
@@ -134,7 +134,7 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 			},
 			Allowed: true,
 		}
-	} else if skipPreloadStatFS == "true" {
+	} else if c.KubevirtSkipPreloadStatFS {
 		admissionResponse = &v1beta1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: "Successful",

--- a/pkg/webhookadmission/webhook.go
+++ b/pkg/webhookadmission/webhook.go
@@ -122,10 +122,22 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 		schedPath = podSpecSchedPath
 	}
 
+	// KUBEVIRT_SKIP_LD_PRELOAD_STATFS environment variable can be configured
+	// by the user as per their need through which stork can get to know if to
+	// actually create the configmap and mount the ld.so.preload and px_statfs.so
+	// files onto the virt-launcher container.
+	skipPreloadStatFS := os.Getenv("KUBEVIRT_SKIP_LD_PRELOAD_STATFS")
 	if !isStorkResource {
 		admissionResponse = &v1beta1.AdmissionResponse{
 			Result: &metav1.Status{
 				Message: "Ignoring backends which are not supported by stork ",
+			},
+			Allowed: true,
+		}
+	} else if skipPreloadStatFS == "true" {
+		admissionResponse = &v1beta1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: "Successful",
 			},
 			Allowed: true,
 		}

--- a/pkg/webhookadmission/webhook.go
+++ b/pkg/webhookadmission/webhook.go
@@ -65,7 +65,7 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 	var admissionResponse *v1beta1.AdmissionResponse
 	var err error
 	var schedPath string
-	patches := []k8sutils.JSONPatchOp{}
+	var patches []k8sutils.JSONPatchOp
 	admissionReview := v1beta1.AdmissionReview{}
 	isStorkResource := false
 	skipHookAnnotation := defaultSkipAnnotation
@@ -131,23 +131,17 @@ func (c *Controller) processMutateRequest(w http.ResponseWriter, req *http.Reque
 			Allowed: true,
 		}
 	} else {
-		// `kubevirt-skip-preload-statfs=true` stork argument can be configured
-		// by the user as per their need through which stork can get to know if to
-		// actually create the configmap and mount the ld.so.preload and px_statfs.so
-		// shared lib onto the virt-launcher container.
-		if c.KubevirtSkipPreloadStatFS {
-			log.Debugf("Skipping the statfs patch formation step since kubevirt-skip-preload-statfs arg is set")
-		} else {
-			// pod object does not have name and namespace populated, so we pass them separately. Also,
-			// if the pod is using generateName, arReq.Name is empty.
-			patches, err = c.Driver.GetPodPatches(arReq.Namespace, &pod)
-			if err != nil {
-				log.Errorf("Failed to get pod patches for pod %s/%s: %v", arReq.Namespace, resourceName, err)
-				c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "could not get pod patches", err.Error())
-				http.Error(w, "Could not get pod patches", http.StatusInternalServerError)
-				return
-			}
+		volume.SkipKubevirtPreloadStatfs = c.KubevirtSkipPreloadStatFS
+		// pod object does not have name and namespace populated, so we pass them separately. Also,
+		// if the pod is using generateName, arReq.Name is empty.
+		patches, err = c.Driver.GetPodPatches(arReq.Namespace, &pod)
+		if err != nil {
+			log.Errorf("Failed to get pod patches for pod %s/%s: %v", arReq.Namespace, resourceName, err)
+			c.Recorder.Event(webhookConfig, v1.EventTypeWarning, "could not get pod patches", err.Error())
+			http.Error(w, "Could not get pod patches", http.StatusInternalServerError)
+			return
 		}
+
 		// create patch
 		log.Debugf("Updating scheduler to stork for Resource:%s, Name: %s, Namespace:%s",
 			arReq.Kind.Kind, resourceName, arReq.Namespace)


### PR DESCRIPTION
**What type of PR is this?**
>improvement

**What this PR does / why we need it**:
Addresses https://purestorage.atlassian.net/browse/PWX-37111. The PR adds a stork argument to bypass the hack we did in order to live migrate a Kubevirt VM when the VM pod is running on a node where the pod’s sharedv4 volume is attached. The solution we implemented was that inside the virt-launcher container, we install our own `.so` file and intercept the `statfs` call made by `libvirtd`. If there is a PX volume underneath the VM disk’s file system, we return `nfs` as the file system type instead of `ext4` regardless of whether it is a bind-mount or nfs-mount.

We are making this change since RedHat is working on adding support for sharedv4 filesystems in libvirtd through the patch: https://lists.libvirt.org/archives/list/devel@lists.libvirt.org/thread/XPCPYID6ZS5NXQCAYCUHFMCXJFL6C3TP/ and thus, getting rid of the preload hack of the `statfs` shared lib.

The workflow for the user would be to add the `kubevirt-skip-preload-statfs=true` argument in the `stork` configuration field in the storage cluster. Stork would read this argument and based on that decide whether to add the `statfs` related patch in the `virt-launcher` container or not.

**Does this PR change a user-facing CRD or CLI?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, 24.4.0 branch.

**Manual Test**
- Live migration failed with the following error post the changes:
```
{"component":"virt-launcher","level":"error","msg":"No disk capacity","pos":"manager.go:780","timestamp":"2024-07-25T06:50:29.486294Z"}
{"component":"virt-launcher","level":"warning","msg":"disk size is not 1MiB-aligned. Adjusting from 10146860236 down to 10146021376.","pos":"util.go:217","timestamp":"2024-07-25T06:50:29.491433Z"}
{"component":"virt-launcher","kind":"","level":"info","msg":"Prepared migration target pod","name":"vm-cirros-containerdisk-newest","namespace":"test-migration","pos":"server.go:172","timestamp":"2024-07-25T06:50:29.491685Z","uid":"01060bdd-0a88-4f30-8bb0-916864a25b6f"}
{"component":"virt-launcher","kind":"","level":"info","msg":"Signaled target pod virt-launcher-vm-cirros-containerdisk-newest-9f8bh to cleanup","name":"vm-cirros-containerdisk-newest","namespace":"test-migration","pos":"server.go:152","timestamp":"2024-07-25T06:50:30.286045Z","uid":"01060bdd-0a88-4f30-8bb0-916864a25b6f"}
panic: received early exit signal
{"component":"virt-launcher-monitor","level":"info","msg":"Reaped pid 12 with status 512","pos":"virt-launcher-monitor.go:125","timestamp":"2024-07-25T06:50:31.787908Z"}
{"component":"virt-launcher-monitor","level":"error","msg":"dirty virt-launcher shutdown: exit-code 2","pos":"virt-launcher-monitor.go:143","timestamp":"2024-07-25T06:50:31.788069Z"}
```
**Testing the filesystem type on OCP cluster**

- Deployed the [virt-launcher-sim](https://github.com/libopenstorage/stork/blob/master/test/integration_test/specs/virt-launcher-sim/virt-launcher-sim.yaml) spec on an OCP cluster. Tried replicating the steps mentioned in this [document](https://docs.google.com/document/d/1HR3U3KWgite71jj3o5t44gvgiCG-Pc2veWzdWXbKtqU/edit#heading=h.ouewau8bwo2k).
```
❯ k get pvc -n test-migration -owide                                                 
NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE     VOLUMEMODE
virt-launcher-sim-pvc   Bound    pvc-e0b29b4f-9623-473b-85a2-20b55ee10fe5   50Gi       RWX            virt-launcher-sim-sc   6m56s   Filesystem

❯ k exec -it pods/px-cluster-ocp-0a11394a-951b-49d8-96ac-3d19215cf2ef-f9rp7 -n kube-system -- bash           
[root@pwx-ocp-208-111-xnh9l-worker-0-6ncjf /]# pxctl v l | grep pvc-e0b29b4f-9623-473b-85a2-20b55ee10fe5
72687925582808734	pvc-e0b29b4f-9623-473b-85a2-20b55ee10fe5	50 GiB	2	v4 (service)	no		no		LOW		up - attached on 10.13.219.72	no

❯ k exec -it pods/px-cluster-ocp-0a11394a-951b-49d8-96ac-3d19215cf2ef-q57zw -n kube-system -- bash                                                         
[root@pwx-ocp-208-111-xnh9l-worker-0-rr8b7 /]# mount | grep 72687925582808734
/dev/pxd/pxd72687925582808734 on /var/lib/osd/pxns/72687925582808734 type ext4 (rw,relatime,seclabel,discard)

❯ k exec -it pods/virt-launcher-sim-dep-7ddf84b8f9-8252n -n test-migration -- bash                                                        
Defaulted container "sv4test" out of: sv4test, sv4test-reader
1000800000@virt-launcher-sim-dep-7ddf84b8f9-8252n:/app$ lsblk | grep 72687925582808734
pxd/pxd72687925582808734  252:6    0    50G  0 disk /shared-vol

1000800000@virt-launcher-sim-dep-7ddf84b8f9-8252n:/app$ stat -f /shared-vol
  File: "/shared-vol"
    ID: 93c7d8c8c35a56dd Namelen: 255     Type: ext2/ext3
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 12822648   Free: 12822632   Available: 12818536
Inodes: Total: 3276800    Free: 3276785
```
- As we can see, the filesystem type is being shown as **ext2/ext3** instead of **nfs**.
