### PR TITLE
PB-7578: perform the volume status retrieval in batches

### DIFF
--- a/drivers/volume/aws/aws.go
+++ b/drivers/volume/aws/aws.go
@@ -326,13 +326,11 @@ func (a *aws) getFiltersFromMap(filters map[string]string) []*ec2.Filter {
 	return tagFilters
 }
 
-func (a *aws) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
+func (a *aws) GetBackupStatus(backup *storkapi.ApplicationBackup) error {
 	client, err := a.getAWSClient(backup.Spec.BackupLocation, backup.Namespace)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 
 	for _, vInfo := range backup.Status.Volumes {
 		if vInfo.DriverName != storkvolume.AWSDriverName {
@@ -340,7 +338,7 @@ func (a *aws) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 		}
 		snapshot, err := a.getEBSSnapshot(vInfo.BackupID, nil, client)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		switch *snapshot.State {
 		case "pending":
@@ -356,10 +354,8 @@ func (a *aws) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.A
 			vInfo.TotalSize = uint64(*snapshot.VolumeSize) * units.GiB
 			vInfo.ActualSize = uint64(*snapshot.VolumeSize) * units.GiB
 		}
-		volumeInfos = append(volumeInfos, vInfo)
 	}
-	return volumeInfos, nil
-
+	return nil
 }
 
 func (a *aws) CancelBackup(backup *storkapi.ApplicationBackup) error {

--- a/drivers/volume/azure/azure.go
+++ b/drivers/volume/azure/azure.go
@@ -342,14 +342,12 @@ func (a *azure) StartBackup(
 	return volumeInfos, nil
 }
 
-func (a *azure) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
+func (a *azure) GetBackupStatus(backup *storkapi.ApplicationBackup) error {
 	azureSession, err := a.getAzureSession(backup.Spec.BackupLocation, backup.Namespace)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	snapshotClient := azureSession.snapshotClient
-
-	volumeInfos := make([]*storkapi.ApplicationBackupVolumeInfo, 0)
 
 	for _, vInfo := range backup.Status.Volumes {
 		if vInfo.DriverName != storkvolume.AzureDriverName {
@@ -357,7 +355,7 @@ func (a *azure) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi
 		}
 		snapshot, err := snapshotClient.Get(context.TODO(), a.resourceGroup, vInfo.BackupID)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		switch *snapshot.ProvisioningState {
 		case "Failed":
@@ -372,10 +370,9 @@ func (a *azure) GetBackupStatus(backup *storkapi.ApplicationBackup) ([]*storkapi
 			vInfo.Status = storkapi.ApplicationBackupStatusInProgress
 			vInfo.Reason = fmt.Sprintf("Volume backup in progress: %v", snapshot.ProvisioningState)
 		}
-		volumeInfos = append(volumeInfos, vInfo)
 	}
 
-	return volumeInfos, nil
+	return nil
 
 }
 

--- a/drivers/volume/mock/volume/driver.mock.go
+++ b/drivers/volume/mock/volume/driver.mock.go
@@ -270,12 +270,11 @@ func (mr *MockDriverMockRecorder) Failover(arg0 interface{}) *gomock.Call {
 }
 
 // GetBackupStatus mocks base method.
-func (m *MockDriver) GetBackupStatus(arg0 *v1alpha1.ApplicationBackup) ([]*v1alpha1.ApplicationBackupVolumeInfo, error) {
+func (m *MockDriver) GetBackupStatus(arg0 *v1alpha1.ApplicationBackup) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupStatus", arg0)
-	ret0, _ := ret[0].([]*v1alpha1.ApplicationBackupVolumeInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // GetBackupStatus indicates an expected call of GetBackupStatus.

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -217,7 +217,7 @@ type BackupRestorePluginInterface interface {
 	StartBackup(*storkapi.ApplicationBackup, []v1.PersistentVolumeClaim) ([]*storkapi.ApplicationBackupVolumeInfo, error)
 	// GetBackupStatus Get the status of backup of the volumes specified in the status
 	// for the backup spec
-	GetBackupStatus(*storkapi.ApplicationBackup) ([]*storkapi.ApplicationBackupVolumeInfo, error)
+	GetBackupStatus(*storkapi.ApplicationBackup) error
 	// CancelBackup Cancel the backup of volumes specified in the status
 	CancelBackup(*storkapi.ApplicationBackup) error
 	// CleanupBackupResources the backup of resource specified backup
@@ -531,8 +531,8 @@ func (b *BackupRestoreNotSupported) StartBackup(
 }
 
 // GetBackupStatus returns ErrNotSupported
-func (b *BackupRestoreNotSupported) GetBackupStatus(*storkapi.ApplicationBackup) ([]*storkapi.ApplicationBackupVolumeInfo, error) {
-	return nil, &errors.ErrNotSupported{}
+func (b *BackupRestoreNotSupported) GetBackupStatus(*storkapi.ApplicationBackup) error {
+	return nil
 }
 
 // CancelBackup returns ErrNotSupported

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -67,34 +67,36 @@ const (
 	nsObjectName       = "namespaces.json"
 	metadataObjectName = "metadata.json"
 
-	allNamespacesSpecifier          = "*"
-	backupVolumeBatchCountEnvVar    = "BACKUP-VOLUME-BATCH-COUNT"
-	defaultBackupVolumeBatchCount   = 3
-	backupResourcesBatchCount       = 15
-	maxRetry                        = 10
-	retrySleep                      = 10 * time.Second
-	genericBackupKey                = "BACKUP_TYPE"
-	kdmpDriverOnly                  = "kdmp"
-	nonKdmpDriverOnly               = "nonkdmp"
-	mixedDriver                     = "mixed"
-	oneMBSizeBytes                  = 1 << (10 * 2)
-	prefixBackup                    = "backup"
-	prefixRestore                   = "restore"
-	applicationBackupCRNameKey      = kdmpAnnotationPrefix + "applicationbackup-cr-name"
-	applicationRestoreCRNameKey     = kdmpAnnotationPrefix + "applicationrestore-cr-name"
-	applicationBackupCRUIDKey       = kdmpAnnotationPrefix + "applicationbackup-cr-uid"
-	applicationRestoreCRUIDKey      = kdmpAnnotationPrefix + "applicationrestore-cr-uid"
-	kdmpAnnotationPrefix            = "kdmp.portworx.com/"
-	pxbackupAnnotationCreateByKey   = pxbackupAnnotationPrefix + "created-by"
-	pxbackupAnnotationCreateByValue = "px-backup"
-	backupObjectNameKey             = kdmpAnnotationPrefix + "backupobject-name"
-	restoreObjectNameKey            = kdmpAnnotationPrefix + "restoreobject-name"
-	pxbackupObjectUIDKey            = pxbackupAnnotationPrefix + "backup-uid"
-	pxbackupAnnotationPrefix        = "portworx.io/"
-	pxbackupObjectNameKey           = pxbackupAnnotationPrefix + "backup-name"
-	backupObjectUIDKey              = kdmpAnnotationPrefix + "backupobject-uid"
-	restoreObjectUIDKey             = kdmpAnnotationPrefix + "restoreobject-uid"
-	skipResourceAnnotation          = "stork.libopenstorage.org/skip-resource"
+	allNamespacesSpecifier           = "*"
+	backupVolumeBatchCountEnvVar     = "BACKUP-VOLUME-BATCH-COUNT"
+	getBackupStatusBatchCountEnvVar  = "GET-BACKUP-STATUS-BATCH-COUNT"
+	defaultBackupVolumeBatchCount    = 3
+	defaultGetBackupStatusBatchCount = 100
+	backupResourcesBatchCount        = 15
+	maxRetry                         = 10
+	retrySleep                       = 10 * time.Second
+	genericBackupKey                 = "BACKUP_TYPE"
+	kdmpDriverOnly                   = "kdmp"
+	nonKdmpDriverOnly                = "nonkdmp"
+	mixedDriver                      = "mixed"
+	oneMBSizeBytes                   = 1 << (10 * 2)
+	prefixBackup                     = "backup"
+	prefixRestore                    = "restore"
+	applicationBackupCRNameKey       = kdmpAnnotationPrefix + "applicationbackup-cr-name"
+	applicationRestoreCRNameKey      = kdmpAnnotationPrefix + "applicationrestore-cr-name"
+	applicationBackupCRUIDKey        = kdmpAnnotationPrefix + "applicationbackup-cr-uid"
+	applicationRestoreCRUIDKey       = kdmpAnnotationPrefix + "applicationrestore-cr-uid"
+	kdmpAnnotationPrefix             = "kdmp.portworx.com/"
+	pxbackupAnnotationCreateByKey    = pxbackupAnnotationPrefix + "created-by"
+	pxbackupAnnotationCreateByValue  = "px-backup"
+	backupObjectNameKey              = kdmpAnnotationPrefix + "backupobject-name"
+	restoreObjectNameKey             = kdmpAnnotationPrefix + "restoreobject-name"
+	pxbackupObjectUIDKey             = pxbackupAnnotationPrefix + "backup-uid"
+	pxbackupAnnotationPrefix         = "portworx.io/"
+	pxbackupObjectNameKey            = pxbackupAnnotationPrefix + "backup-name"
+	backupObjectUIDKey               = kdmpAnnotationPrefix + "backupobject-uid"
+	restoreObjectUIDKey              = kdmpAnnotationPrefix + "restoreobject-uid"
+	skipResourceAnnotation           = "stork.libopenstorage.org/skip-resource"
 	//VmFreezePrefix prefix for freeze rule action
 	vmFreezePrefix = "vm-freeze-pre-rule"
 	//VmUnFreezePrefix prefix for freeze rule action
@@ -976,12 +978,12 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 				return fmt.Errorf("error getting volume driver name: %v", err)
 			}
 			if driverName == volume.PortworxDriverName {
-				volumeInfos, err := driver.GetBackupStatus(backup)
+				batchCount := getBatchCountForGetBackupStatus()
+				err := a.getAndUpdateBackupStatusInBatches(backup, driver, driverName, batchCount)
 				if err != nil {
-					logrus.Errorf("error getting backup status: %v", err)
 					return err
 				}
-				for _, volInfo := range volumeInfos {
+				for _, volInfo := range backup.Status.Volumes {
 					if volInfo.Status == stork_api.ApplicationBackupStatusFailed {
 						continue
 					}
@@ -1046,7 +1048,7 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 		// Skip checking status if no volumes are being backed up
 		if len(backup.Status.Volumes) != 0 {
 			drivers := a.getDriversForBackup(backup)
-			volumeInfos := make([]*stork_api.ApplicationBackupVolumeInfo, 0)
+			batchCount := getBatchCountForGetBackupStatus()
 			for driverName := range drivers {
 				driver, err := volume.Get(driverName)
 				if err != nil {
@@ -1057,15 +1059,11 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 					logrus.Debugf("skipping driver %v for status check", driverName)
 					continue
 				}
-				status, err := driver.GetBackupStatus(backup)
+				err = a.getAndUpdateBackupStatusInBatches(backup, driver, driverName, batchCount)
 				if err != nil {
-					log.ApplicationBackupLog(backup).Errorf("failed to get vol status fro driver %v: %v", driverName, err)
 					return err
 				}
-				volumeInfos = append(volumeInfos, status...)
 			}
-			backup.Status.Volumes = volumeInfos
-
 			// As part of partial success volumeInfos is already available, just update the same to backup CR
 			err = a.client.Update(context.TODO(), backup)
 			if err != nil {
@@ -2778,4 +2776,43 @@ func handleLargeResourceError(a *ApplicationBackupController, backup *stork_api.
 			break
 		}
 	}
+}
+
+func getBatchCountForGetBackupStatus() int {
+	if envValue := os.Getenv(getBackupStatusBatchCountEnvVar); len(envValue) != 0 {
+		batchCount, err := strconv.Atoi(envValue)
+		if err != nil {
+			return defaultGetBackupStatusBatchCount
+		}
+		return batchCount
+	}
+	return defaultGetBackupStatusBatchCount
+}
+
+// getAndUpdateBackupStatusInBatches - fetches the backup status of volumes in batches.
+// Additionally, it updates the backup CR for each batch to prevent backup timeouts in px-backup
+func (a *ApplicationBackupController) getAndUpdateBackupStatusInBatches(
+	backup *stork_api.ApplicationBackup,
+	driver volume.Driver,
+	driverName string,
+	batchCount int,
+) error {
+	volumes := backup.Status.Volumes
+	// Fetch the status of the volumes in batches
+	for i := 0; i < len(volumes); i += batchCount {
+		end := min(i+batchCount, len(volumes))
+		backup.Status.Volumes = volumes[i:end]
+		err := driver.GetBackupStatus(backup)
+		if err != nil {
+			log.ApplicationBackupLog(backup).Errorf("failed to get volume status for driver %v: %v", driverName, err)
+			return err
+		}
+		backup.Status.LastUpdateTimestamp = metav1.Now()
+		backup.Status.Volumes = volumes
+		err = a.client.Update(context.TODO(), backup)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
>improvement


**What this PR does / why we need it**: This PR contains the changes for performing the volume status retrieval in batches . Avoids timeout issue caused in px-backup in case of backups dealing with large number of volumes (in scale)


**Does this PR change a user-facing CRD or CLI?**:
No


testing : 
![Screenshot from 2024-09-02 19-15-32](https://github.com/user-attachments/assets/2c41b161-ae00-4cf7-89cb-e02131b8dc66)


