### PR TITLE
pwx-38383: make the controller cache sync timeout configurable

### DIFF
--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -363,7 +363,7 @@ func run(c *cli.Context) {
 
 	managerOpts := manager.Options{}
 	// Configure the passed custom controller cache sync timeout in the manager.
-	if c.Int64("controller-cache-sync-timeout") != 0 {
+	if c.Int64("controller-cache-sync-timeout") > 0 {
 		ctrlCacheSyncTimeout = time.Duration(c.Int64("controller-cache-sync-timeout")) * time.Minute
 		managerOpts.Controller.CacheSyncTimeout = &ctrlCacheSyncTimeout
 	}

--- a/cmd/stork/stork.go
+++ b/cmd/stork/stork.go
@@ -366,6 +366,7 @@ func run(c *cli.Context) {
 	if c.Int64("controller-cache-sync-timeout") > 0 {
 		ctrlCacheSyncTimeout = time.Duration(c.Int64("controller-cache-sync-timeout")) * time.Minute
 		managerOpts.Controller.CacheSyncTimeout = &ctrlCacheSyncTimeout
+		log.Infof("Setting the controller cache sync-timeout as %d mins.", c.Int64("controller-cache-sync-timeout"))
 	}
 	// Create operator-sdk manager that will manage all controllers.
 	// Setup the controller manager before starting any watches / other controllers


### PR DESCRIPTION
**What type of PR is this?**
improvement

**What this PR does / why we need it**:
Closes [PWX-38383](https://purestorage.atlassian.net/browse/PWX-38383). Adds the `--controller-cache-sync-timeout` flag in stork for the user to tweak the value of cache sync timeout(default: 2 mins) of controllers according to the scale of operations in their cluster. Link to discussion as to why they kept 2 minutes as default: https://github.com/kubernetes-sigs/controller-runtime/pull/1247#discussion_r518110283.

**Does this PR change a user-facing CRD or CLI?**:
Yes

**Is a release note needed?**:
Yes

**Does this change need to be cherry-picked to a release branch?**:
No, directly being merged to release branch.

