### PR TITLE
PWX-38560: add wait for fetching destination volume id in dataExportTest CBT

### DIFF
--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -191,7 +191,7 @@ func TestSnapshot(t *testing.T) {
 
 func TestStorkCbt(t *testing.T) {
 	t.Run("deploymentTest", deploymentMigrationTest)
-	// t.Run("dataExportTest", TestDataExportRsync)
+	t.Run("dataExportTest", TestDataExportRsync)
 	t.Run("testMigrationFailoverFailback", testMigrationFailoverFailback)
 	t.Run("stopDriverTest", stopDriverTest)
 	t.Run("simpleSnapshotTest", simpleSnapshotTest)

--- a/test/integration_test/dataexport_rsync_test.go
+++ b/test/integration_test/dataexport_rsync_test.go
@@ -88,8 +88,19 @@ func TestDataExportRsync(t *testing.T) {
 			destPVC = pvc.Name
 			destPVCObj = pvc
 			var err error
-			destPV, err = core.Instance().GetVolumeForPersistentVolumeClaim(pvc)
-			log.FailOnError(t, err, "failed to get dest PV")
+
+			for i := 0; i < 10; i++ {
+				destPV, err = core.Instance().GetVolumeForPersistentVolumeClaim(pvc)
+				log.FailOnError(t, err, "failed to get dest PV")
+
+				if destPV != "" {
+					break
+				}
+				time.Sleep(6 * time.Second)
+			}
+			if destPV == "" {
+				Dash.Fatal("failed to get destination volume, expected a volume id got blank", destPV)
+			}
 		}
 	}
 	Dash.VerifyFatal(t, namespace != "", true, "Find namespace")


### PR DESCRIPTION
**What type of PR is this?**
>integration-test

**What this PR does / why we need it**:
Attempts to fix the flakiness in `dataExportTest` CBT by waiting for one minute to get the volume id from the PVC. It was failing since in some of the test runs blank value of volume id was getting returned.

