### PR TITLE
PB-8394: skip status check of the backup if it has already failed or succedeed

### DIFF
--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -3494,7 +3494,7 @@ func (p *portworx) GetBackupStatus(backup *storkapi.ApplicationBackup) error {
 		}
 		// Skip for volumes which are in failed state as there is no need to proceed
 		// further and we have to return the orginal volInfo back to caller
-		if vInfo.Status == storkapi.ApplicationBackupStatusFailed {
+		if vInfo.Status == storkapi.ApplicationBackupStatusFailed || vInfo.Status == storkapi.ApplicationBackupStatusSuccessful {
 			continue
 		}
 		token, err := p.getUserToken(vInfo.Options, vInfo.Namespace)


### PR DESCRIPTION
**What type of PR is this?**
bug


**What this PR does / why we need it**: https://purestorage.atlassian.net/browse/PB-8394


**Does this PR change a user-facing CRD or CLI?**: no
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**: no
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**: yes, release-24.3.3
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->
**Error**
<img width="628" alt="Screenshot 2024-10-11 at 12 49 19 AM" src="https://github.com/user-attachments/assets/e9544a6e-ddc0-42d8-b90f-48c2b9696be5">

**After fix**
volume of all the small backups in successful state after 2 hrs as well
<img width="611" alt="Screenshot 2024-10-14 at 2 38 59 PM" src="https://github.com/user-attachments/assets/52500785-396f-40b3-ad85-26c266a5fca6">
<img width="668" alt="Screenshot 2024-10-14 at 2 38 46 PM" src="https://github.com/user-attachments/assets/f81b3a54-b254-4d08-accf-6569d08a65e4">

