### PR TITLE
PB-8482 :: Handling pre-provisioned VSC restore

### DIFF
--- a/drivers/volume/csi/csi.go
+++ b/drivers/volume/csi/csi.go
@@ -1343,6 +1343,15 @@ func (c *csi) restoreVolumeSnapshot(
 		vsObj.Spec.Source.PersistentVolumeClaimName = nil
 		vsObj.Spec.Source.VolumeSnapshotContentName = &vsc.(*kSnapshotv1.VolumeSnapshotContent).Name
 		vsObj.Namespace = namespace
+		// PB-8482 Add restoreSize to annotations
+		// Convert RestoreSize to string and store it in restoreSizeStr
+		restoreSizeStr := vsObj.Status.RestoreSize.String()
+		// Initialize Annotations map if it is nil
+		if vsObj.Annotations == nil {
+			vsObj.Annotations = make(map[string]string)
+		}
+		// Add the restoreSize annotation to the VolumeSnapshot object
+		vsObj.Annotations["px-backup/restoreSize"] = restoreSizeStr
 		vs, err = c.snapshotClient.SnapshotV1().VolumeSnapshots(namespace).Create(context.TODO(), vsObj, metav1.CreateOptions{})
 		if err != nil {
 			if k8s_errors.IsAlreadyExists(err) {
@@ -1363,6 +1372,15 @@ func (c *csi) restoreVolumeSnapshot(
 		vsObj.Spec.Source.PersistentVolumeClaimName = nil
 		vsObj.Spec.Source.VolumeSnapshotContentName = &vsc.(*kSnapshotv1beta1.VolumeSnapshotContent).Name
 		vsObj.Namespace = namespace
+		// PB-8482 Add restoreSize to annotations
+		// Convert RestoreSize to string and store it in restoreSizeStr
+		restoreSizeStr := vsObj.Status.RestoreSize.String()
+		// Initialize Annotations map if it is nil
+		if vsObj.Annotations == nil {
+			vsObj.Annotations = make(map[string]string)
+		}
+		// Add the restoreSize annotation to the VolumeSnapshot object
+		vsObj.Annotations["px-backup/restoreSize"] = restoreSizeStr
 		vs, err = c.snapshotClient.SnapshotV1beta1().VolumeSnapshots(namespace).Create(context.TODO(), vsObj, metav1.CreateOptions{})
 		if err != nil {
 			if k8s_errors.IsAlreadyExists(err) {

--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -354,8 +354,15 @@ func (a *ApplicationBackupController) handle(ctx context.Context, backup *stork_
 		}
 
 		if backup.GetFinalizers() != nil {
+			// Fetch the latest backup object as we need to update after removing the finalizer
+			key := runtimeclient.ObjectKeyFromObject(backup)
+			err := a.client.Get(context.TODO(), key, backup)
+			if err != nil {
+				log.ApplicationBackupLog(backup).Errorf("Error while getting applicationbackup [%v/%v]: %v", backup.Namespace, backup.Name, err)
+				return err
+			}
 			controllers.RemoveFinalizer(backup, controllers.FinalizerCleanup)
-			err := a.client.Update(ctx, backup)
+			err = a.client.Update(ctx, backup)
 			if err != nil {
 				log.ApplicationBackupLog(backup).Errorf("Error while updating applicationbackup [%v/%v]: %v", backup.Namespace, backup.Name, err)
 				return err

--- a/pkg/snapshotter/snapshotter_csi.go
+++ b/pkg/snapshotter/snapshotter_csi.go
@@ -578,7 +578,7 @@ func (c *csiDriver) RestoreVolumeClaim(opts ...Option) (*v1.PersistentVolumeClai
 				errMsg := fmt.Sprintf("failed to get volumesnapshot [%v/%v]", snapshot.Namespace, snapshot.Name)
 				return "", true, fmt.Errorf("%v", errMsg)
 			}
-			if snapshot.Status == nil || snapshot.Status.RestoreSize == nil {
+			if snapshot.Status == nil {
 				errMsg := fmt.Sprintf("volumesnapshot [%v/%v] status is not updated", snapshot.Namespace, snapshot.Name)
 				return "", true, fmt.Errorf("%v", errMsg)
 			}
@@ -601,7 +601,22 @@ func (c *csiDriver) RestoreVolumeClaim(opts ...Option) (*v1.PersistentVolumeClai
 				logrus.Debugf("setting size of pvc %s/%s same as snapshot size %s", pvc.Namespace, pvc.Name, quantity.String())
 				pvc.Spec.Resources.Requests[v1.ResourceStorage] = quantity
 			}
-
+		}
+		// PB-8482 if restore size is nil then set the pvc size to annotation restoreSize
+		if snapshot.Status.RestoreSize == nil {
+			restoreSizeStr, ok := snapshot.Annotations["px-backup/restoreSize"]
+			if !ok {
+				return nil, fmt.Errorf("restoreSize not found either in status or in annotation")
+			}
+			restoreSize, err := resource.ParseQuantity(restoreSizeStr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse restoreSize quantity provided in annotation px-backup/restoreSize: %v", err)
+			}
+			// Update the pvc size only when the volumesnapshot size is greater than PVC size
+			if restoreSize.Cmp(pvc.Spec.Resources.Requests[v1.ResourceStorage]) == 1 {
+				logrus.Debugf("setting size of pvc %s/%s same as snapshot size %s", pvc.Namespace, pvc.Name, restoreSizeStr)
+				pvc.Spec.Resources.Requests[v1.ResourceStorage] = restoreSize
+			}
 		}
 	} else {
 		snapshot, err := c.snapshotClient.SnapshotV1beta1().VolumeSnapshots(o.RestoreNamespace).Get(context.TODO(), o.RestoreSnapshotName, metav1.GetOptions{})
@@ -615,7 +630,7 @@ func (c *csiDriver) RestoreVolumeClaim(opts ...Option) (*v1.PersistentVolumeClai
 				errMsg := fmt.Sprintf("failed to get volumesnapshot [%v/%v]", snapshot.Namespace, snapshot.Name)
 				return "", true, fmt.Errorf("%v", errMsg)
 			}
-			if snapshot.Status == nil || snapshot.Status.RestoreSize == nil {
+			if snapshot.Status == nil {
 				errMsg := fmt.Sprintf("volumesnapshot [%v/%v] status is not updated", snapshot.Namespace, snapshot.Name)
 				return "", true, fmt.Errorf("%v", errMsg)
 			}
@@ -639,6 +654,22 @@ func (c *csiDriver) RestoreVolumeClaim(opts ...Option) (*v1.PersistentVolumeClai
 				pvc.Spec.Resources.Requests[v1.ResourceStorage] = quantity
 			}
 
+		}
+		// PB-8482 if restore size is nil then set the pvc size to annotation restoreSize
+		if snapshot.Status.RestoreSize == nil {
+			restoreSizeStr, ok := snapshot.Annotations["px-backup/restoreSize"]
+			if !ok {
+				return nil, fmt.Errorf("restoreSize not found either in status or in annotation")
+			}
+			restoreSize, err := resource.ParseQuantity(restoreSizeStr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse restoreSize quantity provided in annotation px-backup/restoreSize: %v", err)
+			}
+			// Update the pvc size only when the volumesnapshot size is greater than PVC size
+			if restoreSize.Cmp(pvc.Spec.Resources.Requests[v1.ResourceStorage]) == 1 {
+				logrus.Debugf("setting size of pvc %s/%s same as snapshot size %s", pvc.Namespace, pvc.Name, restoreSizeStr)
+				pvc.Spec.Resources.Requests[v1.ResourceStorage] = restoreSize
+			}
 		}
 	}
 
@@ -1259,6 +1290,15 @@ func (c *csiDriver) restoreVolumeSnapshot(
 		vs.(*kSnapshotv1.VolumeSnapshot).Spec.Source.PersistentVolumeClaimName = nil
 		vs.(*kSnapshotv1.VolumeSnapshot).Spec.Source.VolumeSnapshotContentName = &vsc.(*kSnapshotv1.VolumeSnapshotContent).Name
 		vs.(*kSnapshotv1.VolumeSnapshot).Namespace = namespace
+		// PB-8482 Add restoreSize to annotations
+		// Convert RestoreSize to string and store it in restoreSizeStr
+		restoreSizeStr := vs.(*kSnapshotv1.VolumeSnapshot).Status.RestoreSize.String()
+		// Initialize Annotations map if it is nil
+		if vs.(*kSnapshotv1.VolumeSnapshot).Annotations == nil {
+			vs.(*kSnapshotv1.VolumeSnapshot).Annotations = make(map[string]string)
+		}
+		// Add the restoreSize annotation to the VolumeSnapshot object
+		vs.(*kSnapshotv1.VolumeSnapshot).Annotations["px-backup/restoreSize"] = restoreSizeStr
 		newVS, err = c.snapshotClient.SnapshotV1().VolumeSnapshots(namespace).Create(context.TODO(), vs.(*kSnapshotv1.VolumeSnapshot), metav1.CreateOptions{})
 		if err != nil {
 			if k8s_errors.IsAlreadyExists(err) {
@@ -1271,6 +1311,15 @@ func (c *csiDriver) restoreVolumeSnapshot(
 		vs.(*kSnapshotv1beta1.VolumeSnapshot).Spec.Source.PersistentVolumeClaimName = nil
 		vs.(*kSnapshotv1beta1.VolumeSnapshot).Spec.Source.VolumeSnapshotContentName = &vsc.(*kSnapshotv1beta1.VolumeSnapshotContent).Name
 		vs.(*kSnapshotv1beta1.VolumeSnapshot).Namespace = namespace
+		// PB-8482 Add restoreSize to annotations
+		// Convert RestoreSize to string and store it in restoreSizeStr
+		restoreSizeStr := vs.(*kSnapshotv1.VolumeSnapshot).Status.RestoreSize.String()
+		// Initialize Annotations map if it is nil
+		if vs.(*kSnapshotv1.VolumeSnapshot).Annotations == nil {
+			vs.(*kSnapshotv1.VolumeSnapshot).Annotations = make(map[string]string)
+		}
+		// Add the restoreSize annotation to the VolumeSnapshot object
+		vs.(*kSnapshotv1.VolumeSnapshot).Annotations["px-backup/restoreSize"] = restoreSizeStr
 		newVS, err = c.snapshotClient.SnapshotV1beta1().VolumeSnapshots(namespace).Create(context.TODO(), vs.(*kSnapshotv1beta1.VolumeSnapshot), metav1.CreateOptions{})
 		if err != nil {
 			if k8s_errors.IsAlreadyExists(err) {


### PR DESCRIPTION
- Removing nil check of restore size as per external-snapshotter defaults to nil
- Getting object before removal of finalizer and updation
- Passing snapshot.jsnon restorSize as annotaion in VS
- If created VS.status.RestoreSize is nil then compare with annotaion to handle PB-3966


**What type of PR is this?**
>bug


**What this PR does / why we need it**:
This PR caters recent change in the external snapshotter v4.0.0 and above, the default value of restore size in the volumesnapshot size is set to nil rather than 0. This change was causing our previous calls to fail. To address this, I have removed the nil check, once we create VS and VSC from downloaded object the status.RestoreSize is coming as nil for few CSI. We are passing restoreSize as annotation if created VS.status.RestoreSize is nil then compare with annotation to handle PB-3966.

**Does this PR change a user-facing CRD or CLI?**:

No

**Is a release note needed?**:

No


**Does this change need to be cherry-picked to a release branch?**:

yes 24.3.3, 24.4.0


**Testing**
Tested on OCP 4.16 cluster and Azure k8s cluster with NFS and as well as S3 as backup location 
<img width="1722" alt="image" src="https://github.com/user-attachments/assets/3b611e92-fd4c-4077-baf1-09bfafe25a2b">
<img width="1518" alt="image" src="https://github.com/user-attachments/assets/45602bd2-ac25-46d4-a5dc-ed1aac3ab3ed">


Logs

`stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:31Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:31Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:31Z" level=info msg="Exiting Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:31Z" level=info msg="Reconciling ApplicationRestore restore17/restore17-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:31Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:31Z" level=info msg="Exiting Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:32Z" level=info msg="Reconciling ApplicationRestore restore17/restore17-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:32Z" level=info msg="restoreCrTimestampUpdate: waiting to receive data from channel..." ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:33Z" level=info msg="Updating restore  restore17/restore17-f5d512c in stage/status: / to volume stage"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:35Z" level=info msg="Applying StorageClass /postgres-cephfs-sc" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:35Z" level=warning msg="Error deleting StorageClass postgres-cephfs-sc during restore, ReplacePolicy set to Retain: storageclasses.storage.k8s.io \"postgres-cephfs-sc\" already exists" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:35Z" level=info msg="Updating restore  restore17/restore17-f5d512c in stage/status: Volumes/InProgress to volume stage"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:35Z" level=debug msg="started CSI restore ad20edfd-6957-4665-9c2c-88ba253b68d4" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:36Z" level=info msg="CSI Backup Object 1"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:36Z" level=info msg="VolumeSnapshot Key: backup-66bf38921e64-e8c44a4cfb55, ObjectMeta: {Name:backup-66bf38921e64-e8c44a4cfb55 GenerateName: Namespace:pg SelfLink: UID:f49eb679-8ffb-4059-8590-aad92225a1cd ResourceVersion:20763889 Generation:1 CreationTimestamp:2024-10-17 06:14:37 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection] ManagedFields:[{Manager:snapshot-controller Operation:Update APIVersion:snapshot.storage.k8s.io/v1 Time:2024-10-17 06:14:37 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:metadata\":{\"f:finalizers\":{\".\":{},\"v:\\\"snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection\\\"\":{}}}} Subresource:} {Manager:stork Operation:Update APIVersion:snapshot.storage.k8s.io/v1 Time:2024-10-17 06:14:37 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:spec\":{\".\":{},\"f:source\":{\".\":{},\"f:persistentVolumeClaimName\":{}},\"f:volumeSnapshotClassName\":{}}} Subresource:} {Manager:snapshot-controller Operation:Update APIVersion:snapshot.storage.k8s.io/v1 Time:2024-10-17 06:14:38 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:status\":{\".\":{},\"f:boundVolumeSnapshotContentName\":{},\"f:creationTime\":{},\"f:readyToUse\":{},\"f:restoreSize\":{}}} Subresource:status}]}"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:36Z" level=info msg="VolumeSnapshot Spec: {Source:{PersistentVolumeClaimName:0xc00285ff80 VolumeSnapshotContentName:<nil>} VolumeSnapshotClassName:0xc00285ff90}"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:36Z" level=info msg="VolumeSnapshot Status: {BoundVolumeSnapshotContentName:0xc00285ffa0 CreationTime:2024-10-17 06:14:38 +0000 UTC ReadyToUse:0xc0040d4d16 RestoreSize:2Gi Error:<nil>}"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:36Z" level=info msg="VolumeSnapshotContent Key: backup-66bf38921e64-e8c44a4cfb55, ObjectMeta: {Name:snapcontent-f49eb679-8ffb-4059-8590-aad92225a1cd GenerateName: Namespace: SelfLink: UID:6b02ac6a-0525-45ec-b459-a83e70f84420 ResourceVersion:20763885 Generation:1 CreationTimestamp:2024-10-17 06:14:37 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[snapshot.storage.kubernetes.io/deletion-secret-name:rook-csi-cephfs-provisioner snapshot.storage.kubernetes.io/deletion-secret-namespace:openshift-storage] OwnerReferences:[] Finalizers:[snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection] ManagedFields:[{Manager:snapshot-controller Operation:Update APIVersion:snapshot.storage.k8s.io/v1 Time:2024-10-17 06:14:37 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:snapshot.storage.kubernetes.io/deletion-secret-name\":{},\"f:snapshot.storage.kubernetes.io/deletion-secret-namespace\":{}},\"f:finalizers\":{\".\":{},\"v:\\\"snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection\\\"\":{}}},\"f:spec\":{\".\":{},\"f:deletionPolicy\":{},\"f:driver\":{},\"f:source\":{\".\":{},\"f:volumeHandle\":{}},\"f:sourceVolumeMode\":{},\"f:volumeSnapshotClassName\":{},\"f:volumeSnapshotRef\":{}}} Subresource:} {Manager:csi-snapshotter Operation:Update APIVersion:snapshot.storage.k8s.io/v1 Time:2024-10-17 06:14:38 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:status\":{\".\":{},\"f:creationTime\":{},\"f:readyToUse\":{},\"f:restoreSize\":{},\"f:snapshotHandle\":{}}} Subresource:status}]}"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:36Z" level=info msg="VolumeSnapshotContent Spec: {VolumeSnapshotRef:{Kind:VolumeSnapshot Namespace:pg Name:backup-66bf38921e64-e8c44a4cfb55 UID:f49eb679-8ffb-4059-8590-aad92225a1cd APIVersion:snapshot.storage.k8s.io/v1 ResourceVersion:20763870 FieldPath:} DeletionPolicy:Retain Driver:openshift-storage.cephfs.csi.ceph.com VolumeSnapshotClassName:0xc002a2c050 Source:{VolumeHandle:0xc002a2c060 SnapshotHandle:<nil>}}"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:36Z" level=info msg="VolumeSnapshotContent Status: SnapshotHandle: 0001-0011-openshift-storage-0000000000000001-b50abbe4-d9d3-47c7-973d-771778ff6845, CreationTime: 1729145678027999000, RestoreSize: 2147483648, ReadyToUse: true"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:36Z" level=info msg="VolumeSnapshotClass Key: ocs-storagecluster-cephfsplugin-snapclass, ObjectMeta: {Name:ocs-storagecluster-cephfsplugin-snapclass GenerateName: Namespace: SelfLink: UID:f9fad82f-34de-4e64-bdcd-959c0f1e6953 ResourceVersion:162257 Generation:2 CreationTimestamp:2024-10-02 07:13:58 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ManagedFields:[{Manager:ocs-operator Operation:Update APIVersion:snapshot.storage.k8s.io/v1 Time:2024-10-02 07:13:58 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:driver\":{},\"f:parameters\":{\".\":{},\"f:clusterID\":{},\"f:csi.storage.k8s.io/snapshotter-secret-name\":{},\"f:csi.storage.k8s.io/snapshotter-secret-namespace\":{}}} Subresource:} {Manager:stork Operation:Update APIVersion:snapshot.storage.k8s.io/v1 Time:2024-10-02 07:36:10 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:deletionPolicy\":{}} Subresource:}]}"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:36Z" level=info msg="VolumeSnapshotClass Driver: openshift-storage.cephfs.csi.ceph.com, Parameters: map[clusterID:openshift-storage csi.storage.k8s.io/snapshotter-secret-name:rook-csi-cephfs-provisioner csi.storage.k8s.io/snapshotter-secret-namespace:openshift-storage]"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:36Z" level=info msg="CSI Backup Object 2 &{map[backup-66bf38921e64-e8c44a4cfb55:0xc0040b8780] map[backup-66bf38921e64-e8c44a4cfb55:0xc0002d3880] map[ocs-storagecluster-cephfsplugin-snapclass:0xc0040b88c0] true}"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=debug msg="restoring 1 volumes" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=debug msg="restoring CSI volume backup-66bf38921e64-e8c44a4cfb55" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=debug msg="created vsClass: ocs-storagecluster-cephfsplugin-snapclass" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=info msg="##### Creating VolumeSnapshot of size 2Gi #####"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=warning msg="##### Created VolumeSnapshot but Status is nil #####"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=debug msg="created vs: restore-vs-88ba253b68d4-aad92225a1cd" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=debug msg="created vsc: restore-vsc-88ba253b68d4-a83e70f84420" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=warning msg="##### Before PVC Restore volume snapshot but Status is nil #####"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=info msg="##### snapshot size <nil> #####"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=info msg="##### snapshot size from annotation {{2147483648 0} {<nil>} 2Gi BinarySI} #####"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:37Z" level=debug msg="created pvc: postgres-data" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:42Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:42Z" level=info msg="Exiting Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:52Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:52Z" level=info msg="Exiting Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:57Z" level=info msg="Updating restore  restore17/restore17-f5d512c in stage/status: Volumes/InProgress to volume stage"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:50:57Z" level=info msg="Updating restore  restore17/restore17-f5d512c in stage/status: Volumes/InProgress to volume stage"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:02Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:02Z" level=info msg="Exiting Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:07Z" level=info msg="Updating restore  restore17/restore17-f5d512c in stage/status: Volumes/InProgress to volume stage"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:07Z" level=info msg="Volume restore still in progress: pvc-3b9f578e-7213-4666-b9cb-e8c44a4cfb55-> for namespace pg" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:07Z" level=info msg="restoreCrTimestampUpdate: exiting the go-routine that updates the restore CR timestamp" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:07Z" level=info msg="Reconciling ApplicationRestore restore17/restore17-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:07Z" level=info msg="restoreCrTimestampUpdate: waiting to receive data from channel..." ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:08Z" level=info msg="Updating restore  restore17/restore17-f5d512c in stage/status: Volumes/InProgress to volume stage"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:09Z" level=info msg="Volume restore still in progress: pvc-3b9f578e-7213-4666-b9cb-e8c44a4cfb55-> for namespace pg" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:09Z" level=info msg="Reconciling ApplicationRestore restore17/restore17-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:09Z" level=info msg="restoreCrTimestampUpdate: waiting to receive data from channel..." ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:09Z" level=info msg="restoreCrTimestampUpdate: exiting the go-routine that updates the restore CR timestamp" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:11Z" level=info msg="Updating restore  restore17/restore17-f5d512c in stage/status: Volumes/InProgress to volume stage"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:12Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:12Z" level=info msg="Exiting Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:12Z" level=info msg="Volume restore still in progress: pvc-3b9f578e-7213-4666-b9cb-e8c44a4cfb55-> for namespace pg" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:12Z" level=info msg="Reconciling ApplicationRestore restore17/restore17-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:12Z" level=info msg="restoreCrTimestampUpdate: exiting the go-routine that updates the restore CR timestamp" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:12Z" level=info msg="restoreCrTimestampUpdate: waiting to receive data from channel..." ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:13Z" level=info msg="Updating restore  restore17/restore17-f5d512c in stage/status: Volumes/InProgress to volume stage"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=debug msg="skipping PVC in restore: postgres-data" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=debug msg="skipping CSI PV in restore: pvc-6bbc2d43-0011-47b5-a2cd-8ee1054e74dd" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="Applying Deployment restore17/postgres" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=debug msg="collected 1 snapshots and 1 snapshotcontents to clean" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=debug msg="started clean up of 1 snapshots and 1 snapshotcontents"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="The size of application restore CR obtained 4183 bytes - largeResourceSizeLimit: 1048576" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="Reconciling ApplicationRestore restore17/restore17-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="restoreCrTimestampUpdate: exiting the go-routine that updates the restore CR timestamp" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="restoreCrTimestampUpdate: waiting to receive data from channel..." ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=warning msg="unable to cleanup snapshot :backup-4550c889917e-e8c44a4cfb55, err:volumesnapshots.snapshot.storage.k8s.io \"backup-4550c889917e-e8c44a4cfb55\" not found"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=debug msg="started clean up of 0 snapshots and 0 snapshotcontents"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="started clean up of 0 snapshots and 0 snapshotcontents" ApplicationBackupName=bkp-vikas-f5d512c ApplicationBackupUID=32e7b5d0-54ff-4dd2-9489-4550c889917e Namespace=restore17 ResourceVersion=35211385
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=error msg="Error while updating applicationbackup [restore17/bkp-vikas-f5d512c]: Operation cannot be fulfilled on applicationbackups.stork.libopenstorage.org \"bkp-vikas-f5d512c\": the object has been modified; please apply your changes to the latest version and try again" ApplicationBackupName=bkp-vikas-f5d512c ApplicationBackupUID=32e7b5d0-54ff-4dd2-9489-4550c889917e Namespace=restore17 ResourceVersion=35211385
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=warning msg="unable to cleanup snapshot :backup-4550c889917e-e8c44a4cfb55, err:volumesnapshots.snapshot.storage.k8s.io \"backup-4550c889917e-e8c44a4cfb55\" not found"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=debug msg="started clean up of 0 snapshots and 0 snapshotcontents"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="started clean up of 0 snapshots and 0 snapshotcontents" ApplicationBackupName=bkp-vikas-f5d512c ApplicationBackupUID=32e7b5d0-54ff-4dd2-9489-4550c889917e Namespace=restore17 ResourceVersion=35211387
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="Exiting Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=error msg="Error getting backup: applicationbackups.stork.libopenstorage.org \"bkp-vikas-f5d512c\" not found" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=error msg="*controllers.ApplicationRestoreController: restore17/restore17-f5d512c: applicationbackups.stork.libopenstorage.org \"bkp-vikas-f5d512c\" not found"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="Reconciling ApplicationRestore restore17/restore17-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="restoreCrTimestampUpdate: exiting the go-routine that updates the restore CR timestamp" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="restoreCrTimestampUpdate: waiting to receive data from channel..." ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=debug msg="collected 0 snapshots and 0 snapshotcontents to clean" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=debug msg="started clean up of 0 snapshots and 0 snapshotcontents"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="restoreCrTimestampUpdate: exiting the go-routine that updates the restore CR timestamp" ApplicationRestoreName=restore17-f5d512c ApplicationRestoreUID=ad20edfd-6957-4665-9c2c-88ba253b68d4 Namespace=restore17
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="Reconciling ApplicationRestore restore17/restore17-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:16Z" level=info msg="Reconciling ApplicationRestore restore17/restore17-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:26Z" level=info msg="Reconciling ApplicationBackup restore17/bkp-vikas-f5d512c"
stork-9c97cb7b6-4pvsq stork time="2024-10-27T18:51:26Z" level=info msg="Reconciling ApplicationRestore restore17/restore17-f5d512c"`


