### PR TITLE
pb-7868: vendor lastest kdmp repo from master branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/golang/mock v1.6.0
-	github.com/portworx/kdmp v0.4.1-0.20240730181245-423ce1fdc45b
+	github.com/portworx/kdmp v0.4.1-0.20240905084925-d65069c4bf84
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	kubevirt.io/api v1.0.0
 	kubevirt.io/client-go v0.59.2
@@ -354,7 +354,7 @@ replace (
 	github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240416193513-1e07b4359307
 	github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
-	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240731175905-54a08c6150e8
+	github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240905084925-d65069c4bf84
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240731224434-94e4e354c4b2
 	github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240520065758-b58a5dd88529
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -4102,8 +4102,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polyfloyd/go-errorlint v1.0.5/go.mod h1:APVvOesVSAnne5SClsPxPdfvZTVDojXh1/G3qb5wjGI=
 github.com/portworx/dcos-secrets v0.0.0-20180616013705-8e8ec3f66611/go.mod h1:4hklRW/4DQpLqkcXcjtNprbH2tz/sJaNtqinfPWl/LA=
-github.com/portworx/kdmp v0.4.1-0.20240731175905-54a08c6150e8 h1:4G78GEneyD5B3NbbEVd2MbdHxoV4KPRmMpX/bb+6EGY=
-github.com/portworx/kdmp v0.4.1-0.20240731175905-54a08c6150e8/go.mod h1:Uzm90W9yC4epDqv0wv6cLvTsGfPNtpmuNaE3fKmGC2Q=
+github.com/portworx/kdmp v0.4.1-0.20240905084925-d65069c4bf84 h1:lAMi4592xNKV87ZpTFrlKFCLmE5IxL2RFmRPYMi6p30=
+github.com/portworx/kdmp v0.4.1-0.20240905084925-d65069c4bf84/go.mod h1:Uzm90W9yC4epDqv0wv6cLvTsGfPNtpmuNaE3fKmGC2Q=
 github.com/portworx/kvdb v0.0.0-20190105022415-cccaa09abfc9/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200723230726-2734b7f40194/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=
 github.com/portworx/kvdb v0.0.0-20200929023115-b312c7519467/go.mod h1:Q8YyrNDvPp3DVF96BDcQuaC7fAYUCuUX+l58S7OnD2M=

--- a/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
+++ b/vendor/github.com/portworx/kdmp/pkg/controllers/dataexport/reconcile.go
@@ -1973,6 +1973,7 @@ func startTransferJob(
 			drivers.WithNfsExportDir(nfsExportPath),
 			drivers.WithPodUserId(psaJobUid),
 			drivers.WithPodGroupId(psaJobGid),
+			drivers.WithNfsMountOption(nfsMountOption),
 		)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1099,7 +1099,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/portworx/kdmp v0.4.1-0.20240730181245-423ce1fdc45b => github.com/portworx/kdmp v0.4.1-0.20240731175905-54a08c6150e8
+# github.com/portworx/kdmp v0.4.1-0.20240905084925-d65069c4bf84 => github.com/portworx/kdmp v0.4.1-0.20240905084925-d65069c4bf84
 ## explicit; go 1.21
 github.com/portworx/kdmp/pkg/apis/kdmp
 github.com/portworx/kdmp/pkg/apis/kdmp/v1alpha1
@@ -2647,7 +2647,7 @@ sigs.k8s.io/yaml/goyaml.v2
 # github.com/libopenstorage/autopilot-api => github.com/libopenstorage/autopilot-api v0.6.1-0.20210301232050-ca2633c6e114
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240416193513-1e07b4359307
 # github.com/libopenstorage/secrets => github.com/libopenstorage/secrets v0.0.0-20220413195519-57d1c446c5e9
-# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240731175905-54a08c6150e8
+# github.com/portworx/kdmp => github.com/portworx/kdmp v0.4.1-0.20240905084925-d65069c4bf84
 # github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240731224434-94e4e354c4b2
 # github.com/portworx/torpedo => github.com/portworx/torpedo v0.0.0-20240520065758-b58a5dd88529
 # gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
>bug

**What this PR does / why we need it**:
```
pb-7868: vendor lastest kdmp repo from master branch
```

**Does this PR change a user-facing CRD or CLI?**:
no
**Is a release note needed?**:

```release-note
Issue: KDMP restore with nfs backuplocation of V4 fails.
User Impact: KDMP backup taken to the NFS v4 backuplocation is not usable.
Resolution: Pass mount option of V4 to fix the issue.

```

**Does this change need to be cherry-picked to a release branch?**:
No

