### PR TITLE
pwx-38744 | test: add tests for errored snapshot cleanup

### DIFF
--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -15,11 +15,12 @@ import (
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
 	"github.com/libopenstorage/stork/pkg/log"
 	"github.com/portworx/sched-ops/k8s/core"
-	"github.com/portworx/sched-ops/k8s/externalstorage"
 	k8sextops "github.com/portworx/sched-ops/k8s/externalstorage"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/portworx/sched-ops/task"
 	"github.com/portworx/torpedo/drivers/scheduler"
+	"github.com/portworx/torpedo/drivers/volume/portworx/schedops"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,10 @@ const (
 
 	snapshotScheduleRetryInterval = 10 * time.Second
 	snapshotScheduleRetryTimeout  = 3 * time.Minute
+	// k8sServiceOperationStart is label value for starting Portworx service
+	k8sServiceOperationStart = "start"
+	// k8sServiceOperationStop is label value for stopping Portworx service
+	k8sServiceOperationStop = "stop"
 )
 
 func testSnapshot(t *testing.T) {
@@ -463,6 +468,8 @@ func snapshotScheduleTests(t *testing.T) {
 	t.Run("monthlyTest", monthlySnapshotScheduleTest)
 	t.Run("invalidPolicyTest", invalidPolicySnapshotScheduleTest)
 	t.Run("updateRetainValueTest", updateRetainValueTest)
+	t.Run("deleteErrorSnapshotCRTest", deleteErrorSnapshotCRTest)
+	t.Run("deleteErrorSnapshotCRMultiPVCTest", deleteErrorSnapshotCRMultiPVCTest)
 }
 
 func cloudSnapshotScaleTest(t *testing.T) {
@@ -1102,7 +1109,7 @@ func updateRetainValueTest(t *testing.T) {
 
 	// Verify from the cluster if there are expected number of snapshots.
 	snapCount := 0
-	snapshots, err := externalstorage.Instance().ListSnapshots(namespace)
+	snapshots, err := k8sextops.Instance().ListSnapshots(namespace)
 	log.FailOnError(t, err, "Error listing snapshots")
 	for _, snap := range snapshots.Items {
 		if strings.Contains(snap.Metadata.Name, scheduleName) {
@@ -1163,7 +1170,7 @@ func updateRetainValueTest(t *testing.T) {
 	log.InfoD("Validated snapshotschedule %s to have three volumesnapshots", scheduleName)
 	// Verify from the cluster if there are expected number of snapshots.
 	snapCount = 0
-	snapshots, err = externalstorage.Instance().ListSnapshots(namespace)
+	snapshots, err = k8sextops.Instance().ListSnapshots(namespace)
 	log.FailOnError(t, err, "Error listing snapshots")
 	for _, snap := range snapshots.Items {
 		if strings.Contains(snap.Metadata.Name, scheduleName) {
@@ -1175,6 +1182,479 @@ func updateRetainValueTest(t *testing.T) {
 	deletePolicyAndSnapshotSchedule(t, namespace, policyName, scheduleName)
 	destroyAndWait(t, []*scheduler.Context{ctx})
 
+	// If we are here then the test has passed
+	testResult = testResultPass
+	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
+}
+
+// deleteErrorSnapshotCRTest tests the workflow in which stork deletes the
+// snapshot CRs of snapshots that are in Error state and older than a certain
+// defined time period.
+// 1. Start a volumesnapshot and take one successful snapshot.
+// 2. Bring down the node where the PVC is attached.
+// 3. Wait for couple of snapshots to go into `Error` state.
+// 4. Check if they get cleaned up after 90 seconds.
+// 5. Check if the snapshotschedule object gets updated for the deleted snapshot entries.
+func deleteErrorSnapshotCRTest(t *testing.T) {
+	var testrailID, testResult = 301162, testResultFail
+	runID := testrailSetupForTest(testrailID, &testResult, t.Name())
+	defer updateTestRail(&testResult, testrailID, runID)
+	defer updateDashStats(t.Name(), &testResult)
+
+	// Deploy a dummy application for taking snapshots.
+	ctx := createApp(t, "delete-error-snapshot-cr-test")
+
+	////////////////////////////////////////////////////
+	// Create schedulepolicy and snapshot schedule.
+	////////////////////////////////////////////////////
+	policyName := "intervalpolicy"
+	scheduleName := "errsnap-schedule"
+	retain := 5
+	interval := 1
+	schedPolicy := &storkv1.SchedulePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Policy: storkv1.SchedulePolicyItem{
+			Interval: &storkv1.IntervalPolicy{
+				Retain:          storkv1.Retain(retain),
+				IntervalMinutes: interval,
+			},
+		}}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(schedPolicy)
+		log.FailOnError(t, err, "Error adding annotations to interval schedule policy")
+	}
+
+	_, err := storkops.Instance().CreateSchedulePolicy(schedPolicy)
+	log.FailOnError(t, err, "Error creating interval schedule policy")
+	log.InfoD("Created schedulepolicy %v with %v minute interval and retain at %v", policyName, interval, retain)
+	defer func(sp storkv1.SchedulePolicy) {
+		err := storkops.Instance().DeleteSchedulePolicy(sp.Name)
+		log.FailOnError(t, err, "Error creating interval schedule policy")
+
+	}(*schedPolicy)
+
+	namespace := ctx.GetID()
+	snapSched := &storkv1.VolumeSnapshotSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scheduleName,
+			Namespace: namespace,
+		},
+		Spec: storkv1.VolumeSnapshotScheduleSpec{
+			Template: storkv1.VolumeSnapshotTemplateSpec{
+				Spec: crdv1.VolumeSnapshotSpec{
+					PersistentVolumeClaimName: "mysql-data"},
+			},
+			SchedulePolicyName: policyName,
+		},
+	}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(snapSched)
+		log.FailOnError(t, err, "Error adding annotations to interval schedule policy")
+	}
+
+	_, err = storkops.Instance().CreateSnapshotSchedule(snapSched)
+	log.FailOnError(t, err, "Error creating interval snapshot schedule")
+	defer func(schedule storkv1.VolumeSnapshotSchedule, ns string) {
+		err := storkops.Instance().DeleteSnapshotSchedule(schedule.Name, ns)
+		log.FailOnError(t, err, "Error creating interval schedule policy")
+
+	}(*snapSched, namespace)
+
+	//////////////////////////////////////////////////////////
+	// Wait for creation of one volumesnapshot and validate
+	// the count to match the retain value.
+	/////////////////////////////////////////////////////////
+	sleepTime := time.Duration(1 * time.Minute)
+	log.InfoD("Created snapshotschedule %v in namespace %v, sleeping for %v for schedule to trigger",
+		scheduleName, namespace, sleepTime)
+	time.Sleep(sleepTime)
+
+	snapStatuses, err := storkops.Instance().ValidateSnapshotSchedule(scheduleName,
+		namespace,
+		snapshotScheduleRetryTimeout,
+		snapshotScheduleRetryInterval)
+	log.FailOnError(t, err, "Error validating snapshot schedule")
+	Dash.VerifyFatal(t, len(snapStatuses), 1, "Should have snapshots for only one policy type")
+	log.InfoD("Validated snapshotschedule %s to have two volumesnapshots", scheduleName)
+
+	//////////////////////////////////////////////////////////
+	// Find the pods using the PVC to determine the node.
+	// Post determining, stop portworx service on the node.
+	/////////////////////////////////////////////////////////
+	podLabel := make(map[string]string, 0)
+	podLabel["app"] = "mysql"
+	pvcList, err := core.Instance().GetPersistentVolumeClaims(namespace, podLabel)
+	log.FailOnError(t, err, "Error getting pvcList")
+	log.InfoD("pvcs: %v", pvcList.Items[0].Name)
+
+	pvName, err := core.Instance().GetVolumeForPersistentVolumeClaim(&pvcList.Items[0])
+	log.FailOnError(t, err, "Error getting volume for pvc")
+	log.InfoD("pvName for first PVC: %v", pvName)
+
+	volume1, err := volumeDriver.InspectVolume(pvName)
+	log.FailOnError(t, err, "Error getting inspect volume for %v", pvName)
+	vol1Node := volume1.AttachedOn
+	log.InfoD("node where volumes are attached: %s", vol1Node)
+
+	nodeList, err := core.Instance().GetNodes()
+	log.FailOnError(t, err, "Error getting list of nodes")
+
+	for _, item := range nodeList.Items {
+		for _, address := range item.Status.Addresses {
+			if address.Type == "InternalIP" {
+				if address.Address == vol1Node {
+					vol1Node = item.Status.Addresses[1].Address
+				}
+			}
+		}
+	}
+
+	log.InfoD("node name where volume is attached: %ss", vol1Node)
+	// Bring down portworx on the node where the PVC is attached.
+	err = core.Instance().AddLabelOnNode(vol1Node, schedops.PXServiceLabelKey, k8sServiceOperationStop)
+	log.FailOnError(t, err, "Error bringing down node")
+	defer func(node1 string) {
+		// Bring portworx backup up on the node where the PVC is attached.
+		err = core.Instance().AddLabelOnNode(node1, schedops.PXServiceLabelKey, k8sServiceOperationStart)
+		log.FailOnError(t, err, "Error starting PX on node")
+	}(vol1Node)
+
+	// Wait for some snapshots to go into `Error` state.
+	log.Info("Waiting for 2 minutes to make sure some snapshots get errored out")
+	time.Sleep(2 * time.Minute)
+
+	// Verify that the snapshots are in `Error` state.
+	snapshots, err := k8sextops.Instance().ListSnapshots(namespace)
+	log.FailOnError(t, err, "Error listing snapshots after bringing down the node")
+	errorCount := 0
+	errorSnapshots := make([]string, 0)
+
+	for _, snap := range snapshots.Items {
+		if snap.Status.Conditions[0].Type == crdv1.VolumeSnapshotConditionError {
+			errorCount++
+			errorSnapshots = append(errorSnapshots, snap.Metadata.Name)
+		}
+	}
+	log.Info("Number of errorsnapshots:%d", errorCount)
+	log.Info("Error snapshots list:%v", errorSnapshots)
+	if errorCount == 0 {
+		Dash.Fatal("should have more than one snapshots in Error state")
+	}
+
+	// Wait for 90 seconds more.
+	log.Info("Waiting for 90 seconds more to prevent any transient error")
+	time.Sleep(90 * time.Second)
+
+	// Verify that some of snapshots have been cleaned up.
+	snapshots, err = k8sextops.Instance().ListSnapshots(namespace)
+	log.FailOnError(t, err, "Error listing snapshots after cleanup")
+
+	// Verify if the previous Errored out snapshots do not exist now.
+	snapshotDeleted := true
+	for _, errorSnap := range errorSnapshots {
+		snapshotDeleted = true
+		for _, snap := range snapshots.Items {
+			if errorSnap == snap.Metadata.Name {
+				snapshotDeleted = false
+				break
+			}
+		}
+		if snapshotDeleted {
+			break
+		}
+	}
+	Dash.VerifyFatal(t, snapshotDeleted, true, "Snapshots earlier in error state should get cleaned up")
+
+	// Check if the snapshotschedule object gets updated for the deleted snapshot entries.
+	snapSched, err = storkops.Instance().GetSnapshotSchedule(scheduleName, namespace)
+	log.FailOnError(t, err, "Error getting snapshot schedule")
+
+	for _, errorSnap := range errorSnapshots {
+		for _, item := range snapSched.Status.Items["Interval"] {
+			if item.Name != errorSnap {
+				continue
+			}
+			Dash.VerifyFatal(t, item.Deleted, true, "Deleted key should be set to true for cleaned up snapshot")
+			assert.NotEmpty(t, item.Message)
+		}
+		for _, item := range snapSched.Status.Items["Interval"] {
+			if item.Name != errorSnap {
+				continue
+			}
+			Dash.VerifyFatal(t, item.Deleted, true, "Deleted key should be set to true for cleaned up snapshot")
+			assert.NotEmpty(t, item.Message)
+		}
+	}
+
+	destroyAndWait(t, []*scheduler.Context{ctx})
+	// If we are here then the test has passed
+	testResult = testResultPass
+	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
+}
+
+// deleteErrorSnapshotCRMultiPVCTest tests the workflow in which stork deletes the
+// snapshot CRs of snapshots that are in Error state and older than a certain
+// defined time period for multiple PVCs.
+func deleteErrorSnapshotCRMultiPVCTest(t *testing.T) {
+	var testrailID, testResult = 301163, testResultFail
+	runID := testrailSetupForTest(testrailID, &testResult, t.Name())
+	defer updateTestRail(&testResult, testrailID, runID)
+	defer updateDashStats(t.Name(), &testResult)
+
+	// Deploy a dummy application for taking snapshots.
+	ctxs, err := schedulerDriver.Schedule(generateInstanceID(t, "errorsnapclean"),
+		scheduler.ScheduleOptions{AppKeys: []string{"mysql-2-pvc"}})
+	log.FailOnError(t, err, "Error scheduling task")
+	Dash.VerifyFatal(t, 1, len(ctxs), "Only one task should have started")
+
+	err = schedulerDriver.WaitForRunning(ctxs[0], defaultWaitTimeout, defaultWaitInterval)
+	log.FailOnError(t, err, "Error waiting for pod to get to running state")
+
+	scheduledNodes, err := schedulerDriver.GetNodesForApp(ctxs[0])
+	log.FailOnError(t, err, "Error getting node for app")
+	Dash.VerifyFatal(t, 1, len(scheduledNodes), "App should be scheduled on one node")
+
+	volumeNames := getVolumeNames(t, ctxs[0])
+	Dash.VerifyFatal(t, 2, len(volumeNames), "Should have two volumes")
+
+	verifyScheduledNode(t, scheduledNodes[0], volumeNames)
+	ctx := ctxs[0]
+
+	////////////////////////////////////////////////////
+	// Create schedulepolicy and snapshot schedule.
+	////////////////////////////////////////////////////
+	policyName := "intervalpolicy"
+	scheduleName := "errsnap-schedule"
+	scheduleNameTemp := "errsnap-schedule-temp"
+	retain := 5
+	interval := 1
+	schedPolicy := &storkv1.SchedulePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Policy: storkv1.SchedulePolicyItem{
+			Interval: &storkv1.IntervalPolicy{
+				Retain:          storkv1.Retain(retain),
+				IntervalMinutes: interval,
+			},
+		}}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(schedPolicy)
+		log.FailOnError(t, err, "Error adding annotations to interval schedule policy")
+	}
+
+	_, err = storkops.Instance().CreateSchedulePolicy(schedPolicy)
+	log.FailOnError(t, err, "Error creating interval schedule policy")
+	log.InfoD("Created schedulepolicy %v with %v minute interval and retain at %v", policyName, interval, retain)
+	defer func(sp storkv1.SchedulePolicy) {
+		err := storkops.Instance().DeleteSchedulePolicy(sp.Name)
+		log.FailOnError(t, err, "Error creating interval schedule policy")
+
+	}(*schedPolicy)
+
+	namespace := ctx.GetID()
+	snapSched := &storkv1.VolumeSnapshotSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scheduleName,
+			Namespace: namespace,
+		},
+		Spec: storkv1.VolumeSnapshotScheduleSpec{
+			Template: storkv1.VolumeSnapshotTemplateSpec{
+				Spec: crdv1.VolumeSnapshotSpec{
+					PersistentVolumeClaimName: "mysql-data"},
+			},
+			SchedulePolicyName: policyName,
+		},
+	}
+
+	snapSched1 := &storkv1.VolumeSnapshotSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scheduleNameTemp,
+			Namespace: namespace,
+		},
+		Spec: storkv1.VolumeSnapshotScheduleSpec{
+			Template: storkv1.VolumeSnapshotTemplateSpec{
+				Spec: crdv1.VolumeSnapshotSpec{
+					PersistentVolumeClaimName: "mysql-temp"},
+			},
+			SchedulePolicyName: policyName,
+		},
+	}
+
+	if authTokenConfigMap != "" {
+		err := addSecurityAnnotation(snapSched)
+		log.FailOnError(t, err, "Error adding annotations to interval schedule policy")
+		err = addSecurityAnnotation(snapSched1)
+		log.FailOnError(t, err, "Error adding annotations to interval schedule policy")
+	}
+
+	_, err = storkops.Instance().CreateSnapshotSchedule(snapSched)
+	log.FailOnError(t, err, "Error creating interval snapshot schedule")
+	_, err = storkops.Instance().CreateSnapshotSchedule(snapSched1)
+	log.FailOnError(t, err, "Error creating interval snapshot schedule")
+	defer func(schedule, schedule1 storkv1.VolumeSnapshotSchedule, ns string) {
+		err := storkops.Instance().DeleteSnapshotSchedule(schedule.Name, ns)
+		log.FailOnError(t, err, "Error creating interval schedule policy")
+		err = storkops.Instance().DeleteSnapshotSchedule(schedule1.Name, ns)
+		log.FailOnError(t, err, "Error creating interval schedule policy")
+
+	}(*snapSched, *snapSched1, namespace)
+
+	//////////////////////////////////////////////////////////
+	// Wait for creation of one volumesnapshot and validate
+	// the count to match the retain value.
+	/////////////////////////////////////////////////////////
+	sleepTime := time.Duration(1 * time.Minute)
+	log.InfoD("Created snapshotschedules %v and %v in namespace %v, sleeping for %v for schedule to trigger",
+		scheduleName, scheduleNameTemp, namespace, sleepTime)
+	time.Sleep(sleepTime)
+
+	snapStatuses, err := storkops.Instance().ValidateSnapshotSchedule(scheduleName,
+		namespace,
+		snapshotScheduleRetryTimeout,
+		snapshotScheduleRetryInterval)
+	log.FailOnError(t, err, "Error validating snapshot schedule")
+	Dash.VerifyFatal(t, len(snapStatuses), 1, "Should have snapshots for only one policy type")
+	log.InfoD("Validated snapshotschedule %s to have two volumesnapshots", scheduleName)
+
+	snapStatus, err := storkops.Instance().ValidateSnapshotSchedule(scheduleNameTemp,
+		namespace,
+		snapshotScheduleRetryTimeout,
+		snapshotScheduleRetryInterval)
+	log.FailOnError(t, err, "Error validating snapshot schedule")
+	Dash.VerifyFatal(t, len(snapStatus), 1, "Should have snapshots for only one policy type")
+	log.InfoD("Validated snapshotschedule %s to have two volumesnapshots", scheduleNameTemp)
+
+	//////////////////////////////////////////////////////////
+	// Find the pods using the PVC to determine the node.
+	// Post determining, stop portworx service on the node.
+	/////////////////////////////////////////////////////////
+	podLabel := make(map[string]string, 0)
+	podLabel["app"] = "mysql"
+	pvcList, err := core.Instance().GetPersistentVolumeClaims(namespace, podLabel)
+	log.FailOnError(t, err, "Error getting pvcList")
+	log.InfoD("pvcs: %v\t%v", pvcList.Items[0].Name, pvcList.Items[1].Name)
+
+	pvName1, err := core.Instance().GetVolumeForPersistentVolumeClaim(&pvcList.Items[0])
+	log.FailOnError(t, err, "Error getting volume for pvc")
+	log.InfoD("pvName for first PVC: %v", pvName1)
+
+	pvName2, err := core.Instance().GetVolumeForPersistentVolumeClaim(&pvcList.Items[1])
+	log.FailOnError(t, err, "Error getting volume for pvc")
+	log.InfoD("pvName for second PVC: %v", pvName2)
+
+	volume1, err := volumeDriver.InspectVolume(pvName1)
+	log.FailOnError(t, err, "Error getting inspect volume for %v", pvName1)
+	volume2, err := volumeDriver.InspectVolume(pvName2)
+	log.FailOnError(t, err, "Error getting inspect volume for %v", pvName2)
+	vol1Node, vol2Node := volume1.AttachedOn, volume2.AttachedOn
+	log.InfoD("nodes where volumes are attached: %s and %s", vol1Node, vol2Node)
+
+	nodeList, err := core.Instance().GetNodes()
+	log.FailOnError(t, err, "Error getting list of nodes")
+
+	for _, item := range nodeList.Items {
+		for _, address := range item.Status.Addresses {
+			if address.Type == "InternalIP" {
+				if address.Address == vol1Node {
+					vol1Node = item.Status.Addresses[1].Address
+				}
+				if address.Address == vol2Node {
+					vol2Node = item.Status.Addresses[1].Address
+				}
+			}
+		}
+	}
+
+	log.InfoD("node names where volumes are attached: %s and %s", vol1Node, vol2Node)
+	// Bring down portworx on the node where the PVC is attached.
+	err = core.Instance().AddLabelOnNode(vol1Node, schedops.PXServiceLabelKey, k8sServiceOperationStop)
+	log.FailOnError(t, err, "Error bringing down node")
+	err = core.Instance().AddLabelOnNode(vol2Node, schedops.PXServiceLabelKey, k8sServiceOperationStop)
+	log.FailOnError(t, err, "Error bringing down node")
+	defer func(node1, node2 string) {
+		// Bring portworx backup up on the node where the PVC is attached.
+		err = core.Instance().AddLabelOnNode(node1, schedops.PXServiceLabelKey, k8sServiceOperationStart)
+		log.FailOnError(t, err, "Error starting PX on node")
+		err = core.Instance().AddLabelOnNode(node2, schedops.PXServiceLabelKey, k8sServiceOperationStop)
+		log.FailOnError(t, err, "Error bringing down node")
+	}(vol1Node, vol2Node)
+
+	// Wait for some snapshots to go into `Error` state.
+	log.Info("Waiting for 2 minutes to make sure some snapshots get errored out")
+	time.Sleep(2 * time.Minute)
+
+	// Verify that the snapshots are in `Error` state.
+	snapshots, err := k8sextops.Instance().ListSnapshots(namespace)
+	log.FailOnError(t, err, "Error listing snapshots after bringing down the node")
+	errorCount := 0
+	errorSnapshots := make([]string, 0)
+
+	for _, snap := range snapshots.Items {
+		if snap.Status.Conditions[0].Type == crdv1.VolumeSnapshotConditionError {
+			errorCount++
+			errorSnapshots = append(errorSnapshots, snap.Metadata.Name)
+		}
+	}
+	log.Info("Number of errorsnapshots:%d", errorCount)
+	log.Info("Error snapshots list:%v", errorSnapshots)
+	if errorCount == 0 {
+		Dash.Fatal("should have more than one snapshots in Error state")
+	}
+
+	// Wait for 90 seconds more.
+	log.Info("Waiting for 90 seconds more to prevent any transient error")
+	time.Sleep(90 * time.Second)
+
+	// Verify that some of snapshots have been cleaned up.
+	snapshots, err = k8sextops.Instance().ListSnapshots(namespace)
+	log.FailOnError(t, err, "Error listing snapshots after cleanup")
+
+	// Verify if the previous Errored out snapshots do not exist now.
+	snapshotDeleted := true
+	for _, errorSnap := range errorSnapshots {
+		snapshotDeleted = true
+		for _, snap := range snapshots.Items {
+			if errorSnap == snap.Metadata.Name {
+				snapshotDeleted = false
+				break
+			}
+		}
+		if snapshotDeleted {
+			break
+		}
+	}
+	Dash.VerifyFatal(t, snapshotDeleted, true, "snapshots earlier in error state should get cleaned up")
+
+	// Check if the snapshotschedule object gets updated for the deleted snapshot entries.
+	snapSched, err = storkops.Instance().GetSnapshotSchedule(scheduleName, namespace)
+	log.FailOnError(t, err, "Error getting snapshot schedule")
+	snapSched1, err = storkops.Instance().GetSnapshotSchedule(scheduleNameTemp, namespace)
+	log.FailOnError(t, err, "Error getting snapshot schedule")
+
+	for _, errorSnap := range errorSnapshots {
+		for _, item := range snapSched.Status.Items["Interval"] {
+			if item.Name != errorSnap {
+				continue
+			}
+			Dash.VerifyFatal(t, item.Deleted, true, "Deleted key should be set to true for cleaned up snapshot")
+			assert.NotEmpty(t, item.Message)
+		}
+		for _, item := range snapSched1.Status.Items["Interval"] {
+			if item.Name != errorSnap {
+				continue
+			}
+			Dash.VerifyFatal(t, item.Deleted, true, "Deleted key should be set to true for cleaned up snapshot")
+			assert.NotEmpty(t, item.Message)
+		}
+	}
+
+	destroyAndWait(t, []*scheduler.Context{ctx})
 	// If we are here then the test has passed
 	testResult = testResultPass
 	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Closes [PWX-38744](https://purestorage.atlassian.net/browse/PWX-38744). Adds integration tests for the cleanup of snapshots in `Error` state.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
No

**Test run screenshot and pipeline run**
![Screenshot from 2024-09-14 15-46-53](https://github.com/user-attachments/assets/f84611f0-1e11-4026-801c-24d032d6bcd8)

Jenkins run: https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2024.3.1-dev/job/snapshot-csi-k8s-1-25/2614/

