### PR TITLE
test: comment out preExecRuleTest since it is flaky

### DIFF
--- a/test/integration_test/applicationbackup_test.go
+++ b/test/integration_test/applicationbackup_test.go
@@ -63,7 +63,8 @@ func TestApplicationBackup(t *testing.T) {
 	t.Run("applicationBackupRestoreWithoutNMTest", applicationBackupRestoreWithoutNMTest)
 	t.Run("applicationBackupDelBackupLocation", applicationBackupDelBackupLocation)
 	t.Run("applicationBackupMultiple", applicationBackupMultiple)
-	t.Run("preExecRuleTest", applicationBackupRestorePreExecRuleTest)
+	// NOTE: Commenting this test since it is flaky. Ticket for fix: PB-7097.
+	// t.Run("preExecRuleTest", applicationBackupRestorePreExecRuleTest)
 	t.Run("postExecRuleTest", applicationBackupRestorePostExecRuleTest)
 	t.Run("preExecMissingRuleTest", applicationBackupRestorePreExecMissingRuleTest)
 	t.Run("postExecMissingRuleTest", applicationBackupRestorePostExecMissingRuleTest)


### PR DESCRIPTION
Comments out the `TestApplicationBackup/preExecRuleTest` since it is flaky and has been failing consistently across jobs. Corresponding ticket to fix it: https://purestorage.atlassian.net/browse/PB-7097