### PR TITLE
PWX-37027: DirectAccessVolumes need not to be considered while prioritizing nodes during scheduling.

### DIFF
--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -161,6 +161,7 @@ func (m *Driver) ProvisionVolume(
 	labels map[string]string,
 	needsAntiHyperconvergence bool,
 	windowsVolume bool,
+	directAccessVolume bool,
 	attachedOn string,
 ) error {
 	if _, ok := m.volumes[volumeName]; ok {
@@ -174,6 +175,7 @@ func (m *Driver) ProvisionVolume(
 		Labels:                    labels,
 		NeedsAntiHyperconvergence: needsAntiHyperconvergence,
 		WindowsVolume:             windowsVolume,
+		DirectAttached:            directAccessVolume,
 		AttachedOn:                attachedOn,
 	}
 

--- a/drivers/volume/mock/mock.go
+++ b/drivers/volume/mock/mock.go
@@ -175,7 +175,7 @@ func (m *Driver) ProvisionVolume(
 		Labels:                    labels,
 		NeedsAntiHyperconvergence: needsAntiHyperconvergence,
 		WindowsVolume:             windowsVolume,
-		DirectAttached:            directAccessVolume,
+		DirectAccess:              directAccessVolume,
 		AttachedOn:                attachedOn,
 	}
 

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -537,7 +537,7 @@ func (p *portworx) constructStorkVolume(vol *api.Volume) *storkvolume.Info {
 
 	info.AttachedOn = vol.AttachedOn
 
-	info.DirectAttached = p.volumeIsDirectAttached(info)
+	info.DirectAccess = p.volumeIsDirectAccess(info)
 
 	return info
 
@@ -600,8 +600,8 @@ func (p *portworx) volumePrefersWindowsNodes(volumeInfo *storkvolume.Info) bool 
 	return false
 }
 
-// volumeIsDirectAttached checks if volume is directly attached
-func (p *portworx) volumeIsDirectAttached(volumeInfo *storkvolume.Info) bool {
+// volumeIsDirectAccess checks if volume is directly attached
+func (p *portworx) volumeIsDirectAccess(volumeInfo *storkvolume.Info) bool {
 	if volumeInfo.Labels != nil {
 		if value, ok := volumeInfo.Labels[pureBackendParam]; ok {
 			return value == pureBlockParam || value == pureFileParam

--- a/drivers/volume/portworx/portworx.go
+++ b/drivers/volume/portworx/portworx.go
@@ -537,6 +537,8 @@ func (p *portworx) constructStorkVolume(vol *api.Volume) *storkvolume.Info {
 
 	info.AttachedOn = vol.AttachedOn
 
+	info.DirectAttached = p.volumeIsDirectAttached(info)
+
 	return info
 
 }
@@ -593,6 +595,16 @@ func (p *portworx) volumePrefersWindowsNodes(volumeInfo *storkvolume.Info) bool 
 			if preferWindowsNodesExists, err := strconv.ParseBool(value); err == nil {
 				return preferWindowsNodesExists
 			}
+		}
+	}
+	return false
+}
+
+// volumeIsDirectAttached checks if volume is directly attached
+func (p *portworx) volumeIsDirectAttached(volumeInfo *storkvolume.Info) bool {
+	if volumeInfo.Labels != nil {
+		if value, ok := volumeInfo.Labels[pureBackendParam]; ok {
+			return value == pureBlockParam || value == pureFileParam
 		}
 	}
 	return false

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -287,6 +287,8 @@ type Info struct {
 	WindowsVolume bool
 	// AttachedOn is the node instance identifier for clustered systems.
 	AttachedOn string
+	// DirectAttached flag indicates if the volume is not managed by the underlying storage
+	DirectAttached bool
 }
 
 // NodeStatus Status of driver on a node

--- a/drivers/volume/volume.go
+++ b/drivers/volume/volume.go
@@ -287,8 +287,8 @@ type Info struct {
 	WindowsVolume bool
 	// AttachedOn is the node instance identifier for clustered systems.
 	AttachedOn string
-	// DirectAttached flag indicates if the volume is not managed by the underlying storage
-	DirectAttached bool
+	// DirectAccess flag indicates if the volume is not managed by the underlying storage
+	DirectAccess bool
 }
 
 // NodeStatus Status of driver on a node

--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -731,7 +731,7 @@ func (e *Extender) processPrioritizeRequest(w http.ResponseWriter, req *http.Req
 					}
 				}
 
-				if skipVolumeScoring || volume.WindowsVolume {
+				if skipVolumeScoring || volume.WindowsVolume || volume.DirectAttached {
 					storklog.PodLog(pod).Debugf("Skipping volume %v from scoring", volume.VolumeName)
 					continue
 				}

--- a/pkg/extender/extender.go
+++ b/pkg/extender/extender.go
@@ -731,7 +731,7 @@ func (e *Extender) processPrioritizeRequest(w http.ResponseWriter, req *http.Req
 					}
 				}
 
-				if skipVolumeScoring || volume.WindowsVolume || volume.DirectAttached {
+				if skipVolumeScoring || volume.WindowsVolume || volume.DirectAccess {
 					storklog.PodLog(pod).Debugf("Skipping volume %v from scoring", volume.VolumeName)
 					continue
 				}

--- a/pkg/extender/extender_test.go
+++ b/pkg/extender/extender_test.go
@@ -2618,7 +2618,7 @@ func skipScoringForWindowsPods(t *testing.T) {
 		prioritizeResponse)
 }
 
-// Verify scoring is skipped entirely if Pod uses a volume with winshare "true"
+// Verify scoring is skipped entirely if Pod uses direct access volumes
 func skipScoringForDirectAccessPods(t *testing.T) {
 	nodes := &v1.NodeList{}
 	nodes.Items = append(nodes.Items, *newNode("node1", "node1", "192.168.0.1", "rack1", "a", "zone1"))
@@ -2646,7 +2646,8 @@ func skipScoringForDirectAccessPods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error sending filter request: %v", err)
 	}
-	// All nodes exluding the offline nodes will be returned as scheduler is disabled for Windows Pods
+	// All nodes exluding the offline nodes will be returned
+	// as during schedule time filterResponse should not include offline nodes even if the pod uses direct access volumes
 	verifyFilterResponse(t, nodes, []int{0, 1, 2, 3, 4}, filterResponse)
 
 	nodes.Items = nodes.Items[0:5]

--- a/pkg/extender/extender_test.go
+++ b/pkg/extender/extender_test.go
@@ -377,7 +377,11 @@ func TestExtender(t *testing.T) {
 	t.Run("disableHyperConvergenceTest", disableHyperConvergenceTest)
 	t.Run("preferLocalNodeWithHyperConvergedVolumesTest", preferLocalNodeWithHyperConvergedVolumesTest)
 	t.Run("preferLocalNodeIgnoredWithAntiHyperConvergenceTest", preferLocalNodeIgnoredWithAntiHyperConvergenceTest)
+
 	t.Run("skipScoringForWindowsPods", skipScoringForWindowsPods)
+
+	t.Run("skipScoringForDirectAccessPods", skipScoringForDirectAccessPods)
+
 	t.Run("invalidNodePrioritizeTest", invalidNodePrioritizeTest)
 	t.Run("kubevirtPodScheduling", kubevirtPodScheduling)
 	t.Run("kubevirtPodSchedulingAttachedOnMismatch", kubevirtPodSchedulingAttachedOnMismatch)
@@ -387,6 +391,7 @@ func TestExtender(t *testing.T) {
 	// From here onwards, the tests with cache enabled should be added
 	t.Run("setCacheInstance", setCacheInstance)
 	t.Run("multipleVolumeTestWithCache", multipleVolumeTestWithCache)
+
 	t.Run("teardown", teardown)
 }
 
@@ -660,7 +665,7 @@ func WFFCVolumeTest(t *testing.T) {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, podVolume)
 	driver.AddPVC(pvcClaim)
 	provNodes := []int{}
-	if err := driver.ProvisionVolume("WFFCVol", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("WFFCVol", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -719,7 +724,7 @@ func WFFCMultiVolumeTest(t *testing.T) {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, podVolume1)
 	driver.AddPVC(pvcClaim1)
 	provNodes := []int{}
-	if err := driver.ProvisionVolume("WFFCVol1", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("WFFCVol1", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -739,7 +744,7 @@ func WFFCMultiVolumeTest(t *testing.T) {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, podVolume2)
 	driver.AddPVC(pvcClaim2)
 	provNodes = []int{1}
-	if err := driver.ProvisionVolume("normalVol", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("normalVol", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -788,7 +793,7 @@ func noVolumeNodeTest(t *testing.T) {
 	pod := newPod("noVolumeNode", defaultNamespace, map[string]bool{"noVolumeNode": false})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("noVolumeNode", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("noVolumeNode", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	filterResponse, err := sendFilterRequest(pod, requestNodes)
@@ -849,7 +854,7 @@ func noDriverNodeTest(t *testing.T) {
 	pod := newPod("noDriverNode", defaultNamespace, map[string]bool{"noDriverNode": false})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("noDriverNode", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("noDriverNode", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	filterResponse, err := sendFilterRequest(pod, requestNodes)
@@ -882,7 +887,7 @@ func singleVolumeTest(t *testing.T) {
 
 	pod := newPod("singleVolume", defaultNamespace, map[string]bool{"singleVolume": false})
 
-	if err := driver.ProvisionVolume("singleVolume", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("singleVolume", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	filterResponse, err := sendFilterRequest(pod, nodes)
@@ -934,11 +939,11 @@ func multipleVolumeTest(t *testing.T) {
 	pod := newPod("doubleVolumePod", defaultNamespace, map[string]bool{"volume1": false, "volume2": false})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("volume1", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("volume1", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("volume2", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("volume2", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -985,11 +990,11 @@ func multipleVolumeTestWithCache(t *testing.T) {
 	pod := newPod("doubleVolumePod", defaultNamespace, map[string]bool{"cvolume1": false, "cvolume2": false})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("cvolume1", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("cvolume1", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("cvolume2", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("cvolume2", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1065,11 +1070,11 @@ func multipleVolumeSkipTest(t *testing.T) {
 	pod := newPod("doubleVolumeSkipPod", defaultNamespace, map[string]bool{"included-volume": false, "excluded-volume": true})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("included-volume", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("included-volume", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("excluded-volume", provNodes, 1, map[string]string{skipScoringLabel: "true"}, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("excluded-volume", provNodes, 1, map[string]string{skipScoringLabel: "true"}, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1121,11 +1126,11 @@ func multipleVolumeStorageDownTest(t *testing.T) {
 	pod := newPod("doubleVolumeSkipPod", defaultNamespace, map[string]bool{"vol1": false, "vol2": true})
 
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("vol1", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("vol1", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("vol2", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("vol2", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1172,7 +1177,7 @@ func driverErrorTest(t *testing.T) {
 
 	pod := newPod("driverErrorPod", defaultNamespace, map[string]bool{"driverErrorTest": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("volume1", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("volume1", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1217,7 +1222,7 @@ func driverNodeErrorStateTest(t *testing.T) {
 
 	pod := newPod("driverErrorPod", defaultNamespace, map[string]bool{"driverNodeErrorTest": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("driverNodeErrorTest", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("driverNodeErrorTest", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1267,11 +1272,11 @@ func zoneTest(t *testing.T) {
 
 	pod := newPod("zoneTest", defaultNamespace, map[string]bool{"zoneVolume1": false, "zoneVolume2": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("zoneVolume1", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("zoneVolume1", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("zoneVolume2", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("zoneVolume2", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1319,11 +1324,11 @@ func zoneStorageDownNodeTest(t *testing.T) {
 
 	pod := newPod("zoneStorageDownNodeTest", defaultNamespace, map[string]bool{"zoneVol1": false, "zoneVol2": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("zoneVol1", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("zoneVol1", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("zoneVol2", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("zoneVol2", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	if err := driver.UpdateNodeStatus(0, volume.NodeStorageDown); err != nil {
@@ -1374,11 +1379,11 @@ func regionTest(t *testing.T) {
 
 	pod := newPod("regionTest", defaultNamespace, map[string]bool{"regionVolume1": false, "regionVolume2": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("regionVolume1", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("regionVolume1", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("regionVolume2", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("regionVolume2", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1425,11 +1430,11 @@ func regionStorageDownNodeTest(t *testing.T) {
 
 	pod := newPod("regionStorageDownNodeTest", defaultNamespace, map[string]bool{"regionVol1": false, "regionVol2": false})
 	provNodes := []int{0, 1}
-	if err := driver.ProvisionVolume("regionVol1", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("regionVol1", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes = []int{1, 2}
-	if err := driver.ProvisionVolume("regionVol2", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("regionVol2", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1475,7 +1480,7 @@ func nodeNameTest(t *testing.T) {
 
 	pod := newPod("nodeNameTest", defaultNamespace, map[string]bool{"nodeNameTest": false})
 
-	if err := driver.ProvisionVolume("nodeNameTest", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("nodeNameTest", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	filterResponse, err := sendFilterRequest(pod, nodes)
@@ -1516,7 +1521,7 @@ func ipTest(t *testing.T) {
 
 	pod := newPod("ipTest", defaultNamespace, map[string]bool{"ipTest": false})
 
-	if err := driver.ProvisionVolume("ipTest", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("ipTest", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	filterResponse, err := sendFilterRequest(pod, nodes)
@@ -1575,7 +1580,7 @@ func noReplicasTest(t *testing.T) {
 	pod := newPod("noReplicasTest", defaultNamespace, map[string]bool{"noReplicasTest": false})
 
 	provNodes := []int{0}
-	if err := driver.ProvisionVolume("noReplicasTest", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("noReplicasTest", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	if err := driver.UpdateNodeStatus(0, volume.NodeOffline); err != nil {
@@ -1667,7 +1672,7 @@ func preferLocalNodeTest(t *testing.T) {
 	pod := newPod("preferLocalNodeTest", defaultNamespace, map[string]bool{"preferLocalNodeTest": false})
 
 	provNodes := []int{0}
-	if err := driver.ProvisionVolume("preferLocalNodeTest", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("preferLocalNodeTest", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1694,7 +1699,7 @@ func extenderMetricsTest(t *testing.T) {
 		t.Fatalf("Error creating cluster: %v", err)
 	}
 	// check if pod is hyper-Converged
-	if err := driver.ProvisionVolume("metric-vol-1", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("metric-vol-1", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	pod := newPod("HyperPodTest", defaultNamespace, map[string]bool{"metric-vol-1": false})
@@ -1709,11 +1714,11 @@ func extenderMetricsTest(t *testing.T) {
 	require.Equal(t, testutil.ToFloat64(HyperConvergedPodsCounter), float64(1), "hyperConverged_pods_total not matched")
 
 	// Semi-Hyper converged pod metrics
-	if err := driver.ProvisionVolume("metric-vol-2", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("metric-vol-2", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	provNodes2 := []int{1, 2}
-	if err := driver.ProvisionVolume("metric-vol-3", provNodes2, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("metric-vol-3", provNodes2, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	semiHyperPod := newPod("SemiPodTest", defaultNamespace, map[string]bool{"metric-vol-2": false, "metric-vol-3": false})
@@ -1728,7 +1733,7 @@ func extenderMetricsTest(t *testing.T) {
 	require.Equal(t, testutil.ToFloat64(SemiHyperConvergePodsCounter), float64(1), "semi_hyperConverged_pods_total not matched")
 
 	// non-hyper converged pod metrics
-	if err := driver.ProvisionVolume("non-metric-vol", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("non-metric-vol", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 	nonHyperPod := newPod("NonHyperPodTest", defaultNamespace, map[string]bool{"non-metric-vol": false})
@@ -1760,7 +1765,7 @@ func preferRemoteNodeOnlyIgnoredForHyperConvergedVolumesTest(t *testing.T) {
 	pod := newPod("preferRemoteNodeOnlyIgnoredForHyperConvergedVolumesTest", defaultNamespace, map[string]bool{"preferRemoteNodeOnlyIgnoredForHyperConvergedVolumesTest": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferRemoteNodeOnlyIgnoredForHyperConvergedVolumesTest", provNodes, 6, map[string]string{preferRemoteNodeOnlyParameter: "true"}, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("preferRemoteNodeOnlyIgnoredForHyperConvergedVolumesTest", provNodes, 6, map[string]string{preferRemoteNodeOnlyParameter: "true"}, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1785,7 +1790,7 @@ func preferRemoteNodeOnlyFailedSchedulingTest(t *testing.T) {
 	pod := newPod("preferRemoteNodeOnlyFailedSchedulingTest", defaultNamespace, map[string]bool{"preferRemoteNodeOnlyFailedSchedulingTest": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferRemoteNodeOnlyFailedSchedulingTest", provNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("preferRemoteNodeOnlyFailedSchedulingTest", provNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1810,7 +1815,7 @@ func preferRemoteNodeOnlyAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("preferRemoteNodeOnlyAntiHyperConvergenceTest", defaultNamespace, map[string]bool{"preferRemoteNodeOnlyAntiHyperConvergenceTest": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferRemoteNodeOnlyAntiHyperConvergenceTest", provNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("preferRemoteNodeOnlyAntiHyperConvergenceTest", provNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1859,7 +1864,7 @@ func preferRemoteNodeFalseAntiHyperConvergenceFilterTest(t *testing.T) {
 	pod := newPod("preferRemoteNodeFalseAntiHyperConvergenceFilterTest", defaultNamespace, map[string]bool{"preferRemoteNodeFalseAntiHyperConvergenceFilterTest": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferRemoteNodeFalseAntiHyperConvergenceFilterTest", provNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true", preferRemoteNodeParameter: "false"}, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("preferRemoteNodeFalseAntiHyperConvergenceFilterTest", provNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true", preferRemoteNodeParameter: "false"}, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1887,7 +1892,7 @@ func antiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("sharedV4ServiceAntiHyperConverged", defaultNamespace, map[string]bool{"sharedV4ServiceAntiHyperConverged": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("sharedV4ServiceAntiHyperConverged", provNodes, 3, nil, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("sharedV4ServiceAntiHyperConverged", provNodes, 3, nil, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1928,7 +1933,7 @@ func invalidNodePrioritizeTest(t *testing.T) {
 
 	// First test for Hyperconvergence scenario
 	provNodes := []int{0}
-	if err := driver.ProvisionVolume("HyperConvergedPrioritize", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedPrioritize", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1948,7 +1953,7 @@ func invalidNodePrioritizeTest(t *testing.T) {
 
 	// Test for AntiHyperconvergence scenario
 	provNodes = []int{0}
-	if err := driver.ProvisionVolume("AntiHyperConvergedPrioritize", provNodes, 1, nil, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("AntiHyperConvergedPrioritize", provNodes, 1, nil, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -1983,7 +1988,7 @@ func offlineNodesAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("offlineNodesAntiHyperConvergenceTest", defaultNamespace, map[string]bool{"offlineNodesAntiHyperConvergenceTest": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("offlineNodesAntiHyperConvergenceTest", provNodes, 3, nil, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("offlineNodesAntiHyperConvergenceTest", provNodes, 3, nil, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2019,12 +2024,12 @@ func multiVolumeAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("multiVolumeAntiHyperConvergenceTest", defaultNamespace, map[string]bool{"HyperConvergedVolumes": false, "sharedV4Svc": false})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumes", regularVolumeProvNodes, 3, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumes", regularVolumeProvNodes, 3, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{3, 4, 5}
-	if err := driver.ProvisionVolume("sharedV4Svc", sharedV4SvcProvNodes, 3, nil, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("sharedV4Svc", sharedV4SvcProvNodes, 3, nil, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2067,12 +2072,12 @@ func multiVolume2AntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("multiVolumeAntiHyperConvergenceTest", defaultNamespace, map[string]bool{"HyperConvergedVolumes2": false, "sharedV4Svc2": false})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumes2", regularVolumeProvNodes, 3, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumes2", regularVolumeProvNodes, 3, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{2, 3, 4}
-	if err := driver.ProvisionVolume("sharedV4Svc2", sharedV4SvcProvNodes, 3, nil, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("sharedV4Svc2", sharedV4SvcProvNodes, 3, nil, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2121,12 +2126,12 @@ func multiVolume3PreferRemoteOnlyAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("multiVolumeAntiHyperConvergenceTest", defaultNamespace, map[string]bool{"HyperConvergedVolumes3": false, "sharedV4Svc3": false})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumes3", regularVolumeProvNodes, 3, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumes3", regularVolumeProvNodes, 3, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("sharedV4Svc3", sharedV4SvcProvNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("sharedV4Svc3", sharedV4SvcProvNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true"}, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2174,17 +2179,17 @@ func multiVolume4PreferRemoteNodeAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("multiVolumeAntiHyperConvergenceTest", defaultNamespace, map[string]bool{"HyperConvergedVolumes4": false, "sharedV4Svc41": false, "sharedV4Svc42": false})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumes4", regularVolumeProvNodes, 3, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumes4", regularVolumeProvNodes, 3, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcPreferRemoteFalseProvNodes := []int{3, 4, 5}
-	if err := driver.ProvisionVolume("sharedV4Svc41", sharedV4SvcPreferRemoteFalseProvNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true", preferRemoteNodeParameter: "false"}, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("sharedV4Svc41", sharedV4SvcPreferRemoteFalseProvNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true", preferRemoteNodeParameter: "false"}, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{2}
-	if err := driver.ProvisionVolume("sharedV4Svc42", sharedV4SvcProvNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true", preferRemoteNodeParameter: "true"}, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("sharedV4Svc42", sharedV4SvcProvNodes, 3, map[string]string{preferRemoteNodeOnlyParameter: "true", preferRemoteNodeParameter: "true"}, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2226,12 +2231,12 @@ func multiVolumeSkipHyperConvergedVolumesScoringTest(t *testing.T) {
 	pod := newPod("multiVolumeSkipHyperConvergedVolumesScoringTest", defaultNamespace, map[string]bool{"HyperConvergedVolumesMultiSkip": true, "sharedV4SvcMultiSkip": true})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumesMultiSkip", regularVolumeProvNodes, 3, map[string]string{skipScoringLabel: "true"}, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumesMultiSkip", regularVolumeProvNodes, 3, map[string]string{skipScoringLabel: "true"}, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{3, 4, 5}
-	if err := driver.ProvisionVolume("sharedV4SvcMultiSkip", sharedV4SvcProvNodes, 3, nil, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("sharedV4SvcMultiSkip", sharedV4SvcProvNodes, 3, nil, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2274,12 +2279,12 @@ func multiVolumeSkipAllVolumeScoringTest(t *testing.T) {
 	pod := newPod("multiVolumeSkipAllVolumeScoringTest", defaultNamespace, map[string]bool{"HyperConvergedVolumesSkip": true, "sharedV4SvcMultiVolumeSkip": true})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("HyperConvergedVolumesSkip", regularVolumeProvNodes, 3, map[string]string{skipScoringLabel: "true"}, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("HyperConvergedVolumesSkip", regularVolumeProvNodes, 3, map[string]string{skipScoringLabel: "true"}, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{3, 4, 5}
-	if err := driver.ProvisionVolume("sharedV4SvcMultiVolumeSkip", sharedV4SvcProvNodes, 3, map[string]string{skipScoringLabel: "true"}, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("sharedV4SvcMultiVolumeSkip", sharedV4SvcProvNodes, 3, map[string]string{skipScoringLabel: "true"}, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2322,12 +2327,12 @@ func multiVolumeWithStorageDownNodesAntiHyperConvergenceTest(t *testing.T) {
 	pod := newPod("multiVolumeWithStorageDownNodesAntiHyperConvergenceTest", defaultNamespace, map[string]bool{"StorageDownNodesHyperConvergedVolumes": false, "StorageDownNodeSharedV4Svc": false})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("StorageDownNodesHyperConvergedVolumes", regularVolumeProvNodes, 3, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("StorageDownNodesHyperConvergedVolumes", regularVolumeProvNodes, 3, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
 	sharedV4SvcProvNodes := []int{3, 4, 5}
-	if err := driver.ProvisionVolume("StorageDownNodeSharedV4Svc", sharedV4SvcProvNodes, 3, nil, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("StorageDownNodeSharedV4Svc", sharedV4SvcProvNodes, 3, nil, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2392,7 +2397,7 @@ func nodeMarkedUnschedulableTest(t *testing.T) {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, vol)
 	driver.AddPVC(pvc)
 	provNodes := []int{1}
-	if err := driver.ProvisionVolume("unschedVol", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("unschedVol", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2443,7 +2448,7 @@ func nodeMarkedUnschedulableWFFCVolTest(t *testing.T) {
 	pod.Spec.Volumes = append(pod.Spec.Volumes, podVolume)
 	driver.AddPVC(pvcClaim)
 	provNodes := []int{}
-	if err := driver.ProvisionVolume("unschedWFFCVol", provNodes, 1, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("unschedWFFCVol", provNodes, 1, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2482,7 +2487,7 @@ func disableHyperConvergenceTest(t *testing.T) {
 	pod.Annotations[disableHyperconvergenceAnnotation] = "true"
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("multiVolumeDisableHyperConvergedTest", provNodes, 3, nil, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("multiVolumeDisableHyperConvergedTest", provNodes, 3, nil, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2526,7 +2531,7 @@ func preferLocalNodeWithHyperConvergedVolumesTest(t *testing.T) {
 	pod.Annotations[preferLocalNodeOnlyAnnotation] = "true"
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferLocalNodeWithHyperConvergedVolumesTest", provNodes, 3, nil, false, false, ""); err != nil {
+	if err := driver.ProvisionVolume("preferLocalNodeWithHyperConvergedVolumesTest", provNodes, 3, nil, false, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2554,7 +2559,7 @@ func preferLocalNodeIgnoredWithAntiHyperConvergenceTest(t *testing.T) {
 	pod.Annotations[preferLocalNodeOnlyAnnotation] = "true"
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("preferLocalNodeIgnoredWithAntiHyperConvergenceTest", provNodes, 3, nil, true, false, ""); err != nil {
+	if err := driver.ProvisionVolume("preferLocalNodeIgnoredWithAntiHyperConvergenceTest", provNodes, 3, nil, true, false, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2581,7 +2586,7 @@ func skipScoringForWindowsPods(t *testing.T) {
 	pod := newPod("windowsVolumeSkipScoring", defaultNamespace, map[string]bool{"WindowsVolume": true})
 
 	regularVolumeProvNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("WindowsVolume", regularVolumeProvNodes, 3, map[string]string{"winshare": "true"}, false, true, ""); err != nil {
+	if err := driver.ProvisionVolume("WindowsVolume", regularVolumeProvNodes, 3, map[string]string{"winshare": "true"}, false, true, false, ""); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2596,6 +2601,55 @@ func skipScoringForWindowsPods(t *testing.T) {
 	// All nodes including offline nodes will be returned as scheduler is disabled for Windows Pods
 	verifyFilterResponse(t, nodes, []int{0, 1, 2, 3, 4, 5}, filterResponse)
 
+	prioritizeResponse, err := sendPrioritizeRequest(pod, nodes)
+	if err != nil {
+		t.Fatalf("Error sending prioritize request: %v", err)
+	}
+	verifyPrioritizeResponse(
+		t,
+		nodes,
+		[]float64{
+			defaultScore,
+			defaultScore,
+			defaultScore,
+			defaultScore,
+			defaultScore,
+			defaultScore},
+		prioritizeResponse)
+}
+
+// Verify scoring is skipped entirely if Pod uses a volume with winshare "true"
+func skipScoringForDirectAccessPods(t *testing.T) {
+	nodes := &v1.NodeList{}
+	nodes.Items = append(nodes.Items, *newNode("node1", "node1", "192.168.0.1", "rack1", "a", "zone1"))
+	nodes.Items = append(nodes.Items, *newNode("node2", "node2", "192.168.0.2", "rack1", "a", "zone1"))
+	nodes.Items = append(nodes.Items, *newNode("node3", "node3", "192.168.0.3", "rack1", "a", "zone1"))
+	nodes.Items = append(nodes.Items, *newNode("node4", "node4", "192.168.0.4", "rack1", "a", "zone1"))
+	nodes.Items = append(nodes.Items, *newNode("node5", "node5", "192.168.0.5", "rack1", "a", "zone1"))
+	nodes.Items = append(nodes.Items, *newNode("node6", "node6", "192.168.0.6", "rack1", "a", "zone1"))
+
+	if err := driver.CreateCluster(6, nodes); err != nil {
+		t.Fatalf("Error creating cluster: %v", err)
+	}
+	pod := newPod("directAccessVolumePod", defaultNamespace, map[string]bool{"directAccessVolume": false})
+
+	regularVolumeProvNodes := []int{0, 1, 2}
+	if err := driver.ProvisionVolume("directAccessVolume", regularVolumeProvNodes, 3, map[string]string{"backend": "pure-block"}, false, false, true, ""); err != nil {
+		t.Fatalf("Error provisioning volume: %v", err)
+	}
+
+	if err := driver.UpdateNodeStatus(5, volume.NodeOffline); err != nil {
+		t.Fatalf("Error setting node status to Offline: %v", err)
+	}
+
+	filterResponse, err := sendFilterRequest(pod, nodes)
+	if err != nil {
+		t.Fatalf("Error sending filter request: %v", err)
+	}
+	// All nodes exluding the offline nodes will be returned as scheduler is disabled for Windows Pods
+	verifyFilterResponse(t, nodes, []int{0, 1, 2, 3, 4}, filterResponse)
+
+	nodes.Items = nodes.Items[0:5]
 	prioritizeResponse, err := sendPrioritizeRequest(pod, nodes)
 	if err != nil {
 		t.Fatalf("Error sending prioritize request: %v", err)
@@ -2629,7 +2683,7 @@ func kubevirtPodScheduling(t *testing.T) {
 	pod := newKubevirtPod("KubevirtPod", defaultNamespace, map[string]bool{"KubevirtVolume": true})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("KubevirtVolume", provNodes, 3, map[string]string{"kubevirtPodScheduling": "true"}, false, false, "192.168.0.1"); err != nil {
+	if err := driver.ProvisionVolume("KubevirtVolume", provNodes, 3, map[string]string{"kubevirtPodScheduling": "true"}, false, false, false, "192.168.0.1"); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2787,7 +2841,7 @@ func kubevirtPodSchedulingAttachedOnMismatch(t *testing.T) {
 	pod := newKubevirtPod("KubevirtPod2", "KubevirtNS2", map[string]bool{"KubevirtVolume2": false})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("KubevirtVolume2", provNodes, 3, map[string]string{"kubevirtPodScheduling": "true"}, false, false, "192.168.0.2"); err != nil {
+	if err := driver.ProvisionVolume("KubevirtVolume2", provNodes, 3, map[string]string{"kubevirtPodScheduling": "true"}, false, false, false, "192.168.0.2"); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 
@@ -2896,7 +2950,7 @@ func kubevirtPodSchedulingNonHyperconvergence(t *testing.T) {
 	pod := newKubevirtPod("kubevirtPodNonHyperConvergence", "KubeVirtNS3", map[string]bool{"KubevirtVolumeNonHyperconvergence": true})
 
 	provNodes := []int{0, 1, 2}
-	if err := driver.ProvisionVolume("KubevirtVolumeNonHyperconvergence", provNodes, 3, map[string]string{"kubevirtPodNonHyperConvergence": "true"}, false, false, "192.168.0.1"); err != nil {
+	if err := driver.ProvisionVolume("KubevirtVolumeNonHyperconvergence", provNodes, 3, map[string]string{"kubevirtPodNonHyperConvergence": "true"}, false, false, false, "192.168.0.1"); err != nil {
 		t.Fatalf("Error provisioning volume: %v", err)
 	}
 

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -387,10 +387,10 @@ func (m *Monitor) doesDriverOwnPodVolumes(pod *v1.Pod) (bool, error) {
 		return false, err
 	}
 
-	// DirectAttached Volumes are not considered if pods use those
+	// DirectAccess Volumes are not considered if pods use those
 	volumeCount := 0
 	for _, volume := range volumes {
-		if !volume.DirectAttached {
+		if !volume.DirectAccess {
 			volumeCount++
 		}
 	}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -387,7 +387,15 @@ func (m *Monitor) doesDriverOwnPodVolumes(pod *v1.Pod) (bool, error) {
 		return false, err
 	}
 
-	if len(volumes) == 0 {
+	// DirectAttached Volumes are not considered if pods use those
+	volumeCount := 0
+	for _, volume := range volumes {
+		if !volume.DirectAttached {
+			volumeCount++
+		}
+	}
+
+	if volumeCount == 0 {
 		storklog.PodLog(pod).Debugf("Pod doesn't have any volumes by driver")
 		return false, nil
 	}

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -608,9 +608,9 @@ func testDirectAccessVolume(t *testing.T) {
 	volumeDriver.EXPECT().GetNodes().Return(driverNodes, nil).AnyTimes()
 	volumes := []*volume.Info{
 		{
-			VolumeName:     "volume1",
-			DataNodes:      []string{driverNodes[0].StorageID},
-			DirectAttached: true,
+			VolumeName:   "volume1",
+			DataNodes:    []string{driverNodes[0].StorageID},
+			DirectAccess: true,
 		},
 	}
 
@@ -624,7 +624,7 @@ func testDirectAccessVolume(t *testing.T) {
 	testNodeOfflineTimeout = 95 * time.Second
 	time.Sleep(testNodeOfflineTimeout)
 	_, err = core.Instance().GetPodByName(pod.Name, "")
-	require.NoError(t, err, "pod should not get deleted as there is another node with same IP which is online")
+	require.NoError(t, err, "pod should not get deleted as it has direct access volume")
 }
 
 func testOfflineStorageNodesBatchTest(t *testing.T) {

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -73,6 +73,7 @@ func TestMonitorOfflineNodes(t *testing.T) {
 	t.Run("testOfflineStorageNode", testOfflineStorageNode)
 	t.Run("testDuplicateOfflineWithSameSchedulerID", testDuplicateOfflineWithSameSchedulerID)
 	t.Run("testDuplicateOfflineWithSameIPAddress", testDuplicateOfflineWithSameIPAddress)
+	t.Run("testDirectAccessVolume", testDirectAccessVolume)
 	t.Run("testOfflineStorageNodeForCSIExtPod", testOfflineStorageNodeForCSIExtPod)
 	t.Run("testOfflineStorageNodesBatchTest", testOfflineStorageNodesBatchTest)
 }
@@ -127,13 +128,13 @@ func setup(t *testing.T) {
 	err = driver.UpdateNodeStatus(5, volume.NodeOffline)
 	require.NoError(t, err, "Error setting node status to Offline")
 
-	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil, false, false, "")
+	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil, false, false, false, "")
 	require.NoError(t, err, "Error provisioning volume")
 
-	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil, false, false, "")
+	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil, false, false, false, "")
 	require.NoError(t, err, "Error provisioning volume")
 
-	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil, false, false, "")
+	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil, false, false, false, "")
 	require.NoError(t, err, "Error provisioning volume")
 
 	eventBroadcaster := record.NewBroadcaster()
@@ -211,13 +212,13 @@ func setupWithNewMockDriver(t *testing.T) {
 	err = driver.UpdateNodeStatus(5, volume.NodeOffline)
 	require.NoError(t, err, "Error setting node status to Offline")
 
-	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil, false, false, "")
+	err = driver.ProvisionVolume(driverVolumeName, provNodes, 1, nil, false, false, false, "")
 	require.NoError(t, err, "Error provisioning volume")
 
-	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil, false, false, "")
+	err = driver.ProvisionVolume(attachmentVolumeName, provNodes, 2, nil, false, false, false, "")
 	require.NoError(t, err, "Error provisioning volume")
 
-	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil, false, false, "")
+	err = driver.ProvisionVolume(unknownPodsVolumeName, provNodes, 3, nil, false, false, false, "")
 	require.NoError(t, err, "Error provisioning volume")
 
 	eventBroadcaster := record.NewBroadcaster()
@@ -297,7 +298,7 @@ func setupWithNewMockDriverScale(t *testing.T) {
 
 	for i := 0; i < numNodes; i++ {
 		provNodes := []int{i, (i + 1) % numNodes}
-		err = driver.ProvisionVolume(fmt.Sprintf("%s%d", driverVolumeName, i), provNodes, 1, nil, false, false, "")
+		err = driver.ProvisionVolume(fmt.Sprintf("%s%d", driverVolumeName, i), provNodes, 1, nil, false, false, false, "")
 		require.NoError(t, err, "Error provisioning volume")
 	}
 
@@ -586,6 +587,44 @@ func testDuplicateOfflineWithSameIPAddress(test *testing.T) {
 	time.Sleep(testNodeOfflineTimeout)
 	_, err = core.Instance().GetPodByName(pod.Name, "")
 	require.NoError(test, err, "pod should not get deleted as there is another node with same IP which is online")
+}
+
+func testDirectAccessVolume(t *testing.T) {
+
+	setupWithNewMockDriver(t)
+
+	defer teardownWithNewMockDriver(t)
+
+	pod := newPod("driverPod", []string{driverVolumeName}, nodeForPod)
+	_, err := core.Instance().CreatePod(pod)
+	require.NoError(t, err, "failed to create pod")
+
+	noStoragePod := newPod("noStoragePod", nil, nodeForPod)
+	_, err = core.Instance().CreatePod(noStoragePod)
+	require.NoError(t, err, "failed to create pod")
+
+	driverNodes := getDriverNodes(len(nodes.Items))
+	driverNodes[0].Status = volume.NodeOffline
+	volumeDriver.EXPECT().GetNodes().Return(driverNodes, nil).AnyTimes()
+	volumes := []*volume.Info{
+		{
+			VolumeName:     "volume1",
+			DataNodes:      []string{driverNodes[0].StorageID},
+			DirectAttached: true,
+		},
+	}
+
+	wffcVolumes := make([]*volume.Info, 0)
+
+	volumeDriver.EXPECT().InspectNode("node1").Return(driverNodes[0], nil).AnyTimes()
+	volumeDriver.EXPECT().GetCSIPodPrefix().Return("px-csi-ext-", nil).AnyTimes()
+	volumeDriver.EXPECT().GetPodVolumes(&pod.Spec, pod.Namespace, false).Return(volumes, wffcVolumes, nil).AnyTimes()
+	volumeDriver.EXPECT().GetPodVolumes(&noStoragePod.Spec, noStoragePod.Namespace, false).Return(wffcVolumes, wffcVolumes, nil).AnyTimes()
+
+	testNodeOfflineTimeout = 95 * time.Second
+	time.Sleep(testNodeOfflineTimeout)
+	_, err = core.Instance().GetPodByName(pod.Name, "")
+	require.NoError(t, err, "pod should not get deleted as there is another node with same IP which is online")
 }
 
 func testOfflineStorageNodesBatchTest(t *testing.T) {


### PR DESCRIPTION
Signed-Off-By: Diptiranjan

**What type of PR is this?**
> Uncomment only one and also add the corresponding label in the PR:
bug
unit-test

**What this PR does / why we need it**:
1. DirectAccessVolumes need not to be considered while prioritizing nodes during scheduling.
2. Also if px becomes offline, the pods using only FADA volumes need not be deleted as part of health monitoring.


**Does this PR change a user-facing CRD or CLI?**:
no

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
yes, 24.4.0

Tests:
1. Wrt scheduling
```
1. The event like "time="2024-04-24T16:07:22Z" level=warning msg="Unable to schedule pod using volumes [pvc-86da355f-f0cc-4a94-8245-97d3ac46ccbc] in a hyperconverged fashion.  Make sure you have enough CPU and memory resources available on these nodes: []" Namespace=fada-namespace-141 Owner=ReplicaSet/px-pure-block04-24-16h00m59s-141-87bc9cf59 PodName=px-pure-block04-24-16h00m59s-141-87bc9cf59-c8vwp
" is no more seen 

➜  ~ kubectl -n busy-0 get po
NAME                                  READY   STATUS              RESTARTS   AGE
busybox-deployment-5d7db775bb-hbfg7   0/1     ContainerCreating   0          14s
➜  ~ kubectl -n busy-0 get po
NAME                                  READY   STATUS    RESTARTS   AGE
busybox-deployment-5d7db775bb-hbfg7   1/1     Running   0          20s
➜  ~ kubectl -n busy-0 describe po busybox-deployment-5d7db775bb-hbfg7
Name:         busybox-deployment-5d7db775bb-hbfg7
Namespace:    busy-0
Priority:     0
Node:         ip-10-13-230-144.pwx.purestorage.com/10.13.230.144
Start Time:   Fri, 18 Oct 2024 14:35:25 +0000
Labels:       app=busybox
              pod-template-hash=5d7db775bb
Annotations:  cni.projectcalico.org/containerID: f48516a66360e1b3b276b87305de58c22db3f778856a8486d37d7eec64a258b3
              cni.projectcalico.org/podIP: 10.233.80.79/32
              cni.projectcalico.org/podIPs: 10.233.80.79/32
Status:       Running
IP:           10.233.80.79
IPs:
  IP:           10.233.80.79
Controlled By:  ReplicaSet/busybox-deployment-5d7db775bb
Containers:
  busybox:
    Container ID:  docker://5c83d8f9bf904065647cb8c62e3a2288b6fbb71d798acad408e75f27095086a4
    Image:         busybox
    Image ID:      docker-pullable://busybox@sha256:768e5c6f5cb6db0794eec98dc7a967f40631746c32232b78a3105fb946f3ab83
    Port:          <none>
    Host Port:     <none>
    Args:
      /bin/sh
      -c
      while true; do date >> /data/out.txt; sleep 10; done
    State:          Running
      Started:      Fri, 18 Oct 2024 14:35:41 +0000
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /data from data-volume (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-zztzg (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True
  Initialized                 True
  Ready                       True
  ContainersReady             True
  PodScheduled                True
Volumes:
  data-volume:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  busybox-pvc
    ReadOnly:   false
  kube-api-access-zztzg:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason            Age   From     Message
  ----     ------            ----  ----     -------
  Warning  FailedScheduling  28s   stork    0/4 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/4 nodes are available: 4 Preemption is not helpful for scheduling.
  Warning  FailedScheduling  26s   stork    0/4 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/4 nodes are available: 4 Preemption is not helpful for scheduling.
  Normal   Scheduled         24s   stork    Successfully assigned busy-0/busybox-deployment-5d7db775bb-hbfg7 to ip-10-13-230-144.pwx.purestorage.com
  Normal   Pulling           10s   kubelet  Pulling image "busybox"
  Normal   Pulled            9s    kubelet  Successfully pulled image "busybox" in 659ms (659ms including waiting). Image size: 4269694 bytes.
  Normal   Created           9s    kubelet  Created container busybox
  Normal   Started           9s    kubelet  Started container busybox

Logs wrt scoring:
=============
time="2024-10-18T14:35:25Z" level=debug msg="Skipping volume pvc-2c97acb9-6615-44f1-9b2f-87bc1f225e33 from scoring" Namespace=busy-0 Owner=ReplicaSet/busybox-deployment-5d7db775bb PodName=busybox-deployment-5d7db775bb-hbfg7
time="2024-10-18T14:35:25Z" level=debug msg="Nodes in response:" Namespace=busy-0 Owner=ReplicaSet/busybox-deployment-5d7db775bb PodName=busybox-deployment-5d7db775bb-hbfg7
time="2024-10-18T14:35:25Z" level=debug msg="{Host:ip-10-13-226-123.pwx.purestorage.com Score:5}" Namespace=busy-0 Owner=ReplicaSet/busybox-deployment-5d7db775bb PodName=busybox-deployment-5d7db775bb-hbfg7
time="2024-10-18T14:35:25Z" level=debug msg="{Host:ip-10-13-230-144.pwx.purestorage.com Score:5}" Namespace=busy-0 Owner=ReplicaSet/busybox-deployment-5d7db775bb PodName=busybox-deployment-5d7db775bb-hbfg7
time="2024-10-18T14:35:25Z" level=debug msg="{Host:ip-10-13-227-115.pwx.purestorage.com Score:5}" Namespace=busy-0 Owner=ReplicaSet/busybox-deployment-5d7db775bb PodName=busybox-deployment-5d7db775bb-hbfg7

```

2. Wrt health monitor, this pod does not get evicted and will keep on running on the node where px goes offline.
```
➜  ~ kp get po -lname=stork
➜  ~ kubectl -n busy-0 get po -o wide
NAME                                  READY   STATUS    RESTARTS   AGE     IP             NODE                                   NOMINATED NODE   READINESS GATES
busybox-deployment-5d7db775bb-hbfg7   1/1     Running   0          2m25s   10.233.80.79   ip-10-13-230-144.pwx.purestorage.com   <none>           <none>
➜  ~ kp get nodes -o wide
NAME                                   STATUS   ROLES           AGE   VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
ip-10-13-226-123.pwx.purestorage.com   Ready    <none>          10d   v1.30.0   10.13.226.123   <none>        Ubuntu 20.04.2 LTS   5.4.0-107-generic   docker://26.1.2
ip-10-13-227-115.pwx.purestorage.com   Ready    <none>          10d   v1.30.0   10.13.227.115   <none>        Ubuntu 20.04.2 LTS   5.4.0-107-generic   docker://26.1.2
ip-10-13-228-109.pwx.purestorage.com   Ready    control-plane   10d   v1.30.0   10.13.228.109   <none>        Ubuntu 20.04.2 LTS   5.4.0-107-generic   docker://26.1.2
ip-10-13-230-144.pwx.purestorage.com   Ready    <none>          10d   v1.30.0   10.13.230.144   <none>        Ubuntu 20.04.2 LTS   5.4.0-107-generic   docker://26.1.2
➜  ~ kubectl label node ip-10-13-230-144.pwx.purestorage.com px/service=stop
node/ip-10-13-230-144.pwx.purestorage.com labeled
➜  ~ kubectl -n busy-0 get po -o wide
NAME                                  READY   STATUS    RESTARTS   AGE     IP             NODE                                   NOMINATED NODE   READINESS GATES
busybox-deployment-5d7db775bb-hbfg7   1/1     Running   0          8m13s   10.233.80.79   ip-10-13-230-144.pwx.purestorage.com   <none>           <none>
➜  ~ kubectl -n busy-0 get po -o wide
NAME                                  READY   STATUS    RESTARTS   AGE   IP             NODE                                   NOMINATED NODE   READINESS GATES
busybox-deployment-5d7db775bb-hbfg7   1/1     Running   0          17m   10.233.80.79   ip-10-13-230-144.pwx.purestorage.com   <none>           <none>
```