### PR TITLE
PB-8891:Remove check for IncludeResources for VM backup type

### DIFF
--- a/pkg/applicationmanager/controllers/applicationbackup.go
+++ b/pkg/applicationmanager/controllers/applicationbackup.go
@@ -2719,9 +2719,6 @@ func (a *ApplicationBackupController) validateApplicationBackupParameters(backup
 		if len(backup.Spec.ResourceTypes) != 0 {
 			return fmt.Errorf("resourceType should be nil for backup Object type %v", resourcecollector.PxBackupObjectType_virtualMachine)
 		}
-		if len(backup.Spec.IncludeResources) != 0 {
-			return fmt.Errorf("includeResources should be nil for backup Object type %v", resourcecollector.PxBackupObjectType_virtualMachine)
-		}
 		//check skipAutoExecRules is true for custom rules.
 		if backup.Spec.PreExecRule != "" || backup.Spec.PostExecRule != "" {
 			if !backup.Spec.SkipAutoExecRules {


### PR DESCRIPTION
**What type of PR is this?**

>bug


**What this PR does / why we need it**:
UI sets the includeResource option internally incase of vm type backup and hence it is a valid option for vm type backup.
So removing the check for the same

**Does this PR change a user-facing CRD or CLI?**:
<!--
If yes, explain why the change is needed and paste some example output of the new change.
If no, just write no.
-->

**Is a release note needed?**:
<!--
If yes, add the release-note label to the PR. Also enter a single sentence release-note block below.
If no, just write no and remove the release-note block below.
-->
```release-note
Issue:
User Impact:
Resolution

```

**Does this change need to be cherry-picked to a release branch?**:
<!--
If yes, enter a comma-separated list of branches where it should be cherry-picked.
If no, just write no.
-->

Testing notes :
Created CR way of backup with excludeResourceTypes with backupObjectType as VirtualMachine:

<img width="638" alt="Screenshot 2024-11-25 at 3 07 02 PM" src="https://github.com/user-attachments/assets/d077f378-cb9e-4d73-b128-489e6baefcf2">
Failed with the reason as below:-

<img width="1566" alt="Screenshot 2024-11-25 at 3 08 10 PM" src="https://github.com/user-attachments/assets/238c8340-38a1-4e14-b542-dcceeec22a4f">

Created with includeResource given in VM type backup:
<img width="912" alt="Screenshot 2024-11-25 at 3 16 22 PM" src="https://github.com/user-attachments/assets/0bbd7cab-530b-4c31-a128-b9fcdf7f8d0c">

Backup went through successsfully:
<img width="1473" alt="Screenshot 2024-11-25 at 3 19 28 PM" src="https://github.com/user-attachments/assets/8b166fe2-a99b-45ba-b54f-14b270e1eaaf">



