### PR TITLE
pb-7504: vendor kdmp master to stork master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/golang/mock v1.6.0
-	github.com/portworx/kdmp v0.4.1-0.20240719034240-1f487d1bf635
+	github.com/portworx/kdmp v0.4.1-0.20240730181245-423ce1fdc45b
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	kubevirt.io/api v1.0.0
 	kubevirt.io/client-go v0.59.2
@@ -354,7 +354,7 @@ replace (
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240416193513-1e07b4359307
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
-	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240719034240-1f487d1bf635
+	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240730181245-423ce1fdc45b
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240514213912-ff0ae32b859a
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240520065758-b58a5dd88529
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -4102,8 +4102,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v1.0.5/go.mod h1:APVvOesVSAnne5SClsPxPdfvZTVDojXh1/G3qb5wjGI=
 github.com/portworx/dcos-secrets v0.0.0-20180616013705-8e8ec3f66611/go.mod h1:4hklRW/4DQpLqkcXcjtNprbH2tz/sJaNtqinfPWl/LA=
-github.com/portworx/kdmp v0.4.1-0.20240719034240-1f487d1bf635 h1:lHBjP7xpTd0WEGhk7GJZ1Wq51ww2qTdYXztak0b63aU=
-github.com/portworx/kdmp v0.4.1-0.20240719034240-1f487d1bf635/go.mod h1:Uzm90W9yC4epDqv0wv6cLvTsGfPNtpmuNaE3fKmGC2Q=
+github.com/portworx/kdmp v0.4.1-0.20240730181245-423ce1fdc45b h1:aSFrhc9PWpRKaXeCg4GqHIuYuYHUJMJrVkBOK/UEjd4=
+github.com/portworx/kdmp v0.4.1-0.20240730181245-423ce1fdc45b/go.mod h1:Uzm90W9yC4epDqv0wv6cLvTsGfPNtpmuNaE3fKmGC2Q=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200929023115-b312c7519467/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1099,7 +1099,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20240719034240-1f487d1bf635 => github.com/portworx/kdmp v0.4.1-0.20240719034240-1f487d1bf635
+# github.com/portworx/kdmp v0.4.1-0.20240730181245-423ce1fdc45b => github.com/portworx/kdmp v0.4.1-0.20240730181245-423ce1fdc45b
 ## explicit; go 1.21
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1
@@ -2647,7 +2647,7 @@ sigs.k8s.io/yaml/goyaml.v2
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240416193513-1e07b4359307
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
-# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240719034240-1f487d1bf635
+# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240730181245-423ce1fdc45b
 # github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240514213912-ff0ae32b859a
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240520065758-b58a5dd88529
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7


### PR DESCRIPTION
This fixes the GKE issue with respect to psa security context


**What type of PR is this?** bug
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**: In GKE environment while using its native file store to leverage NFS backup location, the volume is mounted with no write permission for group. Hence backup is failing. Hence this PR fixes the issue by running POD as root instead of non-root user. This will be the case till the time GKE fixes its file store.


**Does this PR change a user-facing CRD or CLI?**: No
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: No
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: 24.3.0
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

