### PR TITLE
pb-7563: fixed the error handling in getting snapshot timeout value during kdmp csi restore.

### DIFF
--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -741,7 +741,7 @@ func (c *csiDriver) RestoreStatus(pvcName, namespace string) (RestoreInfo, error
 	}
 	// Lets use SNAPSHOT_TIMEOUT for restoreTimeout as well.
 	restoreTimeout, err := getSnapshotTimeout()
-	if err == nil {
+	if err != nil {
 		logrus.Warnf("failed to obtain timeout value for snapshot %s: %v, falling back on default snapshot timeout value %s", vsName, err, defaultSnapshotTimeout.String())
 		restoreTimeout = defaultSnapshotTimeout
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
pb-7563: fixed the error handling in getting snapshot timeout value during kdmp csi restore.
```

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
```release-note
Issue: configmap way of setting the CSI snapshot timeout was broken.
User Impact: user were not able to change the default 30m, if the snapshot was taking more time.
Resolution: Fixed to take the value of snapshot timeout from the kdmp-config configmap.

```

**Does this change need to be cherry-picked to a release branch?**:
23.3.0 branch.

