### PR TITLE
pwx-37488 : modify existing migration tests for nfs objectstore provider

### DIFF
--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -28,9 +28,6 @@ const (
 	restoreName          = "mysql-restore"
 	backupSyncAnnotation = "backupsync"
 	configMapName        = "secret-config"
-	s3SecretName         = "s3secret"
-	azureSecretName      = "azuresecret"
-	googleSecretName     = "googlesecret"
 	prepare              = "prepare"
 	fio                  = "fio"
 	verify               = "verify"
@@ -1593,8 +1590,8 @@ func setDefaultsForBackup(t *testing.T) {
 	if !defaultsBackupSet {
 		defaultsBackupSet = true
 	}
-
 }
+
 func getSyncedBackupWithAnnotation(appBackup *storkv1.ApplicationBackup, lookUpAnnotation string) (*storkv1.ApplicationBackup, error) {
 	// Check periodically to see if the backup from this test is synced on second cluster
 	var allAppBackups *storkv1.ApplicationBackupList

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -130,6 +130,10 @@ const (
 	nfsServerExportPathEnv     = "NFS_EXPORT_PATH"
 	defaultNFSServerAddress    = "10.13.248.14"
 	defaultNFSServerExportPath = "stork-nfs"
+	s3SecretName               = "s3secret"
+	azureSecretName            = "azuresecret"
+	googleSecretName           = "googlesecret"
+	nfsSecretName              = "nfssecret"
 
 	tokenKey    = "token"
 	clusterIP   = "ip"
@@ -185,6 +189,7 @@ var bidirectionalClusterpair bool
 var unidirectionalClusterpair bool
 var currentTestSuite string
 var kubevirtScale int
+var provider string = "s3"
 
 // NFS location config variables.
 var nfsSrvAddr, nfsSrvExpPath string
@@ -399,6 +404,9 @@ func setup() error {
 	if nfsSrvExpPath, set = os.LookupEnv(nfsServerExportPathEnv); !set {
 		nfsSrvExpPath = defaultNFSServerExportPath
 	}
+
+	// Fetch the object store provider.
+	provider = os.Getenv("PROVIDER")
 
 	err = setDestinationKubeConfig()
 	if err != nil {
@@ -1267,10 +1275,19 @@ func getObjectStoreArgs(objectStoreType storkv1.BackupLocationType, secretName s
 		objectStoreArgs = append(objectStoreArgs,
 			[]string{"--provider", "nfs",
 				"--nfs-server", string(secretData.Data["serverAddr"]),
-				"--nfs-export-path", string(secretData.Data["subPath"]),
-				"--nfs-sub-path", string(secretData.Data["path"]),
-				"--nfs-mount-ops", string(secretData.Data["mountOptions"]),
-				"--nfs-timeout-seconds", string(secretData.Data["nfsIOTimeoutInSecs"])}...)
+				"--nfs-export-path", string(secretData.Data["subPath"])}...)
+
+		if string(secretData.Data["path"]) != "" {
+			objectStoreArgs = append(objectStoreArgs, "--nfs-sub-path", string(secretData.Data["path"]))
+		}
+
+		if string(secretData.Data["mountOptions"]) != "" {
+			objectStoreArgs = append(objectStoreArgs, "--nfs-mount-ops", string(secretData.Data["mountOptions"]))
+		}
+
+		if string(secretData.Data["nfsIOTimeoutInSecs"]) != "" {
+			objectStoreArgs = append(objectStoreArgs, "--nfs-timeout-seconds", string(secretData.Data["nfsIOTimeoutInSecs"]))
+		}
 	}
 
 	// Handle the encryption case.
@@ -2115,4 +2132,44 @@ func getSourceKubeConfigFile() (string, error) {
 	// dump to remoteFilePath
 	err = os.WriteFile(srcKubeConfigPath, []byte(config), 0644)
 	return srcKubeConfigPath, err
+}
+
+func getSecretForVolumeDriverMigrationTest(volumeDriver string) (string, error) {
+	switch volumeDriver {
+	case "pxd", "aws":
+		if provider == "nfs" {
+			return nfsSecretName, nil
+		}
+		return s3SecretName, nil
+	case "azure":
+		return azureSecretName, nil
+	case "gce":
+		return googleSecretName, nil
+	default:
+		return "", fmt.Errorf("Invalid volume driver provided: %s", volumeDriver)
+	}
+}
+
+func setDefaultsForMigration(t *testing.T) {
+	// Get location types and secret from config maps
+	configMap, err := core.Instance().GetConfigMap(configMapName, "default")
+	log.FailOnError(t, err, "Failed to get config map  %s", configMap.Name)
+
+	allConfigMap = configMap.Data
+
+	// Default backup location
+	defaultBackupLocation, err = getBackupLocationForVolumeDriver(volumeDriverName)
+	log.FailOnError(t, err, "Failed to get default backuplocation for %s: %v", volumeDriverName, err)
+	defaultSecretName, err = getSecretForVolumeDriverMigrationTest(volumeDriverName)
+	log.FailOnError(t, err, "Failed to get default secret name for %s: %v", volumeDriverName, err)
+	log.InfoD("Default backup location set to %v", defaultBackupLocation)
+	defaultConfigMap = getBackupConfigMapForType(allConfigMap, defaultBackupLocation)
+
+	// If running pxd driver backup to all locations
+	if volumeDriverName != "pxd" {
+		allConfigMap = defaultConfigMap
+	}
+	if !defaultsBackupSet {
+		defaultsBackupSet = true
+	}
 }

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -2134,6 +2134,22 @@ func getSourceKubeConfigFile() (string, error) {
 	return srcKubeConfigPath, err
 }
 
+func getBackupLocationForVolumeDriverMigrationTest(volumeDriver string) (storkv1.BackupLocationType, error) {
+	switch volumeDriver {
+	case "pxd", "aws":
+		if provider == "nfs" {
+			return nfsSecretName, nil
+		}
+		return storkv1.BackupLocationS3, nil
+	case "azure":
+		return storkv1.BackupLocationAzure, nil
+	case "gce":
+		return storkv1.BackupLocationGoogle, nil
+	default:
+		return storkv1.BackupLocationType(""), fmt.Errorf("Invalid volume driver provided: %s", volumeDriver)
+	}
+}
+
 func getSecretForVolumeDriverMigrationTest(volumeDriver string) (string, error) {
 	switch volumeDriver {
 	case "pxd", "aws":
@@ -2158,7 +2174,7 @@ func setDefaultsForMigration(t *testing.T) {
 	allConfigMap = configMap.Data
 
 	// Default backup location
-	defaultBackupLocation, err = getBackupLocationForVolumeDriver(volumeDriverName)
+	defaultBackupLocation, err = getBackupLocationForVolumeDriverMigrationTest(volumeDriverName)
 	log.FailOnError(t, err, "Failed to get default backuplocation for %s: %v", volumeDriverName, err)
 	defaultSecretName, err = getSecretForVolumeDriverMigrationTest(volumeDriverName)
 	log.FailOnError(t, err, "Failed to get default secret name for %s: %v", volumeDriverName, err)

--- a/test/integration_test/migration_backup_test.go
+++ b/test/integration_test/migration_backup_test.go
@@ -19,7 +19,7 @@ func TestMigrationBackup(t *testing.T) {
 	err := setMockTime(nil)
 	log.FailOnError(t, err, "Error resetting mock time")
 
-	setDefaultsForBackup(t)
+	setDefaultsForMigration(t)
 	currentTestSuite = t.Name()
 
 	log.InfoD("Using stork volume driver: %s", volumeDriverName)

--- a/test/integration_test/migration_dr_actions_test.go
+++ b/test/integration_test/migration_dr_actions_test.go
@@ -30,7 +30,7 @@ func TestDRActions(t *testing.T) {
 
 	log.InfoD("Using stork volume driver: %s", volumeDriverName)
 	log.InfoD("Backup path being used: %s", backupLocationPath)
-	setDefaultsForBackup(t)
+	setDefaultsForMigration(t)
 
 	// get the destination kubeconfig from configmap in source cluster so that it can be passed to storkctl commands
 	// since both the dr cli commands run in destination cluster

--- a/test/integration_test/migration_features_test.go
+++ b/test/integration_test/migration_features_test.go
@@ -33,7 +33,7 @@ func TestStashStrategyMigration(t *testing.T) {
 	log.InfoD("Using stork volume driver: %s", volumeDriverName)
 	log.InfoD("Backup path being used: %s", backupLocationPath)
 
-	setDefaultsForBackup(t)
+	setDefaultsForMigration(t)
 	currentTestSuite = t.Name()
 
 	t.Run("testMigrationStashStrategyMongoDB", testMigrationStashStrategyMongoDB)

--- a/test/integration_test/migration_stork_failures_test.go
+++ b/test/integration_test/migration_stork_failures_test.go
@@ -33,7 +33,7 @@ func TestMigrationStorkFailures(t *testing.T) {
 
 	log.InfoD("Using stork volume driver: %s", volumeDriverName)
 	log.InfoD("Backup path being used: %s", backupLocationPath)
-	setDefaultsForBackup(t)
+	setDefaultsForMigration(t)
 
 	t.Run("deleteStorkPodsSourceDuringMigrationTest", deleteStorkPodsSourceDuringMigrationTest)
 	t.Run("deleteStorkPodsDestDuringMigrationTest", deleteStorkPodsDestDuringMigrationTest)

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -46,7 +46,7 @@ func TestMigration(t *testing.T) {
 
 	log.InfoD("Using stork volume driver: %s", volumeDriverName)
 	log.InfoD("Backup path being used: %s", backupLocationPath)
-	setDefaultsForBackup(t)
+	setDefaultsForMigration(t)
 	currentTestSuite = t.Name()
 
 	t.Run("testMigration", testMigration)

--- a/test/integration_test/stork-test-pod.yaml
+++ b/test/integration_test/stork-test-pod.yaml
@@ -128,6 +128,12 @@ spec:
       value: test_tag
     - name: TEST_DESCRIPTION
       value: test_description
+    - name: PROVIDER
+      value: provider
+    - name: NFS_SERVER_ADDRESS
+      value: nfs_server_address
+    - name: NFS_EXPORT_PATH
+      value: nfs_export_path
   hostNetwork: false
   hostNetwork: false
   hostPID: false

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -451,6 +451,9 @@ sed -i 's/'username'/'"$SSH_USERNAME"'/g' /testspecs/stork-test-pod.yaml
 sed -i 's/'password'/'"$SSH_PASSWORD"'/g' /testspecs/stork-test-pod.yaml
 sed  -i 's|'openstorage/stork_test:.*'|'"$test_image_name"'|g'  /testspecs/stork-test-pod.yaml
 sed -i 's/'backup_location_path'/'"$backup_location_path"'/g' /testspecs/stork-test-pod.yaml
+sed -i 's/'provider'/'"$PROVIDER"'/g' /testspecs/stork-test-pod.yaml
+sed -i 's/'nfs_server_address'/'"$NFS_SERVER_ADDRESS"'/g' /testspecs/stork-test-pod.yaml
+sed -i 's/'nfs_export_path'/'"$NFS_SERVER_ADDRESS"'/g' /testspecs/stork-test-pod.yaml
 
 # testrail params
 sed -i 's/testrail_run_name/'"$TESTRAIL_RUN_NAME"'/g' /testspecs/stork-test-pod.yaml


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
Modifies the migration tests for NFS based object store provider.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, `release-24.4.0` branch.

**Pipeline runs**
- `TestMigration/testMigration` : https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/bidirectional-migration-clone/9/
- `TestDRActions` : https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/bidirectional-migration-clone/11/