### PR TITLE
PB-8845: Add check to return error if excluderesourcetypes is set for VM type backup

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -2711,9 +2711,16 @@ func (a *ApplicationBackupController) validateApplicationBackupParameters(backup
 		return fmt.Errorf("both ResourceTypes and ExcludeResourceTypes parameter can not be set together")
 	}
 	if IsBackupObjectTypeVirtualMachine(backup) {
+		//Check if excludeResourceType is not specified
+		if len(backup.Spec.ExcludeResourceTypes) != 0 {
+			return fmt.Errorf("excludeResourceType should be nil for backup Object type %v", resourcecollector.PxBackupObjectType_virtualMachine)
+		}
 		//Check resourceTypes is not specified
 		if len(backup.Spec.ResourceTypes) != 0 {
 			return fmt.Errorf("resourceType should be nil for backup Object type %v", resourcecollector.PxBackupObjectType_virtualMachine)
+		}
+		if len(backup.Spec.IncludeResources) != 0 {
+			return fmt.Errorf("includeResources should be nil for backup Object type %v", resourcecollector.PxBackupObjectType_virtualMachine)
 		}
 		//check skipAutoExecRules is true for custom rules.
 		if backup.Spec.PreExecRule != "" || backup.Spec.PostExecRule != "" {


### PR DESCRIPTION


**What type of PR is this?**
>bug


**What this PR does / why we need it**:
We don't need to have excluderesourcetype support incase of vm type of backup.Hence adding a check to return error incase the request comes with exluderesourcetype parameter set


**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

Tested scenario giving excluderesourcetype for VM based backup
![image](https://github.com/user-attachments/assets/520c7242-feed-428c-9c58-2045a287da37)
