### PR TITLE
pwx-38944: test snapshot creation with increased controller cache sync timeout

### DIFF
--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -78,6 +78,7 @@ const (
 	nodeDriverName               = "ssh"
 	cmName                       = "stork-version"
 	defaultAdminNamespace        = "kube-system"
+	storkDeployment              = "stork"
 	schedulerDriverName          = "k8s"
 	remotePairName               = "remoteclusterpair"
 	srcConfig                    = "sourceconfigmap"
@@ -1748,6 +1749,65 @@ func addTestModeEnvironmentVar() error {
 		log.InfoD("Successfully added TEST_MODE environment variable to stork spec in storage cluster")
 	}
 	return nil
+}
+
+// addStorkArgument adds the passed argument to the stork configuration in the storagecluster.
+func addStorkArgument(key, value string) (err error) {
+	stc, err := operator.Instance().ListStorageClusters(pxNamespace)
+	if err != nil {
+		log.InfoD("failed to list PX storage cluster: %v", err)
+		return nil
+	}
+	if len(stc.Items) > 0 {
+		pxStc := (*stc).Items[0]
+		pxStc.Spec.Stork.Args[fmt.Sprintf("--%s", key)] = value
+		_, err = operator.Instance().UpdateStorageCluster(&pxStc)
+		if err != nil {
+			return fmt.Errorf("failed to update PX storagecluster: %v", err)
+		}
+		log.InfoD("Successfully added argument [--%s:%s] to stork spec in storage cluster", key, value)
+	}
+	return nil
+}
+
+// removeStorkArgument removes the argument with the passed key from the stork configuration in the storagecluster.
+func removeStorkArgument(key string) (err error) {
+	stc, err := operator.Instance().ListStorageClusters(pxNamespace)
+	if err != nil {
+		log.InfoD("failed to list PX storage cluster: %v", err)
+		return nil
+	}
+	if len(stc.Items) > 0 {
+		pxStc := (*stc).Items[0]
+		delete(pxStc.Spec.Stork.Args, pxStc.Spec.Stork.Args[key])
+		_, err = operator.Instance().UpdateStorageCluster(&pxStc)
+		if err != nil {
+			return fmt.Errorf("failed to update PX storagecluster: %v", err)
+		}
+		log.InfoD("Successfully removed argument with key %s from stork spec in storage cluster", key)
+	}
+	return nil
+}
+
+// waitForStorkDeployment checks if all the stork pods are healthy until a certain timeout.
+func waitForStorkDeployment() (err error) {
+	// Wait for the new stork pods to come up.
+	log.Info("Waiting for new stork pods to come up")
+	f := func() (interface{}, bool, error) {
+		// Get the stork deployment and check the ready replicas.
+		deployment, err := apps.Instance().GetDeployment(storkDeployment, storkNamespace)
+		if err != nil {
+			return nil, true, err
+		}
+		if deployment.Status.Replicas == 3 && deployment.Status.ReadyReplicas == 3 {
+			return deployment, false, nil
+		}
+		return nil, true, fmt.Errorf("stork pods not ready,expected: 3 got: %d", deployment.Status.ReadyReplicas)
+	}
+	if _, err = task.DoRetryWithTimeout(f, defaultWaitTimeout, defaultWaitInterval); err != nil {
+		return err
+	}
+	return
 }
 
 func IsCloud() bool {

--- a/test/integration_test/snapshot_test.go
+++ b/test/integration_test/snapshot_test.go
@@ -43,6 +43,7 @@ func testSnapshot(t *testing.T) {
 	t.Run("cloudSnapshotTest", cloudSnapshotTest)
 	t.Run("snapshotScaleTest", snapshotScaleTest)
 	t.Run("cloudSnapshotScaleTest", cloudSnapshotScaleTest)
+	t.Run("customCacheSyncTimeoutSnapshotTest", customCacheSyncTimeoutSnapshotTest)
 
 	if !testing.Short() {
 		t.Run("groupSnapshotTest", groupSnapshotTest)
@@ -494,6 +495,35 @@ func cloudSnapshotScaleTest(t *testing.T) {
 	testResult = testResultPass
 	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
 }
+
+func customCacheSyncTimeoutSnapshotTest(t *testing.T) {
+	var testrailID, testResult = 301438, testResultFail
+	runID := testrailSetupForTest(testrailID, &testResult, t.Name())
+	defer updateTestRail(&testResult, testrailID, runID)
+	defer updateDashStats(t.Name(), &testResult)
+
+	// Update stork with the argument.
+	err := addStorkArgument("controller-cache-sync-timeout", "10")
+	log.FailOnError(t, err, "Error adding stork argument")
+	defer func() {
+		err := removeStorkArgument("controller-cache-sync-timeout")
+		log.FailOnError(t, err, "Error removing stork argument")
+		err = waitForStorkDeployment()
+		log.FailOnError(t, err, "Error waiting for new stork pods to come up")
+	}()
+
+	err = waitForStorkDeployment()
+	log.FailOnError(t, err, "Error waiting for new stork pods to come up")
+
+	ctx := createSnapshot(t, []string{"mysql-snap-restore"}, "simple-snap-restore")
+	verifySnapshot(t, ctx, "mysql-data", 3, 2, true, defaultWaitTimeout)
+	destroyAndWait(t, ctx)
+
+	// If we are here then the test has passed
+	testResult = testResultPass
+	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
+}
+
 func deletePolicyAndSnapshotSchedule(t *testing.T, namespace string, policyName string, snapshotScheduleName string) {
 	err := storkops.Instance().DeleteSchedulePolicy(policyName)
 	log.FailOnError(t, err, fmt.Sprintf("Error deleting schedule policy %v", policyName))


### PR DESCRIPTION
**What type of PR is this?**
integration-test

**What this PR does / why we need it**:
Closes [PWX-38944](https://purestorage.atlassian.net/browse/PWX-38944). Tests snapshot creation with increased value of controller cache sync timeout.

**Test run screenshots**
![Screenshot from 2024-09-15 18-23-33](https://github.com/user-attachments/assets/fb77fd48-0194-443b-9da4-5eea33e7942a)

Jenkins pipeline run: https://jenkins.pwx.dev.purestorage.com/job/Stork/view/Stork%2024.3.1-dev/job/snapshot-k8s-1-25-0/1781/