### PR TITLE
pb-7944: In the backupResources(), not returning  the reconciler cycle, after checking and updating the largeResource flag in the backup CR.

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -2061,7 +2061,6 @@ func (a *ApplicationBackupController) backupResources(
 		if err != nil {
 			return err
 		}
-		return nil
 	}
 	// Do any additional preparation for the resources if required
 	if err = a.prepareResources(backup, allObjects); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug


**What this PR does / why we need it**:
```
1) We we exit the reconciler cycle after determining the largeResource status and updating the largeResource flag in the applicationBackup CR.
2) When the control re-enter again, we again fetch all the resources with GetResources and proceed with the upload resource step.
3) In the case of large resource, it doubles up the backup completion time.
```

**Does this PR change a user-facing CRD or CLI?**:
no.

**Is a release note needed?**:
```release-note
Issue: In the case of large resource, the resources fetched twice, which increase the backup completion time.
User Impact: Large resource Backup takes longer time.
Resolution: Avoid the double fetch and uploading resources in the same reconciler context.

```

**Does this change need to be cherry-picked to a release branch?**:
24.4.1

**Testing:**
1) Validated the large resource with and without fix for 750 Namespace and 91629 CM resources
Without fix: 71 mint
With fix: 42 mint.
2) Also validated that update command return updated  CR content:
```
time="2024-08-26T07:37:52Z" level=info msg="sivakumar --- before CR content &{TypeMeta:{Kind:ApplicationBackup APIVersion:stork.libopenstorage.org/v1alpha1} ObjectMeta:{Name:xxxx-1-67d0014 GenerateName: Namespace:siva-1 SelfLink: UID:e803bbd6-3ceb-4797-81c3-9e8d34f8a363 ResourceVersion:1697227 Generation:6 


time="2024-08-26T07:37:52Z" level=info msg="sivakumar --- after CR content &{TypeMeta:{Kind:ApplicationBackup APIVersion:stork.libopenstorage.org/v1alpha1} ObjectMeta:{Name:xxxx-1-67d0014 GenerateName: Namespace:siva-1 SelfLink: UID:e803bbd6-3ceb-4797-81c3-9e8d34f8a363 ResourceVersion:1697228 Generation:7 
```
3) Also validated the resource.json content.
4) Validated non-large resource case as well.
![Screenshot 2024-08-26 at 5 05 57 PM](https://github.com/user-attachments/assets/aa2791a9-8f38-4656-803e-4d3ddfebca0e)
