### PR TITLE
PB-8360: Adding appropriate error check for IBM COS in case the bucket is unlocked

### DIFF
--- a/pkg/objectstore/s3/s3.go
+++ b/pkg/objectstore/s3/s3.go
@@ -110,7 +110,8 @@ func GetObjLockInfo(backupLocation *stork_api.BackupLocation) (*common.ObjLockIn
 				awsErr.Code() == "ObjectLockConfigurationNotFound" ||
 				awsErr.Code() == "NotImplemented" ||
 				awsErr.Code() == "NoSuchBucket" ||
-				awsErr.Code() == "NoSuchBucketObjectLockConfiguration" {
+				awsErr.Code() == "NoSuchBucketObjectLockConfiguration" ||
+				awsErr.Code() == "UnsupportedOperation" {
 				// for a non-objectlocked bucket we needn't throw error
 				return objLockInfo, nil
 			}


### PR DESCRIPTION
Adding appropriate error check for IBM COS in case the bucket is unlocked


**What type of PR is this?**
bug


**What this PR does / why we need it**:
Adds appropriate error check for IBM COS in case the bucket is unlocked
https://purestorage.atlassian.net/browse/PB-8360


**Does this PR change a user-facing CRD or CLI?**:no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:no
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:yes, release-24.3.2, 24.3.3
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

