### PR TITLE
PWX-37036: GetPersistentVolumeClaim needs to use cache in extender, webhook and monitor calls.

### DIFF
--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -202,13 +202,15 @@ func (e *Extender) processFilterRequest(w http.ResponseWriter, req *http.Request
 		}
 		var pvc *v1.PersistentVolumeClaim
 		var err error
+		var msg string
 		if storkcache.Instance() != nil {
 			pvc, err = storkcache.Instance().GetPersistentVolumeClaim(vol.PersistentVolumeClaim.ClaimName, pod.Namespace)
+			msg = fmt.Sprintf("Unable to find PVC %s in informer cache, err: %v", vol.Name, err)
 		} else {
 			pvc, err = core.Instance().GetPersistentVolumeClaim(vol.PersistentVolumeClaim.ClaimName, pod.Namespace)
+			msg = fmt.Sprintf("Unable to find PVC %s, err: %v", vol.Name, err)
 		}
 		if err != nil {
-			msg := fmt.Sprintf("Unable to find PVC %s, err: %v", vol.Name, err)
 			storklog.PodLog(pod).Warnf(msg)
 			e.Recorder.Event(pod, v1.EventTypeWarning, schedulingFailureEventReason, msg)
 			http.Error(w, msg, http.StatusBadRequest)
@@ -505,7 +507,6 @@ func (e *Extender) collectExtenderMetrics() error {
 		if err != nil {
 			log.Errorf("failed to watch pods with informer cache for health monitoring, err: %v", err)
 		}
-		log.Errorf("failed to watch pods with informer cache for metrics, err: %v", err)
 	} else {
 		log.Warnf("Shared informer cache has not been initialized, using watch for extender metrics.")
 		if err := core.Instance().WatchPods("", fn, metav1.ListOptions{}); err != nil {
@@ -893,6 +894,9 @@ func (e *Extender) GetPVNameFromPVC(pvcName string, namespace string) (string, e
 	var err error
 	if storkcache.Instance() != nil {
 		pvc, err = storkcache.Instance().GetPersistentVolumeClaim(pvcName, namespace)
+		if err != nil {
+			log.Debugf("Error getting PVC %s from informer cache: %v", pvcName, err)
+		}
 	} else {
 		pvc, err = core.Instance().GetPersistentVolumeClaim(pvcName, namespace)
 	}

--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -200,7 +200,13 @@ func (e *Extender) processFilterRequest(w http.ResponseWriter, req *http.Request
 		if vol.PersistentVolumeClaim == nil {
 			continue
 		}
-		pvc, err := core.Instance().GetPersistentVolumeClaim(vol.PersistentVolumeClaim.ClaimName, pod.Namespace)
+		var pvc *v1.PersistentVolumeClaim
+		var err error
+		if storkcache.Instance() != nil {
+			pvc, err = storkcache.Instance().GetPersistentVolumeClaim(vol.PersistentVolumeClaim.ClaimName, pod.Namespace)
+		} else {
+			pvc, err = core.Instance().GetPersistentVolumeClaim(vol.PersistentVolumeClaim.ClaimName, pod.Namespace)
+		}
 		if err != nil {
 			msg := fmt.Sprintf("Unable to find PVC %s, err: %v", vol.Name, err)
 			storklog.PodLog(pod).Warnf(msg)
@@ -883,7 +889,13 @@ func (e *Extender) getVMIInfo(refPod *v1.Pod) (string, types.UID) {
 
 // GetPVNameFromPVC returns PV name for a PVC
 func (e *Extender) GetPVNameFromPVC(pvcName string, namespace string) (string, error) {
-	pvc, err := core.Instance().GetPersistentVolumeClaim(pvcName, namespace)
+	var pvc *v1.PersistentVolumeClaim
+	var err error
+	if storkcache.Instance() != nil {
+		pvc, err = storkcache.Instance().GetPersistentVolumeClaim(pvcName, namespace)
+	} else {
+		pvc, err = core.Instance().GetPersistentVolumeClaim(pvcName, namespace)
+	}
 	if err != nil || pvc == nil {
 		return "", fmt.Errorf("error getting PV name for PVC (%v/%v): %w", namespace, pvcName, err)
 	}

--- a/pkg/mock/cache/cache.mock.go
+++ b/pkg/mock/cache/cache.mock.go
@@ -51,6 +51,21 @@ func (mr *MockSharedInformerCacheMockRecorder) GetApplicationRegistration(arg0 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationRegistration", reflect.TypeOf((*MockSharedInformerCache)(nil).GetApplicationRegistration), arg0)
 }
 
+// GetPersistentVolumeClaim mocks base method.
+func (m *MockSharedInformerCache) GetPersistentVolumeClaim(arg0, arg1 string) (*v1.PersistentVolumeClaim, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPersistentVolumeClaim", arg0, arg1)
+	ret0, _ := ret[0].(*v1.PersistentVolumeClaim)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPersistentVolumeClaim indicates an expected call of GetPersistentVolumeClaim.
+func (mr *MockSharedInformerCacheMockRecorder) GetPersistentVolumeClaim(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPersistentVolumeClaim", reflect.TypeOf((*MockSharedInformerCache)(nil).GetPersistentVolumeClaim), arg0, arg1)
+}
+
 // GetStorageClass mocks base method.
 func (m *MockSharedInformerCache) GetStorageClass(arg0 string) (*v10.StorageClass, error) {
 	m.ctrl.T.Helper()

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -245,7 +245,6 @@ func (m *Monitor) driverMonitor() {
 					}
 					k8sNode := driverNodeToK8sNodeMap[node.StorageID]
 					m.wg.Add(1)
-					// wait for 1 min if node is upgrading
 					go m.cleanupDriverNodePods(node, k8sNode, k8sNodeNameToNodeMap)
 				}
 			}
@@ -396,13 +395,16 @@ func (m *Monitor) doesDriverOwnVolumeAttachment(va *storagev1.VolumeAttachment) 
 	}
 
 	var pvc *v1.PersistentVolumeClaim
+	var msg string
 	if storkcache.Instance() != nil {
 		pvc, err = storkcache.Instance().GetPersistentVolumeClaim(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
+		msg = fmt.Sprintf("Error getting persistent volume claim from volume attachment from informer cache: %v", err)
 	} else {
 		pvc, err = core.Instance().GetPersistentVolumeClaim(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
+		msg = fmt.Sprintf("Error getting persistent volume claim from volume attachment: %v", err)
 	}
 	if err != nil {
-		log.Errorf("Error getting persistent volume claim from volume attachment: %v", err)
+		log.Errorf(msg)
 		return false, err
 	}
 

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -395,7 +395,12 @@ func (m *Monitor) doesDriverOwnVolumeAttachment(va *storagev1.VolumeAttachment) 
 		return false, err
 	}
 
-	pvc, err := core.Instance().GetPersistentVolumeClaim(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
+	var pvc *v1.PersistentVolumeClaim
+	if storkcache.Instance() != nil {
+		pvc, err = storkcache.Instance().GetPersistentVolumeClaim(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
+	} else {
+		pvc, err = core.Instance().GetPersistentVolumeClaim(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace)
+	}
 	if err != nil {
 		log.Errorf("Error getting persistent volume claim from volume attachment: %v", err)
 		return false, err

--- a/pkg/webhookadmission/webhook.go
+++ b/pkg/webhookadmission/webhook.go
@@ -189,7 +189,8 @@ func (c *Controller) checkVolumeOwner(volumes []v1.Volume, namespace string) (bo
 		if storkcache.Instance() != nil {
 			pvc, err = storkcache.Instance().GetPersistentVolumeClaim(v.PersistentVolumeClaim.ClaimName, namespace)
 			if err != nil {
-				log.Errorf("failed to watch pods with informer cache for health monitoring, err: %v", err)
+				log.Errorf("failed to get pvc %s/%s from informer cache in webhook handler, err: %v", namespace, v.PersistentVolumeClaim.ClaimName, err)
+				return false, err
 			}
 		} else {
 			pvc, err = core.Instance().GetPersistentVolumeClaim(v.PersistentVolumeClaim.ClaimName, namespace)


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Now informercache will keep the trimmed PVC information.
This will be useful to enhance performance in webhook, extender and monitor.

**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
<!--
TBD
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
yes, 24.3.1
-->

**Test**
1. Tested with 100 pod deployments with webhook enabled and those using one RWO px volume.
2. Took down px in 3 nodes in a 9 node cluster to check if drivermonitor is working fine.

Integration test - https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/strivedi-extender/2/ 
