### PR TITLE
chore: upgrade aws-authenticator and gcloud-cli to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN microdnf clean all && microdnf install -y python3.9 ca-certificates tar gzip
 RUN python3 -m pip install awscli && python3 -m pip install oci-cli && python3 -m pip install rsa --upgrade
 
 
-RUN curl -Lo /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.14/aws-iam-authenticator_0.6.14_linux_amd64 && \
+RUN curl -Lo /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.21/aws-iam-authenticator_0.6.21_linux_amd64 && \
     chmod +x /usr/local/bin/aws-iam-authenticator
 
 #Install asdf
@@ -33,11 +33,11 @@ RUN asdf install kubelogin latest
 RUN asdf global kubelogin latest
 
 #Install Google Cloud SDK
-ARG GCLOUD_SDK=google-cloud-cli-455.0.0-linux-x86_64.tar.gz
+ARG GCLOUD_SDK=google-cloud-cli-483.0.0-linux-x86_64.tar.gz
 ARG GCLOUD_INSTALL_DIR="/usr/lib"
 ENV PATH "${PATH}:$GCLOUD_INSTALL_DIR/google-cloud-sdk/bin"
-# Download GCLOUD_SDK tar bundle, untar it , install gke-gcloud-auth-plugin 
-# and remove the tar bundle and all directory contents except bin directory  
+# Download GCLOUD_SDK tar bundle, untar it , install gke-gcloud-auth-plugin
+# and remove the tar bundle and all directory contents except bin directory
 RUN curl -q -o $GCLOUD_SDK https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/$GCLOUD_SDK && \
     tar xf $GCLOUD_SDK -C $GCLOUD_INSTALL_DIR && rm -rf $GCLOUD_SDK && \
     rm -rf $GCLOUD_INSTALL_DIR/google-cloud-sdk/platform/gsutil \


### PR DESCRIPTION
**What type of PR is this?**
>security fix

**What this PR does / why we need it**:
Upgrades `aws-iam-authenticator` and `gcloud-cli` to the latest versions in order to address CVE-2024-24790

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
TBD
