### PR TITLE
PWX-38924, 38925: fixes for job resource migration and failover timeout

### DIFF
--- a/pkg/action/drutils_test.go
+++ b/pkg/action/drutils_test.go
@@ -7,8 +7,18 @@ import (
 	"github.com/libopenstorage/openstorage/api"
 	mockVolumeDriver "github.com/libopenstorage/stork/drivers/volume/mock/volume"
 	storkv1 "github.com/libopenstorage/stork/pkg/apis/stork/v1alpha1"
+	fakeclient "github.com/libopenstorage/stork/pkg/client/clientset/versioned/fake"
+	"github.com/libopenstorage/stork/pkg/log"
+	"github.com/portworx/sched-ops/k8s/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubernetes "k8s.io/client-go/kubernetes/fake"
 )
+
+var fakeStorkClient *fakeclient.Clientset
 
 func TestGetRemoteNodeName(t *testing.T) {
 	// Setup
@@ -147,4 +157,96 @@ func TestGetRemoteNodeName(t *testing.T) {
 	if remoteNode != expectedRemoteNode {
 		t.Errorf("Expected remote node to be %s, but got %s", expectedRemoteNode, remoteNode)
 	}
+}
+
+/*
+TestCheckForPodStatusUsingPVC tests the checkForPodStatusUsingPVC function that
+returns the following three values:
+- terminated: true if all pods using PVC are terminated
+- terminationInProgress: true if any pod using PVC is not terminated
+- error: error if any error occurs
+
+Cases:
+1. All pods terminated.
+2. Some pods terminated, some not.
+3. All pods terminated, one in completed state.
+*/
+func TestCheckForPodStatusUsingPVC(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := storkv1.AddToScheme(scheme)
+	require.NoError(t, err, "Error adding stork scheme")
+	fakeStorkClient = fakeclient.NewSimpleClientset()
+	fakeKubeClient := kubernetes.NewSimpleClientset()
+	fakeClient := core.New(fakeKubeClient)
+	core.SetInstance(fakeClient)
+
+	// Create some pods that are using a PVC with different status.
+	completedPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "dummy-container",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name: "data-volume",
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "data-volume",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "test-pvc",
+							ReadOnly:  false,
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+		},
+	}
+
+	// Create the pod.
+	_, err = core.Instance().CreatePod(&completedPod)
+	log.FailOnError(t, err, "failed to create test pod")
+	pvcMap := make(map[string]map[string]int)
+	pvcMap["default"] = make(map[string]int)
+	pvcMap["default"]["test-pvc"] = 1
+
+	isTerminated, isTerminationInProgress, err := checkForPodStatusUsingPVC(pvcMap, fakeClient)
+	assert.NoError(t, err, "failed to check status of pods using PVC")
+	assert.Equal(t, true, isTerminated, "pods should show as terminated")
+	assert.Equal(t, true, isTerminationInProgress, "pods should show as termination in progress")
+
+	// Create a pod in Running state which should not be ignored while checking
+	// the pods not terminated.
+	runningPod := completedPod.DeepCopy()
+	runningPod.Name = "test-pod1"
+	runningPod.Status.Phase = corev1.PodRunning
+	_, err = core.Instance().CreatePod(runningPod)
+	log.FailOnError(t, err, "failed to create test pod")
+	pvcMap["default"]["test-pvc"] = 2
+
+	isTerminated, isTerminationInProgress, err = checkForPodStatusUsingPVC(pvcMap, fakeClient)
+	assert.NoError(t, err, "failed to check status of pods using PVC")
+	assert.Equal(t, false, isTerminated, "all pods should NOT show as terminated")
+	assert.Equal(t, false, isTerminationInProgress, "no pods should show as termination in progress")
+
+	// Change the status of running pod to completed. Now it should again return true for terminated.
+	runningPod.Status.Phase = corev1.PodSucceeded
+	_, err = core.Instance().UpdatePod(runningPod)
+	log.FailOnError(t, err, "failed to create test pod")
+
+	isTerminated, isTerminationInProgress, err = checkForPodStatusUsingPVC(pvcMap, fakeClient)
+	assert.NoError(t, err, "failed to check status of pods using PVC")
+	assert.Equal(t, true, isTerminated, "pods should show as terminated")
+	assert.Equal(t, true, isTerminationInProgress, "pods should show as termination in progress")
 }

--- a/pkg/resourcecollector/job.go
+++ b/pkg/resourcecollector/job.go
@@ -5,27 +5,30 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const (
-	controllerUIDLabel = "controller-uid"
+var (
+	controllerUIDLabels = []string{"controller-uid", "batch.kubernetes.io/controller-uid"}
 )
 
-func (r *ResourceCollector) prepareJobForCollection(
-	object runtime.Unstructured,
-	namespaces []string,
-) error {
+func (r *ResourceCollector) prepareJobForCollection(object runtime.Unstructured) error {
 	var job batchv1.Job
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.UnstructuredContent(), &job); err != nil {
 		return err
 	}
 
 	if job.Labels != nil {
-		delete(job.Labels, controllerUIDLabel)
+		for _, label := range controllerUIDLabels {
+			delete(job.Labels, label)
+		}
 	}
 	if job.Spec.Selector != nil && job.Spec.Selector.MatchLabels != nil {
-		delete(job.Spec.Selector.MatchLabels, controllerUIDLabel)
+		for _, label := range controllerUIDLabels {
+			delete(job.Spec.Selector.MatchLabels, label)
+		}
 	}
 	if job.Spec.Template.Labels != nil {
-		delete(job.Spec.Template.Labels, controllerUIDLabel)
+		for _, label := range controllerUIDLabels {
+			delete(job.Spec.Template.Labels, label)
+		}
 	}
 	o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&job)
 	if err != nil {

--- a/pkg/resourcecollector/resourcecollector.go
+++ b/pkg/resourcecollector/resourcecollector.go
@@ -960,7 +960,7 @@ func (r *ResourceCollector) prepareResourcesForCollection(
 				return fmt.Errorf("error preparing ClusterRoleBindings resource %v: %v", metadata.GetName(), err)
 			}
 		case "Job":
-			err := r.prepareJobForCollection(o, namespaces)
+			err := r.prepareJobForCollection(o)
 			if err != nil {
 				return fmt.Errorf("error preparing job resource %v: %v", metadata.GetName(), err)
 			}

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -68,6 +68,7 @@ func testMigration(t *testing.T) {
 	t.Run("statefulsetTest", statefulsetMigrationTest)
 	t.Run("statefulsetStartAppFalseTest", statefulsetMigrationStartAppFalseTest)
 	t.Run("statefulsetRuleTest", statefulsetMigrationRuleTest)
+	t.Run("jobMigrationTest", jobMigrationTest)
 	t.Run("preExecRuleMissingTest", statefulsetMigrationRulePreExecMissingTest)
 	t.Run("postExecRuleMissingTest", statefulsetMigrationRulePostExecMissingTest)
 	t.Run("disallowedNamespaceTest", migrationDisallowedNamespaceTest)
@@ -540,6 +541,32 @@ func statefulsetMigrationRuleTest(t *testing.T) {
 		appKey,
 		nil,
 		"cassandra-migration-rule",
+		true,
+		true,
+		true,
+		false,
+	)
+
+	// If we are here then the test has passed
+	testResult = testResultPass
+	log.InfoD("Test status at end of %s test: %s", t.Name(), testResult)
+}
+
+// jobMigrationTest tests the migration of Job kubernetes resource.
+func jobMigrationTest(t *testing.T) {
+	var testrailID, testResult = 301906, testResultFail
+	runID := testrailSetupForTest(testrailID, &testResult, t.Name())
+	defer updateTestRail(&testResult, testrailID, runID)
+	defer updateDashStats(t.Name(), &testResult)
+	instanceID := "resource-migration-test"
+	appKey := "busybox-job"
+
+	triggerMigrationTest(
+		t,
+		instanceID,
+		appKey,
+		nil,
+		"job-migration-template",
 		true,
 		true,
 		true,

--- a/test/integration_test/specs/busybox-job/job.yaml
+++ b/test/integration_test/specs/busybox-job/job.yaml
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sample-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: busybox
+        image: busybox
+        command: ["echo", "Hello, World!"]
+      restartPolicy: OnFailure

--- a/test/integration_test/specs/fio-job/job.yaml
+++ b/test/integration_test/specs/fio-job/job.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fio-job
+spec:
+  template:
+    metadata:
+      labels:
+        app: fio
+    spec:
+      containers:
+      - name: fio
+        image: alpine:latest
+        command: ["/bin/sh", "-c"]
+        args:
+        - apk add --no-cache fio &&
+          fio --name=mytest-write --directory=/data --filename=testnew --ioengine=libaio --rw=write --bs=4k --size=1G --numjobs=1 --output=/data/fio-write.log &&
+          chmod +r /data/testnew &&
+          touch /data/ingest_complete
+        volumeMounts:
+        - name: data-volume
+          mountPath: /data
+      - name: ingest-checker
+        image: busybox
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          while [ ! -f /data/ingest_complete ]; do
+            echo "Waiting for fio to complete...";
+            sleep 10;
+          done;
+          if grep -q 'err= 0' /data/fio-write.log; then
+            echo "Ingest complete and no errors detected!";
+          else
+            echo "Errors detected in fio log!";
+            exit 1;
+          fi
+        volumeMounts:
+        - name: data-volume
+          mountPath: /data
+      volumes:
+      - name: data-volume
+        persistentVolumeClaim:
+          claimName: fio-pvc
+      restartPolicy: Never
+  backoffLimit: 4

--- a/test/integration_test/specs/fio-job/pvc.yaml
+++ b/test/integration_test/specs/fio-job/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fio-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 3Gi
+  storageClassName: "fio-sc"

--- a/test/integration_test/specs/job-migration-template/migration.yaml
+++ b/test/integration_test/specs/job-migration-template/migration.yaml
@@ -1,0 +1,16 @@
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: Migration
+metadata:
+  name: sample-job-migration
+spec:
+  # This should be the name of the cluster pair
+  clusterPair: remoteclusterpair
+  # If set to false this will migrate only the volumes. No PVCs, apps, etc will be migrated
+  includeResources: true
+  includeOptionalResourceTypes:
+    - Job
+  # If set to false, the deployments and stateful set replicas will be set to 0 on the destination. There will be an annotation with "stork.openstorage.org/migrationReplicas" to store the replica count from the source
+  startApplications: true
+  # List of namespaces to migrate
+  namespaces:
+  - busybox-job-resource-migration-test


### PR DESCRIPTION
**What type of PR is this?**
bug

**What this PR does / why we need it**:
Addresses [PWX-38924](https://purestorage.atlassian.net/browse/PWX-38924) and [PWX-38925](https://purestorage.atlassian.net/browse/PWX-38925).
- Resolves the job migration error:
```
batch/v1, Kind=Job ns32/fio-date: Error applying resource: Job.batch "fio-date" is invalid: [spec.template.metadata.labels[batch.kubernetes.io/controller-uid]: Invalid value: map[string]string{"batch.kubernetes.io/controller-uid":"50366a61-7049-4128-a5cb-20a56d364e04", "batch.kubernetes.io/job-name":"fio-date", "controller-uid":"310f3075-8bbd-4212-a5ea-e78b01da2e8f", "job-name":"fio-date"}: must be '310f3075-8bbd-4212-a5ea-e78b01da2e8f', spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"batch.kubernetes.io/controller-uid":"50366a61-7049-4128-a5cb-20a56d364e04"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: `selector` not auto-generated]
```
- Fixes the case when failover was failing due to a pod in `Succeeded` phase but still in `Bound` state with a PVC due to which stork wasn't proceeding to complete the failover with the error `pods using PVCs from migration are not getting terminated for last 15m0s`
 
**Does this PR change a user-facing CRD or CLI?**:
No

**Is a release note needed?**:
No
