### PR TITLE
pwx-38446: validate clusterdomain status in metro dr tests

### DIFF
--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -2152,7 +2152,8 @@ func validateClusterDomainStatus(t *testing.T, activeSource, activeDest bool) {
 
 	// Parse the JSON output to check the status of the witness node.
 	domainStatus := ClusterDomainStatusOutput{}
-	json.Unmarshal([]byte(actualOutput), &domainStatus)
+	err := json.Unmarshal([]byte(actualOutput), &domainStatus)
+	log.FailOnError(t, err, "failed to unmarshal clusterdomain status json output")
 	for _, info := range domainStatus.Items[0].Status.ClusterDomainInfos {
 		switch info.Name {
 		case "witness":

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -5,6 +5,8 @@ package integrationtest
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -117,15 +119,16 @@ const (
 	defaultWaitInterval      time.Duration = 10 * time.Second
 	backupWaitInterval       time.Duration = 2 * time.Second
 
-	enableClusterDomainTests = "ENABLE_CLUSTER_DOMAIN_TESTS"
-	storageProvisioner       = "STORAGE_PROVISIONER"
-	authSecretConfigMap      = "AUTH_SECRET_CONFIGMAP"
-	backupPathVar            = "BACKUP_LOCATION_PATH"
-	externalTestCluster      = "EXTERNAL_TEST_CLUSTER"
-	cloudDeletionValidation  = "CLOUD_DELETION_VALIDATION"
-	internalLBAws            = "INTERNAL_AWS_LB"
-	portworxNamespace        = "PX_NAMESPACE"
-	enableDashStats          = "ENABLE_DASH"
+	enableClusterDomainTests     = "ENABLE_CLUSTER_DOMAIN_TESTS"
+	storkTestClusterDomainPrefix = "CLUSTER_DOMAIN_PREFIX"
+	storageProvisioner           = "STORAGE_PROVISIONER"
+	authSecretConfigMap          = "AUTH_SECRET_CONFIGMAP"
+	backupPathVar                = "BACKUP_LOCATION_PATH"
+	externalTestCluster          = "EXTERNAL_TEST_CLUSTER"
+	cloudDeletionValidation      = "CLOUD_DELETION_VALIDATION"
+	internalLBAws                = "INTERNAL_AWS_LB"
+	portworxNamespace            = "PX_NAMESPACE"
+	enableDashStats              = "ENABLE_DASH"
 
 	tokenKey    = "token"
 	clusterIP   = "ip"
@@ -2096,4 +2099,72 @@ func getSourceKubeConfigFile() (string, error) {
 	// dump to remoteFilePath
 	err = os.WriteFile(srcKubeConfigPath, []byte(config), 0644)
 	return srcKubeConfigPath, err
+}
+
+// validateClusterDomainStatus validates the cluster domain status for the source, destination and witness clusters.
+func validateClusterDomainStatus(t *testing.T, activeSource, activeDest bool) {
+	var actualSrcDomainStatus, actualDestDomainStatus, witnessNodeDomainStatus string
+	var expectedSrcDomainStatus, expectedDestDomainStatus = "Active", "Active"
+
+	type ClusterDomainStatusOutput struct {
+		Kind       string `json:"kind"`
+		APIVersion string `json:"apiVersion"`
+		Metadata   struct {
+			ResourceVersion string `json:"resourceVersion"`
+		} `json:"metadata"`
+		Items []struct {
+			Kind       string `json:"kind"`
+			APIVersion string `json:"apiVersion"`
+			Metadata   struct {
+				Name              string    `json:"name"`
+				UID               string    `json:"uid"`
+				ResourceVersion   string    `json:"resourceVersion"`
+				Generation        int       `json:"generation"`
+				CreationTimestamp time.Time `json:"creationTimestamp"`
+			} `json:"metadata"`
+			Status struct {
+				LocalDomain        string `json:"localDomain"`
+				ClusterDomainInfos []struct {
+					Name       string `json:"name"`
+					State      string `json:"state"`
+					SyncStatus string `json:"syncStatus"`
+				} `json:"clusterDomainInfos"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+
+	// Set the expected values of cluster domain status.
+	if !activeSource {
+		expectedSrcDomainStatus = "Inactive"
+	}
+	if !activeDest {
+		expectedDestDomainStatus = "Inactive"
+	}
+
+	// Get the actual clusterdomain status.
+	factory := storkctl.NewFactory()
+	var outputBuffer bytes.Buffer
+	cmd := storkctl.NewCommand(factory, os.Stdin, &outputBuffer, os.Stderr)
+	cmdArgs := []string{"get", "clusterdomainsstatus", "-o", "json"}
+	executeStorkCtlCommand(t, cmd, cmdArgs, nil)
+	actualOutput := outputBuffer.String()
+	log.InfoD("Actual output is: %s\n", actualOutput)
+
+	// Parse the JSON output to check the status of the witness node.
+	domainStatus := ClusterDomainStatusOutput{}
+	json.Unmarshal([]byte(actualOutput), &domainStatus)
+	for _, info := range domainStatus.Items[0].Status.ClusterDomainInfos {
+		switch info.Name {
+		case "witness":
+			witnessNodeDomainStatus = info.State
+		case sourceClusterDomain:
+			actualSrcDomainStatus = info.State
+		case destClusterDomain:
+			actualDestDomainStatus = info.State
+		}
+	}
+
+	Dash.VerifyFatal(t, witnessNodeDomainStatus, "Active", "Error validating the status of witness node domain")
+	Dash.VerifyFatal(t, actualSrcDomainStatus, expectedSrcDomainStatus, "Error validating the status of source cluster domain")
+	Dash.VerifyFatal(t, actualDestDomainStatus, expectedDestDomainStatus, "Error validating the status of destination cluster domain")
 }

--- a/test/integration_test/stork-test-pod.yaml
+++ b/test/integration_test/stork-test-pod.yaml
@@ -74,6 +74,8 @@ spec:
       value: http://linstor-op-cs.default:3370/
     - name: ENABLE_CLUSTER_DOMAIN_TESTS
       value: enable_cluster_domain
+    - name: CLUSTER_DOMAIN_PREFIX
+      value: cluster_domain_prefix
     - name: STORAGE_PROVISIONER
       value: storage_provisioner
     - name: AUTH_SECRET_CONFIGMAP

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -449,7 +449,8 @@ sed -i 's/- -backup-scale-count=10/- -backup-scale-count='"$backup_scale"'/g' /t
 sed -i 's/- -kubevirt-scale-count=1/- -kubevirt-scale-count='"$kubevirt_scale"'/g' /testspecs/stork-test-pod.yaml
 sed -i 's/'username'/'"$SSH_USERNAME"'/g' /testspecs/stork-test-pod.yaml
 sed -i 's/'password'/'"$SSH_PASSWORD"'/g' /testspecs/stork-test-pod.yaml
-sed  -i 's|'openstorage/stork_test:.*'|'"$test_image_name"'|g'  /testspecs/stork-test-pod.yaml
+sed -i 's|'openstorage/stork_test:.*'|'"$test_image_name"'|g'  /testspecs/stork-test-pod.yaml
+sed -i 's/'cluster_domain_prefix'/'"$CLUSTER_DOMAIN_PREFIX"'/g' /testspecs/stork-test-pod.yaml
 sed -i 's/'backup_location_path'/'"$backup_location_path"'/g' /testspecs/stork-test-pod.yaml
 
 # testrail params


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
Addresses [PWX-38446](https://purestorage.atlassian.net/browse/PWX-38446). Validates the clusterdomain status for source and destination clusters post failback/failover in metro DR.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Sample test run result**
![Screenshot from 2024-08-11 01-25-35](https://github.com/user-attachments/assets/72662b93-180c-4634-b989-63536c10be11)