### PR TITLE
PWX-38345: Put empty string check in volumeName while collecting the volumes for enumerate call in GetPodVolumes.

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -912,7 +912,7 @@ func (p *portworx) GetPodVolumes(podSpec *v1.PodSpec, namespace string, includeP
 		}
 		// If a volume is pending and WFFC, it doesn't exist in Portworx.
 		// No need of querying it.
-		if !isPendingWFFC {
+		if volumeName != "" && !isPendingWFFC {
 			volumeNameList = append(volumeNameList, volumeName)
 		}
 	}


### PR DESCRIPTION
Signed-Off-By: Diptiranjan


**What type of PR is this?**
>bug

**What this PR does / why we need it**:
In GetPodVolumes while creating volume names list for the enumerateVolumes api call, we have to consider only the pod volumes which has PVC and are not WFFC.


**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
yes, TBD
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 24.2.5

**Test**:
Tested with strong hyperconvergence with annotation `preferLocalNodeOnly` and updated the ticket with the results.
