### PR TITLE
pwx-22735: add auth annotations in volumesnapshot

### DIFF
--- a/pkg/pvcwatcher/pvcwatcher.go
+++ b/pkg/pvcwatcher/pvcwatcher.go
@@ -184,12 +184,10 @@ func (p *PVCWatcher) handleSnapshotScheduleUpdates(pvc *corev1.PersistentVolumeC
 			// Add the `auth-secret-name` and `auth-secret-namespace` annotations
 			// if in auth enabled cluster.
 			if operator_util.AuthEnabled(&pxStc.Spec) {
-				logrus.Debugf("Adding annotation to the snapshotschedule")
 				snapshotSchedule.Annotations[secrets.SecretNameKey] = operator_util.SecurityPXUserTokenSecretName
 				snapshotSchedule.Annotations[secrets.SecretNamespaceKey] = os.Getenv(k8sutils.PxNamespaceEnvName)
 			}
 		}
-		logrus.Debugf("Skipping adding annotation to the snapshotschedule since non auth cluster")
 		_, err = storkops.Instance().CreateSnapshotSchedule(snapshotSchedule)
 		if err != nil {
 			p.recorder.Event(pvc,

--- a/pkg/pvcwatcher/pvcwatcher.go
+++ b/pkg/pvcwatcher/pvcwatcher.go
@@ -184,6 +184,9 @@ func (p *PVCWatcher) handleSnapshotScheduleUpdates(pvc *corev1.PersistentVolumeC
 			// Add the `auth-secret-name` and `auth-secret-namespace` annotations
 			// if in auth enabled cluster.
 			if operator_util.AuthEnabled(&pxStc.Spec) {
+				if snapshotSchedule.Annotations == nil {
+					snapshotSchedule.Annotations = make(map[string]string)
+				}
 				snapshotSchedule.Annotations[secrets.SecretNameKey] = operator_util.SecurityPXUserTokenSecretName
 				snapshotSchedule.Annotations[secrets.SecretNamespaceKey] = os.Getenv(k8sutils.PxNamespaceEnvName)
 			}

--- a/pkg/storkctl/snapshotschedule.go
+++ b/pkg/storkctl/snapshotschedule.go
@@ -2,15 +2,10 @@ package storkctl
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
-	"github.com/libopenstorage/openstorage/pkg/auth/secrets"
-	operator_util "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
-	"github.com/libopenstorage/stork/pkg/k8sutils"
-	"github.com/portworx/sched-ops/k8s/operator"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
 	"github.com/spf13/cobra"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
@@ -63,22 +58,7 @@ func newCreateSnapshotScheduleCommand(cmdFactory Factory, ioStreams genericcliop
 			}
 			snapshotSchedule.Name = snapshotScheduleName
 			snapshotSchedule.Namespace = cmdFactory.GetNamespace()
-			stc, err := operator.Instance().ListStorageClusters(os.Getenv(k8sutils.PxNamespaceEnvName))
-			if err != nil {
-				util.CheckErr(err)
-				return
-			}
-			if len(stc.Items) > 0 {
-				pxStc := (*stc).Items[0]
-				// Add the `auth-secret-name` and `auth-secret-namespace` annotations
-				// if in auth enabled cluster.
-				if operator_util.AuthEnabled(&pxStc.Spec) {
-					snapshotSchedule.Annotations = make(map[string]string)
-					snapshotSchedule.Annotations[secrets.SecretNameKey] = operator_util.SecurityPXUserTokenSecretName
-					snapshotSchedule.Annotations[secrets.SecretNamespaceKey] = pxStc.Namespace
-				}
-			}
-			_, err = storkops.Instance().CreateSnapshotSchedule(snapshotSchedule)
+			_, err := storkops.Instance().CreateSnapshotSchedule(snapshotSchedule)
 			if err != nil {
 				util.CheckErr(err)
 				return

--- a/test/integration_test/dataexport_rsync_test.go
+++ b/test/integration_test/dataexport_rsync_test.go
@@ -30,11 +30,12 @@ const (
 )
 
 func TestDataExportRsync(t *testing.T) {
-	var testResult = testResultFail
+	var testrailID, testResult = 301900, testResultFail
+	runID := testrailSetupForTest(testrailID, &testResult, t.Name())
+	defer updateTestRail(&testResult, testrailID, runID)
+	defer updateDashStats(t.Name(), &testResult)
 	instanceID := "dataexport-test"
 	appKey := "fio-dataexport"
-	currentTestSuite = t.Name()
-	defer updateDashStats(t.Name(), &testResult)
 
 	// Check if default storage class is set. This allows us to run this
 	// test on all platforms such as AWS, AKS where a default storage class
@@ -205,6 +206,10 @@ func TestDataExportRsync(t *testing.T) {
 
 	_, err = task.DoRetryWithTimeout(compareVolSizes, dataExportSuccessWaitTimeout, defaultWaitInterval)
 	log.FailOnError(t, err, "size comparison failed after DataExport rsync job completion")
+
+	// If we are here then the test has passed
+	testResult = testResultPass
+	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
 }
 
 func validateAndCleanupDataExport(

--- a/test/integration_test/snapshot_restore_test.go
+++ b/test/integration_test/snapshot_restore_test.go
@@ -5,11 +5,15 @@ package integrationtest
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
+	"github.com/libopenstorage/openstorage/pkg/auth/secrets"
+	operator_util "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	"github.com/libopenstorage/stork/pkg/k8sutils"
 	"github.com/libopenstorage/stork/pkg/log"
 	k8sextops "github.com/portworx/sched-ops/k8s/externalstorage"
 	storkops "github.com/portworx/sched-ops/k8s/stork"
@@ -193,6 +197,11 @@ func inPlaceSnapshotRestoreDataTest(t *testing.T) {
 			PersistentVolumeClaimName: "vdbench-pvc",
 		},
 	}
+	if authTokenConfigMap != "" {
+		snapObj.Metadata.Annotations = make(map[string]string)
+		snapObj.Metadata.Annotations[secrets.SecretNameKey] = operator_util.SecurityPXUserTokenSecretName
+		snapObj.Metadata.Annotations[secrets.SecretNamespaceKey] = os.Getenv(k8sutils.PxNamespaceEnvName)
+	}
 	vdbenchSnap, err := k8sextops.Instance().CreateSnapshot(snapObj)
 	log.FailOnError(t, err, "Error creating vdbench PVC snapshot")
 
@@ -214,6 +223,11 @@ func inPlaceSnapshotRestoreDataTest(t *testing.T) {
 	}
 	restoreObj.Name = "vdbench-inplace-snapshot-restore"
 	restoreObj.Namespace = fmt.Sprintf("vdbench-repl-2-app-%s", testnamespacePostfix)
+	if authTokenConfigMap != "" {
+		restoreObj.Annotations = make(map[string]string)
+		restoreObj.Annotations[secrets.SecretNameKey] = operator_util.SecurityPXUserTokenSecretName
+		restoreObj.Annotations[secrets.SecretNamespaceKey] = os.Getenv(k8sutils.PxNamespaceEnvName)
+	}
 	vdbenchRestore, err := storkops.Instance().CreateVolumeSnapshotRestore(restoreObj)
 	log.FailOnError(t, err, "Error creating vdbench in-place restore")
 

--- a/test/integration_test/snapshot_restore_test.go
+++ b/test/integration_test/snapshot_restore_test.go
@@ -199,7 +199,7 @@ func inPlaceSnapshotRestoreDataTest(t *testing.T) {
 	}
 	if authTokenConfigMap != "" {
 		snapObj.Metadata.Annotations = make(map[string]string)
-		snapObj.Metadata.Annotations[secrets.SecretNameKey] = operator_util.SecurityPXUserTokenSecretName
+		snapObj.Metadata.Annotations[secrets.SecretNameKey] = operator_util.SecurityPXAdminTokenSecretName
 		snapObj.Metadata.Annotations[secrets.SecretNamespaceKey] = os.Getenv(k8sutils.PxNamespaceEnvName)
 	}
 	vdbenchSnap, err := k8sextops.Instance().CreateSnapshot(snapObj)
@@ -225,7 +225,7 @@ func inPlaceSnapshotRestoreDataTest(t *testing.T) {
 	restoreObj.Namespace = fmt.Sprintf("vdbench-repl-2-app-%s", testnamespacePostfix)
 	if authTokenConfigMap != "" {
 		restoreObj.Annotations = make(map[string]string)
-		restoreObj.Annotations[secrets.SecretNameKey] = operator_util.SecurityPXUserTokenSecretName
+		restoreObj.Annotations[secrets.SecretNameKey] = operator_util.SecurityPXAdminTokenSecretName
 		restoreObj.Annotations[secrets.SecretNamespaceKey] = os.Getenv(k8sutils.PxNamespaceEnvName)
 	}
 	vdbenchRestore, err := storkops.Instance().CreateVolumeSnapshotRestore(restoreObj)

--- a/test/integration_test/stork-test-pod.yaml
+++ b/test/integration_test/stork-test-pod.yaml
@@ -80,8 +80,13 @@ spec:
       value: storage_provisioner
     - name: AUTH_SECRET_CONFIGMAP
       value: auth_secret_configmap
+    - name: PX_JWT_ISSUER
+      value: apps.portworx.io
     - name: PX_SHARED_SECRET
-      value: px_shared_secret_key
+      valueFrom:
+        secretKeyRef:
+          key: apps-secret
+          name: px-system-secrets
     - name: BACKUP_LOCATION_PATH
       value: backup_location_path
     - name: AWS_ACCESS_KEY_ID

--- a/test/integration_test/stork-test-pod.yaml
+++ b/test/integration_test/stork-test-pod.yaml
@@ -83,10 +83,7 @@ spec:
     - name: PX_JWT_ISSUER
       value: apps.portworx.io
     - name: PX_SHARED_SECRET
-      valueFrom:
-        secretKeyRef:
-          key: apps-secret
-          name: px-system-secrets
+      value: px_shared_secret
     - name: BACKUP_LOCATION_PATH
       value: backup_location_path
     - name: AWS_ACCESS_KEY_ID

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -370,9 +370,9 @@ sed -i 's/'SHORT_FLAG'/'"$short_test"'/g' /testspecs/stork-test-pod.yaml
 #  * Pass config map to containing px secret stork-test pod so tests can pick up auth-token
 if [ "$auth_secret_configmap" != "" ] ; then
     sed -i 's/'auth_secret_configmap'/'"$auth_secret_configmap"'/g' /testspecs/stork-test-pod.yaml
-    px_shared_secret=$(kubectl get secret px-system-secrets -n ${px_namespace} -o jsonpath='{.data.apps-secret}' | base64 --decode)
-    sed -i 's/'px_shared_secret'/'"$px_shared_secret"'/g' /testspecs/stork-test-pod.yaml
-    kubectl set env deploy/stork -n kube-system PX_SHARED_SECRET="${px_shared_secret}"
+    # px_shared_secret=$(kubectl get secret px-system-secrets -n ${px_namespace} -o jsonpath='{.data.apps-secret}' | base64 --decode)
+    # sed -i 's/'px_shared_secret'/'"$px_shared_secret"'/g' /testspecs/stork-test-pod.yaml
+    kubectl set env pod/stork-test -n $px_namespace PX_SHARED_SECRET=$(kubectl get secret px-system-secrets -o jsonpath='{.data.apps-secret}' -n ${px_namespace} | base64 --decode)
 else
 	sed -i 's/'auth_secret_configmap'/'\"\"'/g' /testspecs/stork-test-pod.yaml
 fi

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -370,8 +370,9 @@ sed -i 's/'SHORT_FLAG'/'"$short_test"'/g' /testspecs/stork-test-pod.yaml
 #  * Pass config map to containing px secret stork-test pod so tests can pick up auth-token
 if [ "$auth_secret_configmap" != "" ] ; then
     sed -i 's/'auth_secret_configmap'/'"$auth_secret_configmap"'/g' /testspecs/stork-test-pod.yaml
-    sed -i 's/'px_shared_secret_key'/'"$AUTH_SHARED_KEY"'/g' /testspecs/stork-test-pod.yaml
-    kubectl set env deploy/stork -n kube-system PX_SHARED_SECRET="${AUTH_SHARED_KEY}"
+    px_shared_secret=$(kubectl get secret px-system-secrets -n ${px_namespace} -o jsonpath='{.data.apps-secret}' | base64 --decode)
+    sed -i 's/'px_shared_secret'/'"$px_shared_secret"'/g' /testspecs/stork-test-pod.yaml
+    kubectl set env deploy/stork -n kube-system PX_SHARED_SECRET="${px_shared_secret}"
 else
 	sed -i 's/'auth_secret_configmap'/'\"\"'/g' /testspecs/stork-test-pod.yaml
 fi

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -370,9 +370,8 @@ sed -i 's/'SHORT_FLAG'/'"$short_test"'/g' /testspecs/stork-test-pod.yaml
 #  * Pass config map to containing px secret stork-test pod so tests can pick up auth-token
 if [ "$auth_secret_configmap" != "" ] ; then
     sed -i 's/'auth_secret_configmap'/'"$auth_secret_configmap"'/g' /testspecs/stork-test-pod.yaml
-    # px_shared_secret=$(kubectl get secret px-system-secrets -n ${px_namespace} -o jsonpath='{.data.apps-secret}' | base64 --decode)
-    # sed -i 's/'px_shared_secret'/'"$px_shared_secret"'/g' /testspecs/stork-test-pod.yaml
-    kubectl set env pod/stork-test -n $px_namespace PX_SHARED_SECRET=$(kubectl get secret px-system-secrets -o jsonpath='{.data.apps-secret}' -n ${px_namespace} | base64 --decode)
+    px_shared_secret=$(kubectl get secret px-system-secrets -n ${px_namespace} -o jsonpath='{.data.apps-secret}' | base64 --decode)
+    sed -i "s|px_shared_secret|${px_shared_secret}|g" /testspecs/stork-test-pod.yaml
 else
 	sed -i 's/'auth_secret_configmap'/'\"\"'/g' /testspecs/stork-test-pod.yaml
 fi


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
Adds the authentication related annotations in stork volumesnapshots in order to fix volume snapshotting in auth clusters.

**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No

**Does this change need to be cherry-picked to a release branch?**:
Yes, `24.4.0` branch.

**Test run**
https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/snapshot-auth-cluster/22/
https://jenkins.pwx.dev.purestorage.com/job/Users/job/strivedi/job/snapshot-auth-cluster/17/