### PR TITLE
PB-7778 ::  Fail fast if large resource limit is breached for any component

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -654,3 +654,23 @@ func GetAppUidGid(pvcName string, namespace string, backup *stork_api.Applicatio
 	}
 	return uid, gid, nil
 }
+
+// ReorganizeLargeResourceError - Check the error message and if large resource error found, reorganize the error message and return true and error
+func ReorganizeLargeResourceError(err error) (bool, error) {
+	// List of expected error messages from large resources
+	expectedMsgs := []string{
+		"request is too large",
+		"trying to send message larger than max",
+		"Request entity too large",
+	}
+
+	for _, msg := range expectedMsgs {
+		if strings.Contains(err.Error(), msg) {
+			// Reorganize the error as per the requirement
+			return true, fmt.Errorf("%v: Refer doc https://docs.portworx.com/portworx-backup-on-prem/reference/large-res-config", err)
+		}
+	}
+
+	// Return the original error if none of the expected errors were found
+	return false, err
+}


### PR DESCRIPTION
**What type of PR is this?**
>improvement


**What this PR does / why we need it**:
If the largeResourceLimit is not hit but etcd server limit was hit we were not updating the ABCR and hence we kept backup in progress state forever. This PR identifies this error and fails out early and points customer towards to docs to configure large resource params

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
pxb-2.8.0

**Testing**

rather than getting stuck in loop forever we error as soon as we see a large resource error. Same can be verified via logs where earlier we kept on reconciling noe we exit from the loop 
![image](https://github.com/user-attachments/assets/ebdd9539-0475-4b61-a490-22f8899df933)

**Earlier logs**

`time="2024-08-01T11:20:48Z" level=debug msg="Monitoring storage nodes"
time="2024-08-01T11:22:48Z" level=debug msg="Monitoring storage nodes"
time="2024-08-01T11:23:25Z" level=info msg="The size of application backup CR obtained 1000613 bytes - largeResourceSizeLimit: 1048576" ApplicationBackupName=vol-res-2-30k-d31bd9c ApplicationBackupUID=5fb45e0b-a974-4ee8-adfe-1a50e88a6ca9 Namespace=kube-system ResourceVersion=12604801
time="2024-08-01T11:23:25Z" level=error msg="Error backing up resources: etcdserver: request is too large" ApplicationBackupName=vol-res-2-30k-d31bd9c ApplicationBackupUID=5fb45e0b-a974-4ee8-adfe-1a50e88a6ca9 Namespace=kube-system ResourceVersion=12604801
time="2024-08-01T11:24:48Z" level=debug msg="Monitoring storage nodes"
time="2024-08-01T11:26:22Z" level=info msg="The size of application backup CR obtained 1000613 bytes - largeResourceSizeLimit: 1048576" ApplicationBackupName=vol-res-2-30k-d31bd9c ApplicationBackupUID=5fb45e0b-a974-4ee8-adfe-1a50e88a6ca9 Namespace=kube-system ResourceVersion=12606337
time="2024-08-01T11:26:22Z" level=error msg="Error backing up resources: etcdserver: request is too large" ApplicationBackupName=vol-res-2-30k-d31bd9c ApplicationBackupUID=5fb45e0b-a974-4ee8-adfe-1a50e88a6ca9 Namespace=kube-system ResourceVersion=12606337
time="2024-08-01T11:26:48Z" level=debug msg="Monitoring storage nodes"
time="2024-08-01T11:27:22Z" level=debug msg="CRD watch closed (attempting to re-establish)"
time="2024-08-01T11:27:22Z" level=debug msg="watch re-established"
time="2024-08-01T11:28:48Z" level=debug msg="Monitoring storage nodes"
time="2024-08-01T11:29:18Z" level=info msg="The size of application backup CR obtained 1000613 bytes - largeResourceSizeLimit: 1048576" ApplicationBackupName=vol-res-2-30k-d31bd9c ApplicationBackupUID=5fb45e0b-a974-4ee8-adfe-1a50e88a6ca9 Namespace=kube-system ResourceVersion=12607872
time="2024-08-01T11:29:18Z" level=error msg="Error backing up resources: etcdserver: request is too large" ApplicationBackupName=vol-res-2-30k-d31bd9c ApplicationBackupUID=5fb45e0b-a974-4ee8-adfe-1a50e88a6ca9 Namespace=kube-system ResourceVersion=12607872
time="2024-08-01T11:30:48Z" level=debug msg="Monitoring storage nodes"
time="2024-08-01T11:32:14Z" level=info msg="The size of application backup CR obtained 1000613 bytes - largeResourceSizeLimit: 1048576" ApplicationBackupName=vol-res-2-30k-d31bd9c ApplicationBackupUID=5fb45e0b-a974-4ee8-adfe-1a50e88a6ca9 Namespace=kube-system ResourceVersion=12609396
time="2024-08-01T11:32:15Z" level=error msg="Error backing up resources: etcdserver: request is too large" ApplicationBackupName=vol-res-2-30k-d31bd9c ApplicationBackupUID=5fb45e0b-a974-4ee8-adfe-1a50e88a6ca9 Namespace=kube-system ResourceVersion=12609396
time="2024-08-01T11:32:48Z" level=debug msg="Monitoring storage nodes"
time="2024-08-01T11:34:48Z" level=debug msg="Monitoring storage nodes"
`

**Current logs**

`time="2024-08-29T09:43:19Z" level=info msg="Reconciling ApplicationBackup kube-system/abc2-d36b447"
time="2024-08-29T09:43:19Z" level=info msg="Reconciling ApplicationBackup kube-system/abc2-d36b447"
time="2024-08-29T09:43:19Z" level=info msg="Exiting Reconciling ApplicationBackup kube-system/abc2-d36b447"
time="2024-08-29T09:43:19Z" level=info msg="Reconciling ApplicationBackup kube-system/abc2-d36b447"
time="2024-08-29T09:43:19Z" level=error msg="Error updating with defaults: Operation cannot be fulfilled on applicationbackups.stork.libopenstorage.org \"abc2-d36b447\": the object has been modified; please apply your changes to the latest version and try again" ApplicationBackupName=abc2-d36b447 ApplicationBackupUID=328d81b0-5fc8-43b8-80fb-3f502903db76 Namespace=kube-system ResourceVersion=52352446
time="2024-08-29T09:43:19Z" level=info msg="Exiting Reconciling ApplicationBackup kube-system/abc2-d36b447"
time="2024-08-29T09:43:19Z" level=info msg="Reconciling ApplicationBackup kube-system/abc2-d36b447"
time="2024-08-29T09:43:21Z" level=info msg="Received azure environment type AzurePublicCloud from backup location cr"
time="2024-08-29T09:43:21Z" level=debug msg="azure - CreateBucket - url https://pwxautomation.blob.core.windows.net"
time="2024-08-29T09:43:48Z" level=info msg="The size of application backup CR obtained 1569857 bytes - largeResourceSizeLimit: 3145728" ApplicationBackupName=abc2-d36b447 ApplicationBackupUID=328d81b0-5fc8-43b8-80fb-3f502903db76 Namespace=kube-system ResourceVersion=52352575
time="2024-08-29T09:43:49Z" level=error msg="Error backing up resources: rpc error: code = ResourceExhausted desc = trying to send message larger than max (2777707 vs. 2097152): Refer doc https://docs.portworx.com/portworx-backup-on-prem/reference/large-res-config" ApplicationBackupName=abc2-d36b447 ApplicationBackupUID=328d81b0-5fc8-43b8-80fb-3f502903db76 Namespace=kube-system ResourceVersion=52352575
time="2024-08-29T09:43:49Z" level=info msg="Exiting Reconciling ApplicationBackup kube-system/abc2-d36b447"
time="2024-08-29T09:43:49Z" level=info msg="Reconciling ApplicationBackup kube-system/abc2-d36b447"
time="2024-08-29T09:44:01Z" level=info msg="Exiting Reconciling ApplicationBackup kube-system/abc2-d36b447"
time="2024-08-29T09:44:01Z" level=info msg="Reconciling ApplicationBackup kube-system/abc2-d36b447"
time="2024-08-29T09:44:01Z" level=info msg="deleted termination channel entry from controller map for backup [kube-system/abc2-d36b447]" ApplicationBackupName=abc2-d36b447 ApplicationBackupUID=328d81b0-5fc8-43b8-80fb-3f502903db76 Namespace=kube-system ResourceVersion=52352586
time="2024-08-29T09:44:01Z" level=info msg="Exiting Reconciling ApplicationBackup kube-system/abc2-d36b447"`
