### PR TITLE
Stork Health monitor improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ test:
 		      /bin/bash -c 'cd /go/src/github.com/libopenstorage/stork; \
 			  echo "" > coverage.txt; \
 			  for pkg in $(PKGS);	do \
-				  go test -v -tags unittest -coverprofile=profile.out -covermode=atomic $(BUILD_OPTIONS) $${pkg} || exit 1; \
+				  go test --timeout 900s -v -tags unittest -coverprofile=profile.out -covermode=atomic $(BUILD_OPTIONS) $${pkg} || exit 1; \
 				  if [ -f profile.out ]; then \
 					  cat profile.out >> coverage.txt; \
 					  rm profile.out; \

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/rest"
 	clientCache "k8s.io/client-go/tools/cache"
 	controllercache "sigs.k8s.io/controller-runtime/pkg/cache"
@@ -36,8 +37,8 @@ type SharedInformerCache interface {
 	// ListApplicationRegistrations lists the application registration CRs from the cache
 	ListApplicationRegistrations() (*storkv1alpha1.ApplicationRegistrationList, error)
 
-	// ListTransformedPods lists the all the Pods from the cache after applying TransformFunc
-	ListTransformedPods() (*corev1.PodList, error)
+	// ListTransformedPods lists the all the Pods running in a node from the cache after applying TransformFunc
+	ListTransformedPods(nodeName string) (*corev1.PodList, error)
 
 	// WatchPods registers the pod event handlers with the informer cache
 	WatchPods(fn func(object interface{})) error
@@ -201,12 +202,15 @@ func (c *cache) ListApplicationRegistrations() (*storkv1alpha1.ApplicationRegist
 }
 
 // ListTransformedPods lists the all the Pods from the cache after applying TransformFunc
-func (c *cache) ListTransformedPods() (*corev1.PodList, error) {
+func (c *cache) ListTransformedPods(nodeName string) (*corev1.PodList, error) {
 	if c == nil || c.controllerCache == nil {
 		return nil, fmt.Errorf(cacheNotInitializedErr)
 	}
 	podList := &corev1.PodList{}
-	if err := c.controllerCache.List(context.Background(), podList); err != nil {
+	fieldSelector := &client.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}),
+	}
+	if err := c.controllerCache.List(context.Background(), podList, fieldSelector); err != nil {
 		return nil, err
 	}
 	return podList, nil

--- a/pkg/mock/cache/cache.mock.go
+++ b/pkg/mock/cache/cache.mock.go
@@ -112,18 +112,18 @@ func (mr *MockSharedInformerCacheMockRecorder) ListStorageClasses() *gomock.Call
 }
 
 // ListTransformedPods mocks base method.
-func (m *MockSharedInformerCache) ListTransformedPods() (*v1.PodList, error) {
+func (m *MockSharedInformerCache) ListTransformedPods(arg0 string) (*v1.PodList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTransformedPods")
+	ret := m.ctrl.Call(m, "ListTransformedPods", arg0)
 	ret0, _ := ret[0].(*v1.PodList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListTransformedPods indicates an expected call of ListTransformedPods.
-func (mr *MockSharedInformerCacheMockRecorder) ListTransformedPods() *gomock.Call {
+func (mr *MockSharedInformerCacheMockRecorder) ListTransformedPods(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTransformedPods", reflect.TypeOf((*MockSharedInformerCache)(nil).ListTransformedPods))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTransformedPods", reflect.TypeOf((*MockSharedInformerCache)(nil).ListTransformedPods), arg0)
 }
 
 // WatchPods mocks base method.

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -227,7 +227,7 @@ func (m *Monitor) driverMonitor() {
 				// For any Running pod on that node using volume by the driver, kill the pod
 				// Degraded nodes are not considered offline and pods are not deleted from them.
 				if node.Status == volume.NodeOffline || node.Status == volume.NodeDegraded {
-					// Only ini
+					// Only initialize the map when it is absolutely necessary
 					if len(k8sNodeNameToNodeMap) == 0 {
 						k8sNodeNameToNodeMap, err = m.getK8sNodeNameToNodeMap()
 						if err != nil {

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -286,7 +286,7 @@ func (m *Monitor) cleanupDriverNodePods(node *volume.NodeInfo, k8sNode *v1.Node)
 		pods, err = storkcache.Instance().ListTransformedPods(k8sNode.Name)
 	} else {
 		log.Warnf("shared informer cache has not been initialized.")
-		pods, err = core.Instance().GetPods("", nil)
+		pods, err = core.Instance().GetPodsByNode(k8sNode.Name, "")
 	}
 	if err != nil {
 		log.Errorf("Error getting pods: %v", err)
@@ -466,7 +466,7 @@ func (m *Monitor) getVolumeDriverNodesToK8sNodeMap(driverNodes []*volume.NodeInf
 	for _, k8sNode := range k8sNodes.Items {
 		for _, driverNode := range driverNodes {
 			if m.isSameK8sNode(&k8sNode, driverNode) {
-				nodeMap[driverNode.StorageID] = &k8sNode
+				nodeMap[driverNode.StorageID] = k8sNode.DeepCopy()
 			}
 		}
 	}

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -5,6 +5,8 @@ package monitor
 
 import (
 	"fmt"
+	"math"
+	"strconv"
 	"testing"
 	"time"
 
@@ -17,11 +19,10 @@ import (
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/storage"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
-	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,6 +50,8 @@ var (
 	monitor                *Monitor
 	nodes                  *v1.NodeList
 	testNodeOfflineTimeout time.Duration
+	volumeDriver           *mockVolumeDriver.MockDriver
+	mockCtrl               *gomock.Controller
 )
 
 func TestMonitor(t *testing.T) {
@@ -58,17 +61,19 @@ func TestMonitor(t *testing.T) {
 	t.Run("testEvictedDriverPod", testEvictedDriverPod)
 	t.Run("testEvictedOtherDriverPod", testEvictedOtherDriverPod)
 	t.Run("testTempOfflineStorageNode", testTempOfflineStorageNode)
-	t.Run("testOfflineStorageNode", testOfflineStorageNode)
 	t.Run("testOfflineStorageNodeDuplicateIP", testOfflineStorageNodeDuplicateIP)
-	t.Run("testVolumeAttachmentCleanup", testVolumeAttachmentCleanup)
-	t.Run("testOfflineStorageNodeForCSIExtPod", testOfflineStorageNodeForCSIExtPod)
 	t.Run("testStorageDownNode", testStorageDownNode)
 	t.Run("teardown", teardown)
 }
 
+func TestMonitorOfflineNodes(t *testing.T) {
+	t.Run("testOfflineStorageNode", testOfflineStorageNode)
+	t.Run("testOfflineStorageNodeForCSIExtPod", testOfflineStorageNodeForCSIExtPod)
+}
+
 func TestMonitorMethods(t *testing.T) {
 	t.Run("testGetVolumeDriverNodesToK8sNodeMap", testGetVolumeDriverNodesToK8sNodeMap)
-	t.Run("testBatchDeleteOfPodsFromOfflineNodes", testBatchDeleteOfPodsFromOfflineNodes)
+	t.Run("testBatchDeletePodsFromOfflineNodes", testBatchDeletePodsFromOfflineNodes)
 }
 
 func setup(t *testing.T) {
@@ -152,6 +157,101 @@ func setup(t *testing.T) {
 func teardown(t *testing.T) {
 	err := monitor.Stop()
 	require.NoError(t, err, "Error stopping monitor")
+	prometheus.Unregister(HealthCounter)
+}
+
+func setupWithNewMockDriver(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	scheme := runtime.NewScheme()
+	err := stork_api.AddToScheme(scheme)
+	require.NoError(t, err, "Error adding stork scheme")
+
+	fakeStorkClient = fakeclient.NewSimpleClientset()
+	fakeKubeClient := kubernetes.NewSimpleClientset()
+	core.SetInstance(core.New(fakeKubeClient))
+	storage.SetInstance(storage.New(fakeKubeClient.StorageV1()))
+	storkops.SetInstance(storkops.New(fakeKubeClient, fakeStorkClient, nil))
+
+	storkdriver, err := volume.Get(mockDriverName)
+	require.NoError(t, err, "Error getting mock volume driver")
+
+	var ok bool
+	driver, ok = storkdriver.(*mock.Driver)
+	require.True(t, ok, "Error casting mockdriver")
+
+	err = storkdriver.Init(nil)
+	require.NoError(t, err, "Error initializing mock volume driver")
+
+	nodes = &v1.NodeList{}
+	nodes.Items = append(nodes.Items, *newNode(nodeForPod, nodeForPod, "192.168.0.1", "rack1", "", ""))
+	nodes.Items = append(nodes.Items, *newNode("node2.domain", "node2.domain", "192.168.0.2", "rack2", "", ""))
+	nodes.Items = append(nodes.Items, *newNode("node3.domain", "node3.domain", "192.168.0.3", "rack1", "", ""))
+	nodes.Items = append(nodes.Items, *newNode("node4.domain", "node4.domain", "192.168.0.4", "rack2", "", ""))
+	nodes.Items = append(nodes.Items, *newNode("node5.domain", "node5.domain", "192.168.0.5", "rack3", "", ""))
+	nodes.Items = append(nodes.Items, *newNode("node6.domain", "node6.domain", "192.168.0.1", "rack1", "", ""))
+
+	for _, n := range nodes.Items {
+		node, err := core.Instance().CreateNode(&n)
+		require.NoError(t, err, "failed to create fake node")
+		require.NotNil(t, node, "got nil node from create node api")
+	}
+
+	provNodes := []int{0, 1}
+	err = driver.CreateCluster(6, nodes)
+	require.NoError(t, err, "Error creating cluster")
+
+	err = driver.UpdateNodeIP(5, "192.168.0.1")
+	require.NoError(t, err, "Error updating node IP")
+	err = driver.UpdateNodeStatus(5, volume.NodeOffline)
+	require.NoError(t, err, "Error setting node status to Offline")
+
+	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil, false, false, "")
+	require.NoError(t, err, "Error provisioning volume")
+
+	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil, false, false, "")
+	require.NoError(t, err, "Error provisioning volume")
+
+	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil, false, false, "")
+	require.NoError(t, err, "Error provisioning volume")
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: corev1.New(fakeKubeClient.CoreV1().RESTClient()).Events("")})
+	recorder := eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{Component: "storktest"})
+
+	monitor = &Monitor{
+		Driver:      storkdriver,
+		IntervalSec: 30,
+		Recorder:    recorder,
+	}
+
+	mockCtrl = gomock.NewController(t)
+	volumeDriver = mockVolumeDriver.NewMockDriver(mockCtrl)
+
+	driverNodes := getDriverNodes(len(nodes.Items))
+	volumeDriver.EXPECT().GetNodes().Return(driverNodes, nil).Times(1)
+
+	monitor.Driver = volumeDriver
+
+	// overwrite the backoff timers to speed up the tests
+	// this accounts to a backoff of 1 min
+	nodeWaitCallBackoff = wait.Backoff{
+		Duration: initialNodeWaitDelay,
+		Factor:   1,
+		Steps:    nodeWaitSteps,
+	}
+	// 30 (interval)  + 60 (backoff) + 5 (buffer)
+	testNodeOfflineTimeout = 95 * time.Second
+
+	err = monitor.Start()
+	require.NoError(t, err, "failed to start monitor")
+}
+
+func teardownWithNewMockDriver(t *testing.T) {
+	mockCtrl.Finish()
+	err := monitor.Stop()
+	require.NoError(t, err, "Error stopping monitor")
+	//monitor = nil
+	prometheus.Unregister(HealthCounter)
 }
 
 func testUnknownDriverPod(t *testing.T) {
@@ -295,6 +395,11 @@ func newNode(name, hostname, ip, rack, zone, region string) *v1.Node {
 }
 
 func testOfflineStorageNode(t *testing.T) {
+
+	setupWithNewMockDriver(t)
+
+	defer teardownWithNewMockDriver(t)
+
 	pod := newPod("driverPod", []string{driverVolumeName})
 	_, err := core.Instance().CreatePod(pod)
 	require.NoError(t, err, "failed to create pod")
@@ -303,13 +408,24 @@ func testOfflineStorageNode(t *testing.T) {
 	_, err = core.Instance().CreatePod(noStoragePod)
 	require.NoError(t, err, "failed to create pod")
 
-	err = driver.UpdateNodeStatus(0, volume.NodeOffline)
-	require.NoError(t, err, "Error setting node status to Offline")
-	defer func() {
-		err = driver.UpdateNodeStatus(0, volume.NodeOnline)
-		require.NoError(t, err, "Error setting node status to Online")
-	}()
+	driverNodes := getDriverNodes(len(nodes.Items))
+	driverNodes[0].Status = volume.NodeOffline
+	volumeDriver.EXPECT().GetNodes().Return(driverNodes, nil).AnyTimes()
+	volumes := []*volume.Info{
+		{
+			VolumeName: "volume1",
+			DataNodes:  []string{driverNodes[0].StorageID},
+		},
+	}
 
+	wffcVolumes := make([]*volume.Info, 0)
+
+	volumeDriver.EXPECT().InspectNode("node1").Return(driverNodes[0], nil).AnyTimes()
+	volumeDriver.EXPECT().GetCSIPodPrefix().Return("px-csi-ext-", nil).AnyTimes()
+	volumeDriver.EXPECT().GetPodVolumes(&pod.Spec, pod.Namespace, false).Return(volumes, wffcVolumes, nil).AnyTimes()
+	volumeDriver.EXPECT().GetPodVolumes(&noStoragePod.Spec, noStoragePod.Namespace, false).Return(wffcVolumes, wffcVolumes, nil).AnyTimes()
+
+	testNodeOfflineTimeout = 95 * time.Second
 	time.Sleep(testNodeOfflineTimeout)
 	_, err = core.Instance().GetPodByName(pod.Name, "")
 	require.Error(t, err, "expected error from get pod as pod should be deleted")
@@ -371,171 +487,22 @@ func testOfflineStorageNodeDuplicateIP(t *testing.T) {
 	require.NoError(t, err, "expected no error from get pod as pod should not be deleted")
 }
 
-func testVolumeAttachmentCleanup(t *testing.T) {
-	onlineNodeID := 1
-	offlineNodeID := 2
-	podsUnknownNodeID := 3
-	nodeToKeepOnline := nodes.Items[onlineNodeID].Name
-	nodeToTakeOffline := nodes.Items[offlineNodeID].Name
-	nodeToPutUnknownPodsOn := nodes.Items[podsUnknownNodeID].Name
-
-	// Create PVC and PV for all test volumes.
-	for _, volumeName := range []string{driverVolumeName, attachmentVolumeName, unknownPodsVolumeName} {
-		_, err := core.Instance().CreatePersistentVolumeClaim(&v1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      volumeName,
-				Namespace: defaultNamespace,
-			},
-		})
-		require.NoError(t, err, "failed to create pv for %s", volumeName)
-		_, err = core.Instance().CreatePersistentVolume(&v1.PersistentVolume{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      volumeName,
-				Namespace: "",
-			},
-			Spec: v1.PersistentVolumeSpec{
-				ClaimRef: &v1.ObjectReference{
-					Name:      volumeName,
-					Namespace: defaultNamespace,
-				},
-			},
-		})
-		require.NoError(t, err, "failed to create pvc for %s", volumeName)
-	}
-
-	// Create multiple pods on different nodes, some with volumeattachments, some without.
-	// Stop the driver on the node with the attachment and make sure only that pod and volumeattachment are deleted.
-
-	// Create two pods on node N1 that will remain healthy. One attached, one not.
-	healthyPodAttached := newPod("testVolumeAttachmentCleanupHealtyAttached", []string{driverVolumeName})
-	healthyPodAttached.Spec.NodeName = nodeToKeepOnline
-	_, err := core.Instance().CreatePod(healthyPodAttached)
-	require.NoError(t, err, "failed to create healthy attached pod")
-	_, err = storage.Instance().CreateVolumeAttachment(&storagev1.VolumeAttachment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "va-healthy",
-		},
-		Spec: storagev1.VolumeAttachmentSpec{
-			NodeName: nodeToKeepOnline,
-			Source: storagev1.VolumeAttachmentSource{
-				PersistentVolumeName: &driverVolumeName,
-			},
-		},
-	})
-	require.NoError(t, err, "failed to create healthy pod volume attachment")
-
-	healthyPodDetached := newPod("testVolumeAttachmentCleanupHealthyDetached", []string{driverVolumeName})
-	healthyPodDetached.Spec.NodeName = nodeToKeepOnline
-	_, err = core.Instance().CreatePod(healthyPodDetached)
-	require.NoError(t, err, "failed to create healthy detached pod")
-
-	// Create two pods on node N2 that will be taken offline temporarily. One attached, one not.
-	unhealthyPodAttached := newPod("testVolumeAttachmentCleanupUnheathyAttached", []string{attachmentVolumeName})
-	unhealthyPodAttached.Spec.NodeName = nodeToTakeOffline
-	_, err = core.Instance().CreatePod(unhealthyPodAttached)
-	require.NoError(t, err, "failed to create pod")
-	_, err = storage.Instance().CreateVolumeAttachment(&storagev1.VolumeAttachment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "va-unhealthy",
-		},
-		Spec: storagev1.VolumeAttachmentSpec{
-			NodeName: nodeToTakeOffline,
-			Source: storagev1.VolumeAttachmentSource{
-				PersistentVolumeName: &attachmentVolumeName,
-			},
-		},
-	})
-	require.NoError(t, err, "failed to create unhealthy pod volume attachment")
-
-	unhealthyPodDetached := newPod("testVolumeAttachmentCleanupUnheathyDetached", []string{attachmentVolumeName})
-	unhealthyPodDetached.Spec.NodeName = nodeToTakeOffline
-	_, err = core.Instance().CreatePod(unhealthyPodDetached)
-	require.NoError(t, err, "failed to create pod")
-
-	// Create two pods on node N3 that will have unknown state. One attached, one not.
-	unknownPodAttached := newPod("testVolumeAttachmentCleanupUnknownPodAttached", []string{unknownPodsVolumeName})
-	unknownPodAttached.Spec.NodeName = nodeToPutUnknownPodsOn
-	unknownPodAttached.Status = v1.PodStatus{
-		Reason: node.NodeUnreachablePodReason,
-	}
-	_, err = core.Instance().CreatePod(unknownPodAttached)
-	require.NoError(t, err, "failed to create pod")
-	_, err = storage.Instance().CreateVolumeAttachment(&storagev1.VolumeAttachment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "va-unknown",
-		},
-		Spec: storagev1.VolumeAttachmentSpec{
-			NodeName: nodeToPutUnknownPodsOn,
-			Source: storagev1.VolumeAttachmentSource{
-				PersistentVolumeName: &unknownPodsVolumeName,
-			},
-		},
-	})
-	require.NoError(t, err, "failed to create unknown pod volume attachment")
-
-	unknownPodDetached := newPod("testVolumeAttachmentCleanupUnknownPodDetached", []string{unknownPodsVolumeName})
-	unknownPodDetached.Spec.NodeName = nodeToPutUnknownPodsOn
-	unknownPodDetached.Status = v1.PodStatus{
-		Reason: node.NodeUnreachablePodReason,
-	}
-	_, err = core.Instance().CreatePod(unknownPodDetached)
-	require.NoError(t, err, "failed to create unknown detached pod")
-
-	// Kill N2
-	err = driver.UpdateNodeStatus(offlineNodeID, volume.NodeOffline)
-	require.NoError(t, err, "Error setting node status to Offline")
-	defer func() {
-		err = driver.UpdateNodeStatus(offlineNodeID, volume.NodeOnline)
-		require.NoError(t, err, "Error setting node status to Online")
-	}()
-
-	// VolumeAttachments (VA) for N2 and N3 should be deleted, but VA for N1 should remain.
-	time.Sleep(testNodeOfflineTimeout)
-
-	vaList, err := storage.Instance().ListVolumeAttachments()
-	require.NoError(t, err, "expected no error from list vol attachments")
-
-	// There should be exactly one attachment left - the healthy one.
-	require.Equal(t, 1, len(vaList.Items))
-	require.Equal(t, "va-healthy", vaList.Items[0].Name)
-
-	// Healthy pods should remain
-	_, err = core.Instance().GetPodByName(healthyPodAttached.Name, "")
-	require.NoError(t, err, "expected no error from get pod as pod should not be deleted")
-
-	_, err = core.Instance().GetPodByName(healthyPodDetached.Name, "")
-	require.NoError(t, err, "expected no error from get pod as pod should not be deleted")
-
-	// Unhealthy pods should be deleted.
-	_, err = core.Instance().GetPodByName(unhealthyPodAttached.Name, "")
-	require.Error(t, err, "expected error from get pod as pod should be deleted")
-
-	_, err = core.Instance().GetPodByName(unhealthyPodDetached.Name, "")
-	require.Error(t, err, "expected error from get pod as pod should be deleted")
-
-	// Unknown pods should be deleted.
-	_, err = core.Instance().GetPodByName(unknownPodAttached.Name, "")
-	require.Error(t, err, "expected error from get pod as pod should be deleted")
-
-	_, err = core.Instance().GetPodByName(unknownPodDetached.Name, "")
-	require.Error(t, err, "expected error from get pod as pod should be deleted")
-
-	// total pods rescheduled during UT's
-	require.Equal(t, testutil.ToFloat64(HealthCounter), float64(8), "pods_reschduled_total not matched")
-}
-
 func testOfflineStorageNodeForCSIExtPod(t *testing.T) {
+	setupWithNewMockDriver(t)
+
+	defer teardownWithNewMockDriver(t)
+
 	pod := newPod("px-csi-ext-foo", nil)
 	_, err := core.Instance().CreatePod(pod)
 	require.NoError(t, err, "failed to create pod")
 
-	err = driver.UpdateNodeStatus(0, volume.NodeOffline)
-	require.NoError(t, err, "Error setting node status to Offline")
-	defer func() {
-		err = driver.UpdateNodeStatus(0, volume.NodeOnline)
-		require.NoError(t, err, "Error setting node status to Online")
-	}()
+	driverNodes := getDriverNodes(len(nodes.Items))
+	driverNodes[0].Status = volume.NodeOffline
+	volumeDriver.EXPECT().GetNodes().Return(driverNodes, nil).AnyTimes()
+	volumeDriver.EXPECT().InspectNode("node1").Return(driverNodes[0], nil).AnyTimes()
+	volumeDriver.EXPECT().GetCSIPodPrefix().Return("px-csi-ext-", nil).AnyTimes()
 
+	testNodeOfflineTimeout = 95 * time.Second
 	time.Sleep(testNodeOfflineTimeout)
 	_, err = core.Instance().GetPodByName(pod.Name, "")
 	require.Error(t, err, "expected error from get pod as pod should be deleted")
@@ -610,7 +577,7 @@ func testGetVolumeDriverNodesToK8sNodeMap(t *testing.T) {
 	}
 }
 
-func testBatchDeleteOfPodsFromOfflineNodes(t *testing.T) {
+func testBatchDeletePodsFromOfflineNodes(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	scheme := runtime.NewScheme()
 	err := stork_api.AddToScheme(scheme)
@@ -650,7 +617,7 @@ func testBatchDeleteOfPodsFromOfflineNodes(t *testing.T) {
 		require.NotNil(t, node, "got nil node from create node api")
 	}
 
-	// Test the batchDeleteOfPodsFromOfflineNodes function for different number of pods per node
+	// Test the batchDeletePodsFromOfflineNodes function for different number of pods per node
 	node := &volume.NodeInfo{
 		Hostname:    "node1.domain",
 		SchedulerID: "node1",
@@ -677,10 +644,10 @@ func testBatchDeleteOfPodsFromOfflineNodes(t *testing.T) {
 		recorder := eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{Component: "storktest"})
 		monitor.Recorder = recorder
 
-		mockVolumeDriver.EXPECT().InspectNode("storage1").Return(node, nil).Times(1)
+		mockVolumeDriver.EXPECT().InspectNode("storage1").Return(node, nil).Times(int(math.Ceil(float64(podsPerNode) / float64(podDeleteBatchSize))))
 
-		// Call the batchDeleteOfPodsFromOfflineNodes function
-		monitor.batchDeleteOfPodsFromOfflineNodes(nodeToPodsMap["node1"], node, false)
+		// Call the batchDeletePodsFromOfflineNodes function
+		monitor.batchDeletePodsFromOfflineNodes(nodeToPodsMap["node1"], node, false)
 
 		// Check that all the pods running in node1 which is the offline node have been deleted
 		// Since FakeClient does not support FieldSelector (it's a limitation of fake client), better to get all pods
@@ -702,7 +669,7 @@ func testBatchDeleteOfPodsFromOfflineNodes(t *testing.T) {
 
 	}
 
-	// Test the batchDeleteOfPodsFromOfflineNodes function when node status is not offline anymore
+	// Test the batchDeletePodsFromOfflineNodes function when node status is not offline anymore
 	node = &volume.NodeInfo{
 		Hostname:    "node1.domain",
 		SchedulerID: "node1",
@@ -728,10 +695,11 @@ func testBatchDeleteOfPodsFromOfflineNodes(t *testing.T) {
 	recorder := eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{Component: "storktest"})
 	monitor.Recorder = recorder
 
+	//mockVolumeDriver.EXPECT().InspectNode("storage1").Return(node, nil).Times(int(math.Ceil(float64(podsPerNode)/float64(podDeleteBatchSize))))
 	mockVolumeDriver.EXPECT().InspectNode("storage1").Return(node, nil).Times(1)
 
-	// Call the batchDeleteOfPodsFromOfflineNodes function
-	monitor.batchDeleteOfPodsFromOfflineNodes(nodeToPodsMap["node1"], node, false)
+	// Call the batchDeletePodsFromOfflineNodes function
+	monitor.batchDeletePodsFromOfflineNodes(nodeToPodsMap["node1"], node, false)
 
 	// Check that all the pods running in node1 which is the offline node have been deleted
 	// Since FakeClient does not support FieldSelector (it's a limitation of fake client), better to get all pods
@@ -777,4 +745,18 @@ func createPodsOnNodes(t *testing.T, nodes []string, podCountPerNode int) map[st
 		}
 	}
 	return pods
+}
+
+func getDriverNodes(numNodes int) []*volume.NodeInfo {
+	driverNodes := make([]*volume.NodeInfo, 0)
+	for i := 0; i < numNodes; i++ {
+		driverNodes = append(driverNodes, &volume.NodeInfo{
+			Hostname:    "node" + strconv.Itoa(i+1),
+			SchedulerID: "node" + strconv.Itoa(i+1),
+			StorageID:   "node" + strconv.Itoa(i+1),
+			Status:      volume.NodeOnline,
+			RawStatus:   "Ready",
+		})
+	}
+	return driverNodes
 }


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
1. Filtering pods wrt node instead of getting all pods to work on and looping on those to filter out the pods running in offline node.
2. Batch delete of pods in a batch of 5.
3. Do a fresh check of node status before issuing batch delete.
4. Indexing spec.nodeName in informercache to filter out pods running on a node.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
TBD
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
no

**Test**:
UTs - 2 tests from current UT are failing as these need proper mocking of driver.InspectNode() . Will push the fix.

Manual test : 

pods running a node 
```
➜  stork git:(PWX-38468) ✗ kubectl get pods --all-namespaces --field-selector spec.nodeName=ip-10-13-193-24.pwx.purestorage.com
NAMESPACE     NAME                                              READY   STATUS    RESTARTS       AGE
busy-10       busybox-deployment-6dcd7756f9-7q5r6               1/1     Running   0              25m
busy-14       busybox-deployment-6dcd7756f9-ghz9f               1/1     Running   0              25m
busy-16       busybox-deployment-6dcd7756f9-sqdnm               1/1     Running   0              41m
busy-2        busybox-deployment-6dcd7756f9-w7v7r               1/1     Running   0              25m
busy-20       busybox-deployment-654cf6f86f-zf9r2               1/1     Running   0              25m
busy-4        busybox-deployment-6dcd7756f9-zqrm7               1/1     Running   0              25m
busy-6        busybox-deployment-6dcd7756f9-z2nnz               1/1     Running   0              41m
busy-7        busybox-deployment-6dcd7756f9-bkwt9               1/1     Running   0              25m
es            elasticsearch-data-0                              1/1     Running   0              55d
es            elasticsearch-data-2                              1/1     Running   0              21d
kube-system   calico-node-n62mj                                 1/1     Running   32 (76d ago)   155d
kube-system   coredns-69766b66b-2zlsr                           1/1     Running   0              69d
kube-system   kube-proxy-jprg2                                  1/1     Running   1              155d
kube-system   local-px-int-njs5q                                1/1     Running   5 (55m ago)    70d
kube-system   nginx-proxy-ip-10-13-193-24.pwx.purestorage.com   1/1     Running   1 (76d ago)    155d
kube-system   nodelocaldns-7pm2x                                1/1     Running   1              155d
kube-system   portworx-api-kks4x                                2/2     Running   0              70d
kube-system   portworx-kvdb-cjjpx                               1/1     Running   6 (55m ago)    155d
kube-system   px-csi-ext-6c89d5d4f4-7d6fs                       4/4     Running   0              34d
kube-system   stork-996664894-2xdf9                             1/1     Running   0              4m45s
kube-system   stork-scheduler-7d5579975-5zrdc                   1/1     Running   0              34d
mysql         mysql-6d9f9d7947-b9t9l                            1/1     Running   0              68d
mysql5        mysql-6b89f6b6d4-qlxv8                            1/1     Running   0              55d
mysql8        mysql-bb9686cdb-qz7mh                             1/1     Running   0              68d
```

After stopping px on that node, the drivermonitor picked up and started deleting the pods
```
➜  ~ ks logs stork-996664894-6bwnq | grep -i "Deleting pod from node"
time="2024-08-21T11:32:25Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=busy-16 PodName=busybox-deployment-6dcd7756f9-sqdnm
time="2024-08-21T11:32:25Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=busy-6 PodName=busybox-deployment-6dcd7756f9-z2nnz
time="2024-08-21T11:32:25Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=es PodName=elasticsearch-data-0
time="2024-08-21T11:32:25Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=mysql PodName=mysql-6d9f9d7947-b9t9l
time="2024-08-21T11:32:25Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=mysql5 PodName=mysql-6b89f6b6d4-qlxv8
time="2024-08-21T11:32:27Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=busy-10 PodName=busybox-deployment-6dcd7756f9-7q5r6
time="2024-08-21T11:32:27Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=busy-4 PodName=busybox-deployment-6dcd7756f9-zqrm7
time="2024-08-21T11:32:27Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=es PodName=elasticsearch-data-2
time="2024-08-21T11:32:27Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=mysql8 PodName=mysql-bb9686cdb-qz7mh
time="2024-08-21T11:32:27Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=busy-2 PodName=busybox-deployment-6dcd7756f9-w7v7r
time="2024-08-21T11:32:30Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=busy-14 PodName=busybox-deployment-6dcd7756f9-ghz9f
time="2024-08-21T11:32:30Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=busy-20 PodName=busybox-deployment-654cf6f86f-zf9r2
time="2024-08-21T11:32:30Z" level=info msg="Deleting Pod from Node ip-10-13-193-24.pwx.purestorage.com due to volume driver status: Offline (STATUS_OFFLINE)" Namespace=busy-7 PodName=busybox-deployment-6dcd7756f9-bkwt9

```
After pods using px volumes got evicted from the offline node 
```
➜  stork git:(PWX-38468) ✗ kubectl get pods --all-namespaces --field-selector spec.nodeName=ip-10-13-193-24.pwx.purestorage.com
NAMESPACE     NAME                                              READY   STATUS    RESTARTS       AGE
kube-system   calico-node-n62mj                                 1/1     Running   32 (76d ago)   155d
kube-system   coredns-69766b66b-2zlsr                           1/1     Running   0              69d
kube-system   kube-proxy-jprg2                                  1/1     Running   1              155d
kube-system   local-px-int-njs5q                                0/1     Running   6 (2m4s ago)   70d
kube-system   nginx-proxy-ip-10-13-193-24.pwx.purestorage.com   1/1     Running   1 (76d ago)    155d
kube-system   nodelocaldns-7pm2x                                1/1     Running   1              155d
kube-system   portworx-api-kks4x                                1/2     Running   0              70d
kube-system   portworx-kvdb-cjjpx                               0/1     Running   7 (101s ago)   155d
kube-system   stork-996664894-2xdf9                             1/1     Running   0              17m
kube-system   stork-scheduler-7d5579975-5zrdc                   1/1     Running   0              34d
```

**UT**:
```
➜  stork git:(PWX-38468) ✗ /usr/local/go/bin/go test -timeout 1200s -tags unittest,integrationtest  github.com/libopenstorage/stork/pkg/monitor
ok  	github.com/libopenstorage/stork/pkg/monitor	663.688s

Removing testVolumeAttachmentCleanup UT as it is not working.
      1. With existing mocking, the function can only give a fixed output but need dynamic output for InspectNode output
      2. With MockDriver, GetPodsByNode is not giving the desired output as the fieldselector does not work with mockdriver

```
