### PR TITLE
pwx-38616: skip nfs backuplocation while running applicationbackup test

### DIFF
--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -106,6 +106,10 @@ func triggerBackupRestoreTest(
 	backupAllAppsExpected bool,
 ) {
 	for location, secret := range configMap {
+		// Skipping if the location is nfs since the code changes for NFS haven't been merged to master yet.
+		if location == "nfs" {
+			continue
+		}
 		log.InfoD("Backing up to cloud: %v using secret %v", location, secret)
 		var currBackupLocation *storkv1.BackupLocation
 		var err error

--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -106,10 +106,6 @@ func triggerBackupRestoreTest(
 	backupAllAppsExpected bool,
 ) {
 	for location, secret := range configMap {
-		// Skipping if the location is nfs since the code changes for NFS haven't been merged to master yet.
-		if location == "nfs" {
-			continue
-		}
 		log.InfoD("Backing up to cloud: %v using secret %v", location, secret)
 		var currBackupLocation *storkv1.BackupLocation
 		var err error

--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -106,6 +106,9 @@ func triggerBackupRestoreTest(
 	backupAllAppsExpected bool,
 ) {
 	for location, secret := range configMap {
+		if location == "nfs" {
+			continue
+		}
 		log.InfoD("Backing up to cloud: %v using secret %v", location, secret)
 		var currBackupLocation *storkv1.BackupLocation
 		var err error
@@ -1505,8 +1508,6 @@ func getBackupLocationType(locationName storkv1.BackupLocationType) (storkv1.Bac
 		return storkv1.BackupLocationAzure, nil
 	case storkv1.BackupLocationGoogle:
 		return storkv1.BackupLocationGoogle, nil
-	case storkv1.BackupLocationNFS:
-		return storkv1.BackupLocationNFS, nil
 	default:
 		return storkv1.BackupLocationType(""), fmt.Errorf("Invalid backuplocation type: %s", locationName)
 	}

--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -1509,6 +1509,8 @@ func getBackupLocationType(locationName storkv1.BackupLocationType) (storkv1.Bac
 		return storkv1.BackupLocationAzure, nil
 	case storkv1.BackupLocationGoogle:
 		return storkv1.BackupLocationGoogle, nil
+	case storkv1.BackupLocationNFS:
+		return storkv1.BackupLocationNFS, nil
 	default:
 		return storkv1.BackupLocationType(""), fmt.Errorf("Invalid backuplocation type: %s", locationName)
 	}


### PR DESCRIPTION
**What type of PR is this?**
>failing-test

**What this PR does / why we need it**:
Skips the NFS location in `applicationbackuprestore` test.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

