### PR TITLE
fix:PB-7726 Kubevirt auto rule fails if multi virt-launcher pod in er…

### DIFF
--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -256,6 +256,10 @@ func ExecuteRule(
 				logrus.Infof("Ignoring completed pod for running rule %v", pod.Name)
 				continue
 			}
+			if !core.Instance().IsPodRunning(pod) {
+				logrus.Debugf("skipping executing rule on pod %v: Pod not in running state", pod.GetName())
+				continue
+			}
 			logrus.Debugf("Including pod to run rule %v", pod.Name)
 			pods = append(pods, pod)
 		}


### PR DESCRIPTION
…ror state


**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
>feature
>improvement
>cleanup
>api-change
>design
>documentation
>failing-test
>unit-test
>integration-test

**What this PR does / why we need it**:
This PR fixes pre-post exec rules execution login to skip pod which is not in running state. PB-7726

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->
NO
**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue: Kubevirt auto exec rules fails if virt-launcher pod in error state
User Impact: Px-backup with auto exec rules will fail
Resolution
  Run backup with skip auto exec rules option set to true
```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

2.8.0, 27.3