### PR TITLE
PB-8690: check backupId only for pxd volumes for the initial get backup status

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -1012,7 +1012,8 @@ func (a *ApplicationBackupController) backupVolumes(backup *stork_api.Applicatio
 					if volInfo.Status == stork_api.ApplicationBackupStatusFailed {
 						continue
 					}
-					if volInfo.BackupID == "" {
+					// Check if the snapshot is completed only for pxd volumes by checking the backupID
+					if volInfo.DriverName == volume.PortworxDriverName && volInfo.BackupID == "" {
 						log.ApplicationBackupLog(backup).Infof("Snapshot of volume [%v] from namespace [%v] hasn't completed yet, retry checking status",
 							volInfo.PersistentVolumeClaim, volInfo.Namespace) // Some portworx volume snapshot is not completed yet
 						// hence we will retry checking the status in the next reconciler iteration


### PR DESCRIPTION
**What type of PR is this?**
bug : https://purestorage.atlassian.net/browse/PB-8690


**What this PR does / why we need it**: As part batch processing the volume status , backupId is checked for all the volume drivers instead of pxd which causes the reconciler not to proceed further .This PR fixes by having the logic to process only for pxd volumes



**Does this change need to be cherry-picked to a release branch?**:
Yes, needs to be cherry picked to 24.3.3 release


![Screenshot From 2024-11-06 14-17-04](https://github.com/user-attachments/assets/8f3fd4c3-3619-4ec6-9e20-08b0de8850d1)


