### PR TITLE
pwx-38748: upgrade gcloud-sdk version to fix crc32 vuln

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN asdf install kubelogin latest
 RUN asdf global kubelogin latest
 
 #Install Google Cloud SDK
-ARG GCLOUD_SDK=google-cloud-cli-483.0.0-linux-x86_64.tar.gz
+ARG GCLOUD_SDK=google-cloud-cli-489.0.0-linux-x86_64.tar.gz
 ARG GCLOUD_INSTALL_DIR="/usr/lib"
 ENV PATH "${PATH}:$GCLOUD_INSTALL_DIR/google-cloud-sdk/bin"
 # Download GCLOUD_SDK tar bundle, untar it , install gke-gcloud-auth-plugin


### PR DESCRIPTION
**What type of PR is this?**
> security-fix

**What this PR does / why we need it**:
Upgrades gcloud-sdk version to `489.0.0` to fix gcloud-crc32 binary vulnerability. Sample run on my private image: https://aetos.pwx.purestorage.com/security/Stork/24-3-0/2024-08-26-13-07-11-855359

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
Yes

**Does this change need to be cherry-picked to a release branch?**:
Yes, `24.3.0`.

